### PR TITLE
coverage fix for unhandled cases

### DIFF
--- a/src/Idris/Coverage.hs
+++ b/src/Idris/Coverage.hs
@@ -407,6 +407,7 @@ buildSCG (_, n) = do
                   let newscg = buildSCG' ist sc args
                   logLvl 5 $ show newscg
                   addToCG n ( cg { scg = newscg } )
+       [] -> logLvl 5 $ "Could not build SCG for " ++ show n ++ "\n"
 
 buildSCG' :: IState -> SC -> [Name] -> [SCGEntry] 
 buildSCG' ist sc args = nub $ scg sc (zip args args) 
@@ -505,6 +506,8 @@ checkSizeChange n = do
                   let tot = map (checkMP ist (length (argsdef cg))) ms
                   logLvl 3 $ "Paths for " ++ show n ++ " yield " ++ (show tot)
                   return (noPartial tot)
+       [] -> do logLvl 5 $ "No paths for " ++ show n
+                return Unchecked
 
 type MultiPath = [SCGEntry]
 


### PR DESCRIPTION
Error:

src/Idris/Coverage.hs:(402,4)-(409,51): Non-exhaustive patterns in case

Testcase to reproduce:

```
module Test                                             

data Parity : Nat -> Set where
  even : Parity (n + n)
  odd  : Parity (S (n + n)) 

parity : (n : Nat) -> Parity n
parity O         = even {n = O}
parity (S O)     = odd {n = O}
parity (S (S O)) = even {n = S O}
parity (S (S k)) with (parity k)
  parity (S (S (m + m)))     | even ?= even {n = S m}
  parity (S (S (S (m + m)))) | odd  ?= odd {n = S m}

{-
Test.parity_lemma_1 = proof {
  intro;
  rewrite plusSuccRightSucc m m;
  intro;
  trivial;
}

Test.parity_lemma_2 = proof {
  intro;
  rewrite plusSuccRightSucc m m;
  intro;
  trivial;
}
-}
```

prove lemmas without doing :addproof
