### PR TITLE
Allow $TARGET to override libdir on the `idris --install` command.

### DIFF
--- a/src/Pkg/Package.hs
+++ b/src/Pkg/Package.hs
@@ -5,6 +5,7 @@ import System.Directory
 import System.Exit
 import System.IO
 import System.FilePath ((</>), addTrailingPathSeparator)
+import System.Environment (lookupEnv)
 
 import Util.System
 
@@ -101,7 +102,8 @@ toIBCFile (NS n ns) = foldl1 (</>) (reverse (toIBCFile n : ns))
 
 installIBC :: String -> Name -> IO ()
 installIBC p m = do let f = toIBCFile m
-                    d <- getDataDir
+                    target <- lookupEnv "TARGET"
+                    d <- maybe getDataDir return target
                     let destdir = d </> p </> getDest m
                     putStrLn $ "Installing " ++ f ++ " to " ++ destdir
                     system $ "mkdir -p " ++ destdir 


### PR DESCRIPTION
Some way of installing .ibc files to a location other than datadir using idris --install is necessary for making a system package out of this.
I have a standard script for making an Arch Linux package out of a cabal package up at: https://gist.github.com/4158545

During the build step, it runs:

```
cabal configure --prefix=/usr -O
cabal build
```

and then during the package step:

```
cabal copy --destdir=/tmp/idris/pkg
```

Trouble with the current impl is, that last step calls the Makefile, which calls `idris --install base.ipkg`, which then tries to write into /usr/share/idris-9.5 and gets "Permission denied" errors.
That destdir passed to "cabal copy" is already being passed into the Makefile as destdir/datadir: $TARGET=/tmp/idris/pkg/usr/share/idris-0.9.5.
So this just gives a way of installing idris packages to a location other that datadir, if desired:
TARGET=$HOME/foo idris --install blah
