### PR TITLE
Add bash completion file for Idris

### DIFF
--- a/contribs/tool-support/completion/idris.bash
+++ b/contribs/tool-support/completion/idris.bash
@@ -1,0 +1,31 @@
+_idris() {
+    local cur prev words opts LIBRARIES TARGETS
+    _init_completion || return
+
+    opts=$(_parse_help "$1")
+    LIBRARIES="effects"
+    TARGETS="C Java bytecode javascript node"
+
+    case "${prev}" in
+        -o)
+            _filedir
+        ;;
+        -i|--ibcsubdir)
+            _filedir -d
+        ;;
+        -p)
+            COMPREPLY=( $(compgen -W "${LIBRARIES}" -- ${cur}))
+        ;;
+        --target)
+            COMPREPLY=( $(compgen -W "${TARGETS}" -- ${cur}))
+        ;;
+    esac
+
+    if [[ $cur == -* ]]; then
+        COMPREPLY=($(compgen -W "${opts}" -- ${cur}))
+        return
+    fi
+
+    _filedir '@(idr)'
+} &&
+complete -o default -F _idris idris


### PR DESCRIPTION
This is far from perfect, but seems to work reasonbly well.

Also, the targets/libraries should probably not be hardcoded, but at this point
it's not clear how to dynamically generate this.

To use this add a `source $PATH_TO/idris.bash` to your `.bashrc`.

You need to have the bash-completion[1](http://bash-completion.alioth.debian.org/) package installed for this to work.
