### PR TITLE
Reorder the monad transformers in the Idris monad to allow completion

### DIFF
--- a/src/Core/ProofShell.hs
+++ b/src/Core/ProofShell.hs
@@ -11,6 +11,8 @@ import Core.Elaborate
 import Control.Monad.State
 import System.Console.Haskeline
 
+import Idris.AbsSyntaxTree (Idris)
+
 import Util.Pretty
 
 data ShellState = ShellState 
@@ -55,7 +57,7 @@ processCommand (Tac e)  state
                                 err -> (state, show err)
     | otherwise = (state, "No proof in progress")
 
-runShell :: ShellState -> InputT IO ShellState
+runShell :: ShellState -> Idris ShellState
 runShell st = do (prompt, parser) <- 
                            maybe (return ("TT# ", parseCommand)) 
                                  (\st -> do outputStrLn . render . pretty $ st

--- a/src/IRTS/Compiler.hs
+++ b/src/IRTS/Compiler.hs
@@ -73,7 +73,7 @@ compile target f tm
                          Bytecode -> liftIO $ dumpBC c f
                          ToJavaScript -> liftIO $ codegenJavaScript c f outty
             Error e -> fail $ show e 
-  where checkMVs = do i <- get
+  where checkMVs = do i <- getIState
                       case idris_metavars i \\ primDefs of
                             [] -> return ()
                             ms -> fail $ "There are undefined metavariables: " ++ show ms
@@ -91,7 +91,7 @@ irMain tm = do i <- ir tm
 
 allNames :: [Name] -> Name -> Idris [Name]
 allNames ns n | n `elem` ns = return []
-allNames ns n = do i <- get
+allNames ns n = do i <- getIState
                    case lookupCtxt Nothing n (idris_callgraph i) of
                       [ns'] -> do more <- mapM (allNames (n:ns)) (map fst (calls ns')) 
                                   return (nub (n : concat more))
@@ -193,7 +193,7 @@ instance ToIR (TT Name) where
           | (P (DCon t a) n _, args) <- unApply tm
               = irCon env t a n args
           | (P _ n _, args) <- unApply tm
-              = do i <- get
+              = do i <- getIState
                    args' <- mapM (ir' env) args
                    case getPrim i n args' of
                         Just tm -> return tm

--- a/src/Idris/AbsSyntaxTree.hs
+++ b/src/Idris/AbsSyntaxTree.hs
@@ -136,7 +136,7 @@ idrisInit = IState initContext [] [] emptyContext emptyContext emptyContext
 
 -- The monad for the main REPL - reading and processing files and updating 
 -- global state (hence the IO inner monad).
-type Idris = StateT IState (InputT IO)
+type Idris = InputT (StateT IState IO)
 
 -- Commands in the REPL
 

--- a/src/Idris/Error.hs
+++ b/src/Idris/Error.hs
@@ -20,7 +20,7 @@ import Data.Typeable
 iucheck :: Idris ()
 iucheck = do tit <- typeInType
              when (not tit) $
