### PR TITLE
Make LLVM optional but the default

### DIFF
--- a/Setup.hs
+++ b/Setup.hs
@@ -143,6 +143,12 @@ javaFlag flags =
     Just False -> False
     Nothing -> False
 
+llvmFlag flags = 
+  case lookup (FlagName "LLVM") (S.configConfigurationsFlags flags) of
+    Just True -> True
+    Just False -> False
+    Nothing -> False
+
 noEffectsFlag flags =
    case lookup (FlagName "noeffects") (S.configConfigurationsFlags flags) of
       Just True -> True
@@ -167,7 +173,8 @@ main = do
               let withoutEffects = noEffectsFlag $ configFlags lbi
               installStdLib pkg lbi withoutEffects verb
                                     (S.fromFlag $ S.copyDest flags)
-              installLLVMLib verb pkg lbi (S.fromFlag $ S.copyDest flags)
+              when (llvmFlag $ configFlags lbi)  
+                   (installLLVMLib verb pkg lbi (S.fromFlag $ S.copyDest flags))
               when (javaFlag $ configFlags lbi) 
                    (installJavaLib pkg 
                                    lbi 
@@ -180,7 +187,8 @@ main = do
               let withoutEffects = noEffectsFlag $ configFlags lbi
               installStdLib pkg lbi withoutEffects verb
                                     NoCopyDest
-              installLLVMLib verb pkg lbi NoCopyDest
+              when (llvmFlag $ configFlags lbi)  
+                   (installLLVMLib verb pkg lbi NoCopyDest)
               when (javaFlag $ configFlags lbi) 
                    (installJavaLib pkg 
                                    lbi 

--- a/idris.cabal
+++ b/idris.cabal
@@ -242,6 +242,11 @@ Flag NoEffects
   Description: Do not build the effects package
   Default:     False
 
+Flag LLVM
+  Description:  Build the LLVM backend
+  Default:      True
+  manual:       True
+
 Executable     idris
                Main-is: Main.hs
                hs-source-dirs: src
@@ -267,7 +272,7 @@ Executable     idris
                               IRTS.CodegenC, IRTS.Defunctionalise, IRTS.Inliner,
                               IRTS.Compiler, IRTS.CodegenJava, IRTS.Java.ASTBuilding,
                               IRTS.Java.JTypes, IRTS.Java.Mangling, IRTS.BCImp,
-                              IRTS.CodegenJavaScript, IRTS.CodegenLLVM,
+                              IRTS.CodegenJavaScript,
                               IRTS.CodegenCommon, IRTS.DumpBC
 
                               Paths_idris
@@ -276,7 +281,7 @@ Executable     idris
                                 haskeline>=0.7, split, directory,
                                 containers, process, transformers, filepath,
                                 directory, binary, bytestring, text, pretty,
-                                language-java>=0.2.2, libffi, llvm-general>=3.3.4.1 && <3.3.5,
+                                language-java>=0.2.2, libffi,
                                 vector, vector-binary-instances
 
                Extensions:      MultiParamTypeClasses, FunctionalDependencies,
@@ -292,3 +297,9 @@ Executable     idris
                if os(windows)
                   cpp-options: -DWINDOWS
                   build-depends: Win32
+               if flag(LLVM)
+                  other-modules: IRTS.CodegenLLVM
+                  cpp-options: -DIDRIS_LLVM
+                  build-depends: llvm-general>=3.3.4.1 && <3.3.5
+               else
+                  other-modules: Util.LLVMStubs

--- a/src/IRTS/Compiler.hs
+++ b/src/IRTS/Compiler.hs
@@ -1,4 +1,4 @@
-{-# LANGUAGE PatternGuards, TypeSynonymInstances #-}
+{-# LANGUAGE PatternGuards, TypeSynonymInstances, CPP #-}
 
 module IRTS.Compiler where
 
@@ -10,7 +10,11 @@ import IRTS.CodegenC
 import IRTS.CodegenJava
 import IRTS.DumpBC
 import IRTS.CodegenJavaScript
+#ifdef IDRIS_LLVM
 import IRTS.CodegenLLVM
+#else
+import Util.LLVMStubs
+#endif
 import IRTS.Inliner
 
 import Idris.AbsSyntax

--- a/src/Idris/REPL.hs
+++ b/src/Idris/REPL.hs
@@ -1,5 +1,5 @@
 {-# LANGUAGE MultiParamTypeClasses, FlexibleInstances, DeriveFunctor,
-             PatternGuards #-}
+             PatternGuards, CPP #-}
 
 module Idris.REPL where
 
@@ -38,9 +38,11 @@ import IRTS.CodegenCommon
 -- import RTS.Bytecode
 -- import RTS.PreC
 -- import RTS.CodegenC
-
+#ifdef IDRIS_LLVM
 import LLVM.General.Target
-
+#else
+import Util.LLVMStubs
+#endif
 import System.Console.Haskeline as H
 import System.FilePath
 import System.Exit

--- a/src/Util/LLVMStubs.hs
+++ b/src/Util/LLVMStubs.hs
@@ -1,0 +1,30 @@
+{-- 
+
+Things needed to build without LLVM 
+Replaces stuff from LLVM.General.Target and IRTS.CodegenLLVM.
+
+--}
+
+module Util.LLVMStubs where
+
+import qualified Core.TT as TT
+import IRTS.Simplified
+import IRTS.CodegenCommon
+
+
+getDefaultTargetTriple :: IO String
+getDefaultTargetTriple = return ""
+
+getHostCPUName :: IO String
+getHostCPUName = return ""
+
+
+codegenLLVM :: [(TT.Name, SDecl)] ->
+               String -> -- target triple
+               String -> -- target CPU
+               Int -> -- Optimization degree
+               FilePath -> -- output file name
+               OutputType ->
+               IO ()
+
+codegenLLVM _ _ _ _ _ _ = print "Error: This Idris was compiled without the LLVM backend."


### PR DESCRIPTION
LLVM is great, but can be a rather massive tail for this dog to wag. So let's make it optional.

To install without LLVM "cabal install -f -LLVM". 

Tested with and without LLVM on Linux.
