### PR TITLE
Give replicate a simple total definition

### DIFF
--- a/lib/Prelude/List.idr
+++ b/lib/Prelude/List.idr
@@ -125,9 +125,9 @@ partial
 repeat : a -> List a
 repeat x = x :: lazy (repeat x)
 
-%assert_total
 replicate : Nat -> a -> List a
-replicate n x = take n (repeat x)
+replicate O x     = []
+replicate (S n) x = x :: replicate n x
 
 --------------------------------------------------------------------------------
 -- Instances


### PR DESCRIPTION
I don’t see a good reason to define `replicate` in terms of `repeat` and `take`, especially given that `repeat` is partial, hence I replaced that definition with the obvious instead.

Indeed I’m not sure `repeat` should exist as is. It would generally be nicer to use streams that guarantee they are infinitely long for such things, but at the least colists.
