### PR TITLE
Non-tail-recursive ForeignTy

### DIFF
--- a/lib/IO.idr
+++ b/lib/IO.idr
@@ -33,10 +33,8 @@ interpFTy (FAny t) = t
 interpFTy FUnit    = ()
 
 ForeignTy : (xs:List FTy) -> (t:FTy) -> Type
-ForeignTy xs t = mkForeign' (reverse xs) (IO (interpFTy t)) where 
-   mkForeign' : List FTy -> Type -> Type
-   mkForeign' Nil ty       = ty
-   mkForeign' (s :: ss) ty = mkForeign' ss (interpFTy s -> ty)
+ForeignTy Nil     rt = IO (interpFTy rt)
+ForeignTy (t::ts) rt = interpFTy t -> ForeignTy ts rt
 
 
 data Foreign : Type -> Type where


### PR DESCRIPTION
This simplifies the definition of ForeignTy to make it easier to deal with when writing types that must unify with its result. As ForeignTy handles C argument lists, it's unlikely that it will ever be passed a list long enough for linear space use to pose a problem.
