### PR TITLE
Remove "return" from Monad

### DIFF
--- a/lib/Control/IOExcept.idr
+++ b/lib/Control/IOExcept.idr
@@ -16,7 +16,6 @@ instance Applicative (IOExcept e) where
                                    return (f' <$> a'))
 
 instance Monad (IOExcept e) where
-     return = pure
      (ioM x) >>= k = ioM (do x' <- x;
                              case x' of
                                   Right a => let (ioM ka) = k a in

--- a/lib/Control/Monad/Identity.idr
+++ b/lib/Control/Monad/Identity.idr
@@ -16,5 +16,4 @@ instance Applicative Identity where
     (Id f) <$> (Id g) = Id (f g)
 
 instance Monad Identity where
-    return x = Id x
     (Id x) >>= k = k x

--- a/lib/Control/Monad/State.idr
+++ b/lib/Control/Monad/State.idr
@@ -27,8 +27,6 @@ instance Monad f => Applicative (StateT s f) where
                                       return (g b, t))
 
 instance Monad m => Monad (StateT s m) where
-    return x = ST (\st => return (x, st))
-
     (ST f) >>= k = ST (\st => do (v, st') <- f st
                                  let ST kv = k v
                                  kv st')

--- a/lib/Data/Morphisms.idr
+++ b/lib/Data/Morphisms.idr
@@ -30,7 +30,6 @@ instance Applicative (Morphism r) where
   (Mor f) <$> (Mor a) = Mor $ \r => f r $ a r
 
 instance Monad (Morphism r) where
-  return a       = Mor $ const a
   (Mor h) >>= f = Mor $ \r => applyMor (f $ h r) r
 
 instance Semigroup (Endomorphism a) where

--- a/lib/Network/Cgi.idr
+++ b/lib/Network/Cgi.idr
@@ -41,8 +41,6 @@ instance Applicative CGI where
 instance Monad CGI where {
     (>>=) (MkCGI f) k = MkCGI (\s => do v <- f s
                                         getAction (k (fst v)) (snd v))
-
-    return v = MkCGI (\s => return (v, s))
 }
 
 setInfo : CGIInfo -> CGI ()

--- a/lib/Prelude.idr
+++ b/lib/Prelude.idr
@@ -124,23 +124,17 @@ instance Alternative List where
 ---- Monad instances
 
 instance Monad IO where 
-    return t = io_return t
     b >>= k = io_bind b k
 
 instance Monad Maybe where 
-    return t = Just t
-
     Nothing  >>= k = Nothing
     (Just x) >>= k = k x
 
 instance Monad (Either e) where
-    return = Right
-
     (Left n) >>= _ = Left n
     (Right r) >>= f = f r
 
 instance Monad List where 
-    return x = [x]
     m >>= f = concatMap f m
 
 ---- some mathematical operations

--- a/lib/Prelude/Monad.idr
+++ b/lib/Prelude/Monad.idr
@@ -11,8 +11,10 @@ import Prelude.Applicative
 infixl 5 >>=
 
 class Applicative m => Monad (m : Type -> Type) where 
-    return : a -> m a
     (>>=)  : m a -> (a -> m b) -> m b
 
 flatten : Monad m => m (m a) -> m a
 flatten a = a >>= id
+
+return : Monad m => a -> m a
+return = pure

--- a/lib/System/Concurrency/Process.idr
+++ b/lib/System/Concurrency/Process.idr
@@ -23,7 +23,6 @@ instance Applicative (Process msg) where
      (lift f) <$> (lift a) = lift (f <$> a)
 
 instance Monad (Process msg) where
-     return = lift . return
      (lift io) >>= k = lift (do x <- io
                                 case k x of
                                      lift v => v)


### PR DESCRIPTION
Monad has Applicative as a superclass. The methods "pure" and "return" are
supposed to do the same thing. This change does the following:
1. Remove "return" from Monad
2. Remove "return" from all instances of Monad in the standard library
3. Define a compatibility function "return":

return : Monad m => a -> m a
return = pure

This enforces that "return" and "pure" do the same thing.
