### PR TITLE
Additions to Idris Prelude

### DIFF
--- a/lib/prelude/algebra.idr
+++ b/lib/prelude/algebra.idr
@@ -4,6 +4,11 @@ import builtins
 
 %access public
 
+-- XXX: change?
+infix 6 <->
+infix 6 <+>
+infix 6 <*>
+
 -- Sets equipped with a single binary operation that is associative.  Must
 -- satisfy the following laws:
 --   Associativity of <+>:
@@ -36,7 +41,7 @@ class Semigroup a => Monoid a where
 class Monoid a => Group a where
   inverse : a -> a
 
-(<->) : (Group a) => a -> a -> a
+(<->) : Group a => a -> a -> a
 (<->) left right = left <+> (inverse right)
 
 -- Sets equipped with a single binary operation that is associative and

--- a/lib/prelude/nat.idr
+++ b/lib/prelude/nat.idr
@@ -85,37 +85,35 @@ record Multiplicative : Set where
 record Additive : Set where
   getAdditive : Nat -> Additive
 
-instance Semigroup Multiplicative where
-  left <.> right = getMultiplicative $ left' * right'
-    where
-      left'  : Nat
-      left'  =
-        case left of
-          getMultiplicative m => m
+-- XXX: infix operators don't seem to be being exported correctly from
+-- algebra.idr?
+--instance Monoid Multiplicative where
+--  neutral        = getMultiplicative $ S O
+--  left <+> right = getMultiplicative $ left' * right'
+--    where
+--      left'  : Nat
+--      left'  =
+--       case left of
+--          getMultiplicative m => m
 
-      right' : Nat
-      right' =
-        case right of
-          getMultiplicative m => m
+--      right' : Nat
+--      right' =
+--        case right of
+--          getMultiplicative m => m
 
-instance Semigroup Additive where
-  left <.> right = getAdditive $ left' + right'
-    where
-      left'  : Nat
-      left'  =
-        case left of
-          getAdditive m => m
+--instance Monoid Additive where
+--  neutral        = getAdditive $ O
+--  left <+> right = getAdditive $ left' + right'
+--    where
+--      left'  : Nat
+--      left'  =
+--        case left of
+--          getAdditive m => m
 
-      right' : Nat
-      right' =
-        case right of
-          getAdditive m => m
-
-instance Monoid Multiplicative where
-  neutral = getMultiplicative $ S O
-
-instance Monoid Additive where
-  neutral = getAdditive $ O
+--      right' : Nat
+--      right' =
+--        case right of
+--          getAdditive m => m
 
 --------------------------------------------------------------------------------
 -- Auxilliary notions


### PR DESCRIPTION
More additions to Idris Prelude, mainly in the algebra.idr file, with more structures added, also serves to exercise Idris' typeclass support.

Small problem in nat.idr file: infix operators from algebra.idr don't seem to be being exported correctly (so no instances can be defined), or perhaps I'm misunderstanding?
