### PR TITLE
Generate legal DChkCase expressions when defunctionalization is trivial

### DIFF
--- a/src/IRTS/Defunctionalise.hs
+++ b/src/IRTS/Defunctionalise.hs
@@ -212,10 +212,13 @@ mkEval xs = (MN 0 "EVAL", DFun (MN 0 "EVAL") [MN 0 "arg"]
 
 mkApply :: [(Name, Int, EvalApply DAlt)] -> (Name, DDecl)
 mkApply xs = (MN 0 "APPLY", DFun (MN 0 "APPLY") [MN 0 "fn", MN 0 "arg"]
-                             (mkBigCase (MN 0 "APPLY")
-                                        256 (DApp False (MN 0 "EVAL")
-                                            [DV (Glob (MN 0 "fn"))])
-                                 (mapMaybe applyCase xs)))
+                             (case mapMaybe applyCase xs of
+                                [] -> DNothing
+                                cases ->
+                                    mkBigCase (MN 0 "APPLY") 256
+                                              (DApp False (MN 0 "EVAL")
+                                               [DV (Glob (MN 0 "fn"))])
+                                              cases))
   where
     applyCase (n, t, ApplyCase x) = Just x
     applyCase _ = Nothing


### PR DESCRIPTION
In some programs, such as `main = putStrLn "Hello World"`, defunctionalization does not introduce any new constructors, and as a result there are no cases for APPLY to handle. Previously empty DChkCase expressions were generated, which have uncertain semantics. This patch instead generates a definition of APPLY which explicitly returns an undefined value.
