### PR TITLE
LLVM test should return True if no flag is present

### DIFF
--- a/Setup.hs
+++ b/Setup.hs
@@ -120,7 +120,7 @@ llvmFlag flags =
   case lookup (FlagName "LLVM") (S.configConfigurationsFlags flags) of
     Just True -> True
     Just False -> False
-    Nothing -> False
+    Nothing -> True
 
 noEffectsFlag flags =
    case lookup (FlagName "noeffects") (S.configConfigurationsFlags flags) of


### PR DESCRIPTION
Fixes the build of the rts for LLVM.
