### PR TITLE
Allow tests to be parallelized

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -14,15 +14,15 @@ build: dist/setup-config
 	$(CABAL) build $(CABALFLAGS)
 
 test:
-	make -C test IDRIS=../dist/build/idris
+	$(MAKE) -C test IDRIS=../dist/build/idris
 
 test_java:
-	make -C test IDRIS=../dist/build/idris test_java
+	$(MAKE) -C test IDRIS=../dist/build/idris test_java
 
 relib:
-	make -C lib IDRIS=../dist/build/idris/idris RTS=../dist/build/rts/libidris_rts clean
-	make -C effects IDRIS=../dist/build/idris/idris RTS=../dist/build/rts/libidris_rts DIST=../dist/build clean
-	make -C javascript IDRIS=../dist/build/idris/idris RTS=../dist/build/rts/libidris_rts DIST=../dist/build clean
+	$(MAKE) -C lib IDRIS=../dist/build/idris/idris RTS=../dist/build/rts/libidris_rts clean
+	$(MAKE) -C effects IDRIS=../dist/build/idris/idris RTS=../dist/build/rts/libidris_rts DIST=../dist/build clean
+	$(MAKE) -C javascript IDRIS=../dist/build/idris/idris RTS=../dist/build/rts/libidris_rts DIST=../dist/build clean
 	$(CABAL) install $(CABALFLAGS)
 
 linecount:

--- a/test/Makefile
+++ b/test/Makefile
@@ -1,5 +1,9 @@
-test:
-	perl ./runtest.pl all
+TESTS = $(sort $(patsubst %/,%.test,$(wildcard */)))
+
+test: $(TESTS)
+
+%.test:
+	@perl ./runtest.pl $(patsubst %.test,%,$@)
 
 test_java:
 	perl ./runtest.pl all --codegen Java
@@ -63,3 +67,5 @@ diff:
 distclean:
 	rm -f *~
 	rm -f */output
+
+.phony: test test_java test_js update diff distclean $(TESTS)

--- a/test/runtest.pl
+++ b/test/runtest.pl
@@ -9,7 +9,7 @@ sub runtest {
 
     chdir($test);
 
-    print "Running $test...";
+    print "Running $test...\n";
     $got = `sh ./run @idrOpts`;
     $exp = `cat expected`;
 
@@ -33,14 +33,14 @@ sub runtest {
     }
 
     if ($got eq $exp) {
-	print "success\n";
+	print "Ran $test...success\n";
     } else {
 	if ($update == 0) {
 	    $exitstatus = 1;
-	    print "FAILURE\n";
+	    print "Ran $test...FAILURE\n";
 	} else {
 	    system("cp output expected");
-	    print "UPDATED\n";
+	    print "Ran $test...UPDATED\n";
 	}
     }
     chdir("..");


### PR DESCRIPTION
Running `make -j16 test` now runs tests in batches of 16.  This takes 1m
(real) (6m user), whereas `make -j1 test` takes about 5 minutes (both
real and user).  There is a bit of funniness with cancelling `make -j16
test`; I get a bunch of directory/file not found errors.  I'm not sure
why.

I've changed the test printing format a bit; make, unlike, say, the
ninja buildsystem, interleaves outputs rather than buffering them.  I
chose to make sure that the perl script printed entire lines at one,
resulting in output like

```
Running test004...
Ran test004...success
Running test005...
Ran test005...success
Running test006...
Ran test006...success
Running test007...
```

rather than

```
Running test004...success
Running test005...success
Running test006...success
Running test007...
```

with the `success` appearing some time after the `Running testNNN...`
message.
