### PR TITLE
Inline type annotation function

### DIFF
--- a/lib/Builtins.idr
+++ b/lib/Builtins.idr
@@ -40,6 +40,9 @@ namespace Builtins {
 id : a -> a
 id x = x
 
+the : (A : Set) -> A -> A
+the _ = id
+
 const : a -> b -> a
 const x _ = x
 


### PR DESCRIPTION
Hopefully this should negate inconvenience caused by the absence of an inline : a la haskell's ::.
