### PR TITLE
Remove the unused arg from lookup functions

### DIFF
--- a/src/Core/Elaborate.hs
+++ b/src/Core/Elaborate.hs
@@ -171,7 +171,7 @@ checkInjective (tm, l, r) = do ctxt <- get_context
                                if isInj ctxt tm then return ()
                                 else lift $ tfail (NotInjective tm l r) 
   where isInj ctxt (P _ n _) 
-            | isConName Nothing n ctxt = True
+            | isConName n ctxt = True
         isInj ctxt (App f a) = isInj ctxt f
         isInj ctxt (Constant _) = True
         isInj ctxt (TType _) = True
@@ -210,7 +210,7 @@ unique_hole' reusable n
 uniqueNameCtxt :: Context -> Name -> [Name] -> Elab' aux Name
 uniqueNameCtxt ctxt n hs 
     | n `elem` hs = uniqueNameCtxt ctxt (nextName n) hs
-    | [_] <- lookupTy Nothing n ctxt = uniqueNameCtxt ctxt (nextName n) hs
+    | [_] <- lookupTy n ctxt = uniqueNameCtxt ctxt (nextName n) hs
     | otherwise = return n
 
 elog :: String -> Elab' aux ()
@@ -356,7 +356,7 @@ prepare_apply fn imps =
     mkClaims _ _ _ _
             | Var n <- fn
                    = do ctxt <- get_context
-                        case lookupTy Nothing n ctxt of
+                        case lookupTy n ctxt of
                                 [] -> lift $ tfail $ NoSuchVariable n  
                                 _ -> fail $ "Too many arguments for " ++ show fn
             | otherwise = fail $ "Too many arguments for " ++ show fn

--- a/src/Core/ProofShell.hs
+++ b/src/Core/ProofShell.hs
@@ -41,7 +41,7 @@ processCommand (Eval t) state =
                 (state, show nf ++ " : " ++ show ty)
          err -> (state, show err)
 processCommand (Print n) state =
-    case lookupDef Nothing n (ctxt state) of
+    case lookupDef n (ctxt state) of
          [tm] -> (state, show tm)
          _ -> (state, "No such name")
 processCommand (Tac e)  state 

--- a/src/Core/TT.hs
+++ b/src/Core/TT.hs
@@ -244,8 +244,8 @@ addDef n v ctxt = case Map.lookup (nsroot n) ctxt of
 
 -}
 
-lookupCtxtName :: Maybe [String] -> Name -> Ctxt a -> [(Name, a)]
-lookupCtxtName nspace n ctxt = case Map.lookup (nsroot n) ctxt of
+lookupCtxtName :: Name -> Ctxt a -> [(Name, a)]
+lookupCtxtName n ctxt = case Map.lookup (nsroot n) ctxt of
                                   Just xs -> filterNS (Map.toList xs)
                                   Nothing -> []
   where
@@ -258,12 +258,12 @@ lookupCtxtName nspace n ctxt = case Map.lookup (nsroot n) ctxt of
     nsmatch (NS _ _)  _         = False
     nsmatch looking   found     = True
 
-lookupCtxt :: Maybe [String] -> Name -> Ctxt a -> [a]
-lookupCtxt ns n ctxt = map snd (lookupCtxtName ns n ctxt)
+lookupCtxt :: Name -> Ctxt a -> [a]
+lookupCtxt n ctxt = map snd (lookupCtxtName n ctxt)
 
 updateDef :: Name -> (a -> a) -> Ctxt a -> Ctxt a
 updateDef n f ctxt 
-  = let ds = lookupCtxtName Nothing n ctxt in
+  = let ds = lookupCtxtName n ctxt in
         foldr (\ (n, t) c -> addDef n (f t) c) ctxt ds  
 
 toAlist :: Ctxt a -> [(Name, a)]

--- a/src/Core/Typecheck.hs
+++ b/src/Core/Typecheck.hs
@@ -60,7 +60,7 @@ check' :: Bool -> Context -> Env -> Raw -> StateT UCs TC (Term, Type)
 check' holes ctxt env top = chk env top where
   chk env (Var n)
       | Just (i, ty) <- lookupTyEnv n env = return (P Bound n ty, ty)
