### PR TITLE
Add scripts

### DIFF
--- a/src/Idris/AbsSyntax.hs
+++ b/src/Idris/AbsSyntax.hs
@@ -340,6 +340,11 @@ setQuiet q = do i <- getIState
                 let opt' = opts { opt_quiet = q }
                 putIState $ i { idris_options = opt' }
 
+getQuiet :: Idris Bool
+getQuiet = do i <- getIState
+              let opts = idris_options i
+              return (opt_quiet opts)
+
 setTarget :: Target -> Idris ()
 setTarget t = do i <- getIState
                  let opts = idris_options i

--- a/src/Idris/AbsSyntaxTree.hs
+++ b/src/Idris/AbsSyntaxTree.hs
@@ -253,6 +253,7 @@ data Opt = Filename String
          | UseTarget Target
          | OutputTy OutputType
          | Extension LanguageExt
+         | InterpretScript String
     deriving (Show, Eq)
 
 -- Parsed declarations

--- a/src/Idris/IBC.hs
+++ b/src/Idris/IBC.hs
@@ -134,11 +134,12 @@ process :: IBCFile -> FilePath -> Idris ()
 process i fn
    | ver i /= ibcVersion = do iLOG "ibc out of date"
                               fail "Incorrect ibc version"
-   | otherwise =  
+   | otherwise =
             do srcok <- liftIO $ doesFileExist (sourcefile i)
                when srcok $ liftIO $ timestampOlder (sourcefile i) fn
                v <- verbose
-               when (v && srcok) $ iputStrLn $ "Skipping " ++ sourcefile i
+               quiet <- getQuiet
+               when (v && srcok && not quiet) $ iputStrLn $ "Skipping " ++ sourcefile i
                pImports (ibc_imports i)
                pImps (ibc_implicits i)
                pFixes (ibc_fixes i)

--- a/src/Main.hs
+++ b/src/Main.hs
@@ -91,6 +91,8 @@ usagemsg = "Idris version " ++ ver ++ "\n" ++
            "\t--log [level]     Type debugging log level\n" ++
            "\t-S                Do no further compilation of code generator output\n" ++
            "\t-c                Compile to object files rather than an executable\n" ++
+           "\t--exec [expr]     Execute the expression expr in the interpreter, defaulting to\n" ++
+           "\t                  Main.main if none provided, and exit.\n" ++
            "\t--ideslave        Ideslave mode (for editors; in/ouput wrapped in s-expressions)\n" ++
            "\t--libdir          Show library install directory and exit\n" ++
            "\t--link            Show C library directories and exit (for C linking)\n" ++


### PR DESCRIPTION
This commit adds a new command-line argument to Idris that allows an arbitrary
expression to be run in the executor. Two forms are supported:

idris Foo.idr --opt1 --exec

causes Main.main to be run after loading Foo.idr, while

idris Foo.idr --opt1 --exec expr

causes expr to be run using the executor.

This can be used to run Idris programs without having to compile them, giving
a faster startup for quick tasks. It can also be used to test the behavior of
the executor against the behavior of compiled code more easily.
