### PR TITLE
Fix the LLVM flag

### DIFF
--- a/Setup.hs
+++ b/Setup.hs
@@ -117,7 +117,7 @@ checkStdLib local withoutEffects verbosity
                ]
 
 llvmFlag flags = 
-  case lookup (FlagName "LLVM") (S.configConfigurationsFlags flags) of
+  case lookup (FlagName "llvm") (S.configConfigurationsFlags flags) of
     Just True -> True
     Just False -> False
     Nothing -> True


### PR DESCRIPTION
Apparently Cabal normalizes the flags to lower case, and the
lookup for "LLVM" does nothing. Commit
2972b75a1896fc8d0db1e4d442f6aa5b2e1caf8e isn't wrong, but the problem
is that it ever gets to the Nothing case. The flag should always
be there.