-      | (P nt n' ty : _) <- lookupP Nothing n ctxt = return (P nt n' ty, ty)
+      | (P nt n' ty : _) <- lookupP n ctxt = return (P nt n' ty, ty)
       | otherwise = do lift $ tfail $ NoSuchVariable n
   chk env (RApp f a)
       = do (fv, fty) <- chk env f

--- a/src/IRTS/Compiler.hs
+++ b/src/IRTS/Compiler.hs
@@ -98,7 +98,7 @@ irMain tm = do i <- ir tm
 allNames :: [Name] -> Name -> Idris [Name]
 allNames ns n | n `elem` ns = return []
 allNames ns n = do i <- getIState
-                   case lookupCtxt Nothing n (idris_callgraph i) of
+                   case lookupCtxt n (idris_callgraph i) of
                       [ns'] -> do more <- mapM (allNames (n:ns)) (map fst (calls ns')) 
                                   return (nub (n : concat more))
                       _ -> return [n]
@@ -205,12 +205,12 @@ instance ToIR (TT Name) where
                         Just tm -> return tm
                         _ -> do
                                  let collapse 
-                                        = case lookupCtxt Nothing n 
+                                        = case lookupCtxt n
                                                    (idris_optimisation i) of
                                                [oi] -> collapsible oi
                                                _ -> False
                                  let unused 
-                                        = case lookupCtxt Nothing n 
+                                        = case lookupCtxt n
                                                       (idris_callgraph i) of
                                                [CGInfo _ _ _ _ unusedpos] -> 
                                                       unusedpos

--- a/src/IRTS/Defunctionalise.hs
+++ b/src/IRTS/Defunctionalise.hs
@@ -80,14 +80,14 @@ addApps defs (n, LFun _ _ args e)
 --     aa env e@(LApp tc (MN 0 "EVAL") [a]) = e
     aa env (LApp tc (LV (Glob n)) args)
        = do args' <- mapM (aa env) args 
-            case lookupCtxt Nothing n defs of
+            case lookupCtxt n defs of
                 [LConstructor _ i ar] -> return $ DApp tc n args'
                 [LFun _ _ as _] -> let arity = length as in
                                        fixApply tc n args' arity
                 [] -> return $ chainAPPLY (DV (Glob n)) args'
     aa env (LLazyApp n args)
        = do args' <- mapM (aa env) args
-            case lookupCtxt Nothing n defs of
+            case lookupCtxt n defs of
                 [LConstructor _ i ar] -> return $ DApp False n args'
                 [LFun _ _ as _] -> let arity = length as in
                                        fixLazyApply n args' arity

--- a/src/IRTS/Simplified.hs
+++ b/src/IRTS/Simplified.hs
@@ -46,7 +46,7 @@ simplify :: Bool -> DExp -> State (DDefs, Int) SExp
 simplify tl (DV (Loc i)) = return (SV (Loc i))
 simplify tl (DV (Glob x)) 
     = do ctxt <- ldefs
-         case lookupCtxt Nothing x ctxt of
+         case lookupCtxt x ctxt of
               [DConstructor _ t 0] -> return $ SCon t x []
               _ -> return $ SV (Glob x)
 simplify tl (DApp tc n args) = do args' <- mapM sVar args
@@ -88,7 +88,7 @@ simplify tl (DError str) = return $ SError str
 
 sVar (DV (Glob x))
     = do ctxt <- ldefs
-         case lookupCtxt Nothing x ctxt of
+         case lookupCtxt x ctxt of
               [DConstructor _ t 0] -> sVar (DC t x [])
               _ -> return (Glob x, Nothing)
 sVar (DV x) = return (x, Nothing)
@@ -136,7 +136,7 @@ scopecheck ctxt envTop tm = sc envTop tm where
     sc env (SV (Glob n)) =
        case lookup n (reverse env) of -- most recent first
               Just i -> do lvar i; return (SV (Loc i))
-              Nothing -> case lookupCtxt Nothing n ctxt of
+              Nothing -> case lookupCtxt n ctxt of
                               [DConstructor _ i ar] ->
                                   if True -- ar == 0 
                                      then return (SCon i n [])
@@ -146,7 +146,7 @@ scopecheck ctxt envTop tm = sc envTop tm where
                               [] -> fail $ "Codegen error: No such variable " ++ show n
     sc env (SApp tc f args)
        = do args' <- mapM (scVar env) args
