### PR TITLE
Added cast instances both directions between Maybe and Monoids.

### DIFF
--- a/lib/Prelude/Maybe.idr
+++ b/lib/Prelude/Maybe.idr
@@ -2,6 +2,7 @@ module Prelude.Maybe
 
 import Builtins
 import Prelude.Algebra
+import Prelude.Cast
 
 %access public
 %default total
@@ -58,3 +59,11 @@ instance (Semigroup a) => Semigroup (Maybe a) where
 
 instance (Monoid a) => Monoid (Maybe a) where
   neutral = Nothing
+
+
+instance (Monoid a, Eq a) => Cast a (Maybe a) where
+  cast x = if x == neutral then Nothing else Just x
+
+instance (Monoid a) => Cast (Maybe a) a where
+  cast Nothing = neutral
+  cast (Just x) = x


### PR DESCRIPTION
Casting `m: Maybe a` _to_ a monoid would be equivalent to `fromMaybe neutral m`.
Scalaz has a `.orZero` / `~` method that's handy for just convering a Maybe a to a "" or 0 or whatever - the Monoid identity is a common "default" value on "no value".
https://github.com/scalaz/scalaz/blob/master/core/src/main/scala/scalaz/OptionW.scala#L82

The other direction should be an inverse pretty much. We have a fair amount of that going on in our (non-Idris) code at work - turning false, "", etc into Nothing (I notice there's no Monoid instance for Boolean as I write this - could add one to this PR. It's just xor / false).  `toMaybe b j` might be equivalent to `fmap (const j) (cast b)`.
