### PR TITLE
Missing case in Idris.Parser

### DIFF
--- a/src/Idris/Parser.hs
+++ b/src/Idris/Parser.hs
@@ -213,6 +213,7 @@ openBlock = do lchar '{'
 closeBlock :: IParser ()
 closeBlock = do ist <- getState
                 bs <- case brace_stack ist of
+                        []  -> eof >> return []
                         Nothing : xs -> (lchar '}' >> return xs) <|> (eof >> return [])
                         Just lvl : xs -> (do i   <- indent
                                              inp <- getInput


### PR DESCRIPTION
This module:

        module main

        using (A : Type) 
          data W : Type where
            Ok : (r : A -> A -> Type) -> W

gave the error 

        src/Idris/Parser.hs:(215,23)-(223,86): Non-exhaustive patterns in case
    
which seemed to be repaired by this amendment for the [] case.
