### PR TITLE
Fix missing case in Idris.Primitives.p_strLen

### DIFF
--- a/src/Idris/Primitives.hs
+++ b/src/Idris/Primitives.hs
@@ -625,6 +625,7 @@ p_floatFloor = p_fPrim (fromInteger . floor)
 p_floatCeil = p_fPrim (fromInteger . ceiling)
 
 p_strLen [VConstant (Str xs)] = Just $ VConstant (I (length xs))
+p_strLen _ = Nothing
 p_strHead [VConstant (Str (x:xs))] = Just $ VConstant (Ch x)
 p_strHead _ = Nothing
 p_strTail [VConstant (Str (x:xs))] = Just $ VConstant (Str xs)


### PR DESCRIPTION
Forgot the line `p_strLen _ = Nothing`. :)
