### PR TITLE
Enable alternate names for shared libraries

### DIFF
--- a/src/Idris/IBC.hs
+++ b/src/Idris/IBC.hs
@@ -249,7 +249,11 @@ pLibs :: [String] -> Idris ()
 pLibs ls = mapM_ addLib ls
 
 pDyLibs :: [String] -> Idris ()
-pDyLibs ls = mapM_ addDyLib ls
+pDyLibs ls = do res <- mapM (addDyLib . return) ls
+                mapM_ checkLoad res
+                return ()
+    where checkLoad (Left _) = return ()
+          checkLoad (Right err) = fail err
 
 pHdrs :: [String] -> Idris ()
 pHdrs hs = mapM_ addHdr hs

--- a/test/test022/test022.idr
+++ b/test/test022/test022.idr
@@ -1,6 +1,6 @@
 module Main
 
-%dynamic "libm"
+%dynamic "dummy", "libm", "msvcrt"
 
 x : Float
 x = unsafePerformIO (mkForeign (FFun "sin" [FFloat] FFloat) 1.6)


### PR DESCRIPTION
This should fix test022 on Windows.

All tests pass on Linux and Mac.