-            case lookupCtxt Nothing f ctxt of
+            case lookupCtxt f ctxt of
                 [DConstructor n tag ar] ->
                     if True -- (ar == length args)
                        then return $ SCon tag n args'
@@ -160,7 +160,7 @@ scopecheck ctxt envTop tm = sc envTop tm where
             return $ SForeign l ty f args'
     sc env (SCon tag f args)
        = do args' <- mapM (scVar env) args
-            case lookupCtxt Nothing f ctxt of
+            case lookupCtxt f ctxt of
                 [DConstructor n tag ar] ->
                     if True -- (ar == length args)
                        then return $ SCon tag n args'
@@ -197,7 +197,7 @@ scopecheck ctxt envTop tm = sc envTop tm where
     scVar env (Glob n) =
        case lookup n (reverse env) of -- most recent first
               Just i -> do lvar i; return (Loc i)
-              Nothing -> case lookupCtxt Nothing n ctxt of
+              Nothing -> case lookupCtxt n ctxt of
                               [DConstructor _ i ar] ->
                                   fail $ "Codegen error : can't pass constructor here"
                               [_] -> return (Glob n)
@@ -207,7 +207,7 @@ scopecheck ctxt envTop tm = sc envTop tm where
 
     scalt env (SConCase _ i n args e)
        = do let env' = env ++ zip args [length env..]
-            tag <- case lookupCtxt Nothing n ctxt of
+            tag <- case lookupCtxt n ctxt of
                         [DConstructor _ i ar] -> 
                              if True -- (length args == ar) 
                                 then return i

--- a/src/Idris/AbsSyntaxTree.hs
+++ b/src/Idris/AbsSyntaxTree.hs
@@ -1128,7 +1128,7 @@ namesIn uvars ist tm = nub $ ni [] tm
   where
     ni env (PRef _ n)        
         | not (n `elem` env) 
-            = case lookupTy Nothing n (tt_ctxt ist) of
+            = case lookupTy n (tt_ctxt ist) of
                 [] -> [n]
                 _ -> if n `elem` (map fst uvars) then [n] else []
     ni env (PApp _ f as)   = ni env f ++ concatMap (ni env) (map getTm as)
@@ -1152,7 +1152,7 @@ usedNamesIn vars ist tm = nub $ ni [] tm
   where
     ni env (PRef _ n)        
         | n `elem` vars && not (n `elem` env) 
-            = case lookupTy Nothing n (tt_ctxt ist) of
+            = case lookupTy n (tt_ctxt ist) of
                 [] -> [n]
                 _ -> []
     ni env (PApp _ f as)   = ni env f ++ concatMap (ni env) (map getTm as)

--- a/src/Idris/Delaborate.hs
+++ b/src/Idris/Delaborate.hs
@@ -41,7 +41,7 @@ delab' ist tm fullname = de [] tm
     de env (TType i) = PType 
 
     dens x | fullname = x
-    dens ns@(NS n _) = case lookupCtxt Nothing n (idris_implicits ist) of
+    dens ns@(NS n _) = case lookupCtxt n (idris_implicits ist) of
                               [_] -> n -- just one thing
                               _ -> ns
     dens n = n
@@ -62,7 +62,7 @@ delab' ist tm fullname = de [] tm
     deFn env f args = PApp un (de env f) (map pexp (map (de env) args))
 
     mkPApp n args 
-        | [imps] <- lookupCtxt Nothing n (idris_implicits ist)
+        | [imps] <- lookupCtxt n (idris_implicits ist)
             = PApp un (PRef un n) (zipWith imp (imps ++ repeat (pexp undefined)) args)
         | otherwise = PApp un (PRef un n) (map pexp args)
 

--- a/src/Idris/Docs.hs
+++ b/src/Idris/Docs.hs
@@ -65,9 +65,9 @@ instance Show Doc where
 getDocs :: Name -> Idris Doc
 getDocs n 
    = do i <- getIState
-        case lookupCtxt Nothing n (idris_classes i) of
+        case lookupCtxt n (idris_classes i) of
              [ci] -> docClass n ci
-             _ -> case lookupCtxt Nothing n (idris_datatypes i) of
+             _ -> case lookupCtxt n (idris_datatypes i) of
                        [ti] -> docData n ti
                        _ -> do fd <- docFun n
                                return (FunDoc fd)
