### PR TITLE
Updating incorrect operator used in the tutorial demonstrating filter and dependent pairs.

### DIFF
--- a/tutorial/typesfuns.tex
+++ b/tutorial/typesfuns.tex
@@ -922,7 +922,7 @@ If the \texttt{Vect} is empty, the result is easy:
 
 \begin{SaveVerbatim}{vfilternil}
 
-filter p Nil = (_ , [])
+filter p Nil = (_ ** [])
 
 \end{SaveVerbatim}
 \useverb{vfilternil}


### PR DESCRIPTION
Changing the operator used to construct the base case dependent pair in filter function.
