### PR TITLE
Add type provider errors + test case

### DIFF
--- a/src/Core/Execute.hs
+++ b/src/Core/Execute.hs
@@ -29,7 +29,7 @@ step :: TT Name -> Idris (Maybe (TT Name))
 step tm = step' (unApply tm)
     where step' (P _ (UN "unsafePerformIO") _, [_, arg] ) = step arg -- Only step if arg can be stepped
           step' (P _ (UN "mkForeign") _, args) = stepForeign args
-          step' (P _ (UN "prim__IO") _, [_, arg]) = step arg
+          step' (P _ (UN "prim__IO") _, [_, arg]) = return (Just arg)
           step' (P _ (UN "prim__readString") _, [(P _ (UN "prim__stdin") _)]) =
               do line <- lift $ getLine
                  return . Just . Constant . Str $ line

--- a/src/Core/TT.hs
+++ b/src/Core/TT.hs
@@ -73,6 +73,7 @@ data Err = Msg String
          | ProofSearchFail Err
          | NoRewriting Term
          | At FC Err
+         | ProviderError String
   deriving Eq
 
 instance Sized Err where
@@ -91,6 +92,7 @@ instance Sized Err where
   size UniverseError = 1
   size ProgramLineComment = 1
   size (At fc err) = size fc + size err
+  size (ProviderError msg) = length msg
   size _ = 1
 
 score :: Err -> Int
@@ -106,6 +108,7 @@ instance Show Err where
     show (CantUnify _ l r e sc i) = "CantUnify " ++ show l ++ " " ++ show r ++ " "
                                       ++ show e ++ " in " ++ show sc ++ " " ++ show i
     show (Inaccessible n) = show n ++ " is not an accessible pattern variable"
+    show (ProviderError msg) = "Type provider error: " ++ msg
     show _ = "Error"
 
 instance Pretty Err where
@@ -118,6 +121,7 @@ instance Pretty Err where
     else
       text "Cannot unify" <+> colon <+> pretty l <+> text "and" <+> pretty r $$
         nest nestingSize (text "where" <+> pretty e <+> text "with" <+> (text . show $ i))
+  pretty (ProviderError msg) = text msg
   pretty _ = text "Error"
 
 data TC a = OK a

--- a/src/Idris/Delaborate.hs
+++ b/src/Idris/Delaborate.hs
@@ -118,6 +118,7 @@ pshow i (AlreadyDefined n) = show n ++ " is already defined"
 pshow i (ProofSearchFail e) = pshow i e
 pshow i (NoRewriting tm) = "rewrite did not change type " ++ show (delab i tm)
 pshow i (At f e) = show f ++ ":" ++ pshow i e
+pshow i (ProviderError msg) = "Type provider error: " ++ msg
 
 showSc i [] = ""
 showSc i xs = "\n\nIn context:\n" ++ showSep "\n" (map showVar (reverse xs))

--- a/src/Idris/ElabDecls.hs
+++ b/src/Idris/ElabDecls.hs
@@ -197,7 +197,7 @@ elabProvider info syn fc n ty tm
                        "\".\nYou must turn on TypeProviders extension."
            else do let expected = providerTy fc ty
                    let using = unProv fc tm
-                   logLvl 1 $ "** Providing " ++
+                   logLvl 1 $ "Providing " ++
                               show n ++ " : " ++ show expected ++
                               " as " ++ show using
                    (e', et) <- elabVal toplevel False using
@@ -207,6 +207,8 @@ elabProvider info syn fc n ty tm
                    let et' = normaliseAll ctxt [] et
                    elabType info syn "" fc [] n ty
                    rhs <- execute e''
+                   logLvl 1 $ "Normalized " ++ show n ++ "'s RHS to " ++ show rhs
+                   providerError rhs
                    elabClauses info fc [] n [PClause fc n (PRef fc $ n) [] (delab i rhs) []]
                    logLvl 1 $ "** Elaborated: " ++ show e' ++ " :as: " ++ show et
                    logLvl 1 $ "** Evaluated: " ++ show rhs ++ " :as: " ++ show et'

--- a/src/Idris/Providers.hs
+++ b/src/Idris/Providers.hs
@@ -2,13 +2,33 @@ module Idris.Providers where
 
 import Core.TT
 import Core.Evaluate
+import Core.Execute
 import Idris.AbsSyntax
 import Idris.AbsSyntaxTree
+import Idris.Error
+
+import Debug.Trace
 
 -- | Wrap a type provider in the type of type providers
 providerTy :: FC -> PTerm -> PTerm
 providerTy fc tm = PApp fc (PRef fc $ UN "Provider") [PExp 0 False tm ""]
 
--- | Wrap the RHS of a type provider definition 
+-- | Wrap the RHS of a type provider definition
 unProv :: FC -> PTerm -> PTerm
 unProv fc tm = PApp fc (PRef fc $ NS (UN "unProv") ["Providers"]) [PExp 0 False tm ""]
+
+-- | Handle an error, if the type provider returned an error. Otherwise do nothing.
+providerError :: TT Name -> Idris ()
+providerError tm = case unApply tm of
+                     (P _ (NS (UN "unProv") ["Providers"]) _, [_, tm']) ->
+                         case unApply tm' of
+                           (P _ (NS (UN "Error") ["Providers"]) _, [_, err]) ->
+                               do str <- execute err
+                                  case (unApply str) of
+                                    (Constant (Str msg), []) ->
+                                        ierror . ProviderError $ msg
+                                    (P _ (UN "prim__IO") _, [_, (Constant (Str msg))]) ->
+                                        ierror . ProviderError $ msg
+                                    _ -> fail "Error in type provider."
+                           _ -> return ()
+                     _ -> return ()

--- a/test/test023/expected
+++ b/test/test023/expected
@@ -1,0 +1,1 @@
+Type provider error: Always fails

--- a/test/test023/run
+++ b/test/test023/run
@@ -1,0 +1,3 @@
+#!/bin/bash
+idris --quiet test023.idr -o test023
+rm -f test023 *.ibc

--- a/test/test023/test023.idr
+++ b/test/test023/test023.idr
@@ -1,0 +1,23 @@
+module Main
+
+-- Simple test case for trivial type providers.
+
+import Providers
+
+%language TypeProviders
+
+-- Provide the Unit type
+goodProvider : Provider Type
+goodProvider = Provide (return (the Type ()))
+
+%provide (Unit : Type) with goodProvider
+
+foo : Unit
+foo = ()
+
+-- Always fail
+badProvider : Provider Type
+badProvider = Error (return "Always fails")
+
+%provide (t : Type) with badProvider
+


### PR DESCRIPTION
Type provider errors now signal a top-level error. test023 contains a
trivially succeeding type provder and a trivially failing type provider.