@@ -81,7 +81,7 @@ docData n ti
 docClass :: Name -> ClassInfo -> Idris Doc
 docClass n ci
   = do i <- getIState
-       let docstr = case lookupCtxt Nothing n (idris_docstrings i) of
+       let docstr = case lookupCtxt n (idris_docstrings i) of
                          [str] -> str
                          _ -> ""
        mdocs <- mapM docFun (map fst (class_methods ci))
@@ -90,13 +90,13 @@ docClass n ci
 docFun :: Name -> Idris FunDoc
 docFun n
   = do i <- getIState
-       let docstr = case lookupCtxt Nothing n (idris_docstrings i) of
+       let docstr = case lookupCtxt n (idris_docstrings i) of
                          [str] -> str
                          _ -> ""
-       let ty = case lookupTy Nothing n (tt_ctxt i) of
+       let ty = case lookupTy n (tt_ctxt i) of
                      (t : _) -> t
        let argnames = map fst (getArgTys ty)
-       let args = case lookupCtxt Nothing n (idris_implicits i) of
+       let args = case lookupCtxt n (idris_implicits i) of
                        [args] -> zip argnames args
                        _ -> []
        let infixes = idris_infixes i

--- a/src/Idris/ElabDecls.hs
+++ b/src/Idris/ElabDecls.hs
@@ -69,7 +69,7 @@ elabType info syn doc fc opts n ty' = {- let ty' = piBind (params info) ty_in
          let nty' = normalise ctxt [] nty
          let (t, _) = unApply (getRetTy nty')
          let corec = case t of
-                        P _ rcty _ -> case lookupCtxt Nothing rcty (idris_datatypes i) of
+                        P _ rcty _ -> case lookupCtxt rcty (idris_datatypes i) of
                                         [TI _ True _] -> True
                                         _ -> False
                         _ -> False
@@ -93,14 +93,14 @@ elabPostulate info syn doc fc opts n ty
          -- make sure it's collapsible, so it is never needed at run time
          -- start by getting the elaborated type
          ctxt <- getContext
-         fty <- case lookupTy Nothing n ctxt of
+         fty <- case lookupTy n ctxt of
             [] -> tclift $ tfail $ (At fc (NoTypeDecl n)) -- can't happen!
             [ty] -> return ty
          ist <- getIState
          let (ap, _) = unApply (getRetTy (normalise ctxt [] fty))
          logLvl 5 $ "Checking collapsibility of " ++ show (ap, fty)
          let postOK = case ap of
-                            P _ tn _ -> case lookupCtxt Nothing tn
+                            P _ tn _ -> case lookupCtxt tn
                                                 (idris_optimisation ist) of
                                             [oi] -> collapsible oi
                                             _ -> False
@@ -219,10 +219,10 @@ elabRecord info syn doc fc tyn ty cdoc cn cty
     = do elabData info syn doc fc False (PDatadecl tyn ty [(cdoc, cn, cty, fc)]) 
          cty' <- implicit syn cn cty
          i <- getIState
-         cty <- case lookupTy Nothing cn (tt_ctxt i) of
+         cty <- case lookupTy cn (tt_ctxt i) of
                     [t] -> return (delab i t)
                     _ -> fail "Something went inexplicably wrong"
-         cimp <- case lookupCtxt Nothing cn (idris_implicits i) of
+         cimp <- case lookupCtxt cn (idris_implicits i) of
                     [imps] -> return imps
          let ptys = getProjs [] (renameBs cimp cty)
          let ptys_u = getProjs [] cty
@@ -363,7 +363,7 @@ elabClauses :: ElabInfo -> FC -> FnOpts -> Name -> [PClause] -> Idris ()
 elabClauses info fc opts n_in cs = let n = liftname info n_in in  
       do ctxt <- getContext
          -- Check n actually exists, with no definition yet
-         let tys = lookupTy Nothing n ctxt
+         let tys = lookupTy n ctxt
          checkUndefined n ctxt
          unless (length tys > 1) $ do
            fty <- case tys of
@@ -380,7 +380,7 @@ elabClauses info fc opts n_in cs = let n = liftname info n_in in
            logLvl 5 $ "Checking collapsibility of " ++ show (ap, fty)
            -- FIXME: Really ought to only do this for total functions!
            let doNothing = case ap of
-                              P _ tn _ -> case lookupCtxt Nothing tn
+                              P _ tn _ -> case lookupCtxt tn
                                                   (idris_optimisation ist) of
                                               [oi] -> collapsible oi
                                               _ -> False
@@ -388,7 +388,7 @@ elabClauses info fc opts n_in cs = let n = liftname info n_in in
            solveDeferred n
            ist <- getIState
            when doNothing $ 
-              case lookupCtxt Nothing n (idris_optimisation ist) of
+              case lookupCtxt n (idris_optimisation ist) of
                  [oi] -> do let opts = addDef n (oi { collapsible = True }) 
                                            (idris_optimisation ist)
                             putIState (ist { idris_optimisation = opts })
@@ -460,7 +460,7 @@ elabClauses info fc opts n_in cs = let n = liftname info n_in in
            ctxt <- getContext
            ist <- getIState
            putIState (ist { idris_patdefs = addDef n pdef' (idris_patdefs ist) })
-           case lookupTy (namespace info) n ctxt of
+           case lookupTy n ctxt of
                [ty] -> do updateContext (addCasedef n (inlinable opts)
                                                        tcase knowncovering 
                                                        (AssertTotal `elem` opts)
@@ -471,7 +471,7 @@ elabClauses info fc opts n_in cs = let n = liftname info n_in in
                           totcheck (fc, n)
                           when (tot /= Unchecked) $ addIBC (IBCTotal n tot)
                           i <- getIState
-                          case lookupDef Nothing n (tt_ctxt i) of
+                          case lookupDef n (tt_ctxt i) of
                               (CaseOp _ _ _ _ _ scargs sc scargs' sc' : _) ->
                                   do let calls = findCalls sc' scargs'
                                      let used = findUsedArgs sc' scargs'
@@ -487,7 +487,7 @@ elabClauses info fc opts n_in cs = let n = liftname info n_in in
                [] -> return ()
            return ()
   where
-    checkUndefined n ctxt = case lookupDef Nothing n ctxt of
+    checkUndefined n ctxt = case lookupDef n ctxt of
                                  [] -> return ()
                                  [TyDecl _ _] -> return ()
                                  _ -> tclift $ tfail (At fc (AlreadyDefined n))
@@ -572,10 +572,10 @@ elabClause info tcgen (cnum, PClause fc fname lhs_in withs rhs_in whereblock)
         -- pattern bindings
         i <- getIState
         -- get the parameters first, to pass through to any where block
-        let fn_ty = case lookupTy Nothing fname (tt_ctxt i) of
+        let fn_ty = case lookupTy fname (tt_ctxt i) of
                          [t] -> t
                          _ -> error "Can't happen (elabClause function type)"
-        let fn_is = case lookupCtxt Nothing fname (idris_implicits i) of
+        let fn_is = case lookupCtxt fname (idris_implicits i) of
                          [t] -> t
                          _ -> [] 
         let params = getParamsInType i [] fn_is fn_ty
@@ -679,7 +679,7 @@ elabClause info tcgen (cnum, PClause fc fname lhs_in withs rhs_in whereblock)
         = getParamsInType i (n : env) is (instantiate (P Bound n t) sc)
     getParamsInType i env is tm@(App f a)
         | (P _ tn _, args) <- unApply tm 
-           = case lookupCtxt Nothing tn (idris_datatypes i) of
+           = case lookupCtxt tn (idris_datatypes i) of
                 [t] -> nub $ paramNames args env (param_pos t) ++
                              getParamsInType i env is f ++ 
                              getParamsInType i env is a
@@ -955,7 +955,7 @@ elabClass info syn doc fc constraints tn ps ds
              let conn = case con of
                             PRef _ n -> n
                             PApp _ (PRef _ n) _ -> n
-             let conn' = case lookupCtxtName Nothing conn (idris_classes i) of
+             let conn' = case lookupCtxtName conn (idris_classes i) of
                                 [(n, _)] -> n
                                 _ -> conn
              addInstance False conn' cfn
@@ -1016,7 +1016,7 @@ elabInstance :: ElabInfo -> SyntaxInfo ->
                 [PDecl] -> Idris ()
 elabInstance info syn fc cs n ps t expn ds
     = do i <- getIState 
-         (n, ci) <- case lookupCtxtName (namespace info) n (idris_classes i) of
+         (n, ci) <- case lookupCtxtName n (idris_classes i) of
                        [c] -> return c
                        _ -> fail $ show fc ++ ":" ++ show n ++ " is not a type class"
          let constraint = PApp fc (PRef fc n) (map pexp ps)
@@ -1076,7 +1076,7 @@ elabInstance info syn fc cs n ps t expn ds
     checkNotOverlapping i t n
      | take 2 (show n) == "@@" = return ()
      | otherwise
-        = case lookupTy Nothing n (tt_ctxt i) of
+        = case lookupTy n (tt_ctxt i) of
             [t'] -> let tret = getRetType t
                         tret' = getRetType (delab i t') in
                         case matchClause i tret' tret of
@@ -1113,7 +1113,7 @@ elabInstance info syn fc cs n ps t expn ds
       | PRef _ n <- getTm p 
         = do ps' <- getWParams ps
              ctxt <- getContext
-             case lookupP Nothing n ctxt of
+             case lookupP n ctxt of
                 [] -> return (pimp n (PRef fc n) : ps')
                 _ -> return ps'
     getWParams (_ : ps) = getWParams ps
@@ -1248,7 +1248,7 @@ elabDecl' what info d@(PClauses f o n ps)
   | what /= ETypes
     = do iLOG $ "Elaborating clause " ++ show n
          i <- getIState -- get the type options too
-         let o' = case lookupCtxt Nothing n (idris_flags i) of
+         let o' = case lookupCtxt n (idris_flags i) of
                     [fs] -> fs
                     [] -> []
          elabClauses info f (o ++ o') n ps

--- a/src/Idris/IBC.hs
+++ b/src/Idris/IBC.hs
@@ -82,28 +82,28 @@ mkIBC (i:is) f = do ist <- getIState
                     mkIBC is f'
 
 ibc i (IBCFix d) f = return f { ibc_fixes = d : ibc_fixes f } 
-ibc i (IBCImp n) f = case lookupCtxt Nothing n (idris_implicits i) of
+ibc i (IBCImp n) f = case lookupCtxt n (idris_implicits i) of
                         [v] -> return f { ibc_implicits = (n,v): ibc_implicits f     }
                         _ -> fail "IBC write failed"
 ibc i (IBCStatic n) f 
-                   = case lookupCtxt Nothing n (idris_statics i) of
+                   = case lookupCtxt n (idris_statics i) of
                         [v] -> return f { ibc_statics = (n,v): ibc_statics f     }
                         _ -> fail "IBC write failed"
 ibc i (IBCClass n) f 
-                   = case lookupCtxt Nothing n (idris_classes i) of
+                   = case lookupCtxt n (idris_classes i) of
                         [v] -> return f { ibc_classes = (n,v): ibc_classes f     }
                         _ -> fail "IBC write failed"
 ibc i (IBCInstance int n ins) f 
                    = return f { ibc_instances = (int,n,ins): ibc_instances f     }
 ibc i (IBCDSL n) f 
-                   = case lookupCtxt Nothing n (idris_dsls i) of
+                   = case lookupCtxt n (idris_dsls i) of
                         [v] -> return f { ibc_dsls = (n,v): ibc_dsls f     }
                         _ -> fail "IBC write failed"
 ibc i (IBCData n) f 
-                   = case lookupCtxt Nothing n (idris_datatypes i) of
+                   = case lookupCtxt n (idris_datatypes i) of
                         [v] -> return f { ibc_datatypes = (n,v): ibc_datatypes f     }
                         _ -> fail "IBC write failed"
-ibc i (IBCOpt n) f = case lookupCtxt Nothing n (idris_optimisation i) of
+ibc i (IBCOpt n) f = case lookupCtxt n (idris_optimisation i) of
                         [v] -> return f { ibc_optimise = (n,v): ibc_optimise f     }
                         _ -> fail "IBC write failed"
 ibc i (IBCSyntax n) f = return f { ibc_syntax = n : ibc_syntax f }
@@ -113,13 +113,13 @@ ibc i (IBCObj n) f = return f { ibc_objs = n : ibc_objs f }
 ibc i (IBCLib n) f = return f { ibc_libs = n : ibc_libs f }
 ibc i (IBCDyLib n) f = return f {ibc_dynamic_libs = n : ibc_dynamic_libs f }
 ibc i (IBCHeader n) f = return f { ibc_hdrs = n : ibc_hdrs f }
-ibc i (IBCDef n) f = case lookupDef Nothing n (tt_ctxt i) of
+ibc i (IBCDef n) f = case lookupDef n (tt_ctxt i) of
                         [v] -> return f { ibc_defs = (n,v) : ibc_defs f     }
                         _ -> fail "IBC write failed"
-ibc i (IBCDoc n) f = case lookupCtxt Nothing n (idris_docstrings i) of
+ibc i (IBCDoc n) f = case lookupCtxt n (idris_docstrings i) of
                         [v] -> return f { ibc_docstrings = (n,v) : ibc_docstrings f }
                         _ -> fail "IBC write failed"
-ibc i (IBCCG n) f = case lookupCtxt Nothing n (idris_callgraph i) of
+ibc i (IBCCG n) f = case lookupCtxt n (idris_callgraph i) of
                         [v] -> return f { ibc_cg = (n,v) : ibc_cg f     }
                         _ -> fail "IBC write failed"
 ibc i (IBCCoercion n) f = return f { ibc_coercions = n : ibc_coercions f }

--- a/src/Idris/Parser.hs
+++ b/src/Idris/Parser.hs
@@ -881,7 +881,7 @@ pApp syn = do f <- pSimpleExpr syn
               return (dslify i $ PApp fc f args)
   where
     dslify i (PApp fc (PRef _ f) [a])
-        | [d] <- lookupCtxt Nothing f (idris_dsls i)
+        | [d] <- lookupCtxt f (idris_dsls i)
             = desugar (syn { dsl_info = d }) i (getTm a)
     dslify i t = t
 

--- a/src/Idris/Prover.hs
+++ b/src/Idris/Prover.hs
@@ -26,7 +26,7 @@ prover :: Bool -> Name -> Idris ()
 prover lit x =
            do ctxt <- getContext
               i <- getIState
-              case lookupTy Nothing x ctxt of
+              case lookupTy x ctxt of
                   [t] -> if elem x (idris_metavars i)
                                then prove ctxt lit x t
                                else fail $ show x ++ " is not a metavariable"

--- a/src/Idris/REPL.hs
+++ b/src/Idris/REPL.hs
@@ -129,7 +129,7 @@ resolveProof :: Name -> Idris Name
 resolveProof n'
   = do i <- getIState
        ctxt <- getContext
-       n <- case lookupNames Nothing n' ctxt of
+       n <- case lookupNames n' ctxt of
                  [x] -> return x
                  [] -> return n'
                  ns -> fail $ pshow i (CantResolveAlts (map show ns))
@@ -207,7 +207,7 @@ process fn (Check (PRef _ n))
                   = do ctxt <- getContext
                        ist <- getIState
                        imp <- impShow
-                       case lookupTy Nothing n ctxt of
+                       case lookupTy n ctxt of
                         ts@(_:_) -> mapM_ (\t -> iputStrLn $ show n ++ " : " ++
                                                        showImp imp (delab ist t)) ts
                         [] -> iputStrLn $ "No such variable " ++ show n
@@ -220,7 +220,7 @@ process fn (Check t) = do (tm, ty) <- elabVal toplevel False t
                                     showImp imp (delab ist ty))
 
 process fn (DocStr n) = do i <- getIState
-                           case lookupCtxtName Nothing n (idris_docstrings i) of
+                           case lookupCtxtName n (idris_docstrings i) of
                                 [] -> iputStrLn $ "No documentation for " ++ show n
                                 ns -> mapM_ showDoc ns 
     where showDoc (n, d) 
@@ -237,8 +237,8 @@ process fn Universes = do i <- getIState
                             OK _ -> iputStrLn "Universes OK"
 process fn (Defn n) = do i <- getIState
                          iputStrLn "Compiled patterns:\n"
-                         liftIO $ print (lookupDef Nothing n (tt_ctxt i))
-                         case lookupCtxt Nothing n (idris_patdefs i) of
+                         liftIO $ print (lookupDef n (tt_ctxt i))
+                         case lookupCtxt n (idris_patdefs i) of
                             [] -> return ()
                             [d] -> do iputStrLn "Original definiton:\n"
                                       mapM_ (printCase i) d
@@ -255,25 +255,25 @@ process fn (TotCheck n) = do i <- getIState
                                 _ -> return ()
 process fn (DebugInfo n) 
    = do i <- getIState
-        let oi = lookupCtxtName Nothing n (idris_optimisation i)
+        let oi = lookupCtxtName n (idris_optimisation i)
         when (not (null oi)) $ iputStrLn (show oi)
-        let si = lookupCtxt Nothing n (idris_statics i)
+        let si = lookupCtxt n (idris_statics i)
         when (not (null si)) $ iputStrLn (show si)
-        let di = lookupCtxt Nothing n (idris_datatypes i)
+        let di = lookupCtxt n (idris_datatypes i)
         when (not (null di)) $ iputStrLn (show di)
-        let d = lookupDef Nothing n (tt_ctxt i)
+        let d = lookupDef n (tt_ctxt i)
         when (not (null d)) $ liftIO $
            do print (head d)
-        let cg = lookupCtxtName Nothing n (idris_callgraph i)
+        let cg = lookupCtxtName n (idris_callgraph i)
         findUnusedArgs (map fst cg)
         i <- getIState
-        let cg' = lookupCtxtName Nothing n (idris_callgraph i)
+        let cg' = lookupCtxtName n (idris_callgraph i)
         sc <- checkSizeChange n
         iputStrLn $ "Size change: " ++ show sc
         when (not (null cg')) $ do iputStrLn "Call graph:\n"
                                    iputStrLn (show cg')
 process fn (Info n) = do i <- getIState
-                         case lookupCtxt Nothing n (idris_classes i) of
+                         case lookupCtxt n (idris_classes i) of
                               [c] -> classInfo c
                               _ -> iputStrLn "Not a class"
 process fn (Search t) = iputStrLn "Not implemented"
@@ -330,7 +330,7 @@ process fn (ShowProof n')
 process fn (Prove n')
      = do ctxt <- getContext
           ist <- getIState
-          n <- case lookupNames Nothing n' ctxt of
+          n <- case lookupNames n' ctxt of
                     [x] -> return x
                     [] -> return n'
                     ns -> fail $ pshow ist (CantResolveAlts (map show ns))
@@ -381,7 +381,7 @@ process fn (Pattelab t)
           iputStrLn $ show tm ++ "\n\n : " ++ show ty
 
 process fn (Missing n) = do i <- getIState
-                            case lookupDef Nothing n (tt_ctxt i) of
+                            case lookupDef n (tt_ctxt i) of
                                 [CaseOp _ _ _ _ _ args t _ _]
                                     -> do tms <- genMissing n args t
                                           iputStrLn (showSep "\n" (map (showImp True) tms))
@@ -431,7 +431,7 @@ dumpInstance :: Name -> Idris ()
 dumpInstance n = do i <- getIState
                     ctxt <- getContext
                     imp <- impShow
-                    case lookupTy Nothing n ctxt of
+                    case lookupTy n ctxt of
                          ts -> mapM_ (\t -> iputStrLn $ showImp imp (delab i t)) ts
 
 showTotal t@(Partial (Other ns)) i

--- a/src/Idris/UnusedArgs.hs
+++ b/src/Idris/UnusedArgs.hs
@@ -15,7 +15,7 @@ findUnusedArgs ns = mapM_ traceUnused ns
 traceUnused :: Name -> Idris ()
 traceUnused n 
    = do i <- getIState
-        case lookupCtxt Nothing n (idris_callgraph i) of 
+        case lookupCtxt n (idris_callgraph i) of 
           [CGInfo args calls scg usedns _] ->
                 do let argpos = zip args [0..]
                    let fargs = concatMap (getFargpos calls) argpos
@@ -39,7 +39,7 @@ used path g j
    | otherwise 
        = do logLvl 5 $ (show ((g, j) : path)) 
             i <- getIState
-            case lookupCtxt Nothing g (idris_callgraph i) of
+            case lookupCtxt g (idris_callgraph i) of
                [CGInfo args calls scg usedns unused] ->
                   if (j >= length args) 
                     then -- overapplied, assume used


### PR DESCRIPTION
Previously, there was an ignored argument to lookupCtxtName and its
derivatives. This has been removed to prevent confusion.

Fixes #275