-                do ist <- get
+                do ist <- getIState
                    idrisCatch (tclift $ ucheck (idris_constraints ist))
                               (\e -> do let msg = show e
                                         setErrLine (getErrLine msg)
@@ -46,13 +46,13 @@ ifail :: String -> Idris ()
 ifail str = throwIO (IErr str)
 
 ierror :: Err -> Idris ()
-ierror err = do i <- get
+ierror err = do i <- getIState
                 throwIO (IErr $ pshow i err)
 
 tclift :: TC a -> Idris a
 tclift tc = case tc of
                OK v -> return v
-               Error err -> do i <- get
+               Error err -> do i <- getIState
                                case err of
                                   At (FC f l) e -> setErrLine l
                                   _ -> return ()

--- a/src/Idris/Parser.hs
+++ b/src/Idris/Parser.hs
@@ -110,7 +110,7 @@ loadSource lidr f
                     v <- verbose
                     when v $ iputStrLn $ "Type checking " ++ f
                     elabDecls toplevel ds
-                    i <- get
+                    i <- getIState
                     -- simplify every definition do give the totality checker
                     -- a better chance
                     mapM_ (\n -> do logLvl 5 $ "Simplifying " ++ show n
@@ -118,7 +118,7 @@ loadSource lidr f
                              (map snd (idris_totcheck i))
                     -- build size change graph from simplified definitions
                     iLOG "Totality checking"
-                    i <- get
+                    i <- getIState
                     mapM_ buildSCG (idris_totcheck i)
                     mapM_ checkDeclTotality (idris_totcheck i)
                     iLOG ("Finished " ++ f)
@@ -162,7 +162,7 @@ parseTac i = runParser (do t <- pTactic defaultSyntax
 
 parseImports :: FilePath -> String -> Idris ([String], [String], String, SourcePos)
 parseImports fname input 
-    = do i <- get
+    = do i <- getIState
          case runParser (do whiteSpace
                             mname <- pHeader
                             ps    <- many pImport
@@ -170,7 +170,7 @@ parseImports fname input
                             pos   <- getPosition
                             return ((mname, ps, rest, pos), i)) i fname input of
               Left err     -> fail (show err)
-              Right (x, i) -> do put i
+              Right (x, i) -> do putIState i
                                  return x
 
 pHeader :: IParser [String]
@@ -275,7 +275,7 @@ pImport = do reserved "import"; f <- identifier; option ';' (lchar ';')
 parseProg :: SyntaxInfo -> FilePath -> String -> SourcePos -> 
              Idris [PDecl]
 parseProg syn fname input pos
-    = do i <- get
+    = do i <- getIState
          case runParser (do setPosition pos
                             whiteSpace
                             ps <- many (pDecl syn)
@@ -284,7 +284,7 @@ parseProg syn fname input pos
                             return (concat ps, i')) i fname input of
             Left err     -> do iputStrLn (show err)
                                return []
-            Right (x, i) -> do put i
+            Right (x, i) -> do putIState i
                                return (collect x)
 
 -- Collect PClauses with the same function name

--- a/src/Idris/UnusedArgs.hs
+++ b/src/Idris/UnusedArgs.hs
@@ -14,7 +14,7 @@ findUnusedArgs ns = mapM_ traceUnused ns
 
 traceUnused :: Name -> Idris ()
 traceUnused n 
-   = do i <- get
+   = do i <- getIState
         case lookupCtxt Nothing n (idris_callgraph i) of 
           [CGInfo args calls scg usedns _] ->
                 do let argpos = zip args [0..]
@@ -38,7 +38,7 @@ used path g j
    | (g, j) `elem` path = return False -- cycle, never used on the way
    | otherwise 
        = do logLvl 5 $ (show ((g, j) : path)) 
-            i <- get
+            i <- getIState
             case lookupCtxt Nothing g (idris_callgraph i) of
                [CGInfo args calls scg usedns unused] ->
                   if (j >= length args) 

--- a/src/Main.hs
+++ b/src/Main.hs
@@ -39,7 +39,7 @@ import Paths_idris
 
 main = do xs <- getArgs
           let opts = parseArgs xs
-          runInputT defaultSettings $ execStateT (runIdris opts) idrisInit
+          execStateT (runInputT haskelineSettings $ runIdris opts) idrisInit
 
 runIdris :: [Opt] -> Idris ()
 runIdris opts = do


### PR DESCRIPTION
I'm working on improving tab completion in the Idris REPL. I wanted to send this right now to prevent too much divergence over time, as it did a fairly drastic change.

Completion of names will require access to the interpreter state. Unfortunately, the stacking order of the monad transformers didn't allow this. This has been changed. As a side effect, when get was used to access the state, it has been consistently replaced with getIState.

The standard library typechecks with no problems following this change.
