### PR TITLE
Remove the unicode from the source files.

### DIFF
--- a/lib/Prelude/Maybe.idr
+++ b/lib/Prelude/Maybe.idr
@@ -66,7 +66,7 @@ instance (Eq a) => Eq (Maybe a) where
 -- | Lift a semigroup into 'Maybe' forming a 'Monoid' according to
 -- <http://en.wikipedia.org/wiki/Monoid>: "Any semigroup S may be
 -- turned into a monoid simply by adjoining an element i not in S
--- and defining i+i = i and i+s = s = s+i for all s ∈ S."
+-- and defining i+i = i and i+s = s = s+i for all s in S."
 
 instance (Semigroup a) => Semigroup (Maybe a) where
   Nothing <+> m = m


### PR DESCRIPTION
This has tripped up at least a couple people trying to install idris, because their
LANG setting did not include unicode, or something.  This comment was just copied
and pasted from the comments of the Haskell lib.  The benefits of having a math
symbol in there don't seem to be worth the pain it causes some people.
