### PR TITLE
rename fmap to map

### DIFF
--- a/contribs/lib/SQLite3/Sqlite3.idr
+++ b/contribs/lib/SQLite3/Sqlite3.idr
@@ -41,8 +41,8 @@ forM xs f = (sequence (map f xs))
 data DB a = MkDB (IO (Either String a))
 
 instance Functor DB where
-  fmap f (MkDB action) = MkDB (do res <- action
-                                  return (fmap f res))
+  map f (MkDB action) = MkDB (do res <- action
+                                 return (map f res))
 
 
 instance Applicative DB where
@@ -50,7 +50,7 @@ instance Applicative DB where
   (MkDB f) <$> (MkDB x) = MkDB (do f' <- f
                                    case f' of
                                      Left err => return (Left err)
-                                     Right op => x >>= (return . fmap op))
+                                     Right op => x >>= (return . map op))
 
 
 instance Monad DB where

--- a/contribs/lib/SimpleParser/SimpleParser.idr
+++ b/contribs/lib/SimpleParser/SimpleParser.idr
@@ -24,7 +24,7 @@ parse : Parser a -> String -> Either String (a, String)
 parse (P p) inp = p inp
 
 instance Functor Parser where
-  fmap f p = P (\inp => case parse p inp of
+  map f p = P (\inp => case parse p inp of
                           Left err        => Left err
                           Right (v, rest) => Right ((f v), rest))
 
@@ -90,7 +90,7 @@ char : Char -> Parser Char
 char x = sat (== x)
 
 string : String -> Parser String
-string s = fmap pack (traverse char (unpack s))
+string s = map pack (traverse char (unpack s))
 
 many1 : Parser a -> Parser (List a)
 many : Parser a -> Parser (List a)
@@ -110,7 +110,7 @@ bool = parseTrue <|> parseFalse
                         pure False
 
 ident : Parser String
-ident = fmap pack [| letter :: many1 alphanum |]
+ident = map pack [| letter :: many1 alphanum |]
 
 nat : Parser Int
 nat = do xs <- many digit
@@ -148,7 +148,7 @@ symbol : String -> Parser String
 symbol xs = token (string xs)
 
 strToken : Parser String
-strToken = fmap pack (token (many1 alphanum))
+strToken = map pack (token (many1 alphanum))
 
 
 --------------------------------------------------------------------------------
@@ -160,12 +160,12 @@ factor : Parser Int
 term   : Parser Int
 
 expr = do t <- term
-          fmap (t+) (symbol "+" $> expr) <|> pure t
+          map (t+) (symbol "+" $> expr) <|> pure t
 
 factor = (symbol "(" $> expr <$ symbol ")") <|> natural
 
 term = do f <- factor
-          fmap (f*) (symbol "*" $> term) <|> pure f
+          map (f*) (symbol "*" $> term) <|> pure f
 
 eval : String -> Maybe Int
 eval xs = case (parse expr xs) of

--- a/lib/Control/IOExcept.idr
+++ b/lib/Control/IOExcept.idr
@@ -8,7 +8,7 @@ data IOExcept : Type -> Type -> Type where
      ioM : IO (Either err a) -> IOExcept err a
 
 instance Functor (IOExcept e) where
-     fmap f (ioM fn) = ioM (fmap (fmap f) fn)
+     map f (ioM fn) = ioM (map (map f) fn)
 
 instance Applicative (IOExcept e) where
      pure x = ioM (pure (pure x))

--- a/lib/Control/Monad/Identity.idr
+++ b/lib/Control/Monad/Identity.idr
@@ -8,7 +8,7 @@ public record Identity : Type -> Type where
     Id : (runIdentity : a) -> Identity a
 
 instance Functor Identity where
-    fmap fn (Id a) = Id (fn a)
+    map fn (Id a) = Id (fn a)
 
 instance Applicative Identity where
     pure x = Id x

--- a/lib/Control/Monad/State.idr
+++ b/lib/Control/Monad/State.idr
@@ -15,7 +15,7 @@ record StateT : Type -> (Type -> Type) -> Type -> Type where
          (runStateT : s -> m (a, s)) -> StateT s m a
 
 instance Functor f => Functor (StateT s f) where
-    fmap f (ST g) = ST (\st => fmap (mapFst f) (g st)) where
+    map f (ST g) = ST (\st => map (mapFst f) (g st)) where
        mapFst : (a -> x) -> (a, b) -> (x, b)
        mapFst fn (a, b) = (fn a, b)
 

--- a/lib/Data/Morphisms.idr
+++ b/lib/Data/Morphisms.idr
@@ -23,7 +23,7 @@ applyEndo : Endomorphism a -> a -> a
 applyEndo (Endo f) a = f a
 
 instance Functor (Morphism r) where
-  fmap f (Mor a) = Mor (f . a)
+  map f (Mor a) = Mor (f . a)
 
 instance Applicative (Morphism r) where
   pure a                = Mor $ const a

--- a/lib/Data/SortedMap.idr
+++ b/lib/Data/SortedMap.idr
@@ -226,10 +226,10 @@ toList Empty = []
 toList (M _ t) = treeToList t
 
 instance Functor (Tree n k) where
-  fmap f (Leaf k v) = Leaf k (f v)
-  fmap f (Branch2 t1 k t2) = Branch2 (fmap f t1) k (fmap f t2)
-  fmap f (Branch3 t1 k1 t2 k2 t3) = Branch3 (fmap f t1) k1 (fmap f t2) k2 (fmap f t3)
+  map f (Leaf k v) = Leaf k (f v)
+  map f (Branch2 t1 k t2) = Branch2 (map f t1) k (map f t2)
+  map f (Branch3 t1 k1 t2 k2 t3) = Branch3 (map f t1) k1 (map f t2) k2 (map f t3)
 
 instance Functor (SortedMap k) where
-  fmap _ Empty = Empty
-  fmap f (M n t) = M _ (fmap f t)
+  map _ Empty = Empty
+  map f (M n t) = M _ (map f t)

--- a/lib/Language/Reflection.idr
+++ b/lib/Language/Reflection.idr
@@ -88,15 +88,15 @@ data Binder a = Lam a
 
 
 instance Functor Binder where
-  fmap f (Lam x) = Lam (f x)
-  fmap f (Pi x) = Pi (f x)
-  fmap f (Let x y) = Let (f x) (f y)
-  fmap f (NLet x y) = NLet (f x) (f y)
-  fmap f (Hole x) = Hole (f x)
-  fmap f (GHole x) = GHole (f x)
-  fmap f (Guess x y) = Guess (f x) (f y)
-  fmap f (PVar x) = PVar (f x)
-  fmap f (PVTy x) = PVTy (f x)
+  map f (Lam x) = Lam (f x)
+  map f (Pi x) = Pi (f x)
+  map f (Let x y) = Let (f x) (f y)
+  map f (NLet x y) = NLet (f x) (f y)
+  map f (Hole x) = Hole (f x)
+  map f (GHole x) = GHole (f x)
+  map f (Guess x y) = Guess (f x) (f y)
+  map f (PVar x) = PVar (f x)
+  map f (PVTy x) = PVTy (f x)
 
 total
 traverse : (Applicative f) =>  (a -> f b) -> Binder a -> f (Binder b)

--- a/lib/Network/Cgi.idr
+++ b/lib/Network/Cgi.idr
@@ -28,8 +28,8 @@ getAction : CGI a -> CGIInfo -> IO (a, CGIInfo)
 getAction (MkCGI act) = act
 
 instance Functor CGI where
-    fmap f (MkCGI c) = MkCGI (\s => do (a, i) <- c s
-                                       return (f a, i))
+    map f (MkCGI c) = MkCGI (\s => do (a, i) <- c s
+                                      return (f a, i))
 
 instance Applicative CGI where
     pure v = MkCGI (\s => return (v, s))

--- a/lib/Prelude.idr
+++ b/lib/Prelude.idr
@@ -69,18 +69,15 @@ instance Show a => Show (Maybe a) where
 ---- Functor instances
 
 instance Functor IO where
-    fmap f io = io_bind io (io_return . f)
+    map f io = io_bind io (io_return . f)
 
 instance Functor Maybe where 
-    fmap f (Just x) = Just (f x)
-    fmap f Nothing  = Nothing
+    map f (Just x) = Just (f x)
+    map f Nothing  = Nothing
 
 instance Functor (Either e) where
-    fmap f (Left l) = Left l
-    fmap f (Right r) = Right (f r)
-
-instance Functor List where 
-    fmap = map
+    map f (Left l) = Left l
+    map f (Right r) = Right (f r)
 
 ---- Applicative instances
 
@@ -252,7 +249,7 @@ putChar c = mkForeign (FFun "putchar" [FInt] FUnit) (cast c)
 
 partial
 getChar : IO Char
-getChar = fmap cast $ mkForeign (FFun "getchar" [] FInt)
+getChar = map cast $ mkForeign (FFun "getchar" [] FInt)
 
 ---- some basic file handling
 

--- a/lib/Prelude/Applicative.idr
+++ b/lib/Prelude/Applicative.idr
@@ -13,11 +13,11 @@ class Functor f => Applicative (f : Type -> Type) where
 
 infixl 2 <$
 (<$) : Applicative f => f a -> f b -> f a
-a <$ b = fmap const a <$> b
+a <$ b = map const a <$> b
 
 infixl 2 $>
 ($>) : Applicative f => f a -> f b -> f b
-a $> b = fmap (const id) a <$> b
+a $> b = map (const id) a <$> b
 
 infixl 3 <|>
 class Applicative f => Alternative (f : Type -> Type) where
@@ -32,7 +32,7 @@ when a f = if a then f else pure ()
 
 sequence : Applicative f => List (f a) -> f (List a)
 sequence []        = pure []
-sequence (x :: xs) = fmap (::) x <$> sequence xs
+sequence (x :: xs) = map (::) x <$> sequence xs
 
 sequence_ : Applicative f => List (f a) -> f ()
 sequence_ [] = pure ()

--- a/lib/Prelude/Functor.idr
+++ b/lib/Prelude/Functor.idr
@@ -1,4 +1,4 @@
 module Prelude.Functor
 
 class Functor (f : Type -> Type) where 
-    fmap : (a -> b) -> f a -> f b
+    map : (a -> b) -> f a -> f b

--- a/lib/Prelude/List.idr
+++ b/lib/Prelude/List.idr
@@ -3,6 +3,7 @@ module Prelude.List
 import Builtins
 
 import Prelude.Algebra
+import Prelude.Functor
 import Prelude.Maybe
 import Prelude.Nat
 
@@ -163,6 +164,10 @@ instance Monoid (List a) where
 -- instance VerifiedSemigroup (List a) where
 --  semigroupOpIsAssociative = appendAssociative
 
+instance Functor List where
+  map f []      = []
+  map f (x::xs) = f x :: map f xs
+
 --------------------------------------------------------------------------------
 -- Zips and unzips
 --------------------------------------------------------------------------------
@@ -200,10 +205,6 @@ unzip3 ((l, c, r)::xs) with (unzip3 xs)
 --------------------------------------------------------------------------------
 -- Maps
 --------------------------------------------------------------------------------
-
-map : (a -> b) -> List a -> List b
-map f []      = []
-map f (x::xs) = f x :: map f xs
 
 mapMaybe : (a -> Maybe b) -> List a -> List b
 mapMaybe f []      = []

--- a/lib/System/Concurrency/Process.idr
+++ b/lib/System/Concurrency/Process.idr
@@ -16,7 +16,7 @@ data Process : (msgType : Type) -> Type -> Type where
      lift : IO a -> Process msg a
 
 instance Functor (Process msg) where
-     fmap f (lift a) = lift (fmap f a)
+     map f (lift a) = lift (map f a)
 
 instance Applicative (Process msg) where
      pure = lift . return

--- a/test/reg001/reg001.idr
+++ b/test/reg001/reg001.idr
@@ -2,7 +2,7 @@ apply : (a -> b) -> a -> b
 apply f x = f x
 
 class Functor f => VerifiedFunctor (f : Type -> Type) where 
-   identity : (fa : f a) -> fmap id fa = fa 
+   identity : (fa : f a) -> map id fa = fa 
 
 data Imp : Type where 
    MkImp : {any : Type} -> any -> Imp

--- a/test/test007/test007.idr
+++ b/test/test007/test007.idr
@@ -14,7 +14,7 @@ fetch x = MkEval (\e => fetchVal e) where
     fetchVal ((v, val) :: xs) = if (x == v) then (Just val) else (fetchVal xs)
 
 instance Functor Eval where
-    fmap f (MkEval g) = MkEval (\e => fmap f (g e))
+    map f (MkEval g) = MkEval (\e => map f (g e))
 
 instance Applicative Eval where 
     pure x = MkEval (\e => Just x)

--- a/tutorial/examples/idiom.idr
+++ b/tutorial/examples/idiom.idr
@@ -14,7 +14,7 @@ fetch x = MkEval (\e => fetchVal e) where
     fetchVal ((v, val) :: xs) = if (x == v) then (Just val) else (fetchVal xs)
 
 instance Functor Eval where
-    fmap f (MkEval g) = MkEval (\e => fmap f (g e))
+    map f (MkEval g) = MkEval (\e => map f (g e))
 
 instance Applicative Eval where 
     pure x = MkEval (\e => Just x)


### PR DESCRIPTION
> < Ralith> someone should rename fmap to map already

To still allow disambiguation of `List.map` vs. `Functor.map` on `List` arguments, I replaced the former entirely by moving the `Functor` instance of `List` into `Prelude/List.idr` (and importing `Prelude.Functor` there). Other than this, nearly the whole change was made by global search-and-replace.
