### PR TITLE
Add primitive type names to name completion

### DIFF
--- a/src/Idris/Completion.hs
+++ b/src/Idris/Completion.hs
@@ -59,7 +59,11 @@ nameString _            = Nothing
 names :: Idris [String]
 names = do i <- get
            let ctxt = tt_ctxt i
-           return $ nub $ mapMaybe (nameString . fst) $ ctxtAlist ctxt
+           return . nub $
+             mapMaybe (nameString . fst) (ctxtAlist ctxt) ++
+             -- Explicitly add primitive types, as these are special-cased in the parser
+             ["Int", "Integer", "Float", "Char", "String", "Type",
+              "Ptr", "Bits8", "Bits16", "Bits32", "Bits64"]
 
 metavars :: Idris [String]
 metavars = do i <- get


### PR DESCRIPTION
This is necessary because these are treated specially by the parser and are
thus not in the global definition context, from which name completion is
drawn.

Fixes #304.
