### PR TITLE
Allow documentation comments for records.

### DIFF
--- a/src/Idris/Parser.hs
+++ b/src/Idris/Parser.hs
@@ -1136,7 +1136,8 @@ accData a n ns = do addAcc n a
                     mapM_ (`addAcc` a) ns
 
 pRecord :: SyntaxInfo -> IParser PDecl
-pRecord syn = do acc <- pAccessibility
+pRecord syn = do doc <- option "" (pDocComment '|')
+                 acc <- pAccessibility
                  reserved "record"
                  fc <- pfc
                  tyn_in <- pfName
@@ -1154,7 +1155,7 @@ pRecord syn = do acc <- pAccessibility
                                                      syn_namespace syn }
                  let fns = getRecNames rsyn cty
                  mapM_ (\n -> addAcc n acc) fns
-                 return $ PRecord "" rsyn fc tyn ty cdoc cn cty
+                 return $ PRecord doc rsyn fc tyn ty cdoc cn cty
   where
     getRecNames syn (PPi _ n _ sc) = [expandNS syn n, expandNS syn (mkSet n)]
                                        ++ getRecNames syn sc


### PR DESCRIPTION
Before, you'd get this kind of parse error with this kind of file:

``` idris
-- | Some comment.
record Id : Type -> Type where
  mkId : (runId : a) -> Id a
```

```
% idris todo.idr
     ____    __     _                                          
    /  _/___/ /____(_)____                                     
    / // __  / ___/ / ___/     Version 0.9.5.2
  _/ // /_/ / /  / (__  )      http://www.idris-lang.org/      
 /___/\__,_/_/  /_/____/       Type :? for help                

"./todo.idr" (line 2, column 1):
unexpected "r"
expecting "public", "abstract", "private" or "class"
```

But now it works nicely:

```
﻿% idris todo.idr 
     ____    __     _                                          
    /  _/___/ /____(_)____                                     
    / // __  / ___/ / ___/     Version 0.9.5.2
  _/ // /_/ / /  / (__  )      http://www.idris-lang.org/      
 /___/\__,_/_/  /_/____/       Type :? for help                

Type checking ./todo.idr
*todo> :doc Id
Data type Id : Type -> Type
  -- Some comment.
Arguments:
    Type

Constructors:

mkId : (a : Type) -> a -> Id a

Arguments:
    runId : a
```
