### PR TITLE
Remove old ifdefs for supporting base<4 since we require base>=4

### DIFF
--- a/src/IRTS/CodegenCommon.hs
+++ b/src/IRTS/CodegenCommon.hs
@@ -1,5 +1,3 @@
-{-# LANGUAGE CPP #-}
-
 module IRTS.CodegenCommon where
 
 import Core.TT
@@ -14,9 +12,4 @@ data OutputType = Raw | Object | Executable deriving (Eq, Show)
 environment :: String -> IO (Maybe String)
 environment x = Control.Exception.catch (do e <- getEnv x
                                             return (Just e))
-#if MIN_VERSION_base(4,0,0)
                           (\y-> do return (y::SomeException);  return Nothing)
-#endif
-#if !MIN_VERSION_base(4,0,0)
-                          (\_->  return Nothing)
-#endif

--- a/src/Util/System.hs
+++ b/src/Util/System.hs
@@ -15,22 +15,15 @@ import System.FilePath ((</>), addTrailingPathSeparator, normalise)
 import System.Environment
 import System.IO
 import System.IO.Error
-#if MIN_VERSION_base(4,0,0)
 import Control.Exception as CE
-#endif
 
 import Paths_idris
 
-#if MIN_VERSION_base(4,0,0)
 catchIO :: IO a -> (IOError -> IO a) -> IO a
 catchIO = CE.catch
 
 throwIO :: IOError -> IO a
 throwIO = CE.throw
-#else
-catchIO = catch
-throwIO = throw
-#endif
 
 
 


### PR DESCRIPTION
This cleans up some cruft and makes it easier to load bits of idris in `ghci`, which doesn't understand MIN_VERSION_base.
