### PR TITLE
Add import Prelude.Functor in Prelude/Vect.idr

### DIFF
--- a/lib/Prelude/Vect.idr
+++ b/lib/Prelude/Vect.idr
@@ -1,6 +1,7 @@
 module Prelude.Vect
 
 import Prelude.Fin
+import Prelude.Functor
 import Prelude.List
 import Prelude.Nat
 


### PR DESCRIPTION
This is imported transitively through Prelude.List, but really should be
explicit.
