### PR TITLE
lines isn't words

### DIFF
--- a/lib/Prelude/Strings.idr
+++ b/lib/Prelude/Strings.idr
@@ -88,7 +88,7 @@ lines' s = case dropWhile isNL s of
                   in w :: words' s''
 
 lines : String -> List String
-lines s = map pack $ words' $ unpack s
+lines s = map pack $ lines' $ unpack s
 
 partial
 foldr1 : (a -> a -> a) -> List a -> a


### PR DESCRIPTION
A very small fix, fixing "lines".
I assume this something someone forgot to fix after a copy/paste from the definition of "words".
