### PR TITLE
Make dynamic library extension platform-dependent

### DIFF
--- a/idris.cabal
+++ b/idris.cabal
@@ -114,3 +114,9 @@ Executable     idris
                                 FlexibleInstances, TemplateHaskell
                ghc-prof-options: -auto-all -caf-all
                ghc-options: -rtsopts
+               if os(linux)
+                  cpp-options: -DLINUX
+               if os(darwin)
+                  cpp-options: -DMACOSX
+               if os(windows)
+                  cpp-options: -DWINDOWS

--- a/src/Util/DynamicLinker.hs
+++ b/src/Util/DynamicLinker.hs
@@ -1,18 +1,27 @@
 -- | Platform-specific dynamic linking support. Add new platforms to this file
 -- through conditional compilation.
-{-# LANGUAGE ExistentialQuantification #-}
+{-# LANGUAGE ExistentialQuantification, CPP #-}
 module Util.DynamicLinker where
 
 import Foreign.LibFFI
 import Foreign.Ptr (nullPtr, FunPtr, nullFunPtr)
 import System.Posix.DynamicLinker
 
+hostDynamicLibExt :: String
+#ifdef LINUX
+hostDynamicLibExt = "so"
+#elif MACOSX
+hostDynamicLibExt = "dylib"
+#elif WINDOWS
+hostDynamicLibExt = "dll"
+#endif
+
 data DynamicLib = Lib { lib_name :: String
                       , lib_handle :: DL
                       }
 
 tryLoadLib :: String -> IO (Maybe DynamicLib)
-tryLoadLib lib = do handle <- dlopen lib [RTLD_NOW]
+tryLoadLib lib = do handle <- dlopen (lib ++ "." ++ hostDynamicLibExt) [RTLD_NOW]
                     if undl handle == nullPtr
                       then return Nothing
                       else return . Just $ Lib lib handle

--- a/test/test022/test022.idr
+++ b/test/test022/test022.idr
@@ -1,6 +1,6 @@
 module Main
 
-%dynamic "libm.so"
+%dynamic "libm"
 
 x : Float
 x = unsafePerformIO (mkForeign (FFun "sin" [FFloat] FFloat) 1.6)


### PR DESCRIPTION
New syntax is %dynamic "libm" instead of %dynamic "libm.so".
