### PR TITLE
Add pkg-config gc flags to llvm Makefile

### DIFF
--- a/llvm/Makefile
+++ b/llvm/Makefile
@@ -1,13 +1,14 @@
 include ../config.mk
 
-CFLAGS:=-Wextra -fPIC -Wno-unused-parameter $(CFLAGS)
+PKG_CONFIG_CFLAGS:=$(shell (pkg-config --version >/dev/null 2>&1) && pkg-config --cflags bdw-gc)
+CFLAGS:=-Wextra -fPIC -Wno-unused-parameter $(PKG_CONFIG_CFLAGS) $(CFLAGS)
 SOURCES=defs.c
 OBJECTS=$(SOURCES:.c=.o)
 LIB=libidris_rts.a
 
 build: $(SOURCES) $(LIB)
 
-$(LIB): $(OBJECTS) 
+$(LIB): $(OBJECTS)
 	ar r $@ $(OBJECTS)
 	ranlib $@
 


### PR DESCRIPTION
This makes building work for systems which have gc installed in a
non-standard location.  The invocation was pulled from
https://github.com/schani/clojurec/pull/2.  I'm not sure whether or not
the --libs is needed; I have the relevant library path in LD_RUN_PATH
and LD_LIBRARY_PATH, but I think the --libs is needed if this is not the
case.
