### PR TITLE
rename IO into UnsafeIO

### DIFF
--- a/effects/Effect/Exception.idr
+++ b/effects/Effect/Exception.idr
@@ -10,7 +10,7 @@ data Exception : Type -> Type -> Type -> Type -> Type where
 instance Handler (Exception a) Maybe where
      handle _ (Raise e) k = Nothing
 
-instance Show a => Handler (Exception a) IO where
+instance Show a => Handler (Exception a) UnsafeIO where
      handle _ (Raise e) k = do print e
                                believe_me (exit 1)
 

--- a/effects/Effect/File.idr
+++ b/effects/Effect/File.idr
@@ -14,7 +14,7 @@ data FileIO : Effect where
      WriteLine : String -> FileIO (OpenFile Write) (OpenFile Write) ()
      EOF       :           FileIO (OpenFile Read)  (OpenFile Read) Bool
 
-instance Handler FileIO IO where
+instance Handler FileIO UnsafeIO where
     handle () (Open fname m) k = do h <- openFile fname m
                                     k (FH h) ()
     handle (FH h) Close      k = do closeFile h

--- a/effects/Effect/Memory.idr
+++ b/effects/Effect/Memory.idr
@@ -46,23 +46,23 @@ do_malloc size with (fromInteger (cast size) == size)
   | False = ioe_fail "The target architecture does not support adressing enough memory"
 
 private
-do_memset : Ptr -> Nat -> Bits8 -> Nat -> IO ()
+do_memset : Ptr -> Nat -> Bits8 -> Nat -> UnsafeIO ()
 do_memset ptr offset c size
   = mkForeign (FFun "idris_memset" [FPtr, FInt, FByte, FInt] FUnit)
               ptr (fromInteger $ cast offset) c (fromInteger $ cast size)
 
 private
-do_free : Ptr -> IO ()
+do_free : Ptr -> UnsafeIO ()
 do_free ptr = mkForeign (FFun "free" [FPtr] FUnit) ptr
 
 private
-do_memmove : Ptr -> Ptr -> Nat -> Nat -> Nat -> IO ()
+do_memmove : Ptr -> Ptr -> Nat -> Nat -> Nat -> UnsafeIO ()
 do_memmove dest src dest_offset src_offset size
   = mkForeign (FFun "idris_memmove" [FPtr, FPtr, FInt, FInt, FInt] FUnit)
               dest src (fromInteger $ cast dest_offset) (fromInteger $ cast src_offset) (fromInteger $ cast size)
 
 private
-do_peek : Ptr -> Nat -> (size : Nat) -> IO (Vect size Bits8)
+do_peek : Ptr -> Nat -> (size : Nat) -> UnsafeIO (Vect size Bits8)
 do_peek _   _       Z = return (Prelude.Vect.Nil)
 do_peek ptr offset (S n)
   = do b <- mkForeign (FFun "idris_peek" [FPtr, FInt] FByte) ptr (fromInteger $ cast offset)
@@ -70,7 +70,7 @@ do_peek ptr offset (S n)
        Prelude.Monad.return (Prelude.Vect.(::) b bs)
 
 private
-do_poke : Ptr -> Nat -> Vect size Bits8 -> IO ()
+do_poke : Ptr -> Nat -> Vect size Bits8 -> UnsafeIO ()
 do_poke _   _      []     = return ()
 do_poke ptr offset (b::bs)
   = do mkForeign (FFun "idris_poke" [FPtr, FInt, FByte] FUnit) ptr (fromInteger $ cast offset) b

--- a/effects/Effect/StdIO.idr
+++ b/effects/Effect/StdIO.idr
@@ -7,7 +7,7 @@ data StdIO : Effect where
      PutStr : String -> StdIO () () ()
      GetStr : StdIO () () String
 
-instance Handler StdIO IO where
+instance Handler StdIO UnsafeIO where
     handle () (PutStr s) k = do putStr s; k () ()
     handle () GetStr     k = do x <- getLine; k () x 
 
@@ -15,7 +15,7 @@ instance Handler StdIO (IOExcept a) where
     handle () (PutStr s) k = do ioe_lift (putStr s); k () ()
     handle () GetStr     k = do x <- ioe_lift getLine; k () x 
 
--- Handle effects in a pure way, for simulating IO for unit testing/proof
+-- Handle effects in a pure way, for simulating UnsafeIO for unit testing/proof
 
 data IOStream a = MkStream (List String -> (a, List String))
   

--- a/javascript/JavaScript.idr
+++ b/javascript/JavaScript.idr
@@ -4,7 +4,7 @@ module JavaScript
 
 -- TODO: Get rid of this hack, and find a better way.
 private
-isUndefined : Ptr -> IO Bool
+isUndefined : Ptr -> UnsafeIO Bool
 isUndefined p = do
   res <- mkForeign (
     FFun "(function(arg) { return arg === undefined;})" [FPtr] FString) p
@@ -26,16 +26,16 @@ abstract
 data Element : Type where
   MkElem : Ptr -> Element
 
-setText : Element -> String -> IO ()
+setText : Element -> String -> UnsafeIO ()
 setText (MkElem p) s =
   mkForeign (FFun ".textContent=" [FPtr, FString] FUnit) p s
 
 
-setOnClick : Element -> (Event -> IO Bool) -> IO ()
+setOnClick : Element -> (Event -> UnsafeIO Bool) -> UnsafeIO ()
 setOnClick (MkElem e) f =
   mkForeign (
     FFun "['onclick']=" [ FPtr
-                        , FFunction (FAny Event) (FAny (IO Bool))
+                        , FFunction (FAny Event) (FAny (UnsafeIO Bool))
                         ] FUnit) e f
 --------------------------------------------------------------------------------
 -- Nodelists
@@ -44,7 +44,7 @@ abstract
 data NodeList : Type where
   MkNodeList : Ptr -> NodeList
 
-elemAt : NodeList -> Nat -> IO (Maybe Element)
+elemAt : NodeList -> Nat -> UnsafeIO (Maybe Element)
 elemAt (MkNodeList p) i = do
   e <- mkForeign (FFun ".item" [FPtr, FInt] FPtr) p (prim__truncBigInt_Int (cast i))
   d <- isUndefined e
@@ -59,13 +59,13 @@ abstract
 data Interval : Type where
   MkInterval : Ptr -> Interval
 
-setInterval : (() -> IO ()) -> Float -> IO Interval
+setInterval : (() -> UnsafeIO ()) -> Float -> UnsafeIO Interval
 setInterval f t = do
   e <- mkForeign (
-    FFun "setInterval" [FFunction FUnit (FAny (IO ())), FFloat] FPtr) f t
+    FFun "setInterval" [FFunction FUnit (FAny (UnsafeIO ())), FFloat] FPtr) f t
   return (MkInterval e)
 
-clearInterval : Interval -> IO ()
+clearInterval : Interval -> UnsafeIO ()
 clearInterval (MkInterval p) =
   mkForeign (FFun "clearInterval" [FPtr] FUnit) p
 
@@ -75,27 +75,27 @@ clearInterval (MkInterval p) =
 data Timeout : Type where
   MkTimeout : Ptr -> Timeout
 
-setTimeout : (() -> IO ()) -> Float -> IO Timeout
+setTimeout : (() -> UnsafeIO ()) -> Float -> UnsafeIO Timeout
 setTimeout f t = do
   e <- mkForeign (
-    FFun "setTimeout" [FFunction FUnit (FAny (IO ())), FFloat] FPtr) f t
+    FFun "setTimeout" [FFunction FUnit (FAny (UnsafeIO ())), FFloat] FPtr) f t
   return (MkTimeout e)
 
-clearTimeout : Timeout -> IO ()
+clearTimeout : Timeout -> UnsafeIO ()
 clearTimeout (MkTimeout p) =
   mkForeign (FFun "clearTimeout" [FPtr] FUnit) p
 
 --------------------------------------------------------------------------------
--- Basic IO
+-- Basic UnsafeIO
 --------------------------------------------------------------------------------
-alert : String -> IO ()
+alert : String -> UnsafeIO ()
 alert msg =
   mkForeign (FFun "alert" [FString] FUnit) msg
 
 --------------------------------------------------------------------------------
 -- DOM
 --------------------------------------------------------------------------------
-query : String -> IO NodeList
+query : String -> UnsafeIO NodeList
 query q = do
   e <- mkForeign (FFun "document.querySelectorAll" [FString] FPtr) q
   return (MkNodeList e)

--- a/lib/Control/IOExcept.idr
+++ b/lib/Control/IOExcept.idr
@@ -2,10 +2,10 @@ module Control.IOExcept
 
 import Prelude
 
--- An IO monad with exception handling
+-- An UnsafeIO monad with exception handling
 
 data IOExcept : Type -> Type -> Type where
-     ioM : IO (Either err a) -> IOExcept err a
+     ioM : UnsafeIO (Either err a) -> IOExcept err a
 
 instance Functor (IOExcept e) where
      map f (ioM fn) = ioM (map (map f) fn)
@@ -22,14 +22,14 @@ instance Monad (IOExcept e) where
                                                  ka
                                   Left err => return (Left err))
 
-ioe_lift : IO a -> IOExcept err a
+ioe_lift : UnsafeIO a -> IOExcept err a
 ioe_lift op = ioM (do op' <- op
                       return (Right op'))
 
 ioe_fail : err -> IOExcept err a
 ioe_fail e = ioM (return (Left e))
 
-ioe_run : IOExcept err a -> (err -> IO b) -> (a -> IO b) -> IO b
+ioe_run : IOExcept err a -> (err -> UnsafeIO b) -> (a -> UnsafeIO b) -> UnsafeIO b
 ioe_run (ioM act) err ok = do act' <- act
                               case act' of
                                    Left e => err e

--- a/lib/IO.idr
+++ b/lib/IO.idr
@@ -2,23 +2,23 @@ import Prelude.List
 
 %access public
 
-abstract data IO a = prim__IO a
+abstract data UnsafeIO a = prim__IO a
 
 abstract
-io_bind : IO a -> (a -> IO b) -> IO b
+io_bind : UnsafeIO a -> (a -> UnsafeIO b) -> UnsafeIO b
 io_bind (prim__IO v) k = k v
 
-unsafePerformIO : IO a -> a
+unsafePerformIO : UnsafeIO a -> a
 -- compiled as primitive
 
 abstract
-io_return : a -> IO a
+io_return : a -> UnsafeIO a
 io_return x = prim__IO x
 
 -- This may seem pointless, but we can use it to force an
 -- evaluation of main that Epic wouldn't otherwise do...
 
-run__IO : IO () -> IO ()
+run__IO : UnsafeIO () -> UnsafeIO ()
 run__IO v = io_bind v (\v' => io_return v')
 
 data IntTy = ITChar | ITNative | IT8 | IT16 | IT32 | IT64 | IT8x16 | IT16x8 | IT32x4 | IT64x2
@@ -89,7 +89,7 @@ interpFTy FUnit            = ()
 interpFTy (FFunction a b) = interpFTy a -> interpFTy b
 
 ForeignTy : (xs:List FTy) -> (t:FTy) -> Type
-ForeignTy Nil     rt = IO (interpFTy rt)
+ForeignTy Nil     rt = UnsafeIO (interpFTy rt)
 ForeignTy (t::ts) rt = interpFTy t -> ForeignTy ts rt
 
 
@@ -101,7 +101,7 @@ mkForeign : Foreign x -> x
 mkLazyForeign : Foreign x -> x
 -- mkForeign and mkLazyForeign compiled as primitives
 
-fork : |(thread:IO ()) -> IO Ptr
+fork : |(thread:UnsafeIO ()) -> UnsafeIO Ptr
 fork x = io_return prim__vm -- compiled specially
 
 

--- a/lib/Prelude/Heap.idr
+++ b/lib/Prelude/Heap.idr
@@ -202,7 +202,7 @@ deleteMinimumEmptyAbsurd = proof {
 
 {-  XXX: poor performance when compiled, diverges when used in the REPL, but it
          does seem to work correctly!
-main : IO ()
+main : UnsafeIO ()
 main = do
   _ <- print $ main.sort [10, 3, 7, 2, 9, 1, 8, 0, 6, 4, 5]
   _ <- print $ main.sort ["orange", "apple", "pear", "lime", "durian"]

--- a/lib/System.idr
+++ b/lib/System.idr
@@ -5,27 +5,27 @@ import Prelude
 %default partial
 %access public
 
-getArgs : IO (List String)
+getArgs : UnsafeIO (List String)
 getArgs = do n <- numArgs
              ga' [] 0 n 
   where
-    numArgs : IO Int
+    numArgs : UnsafeIO Int
     numArgs = mkForeign (FFun "idris_numArgs" [FPtr] FInt) prim__vm
 
-    getArg : Int -> IO String
+    getArg : Int -> UnsafeIO String
     getArg x = mkForeign (FFun "idris_getArg" [FPtr, FInt] (FAny String)) prim__vm x
 
-    ga' : List String -> Int -> Int -> IO (List String)
+    ga' : List String -> Int -> Int -> UnsafeIO (List String)
     ga' acc i n = if (i == n) then (return $ reverse acc) else
                     do arg <- getArg i
                        ga' (arg :: acc) (i+1) n
 
-getEnv : String -> IO String
+getEnv : String -> UnsafeIO String
 getEnv x = mkForeign (FFun "getenv" [FString] FString) x
 
-exit : Int -> IO ()
+exit : Int -> UnsafeIO ()
 exit code = mkForeign (FFun "exit" [FInt] FUnit) code
 
-usleep : Int -> IO ()
+usleep : Int -> UnsafeIO ()
 usleep i = mkForeign (FFun "usleep" [FInt] FUnit) i
 

--- a/lib/System/Concurrency/Process.idr
+++ b/lib/System/Concurrency/Process.idr
@@ -13,7 +13,7 @@ data ProcID msg = MkPID Ptr
 -- message which can be send, and the return type.
 
 data Process : (msgType : Type) -> Type -> Type where
-     lift : IO a -> Process msg a
+     lift : UnsafeIO a -> Process msg a
 
 instance Functor (Process msg) where
      map f (lift a) = lift (map f a)
@@ -27,7 +27,7 @@ instance Monad (Process msg) where
                                 case k x of
                                      lift v => v)
 
-run : Process msg x -> IO x
+run : Process msg x -> UnsafeIO x
 run (lift prog) = prog
 
 -- Get current process ID
@@ -50,7 +50,7 @@ msgWaiting = lift checkMsgs
 recv : Process msg msg
 recv {msg} = do (senderid, m) <- lift get
                 return m
-  where get : IO (Ptr, msg)
+  where get : UnsafeIO (Ptr, msg)
         get = getMsg
 
 -- receive a message, and return with the sender's process ID.
@@ -59,7 +59,7 @@ recvWithSender : Process msg (ProcID msg, msg)
 recvWithSender {msg} 
      = do (senderid, m) <- lift get
           return (MkPID senderid, m)
-  where get : IO (Ptr, msg)
+  where get : UnsafeIO (Ptr, msg)
         get = getMsg
 
 create : |(thread : Process msg ()) -> Process msg (ProcID msg)

--- a/lib/System/Concurrency/Raw.idr
+++ b/lib/System/Concurrency/Raw.idr
@@ -8,12 +8,12 @@ import System
 
 -- Send a message of any type to the thread with the given thread id
 
-sendToThread : (thread_id : Ptr) -> a -> IO ()
+sendToThread : (thread_id : Ptr) -> a -> UnsafeIO ()
 sendToThread {a} dest val 
    = mkForeign (FFun "idris_sendMessage" 
         [FPtr, FPtr, FAny a] FUnit) prim__vm dest val
 
-checkMsgs : IO Bool
+checkMsgs : UnsafeIO Bool
 checkMsgs = do msgs <- mkForeign (FFun "idris_checkMessage"
                         [FPtr] FInt) prim__vm
                return (intToBool msgs)
@@ -21,7 +21,7 @@ checkMsgs = do msgs <- mkForeign (FFun "idris_checkMessage"
 -- Check inbox for messages. If there are none, blocks until a message
 -- arrives.
 
-getMsg : IO a
+getMsg : UnsafeIO a
 getMsg {a} = mkForeign (FFun "idris_recvMessage" 
                 [FPtr] (FAny a)) prim__vm
 

--- a/src/IRTS/Compiler.hs
+++ b/src/IRTS/Compiler.hs
@@ -296,7 +296,7 @@ getFTypes tm = case unApply tm of
 
 mkIty' (P _ (UN ty) _) = mkIty ty
 mkIty' (App (P _ (UN "FIntT") _) (P _ (UN intTy) _)) = mkIntIty intTy
-mkIty' (App (App (P _ (UN "FFunction") _) _) (App (P _ (UN "FAny") _) (App (P _ (UN "IO") _) _))) = FFunctionIO
+mkIty' (App (App (P _ (UN "FFunction") _) _) (App (P _ (UN "FAny") _) (App (P _ (UN "UnsafeIO") _) _))) = FFunctionIO
 mkIty' (App (App (P _ (UN "FFunction") _) _) _) = FFunction
 mkIty' _ = FAny
 

--- a/src/Idris/ElabDecls.hs
+++ b/src/Idris/ElabDecls.hs
@@ -269,7 +269,7 @@ elabProvider info syn fc n ty tm
          -- Elaborate the provider term to TT and check that the type matches
          (e, et) <- elabVal toplevel False tm
          unless (isProviderOf ty' et) $
-           fail $ "Expected provider type IO (Provider (" ++
+           fail $ "Expected provider type UnsafeIO (Provider (" ++
                   show ty' ++ "))" ++ ", got " ++ show et ++ " instead."
 
          -- Create the top-level type declaration
@@ -293,7 +293,7 @@ elabProvider info syn fc n ty tm
 
           isProviderOf :: TT Name -> TT Name -> Bool
           isProviderOf tp prov
-            | (P _ (UN "IO") _, [prov']) <- unApply prov
+            | (P _ (UN "UnsafeIO") _, [prov']) <- unApply prov
             , (P _ (NS (UN "Provider") ["Providers"]) _, [tp']) <- unApply prov'
             , tp == tp' = True
           isProviderOf _ _ = False

--- a/src/Idris/Providers.hs
+++ b/src/Idris/Providers.hs
@@ -24,4 +24,4 @@ getProvided tm | (P _ (UN "io_return") _, [tp, result]) <- unApply tm
                , (P _ (NS (UN "Provide") ["Providers"]) _, [_, res]) <- unApply result =
                      return res
                | otherwise = fail $ "Internal type provider error: result was not " ++
-                                    "IO (Provider a), or perhaps missing normalisation."
+                                    "UnsafeIO (Provider a), or perhaps missing normalisation."

--- a/test/reg002/reg002.idr
+++ b/test/reg002/reg002.idr
@@ -27,5 +27,5 @@ swap Nil            = Nil
 swap (x :: Nil)     = x :: Nil
 swap (x :: y :: xs) = (y :: x :: (swap xs))
 
-main : IO ()
+main : UnsafeIO ()
 main = print (swap [1,2,3,4,5])

--- a/test/reg004/reg004.idr
+++ b/test/reg004/reg004.idr
@@ -12,5 +12,5 @@ h True = r2 where
   r2 : Nat
   r2 = r
 
-main : IO ()
+main : UnsafeIO ()
 main = do print (h True); print (h False)

--- a/test/reg005/reg005.idr
+++ b/test/reg005/reg005.idr
@@ -35,7 +35,7 @@ compress xs with (rle xs)
 compressString : String -> String
 compressString xs = compress (fromList (unpack xs))
 
-main : IO ()
+main : UnsafeIO ()
 main = putStrLn (compressString "foooobaaaarbaaaz")
 
 

--- a/test/reg013/reg013.idr
+++ b/test/reg013/reg013.idr
@@ -1,6 +1,6 @@
 module Main
 
-main : IO ()
+main : UnsafeIO ()
 main = do
   print $ prim_lenString "hallo"
   print $ prim_lenString "1"

--- a/test/reg016/reg016.idr
+++ b/test/reg016/reg016.idr
@@ -1,6 +1,6 @@
 module Main
 
-main : IO ()
+main : UnsafeIO ()
 main = do print $ the Integer 4294967295
           print $ the Integer 4294967296
           print $ the Integer 4294967297

--- a/test/reg017/reg017.idr
+++ b/test/reg017/reg017.idr
@@ -9,5 +9,5 @@ foo : { t : Type } ->
       Nat
 foo {t} a {prfA = p} b c {prfBC} = b
 
-main : IO ()
+main : UnsafeIO ()
 main = print $ foo 3 4 4

--- a/test/reg018/reg018d.idr
+++ b/test/reg018/reg018d.idr
@@ -8,5 +8,5 @@ pull {n=S _} (fS n) (x :: xs) =
   let (v, vs) = pull n xs in
         (v, x::vs)
 
-main : IO ()
+main : UnsafeIO ()
 main = print (pull fZ [0, 1, 2])

--- a/test/reg020/reg020.idr
+++ b/test/reg020/reg020.idr
@@ -31,7 +31,7 @@ sumOfAllLengths : Nat
 sumOfAllLengths = foldl (\ l, s => l + (Strings.length s)) (Strings.length $ head all) (tail all)
 
 
-main : IO ()
+main : UnsafeIO ()
 main = do putStrLn $ "length of: '" ++ emptyString ++ "' is: " ++ (show $ length emptyString)
           putStrLn $ "length of: '" ++ helloWorld ++ "' is: " ++ (show $ length helloWorld)
           putStrLn $ "length of: '" ++ spaceOnly ++ "' is: " ++ (show $ length spaceOnly)

--- a/test/test001/test001.idr
+++ b/test/test001/test001.idr
@@ -88,7 +88,7 @@ testFac = interp [] eFac 4
 testEnv : Int -> Env [TyInt,TyInt]
 testEnv x = [x,x]
 
-main : IO ()
+main : UnsafeIO ()
 main = do { print testFac
             print test }
 

--- a/test/test003/Lit.lidr
+++ b/test/test003/Lit.lidr
@@ -7,7 +7,7 @@ Test some string primitives while we're at it
   
 Literate main program
 
-> main : IO ()
+> main : UnsafeIO ()
 > main = do { putStrLn (show (strHead st))
 >             putStrLn (show (strIndex st 3))
 >             putStrLn (strCons 'z' st)

--- a/test/test003/test003.lidr
+++ b/test/test003/test003.lidr
@@ -4,5 +4,5 @@ Import the literate module
 
 > import Lit
 
-> main : IO ()
+> main : UnsafeIO ()
 > main = Lit.main

--- a/test/test003/test003a.lidr
+++ b/test/test003/test003a.lidr
@@ -1,3 +1,3 @@
 Broken
-> main : IO ();
+> main : UnsafeIO ();
 > main = putStrLn "Foo";

--- a/test/test004/test004.idr
+++ b/test/test004/test004.idr
@@ -1,6 +1,6 @@
 module Main
 
-dumpFile : String -> IO ()
+dumpFile : String -> UnsafeIO ()
 dumpFile fn = do { h <- openFile fn Read
                    while (do { x <- feof h
                                return (not x) })
@@ -8,7 +8,7 @@ dumpFile fn = do { h <- openFile fn Read
                                putStr l })
                    closeFile h }
 
-main : IO ()
+main : UnsafeIO ()
 main = do { h <- openFile "testfile" Write
             fwrite h "Hello!\nWorld!\n"
             closeFile h

--- a/test/test005/test005.idr
+++ b/test/test005/test005.idr
@@ -6,7 +6,7 @@ tstr = "abc123"
 tlist : List Int
 tlist = [1, 2, 3, 4, 5]
 
-main : IO ()
+main : UnsafeIO ()
 main = do print (abs (-8))
           print (abs (S Z))
           print (span isAlpha tstr)

--- a/test/test006/test006.idr
+++ b/test/test006/test006.idr
@@ -17,7 +17,7 @@ natToBin k with (parity k)
    natToBin (j + j)     | even {n = j} = False :: natToBin j
    natToBin (S (j + j)) | odd {n = j}  = True  :: natToBin j
 
-main : IO ()
+main : UnsafeIO ()
 main = do print (natToBin 42)
 
 ---------- Proofs ----------

--- a/test/test007/test007.idr
+++ b/test/test007/test007.idr
@@ -34,7 +34,7 @@ runEval env e with (eval e) {
     | MkEval envFn = envFn env
 }
 
-main : IO ()
+main : UnsafeIO ()
 main = do print [| (\x => x *2) (Just 4) |]
           print [| plus (Just 4) (Just 5) |]
           print (runEval [("x",21), ("y", 20)] (Add (Val 1) (Add (Var "x") (Var "y"))))

--- a/test/test008/test008.idr
+++ b/test/test008/test008.idr
@@ -13,10 +13,10 @@ foo : (Int, String)
 foo = (4, "foo")
 
 
-ioVals : IO (String, String)
+ioVals : UnsafeIO (String, String)
 ioVals = do { return ("First", "second") } 
 
-main : IO ()
+main : UnsafeIO ()
 main = do (a, b) <- ioVals
           putStr (show a ++ " and " ++ show b ++ "? ")
           let x = "bar"

--- a/test/test009/test009.idr
+++ b/test/test009/test009.idr
@@ -4,6 +4,6 @@ pythag : Int -> List (Int, Int, Int)
 pythag n = [ (x, y, z) | z <- [1..n], y <- [1..z], x <- [1..y],
                            x*x + y*y == z*z ]
 
-main : IO ()
+main : UnsafeIO ()
 main = putStrLn (show (pythag 50))
       

--- a/test/test011/test011.idr
+++ b/test/test011/test011.idr
@@ -15,7 +15,7 @@ testFoo = MkFoo "name" [1,2,3] [4,5,6,7]
 person : Person
 person = MkPerson "Fred" 30
 
-main : IO ()
+main : UnsafeIO ()
 main = do let x = record { name = "foo", 
                            more_things = reverse ["a","b"] } testFoo
           print $ name x

--- a/test/test012/test012a.idr
+++ b/test/test012/test012a.idr
@@ -6,5 +6,5 @@ f x = x + 1
 foo : Nat -> Nat
 foo (f x) = x
               
-main : IO ()
+main : UnsafeIO ()
 main = putStrLn (show (foo 1))

--- a/test/test013/test013.idr
+++ b/test/test013/test013.idr
@@ -1,13 +1,13 @@
 module Main
 
-forLoop : List a -> (a -> IO ()) -> IO ()
+forLoop : List a -> (a -> UnsafeIO ()) -> UnsafeIO ()
 forLoop [] f = return ()
 forLoop (x :: xs) f = do f x
                          forLoop xs f
 
 syntax for {x} "in" [xs] ":" [body] = forLoop xs (\x => body)
 
-main : IO ()
+main : UnsafeIO ()
 main = do putStrLn "Counting:"
           for x in [1..10]: 
               putStrLn $ "Number " ++ show x

--- a/test/test014/test014.idr
+++ b/test/test014/test014.idr
@@ -61,6 +61,6 @@ readH fn = res (do let x = open fn Reading
                           rclose x
                        else rputStrLn "Error")
 
-main : IO ()
+main : UnsafeIO ()
 main = run (readH "test")
 

--- a/test/test015/test015.idr
+++ b/test/test015/test015.idr
@@ -64,13 +64,13 @@ adc (numx # bX) (numy # bY) carry
    ?= let (bitpair carry0 lsb) = addBit bX bY carry in 
           adc numx numy carry0 # lsb
 
-readNum : IO Nat
+readNum : UnsafeIO Nat
 readNum = do putStr "Enter a number:"
              i <- getLine
              let n : Integer = cast i
              return (fromInteger n)
 
-main : IO ()
+main : UnsafeIO ()
 main = do let Just bin1 = natToBin 8 42
           print bin1
           let Just bin2 = natToBin 8 89

--- a/test/test016/test016.idr
+++ b/test/test016/test016.idr
@@ -12,6 +12,6 @@ take Z _ = []
 take (S n) (x :: xs) = x :: take n xs
 take n [] = []
 
-main : IO ()
+main : UnsafeIO ()
 main = do print (take 10 (Main.countFrom 10))
 

--- a/test/test018/test018.idr
+++ b/test/test018/test018.idr
@@ -3,20 +3,20 @@ module Main
 import System
 import System.Concurrency.Raw
 
-recvMsg : IO (Ptr, String)
+recvMsg : UnsafeIO (Ptr, String)
 recvMsg = getMsg
 
-pong : IO ()
+pong : UnsafeIO ()
 pong = do -- putStrLn "Waiting for ping"
           (sender, x) <- recvMsg
           putStrLn x
           putStrLn "Received"
           sendToThread sender "Hello to you too!"
 
-ping : Ptr -> IO ()
+ping : Ptr -> UnsafeIO ()
 ping thread = sendToThread thread (prim__vm, "Hello!")
 
-pingpong : IO ()
+pingpong : UnsafeIO ()
 pingpong 
      = do th <- fork pong
           putStrLn "Sending"
@@ -26,6 +26,6 @@ pingpong
           usleep 100000
           putStrLn "Finished"
 
-main : IO ()
+main : UnsafeIO ()
 main = do pingpong; pingpong; pingpong
 

--- a/test/test018/test018a.idr
+++ b/test/test018/test018a.idr
@@ -24,12 +24,12 @@ mainProc = do mainID <- myID
               recv -- block until everything done
               return ()
 
-repeatIO : Int -> IO ()
+repeatIO : Int -> UnsafeIO ()
 repeatIO 0 = return ()
 repeatIO n = do print n
                 run mainProc 
                 repeatIO (n - 1)
 
-main : IO ()
+main : UnsafeIO ()
 main = repeatIO 100
 

--- a/test/test019/test019.lidr
+++ b/test/test019/test019.lidr
@@ -11,6 +11,6 @@
 >               |   True     =  ifTrue  x
 >               |   False    =  ifFalse x
 
-> main : IO ()
+> main : UnsafeIO ()
 > main = print (test ((S 4) ==) 5 oh)
 

--- a/test/test020/test020.idr
+++ b/test/test020/test020.idr
@@ -18,7 +18,7 @@ intString = show
 test : Integer -> String
 test x = "Number " ++ x
 
-main : IO ()
+main : UnsafeIO ()
 main = do print (foo [1,2,3])
           print (test 42)
 

--- a/test/test020/test020a.idr
+++ b/test/test020/test020a.idr
@@ -13,6 +13,6 @@ forget' (x :: xs) = forget xs
 foo : Vect n a -> List a
 foo xs = reverse xs
 
-main : IO ()
+main : UnsafeIO ()
 main = print (foo [1,2,3])
 

--- a/test/test021/test021.idr
+++ b/test/test021/test021.idr
@@ -31,7 +31,7 @@ testFile = catch (do open "testFile" Read
                      putStrLn (show ls))
                  (\err => putStrLn ("Handled: " ++ show err))
 
-main : IO ()
+main : UnsafeIO ()
 main = do ioe_run (run [(), (), Count := 0] testFile)
                   (\err => print err) (\ok => return ())
 

--- a/test/test021/test021a.idr
+++ b/test/test021/test021a.idr
@@ -17,7 +17,7 @@ Env = List (String, Integer)
 -- Evaluator t 
 --    = Eff m [EXCEPTION String, RND, STATE Env] t
 
-eval : Expr -> Eff IO [EXCEPTION String, STDIO, RND, STATE Env] Integer
+eval : Expr -> Eff UnsafeIO [EXCEPTION String, STDIO, RND, STATE Env] Integer
 eval (Var x) = do vs <- get
                   case lookup x vs of
                         Nothing => raise ("No such variable " ++ x)
@@ -31,10 +31,10 @@ eval (Random upper) = do val <- rndInt 0 upper
 testExpr : Expr
 testExpr = Add (Add (Var "foo") (Val 42)) (Random 100)
 
-runEval : List (String, Integer) -> Expr -> IO Integer
+runEval : List (String, Integer) -> Expr -> UnsafeIO Integer
 runEval args expr = run [(), (), 123456, args] (eval expr)
 
-main : IO ()
+main : UnsafeIO ()
 main = do let x = 42
           val <- runEval [("foo", x)] testExpr
           putStrLn $ "Answer: " ++ show val

--- a/test/test023/test023.idr
+++ b/test/test023/test023.idr
@@ -7,7 +7,7 @@ import Providers
 %language TypeProviders
 
 -- Provide the Unit type
-goodProvider : IO (Provider Type)
+goodProvider : UnsafeIO (Provider Type)
 goodProvider = return (Provide (the Type ()))
 
 %provide (Unit : Type) with goodProvider
@@ -16,7 +16,7 @@ foo : Unit
 foo = ()
 
 -- Always fail
-badProvider : IO (Provider Type)
+badProvider : UnsafeIO (Provider Type)
 badProvider = return (Error "Always fails")
 
 %provide (t : Type) with badProvider

--- a/test/test024/test024.idr
+++ b/test/test024/test024.idr
@@ -1,6 +1,6 @@
 module Main
 
-main : IO ()
+main : UnsafeIO ()
 main = do l <- getLine
           let ll = l ++ l
           putStrLn ll

--- a/test/test025/test025.idr
+++ b/test/test025/test025.idr
@@ -27,7 +27,7 @@ testMemory = do Src :- allocate 5
                 Dst :- free
                 return (map (prim__zextB8_Int) res)
 
-main : IO ()
+main : UnsafeIO ()
 main = do ioe_run (run [Dst := (), Src := ()] testMemory)
                   (\err => print err) (\ok => print ok)
 

--- a/test/test026/test026.idr
+++ b/test/test026/test026.idr
@@ -11,7 +11,7 @@ strToType "Int" = Int
 strToType _ = Nat
 
 -- If the file contains "Int", provide Int as a type, otherwise provide Nat
-fromFile : String -> IO (Provider Type)
+fromFile : String -> UnsafeIO (Provider Type)
 fromFile fname = do str <- readFile fname
                     return (Provide (strToType (trim str)))
 

--- a/test/test027/test027.idr
+++ b/test/test027/test027.idr
@@ -18,7 +18,7 @@ using (Ord a, Num n)
   mprod [] = 1
   mprod (x :: xs) = x * mprod xs
 
-main : IO ()
+main : UnsafeIO ()
 main = do print $ isort [1,5,3,5,1,9,8]
           print $ msum [1..10]
           print $ mprod [1..10]

--- a/test/test028/test028.idr
+++ b/test/test028/test028.idr
@@ -1,5 +1,5 @@
 {--}
 module Main
 --
-main : IO ()
+main : UnsafeIO ()
 main = print "hello, world!"

--- a/tutorial/classes.tex
+++ b/tutorial/classes.tex
@@ -221,7 +221,7 @@ basis of \texttt{do}-notation introduced in Section \ref{sect:do}. Inside a
 \end{itemize}
 
 \noindent
-\texttt{IO} is an instance of \texttt{Monad}, defined using primitive functions.
+\texttt{UnsafeIO} is an instance of \texttt{Monad}, defined using primitive functions.
 We can also define an instance for \texttt{Maybe}, as follows:
 
 \begin{SaveVerbatim}{maybemonad}

--- a/tutorial/examples/binary.idr
+++ b/tutorial/examples/binary.idr
@@ -31,7 +31,7 @@ intToNat : Int -> Nat
 intToNat 0 = Z
 intToNat x = if (x>0) then (S (intToNat (x-1))) else Z
 
-main : IO ()
+main : UnsafeIO ()
 main = do putStr "Enter a number: "
           x <- getLine
           print (natToBin (fromInteger (cast x)))

--- a/tutorial/examples/bmain.idr
+++ b/tutorial/examples/bmain.idr
@@ -2,7 +2,7 @@ module Main
 
 import btree
 
-main : IO ()
+main : UnsafeIO ()
 main = do let t = toTree [1,8,2,7,9,3] 
           print (toList t)
 

--- a/tutorial/examples/hello.idr
+++ b/tutorial/examples/hello.idr
@@ -1,5 +1,5 @@
 module Main
 
-main : IO ()
+main : UnsafeIO ()
 main = putStrLn "Hello world"
 

--- a/tutorial/examples/interp.idr
+++ b/tutorial/examples/interp.idr
@@ -64,7 +64,7 @@ testFac = interp [] fact 4
 unitTestFac : so (interp [] fact 4 == 24)
 unitTestFac = oh
 
-main : IO ()
+main : UnsafeIO ()
 main = do putStr "Enter a number: "
           x <- getLine
           print (interp [] fact (cast x)) 

--- a/tutorial/interp.tex
+++ b/tutorial/interp.tex
@@ -325,7 +325,7 @@ on user input:
 
 \begin{SaveVerbatim}{factmain}
 
-main : IO ()
+main : UnsafeIO ()
 main = do putStr "Enter a number: "
           x <- getLine
           print (interp [] fact (cast x)) 

--- a/tutorial/miscellany.tex
+++ b/tutorial/miscellany.tex
@@ -117,7 +117,7 @@ greater than sign \texttt{>}, for example:
 
 This is a comment. The main program is below
 
-> main : IO ()
+> main : UnsafeIO ()
 > main = putStrLn "Hello literate world!\n"
 
 \end{SaveVerbatim}
@@ -176,15 +176,15 @@ ForeignTy : (xs:List FTy) -> (t:FTy) -> Type
 
 \noindent
 A foreign function is assumed to be impure, so \texttt{ForeignTy} builds an
-\texttt{IO} type, for example:
+\texttt{UnsafeIO} type, for example:
 
 \begin{SaveVerbatim}{ftyex}
 
 Idris> ForeignTy [FInt, FString] FString
-Int -> String -> IO String : Type
+Int -> String -> UnsafeIO String : Type
 
 Idris> ForeignTy [FInt, FString] FUnit 
-Int -> String -> IO () : Type
+Int -> String -> UnsafeIO () : Type
 
 \end{SaveVerbatim}
 \useverb{ftyex}
@@ -211,7 +211,7 @@ an external function \texttt{putStr} defined in the run-time system:
 
 \begin{SaveVerbatim}{putStrex}
 
-putStr : String -> IO ()
+putStr : String -> UnsafeIO ()
 putStr x = mkForeign (FFun "putStr" [FString] FUnit) x
 \end{SaveVerbatim}
 \useverb{putStrex}
@@ -234,9 +234,9 @@ This is made possible through the following directives:
 
 \subsubsection*{Testing foreign function calls}
 Normally, the Idris interpreter (used for typechecking and at the REPL) will
-not perform IO actions.  Additionally, as it neither generates C code nor
+not perform UnsafeIO actions.  Additionally, as it neither generates C code nor
 compiles to machine code, the \texttt{\%lib}, \texttt{\%include} and
-\texttt{\%link} directives have no effect. IO actions and FFI calls can be
+\texttt{\%link} directives have no effect. UnsafeIO actions and FFI calls can be
 tested using the special REPL command \texttt{:x EXPR}, and C libraries can be
 dynamically loaded in the interpreter by using the \texttt{:dynamic} command
 or the \texttt{\%dynamic} directive. For example:
@@ -258,7 +258,7 @@ against it, a type provider could read the schema of a real database during
 type checking.
 
 Idris type providers use the ordinary execution semantics of Idris to run an
-IO action and extract the result. This result is then saved as a constant in
+UnsafeIO action and extract the result. This result is then saved as a constant in
 the compiled code. It can be a type, in which case it is used like any other
 type, or it can be a value, in which case it can be used as any other value,
 including as an index in types.
@@ -275,7 +275,7 @@ use the \texttt{\%language} directive:
 
 
 A provider \texttt{p} for some type \texttt{t} is simply an expression of type
-\texttt{IO (Provider t)}. The \texttt{\%provide} directive causes the type
+\texttt{UnsafeIO (Provider t)}. The \texttt{\%provide} directive causes the type
 checker to execute the action and bind the result to a name.  This is perhaps
 best illustrated with a simple example. The type provider \texttt{fromFile}
 reads a text file. If the file consists of the string \texttt{"Int"}, then the
@@ -288,7 +288,7 @@ strToType : String -> Type
 strToType "Int" = Int
 strToType _ = Nat
 
-fromFile : String -> IO (Provider Type)
+fromFile : String -> UnsafeIO (Provider Type)
 fromFile fname = do str <- readFile fname
                     return (Provide (strToType (trim str)))
 
@@ -311,7 +311,7 @@ foo = 2
 If the file named \texttt{theType} consists of the word \texttt{Int}, then
 \texttt{foo} will be an \texttt{Int}. Otherwise, it will be a \texttt{Nat}.
 When Idris encounters the directive, it first checks that the provider
-expression \texttt{fromFile "theType"} has type \texttt{IO (Provider
+expression \texttt{fromFile "theType"} has type \texttt{UnsafeIO (Provider
   Type)}. Next, it executes the provider. If the result is \texttt{Provide t},
 then \texttt{T1} is defined as \texttt{t}. Otherwise, the result is an error.
 

--- a/tutorial/modules.tex
+++ b/tutorial/modules.tex
@@ -39,7 +39,7 @@ module Main
 
 import btree
 
-main : IO ()
+main : UnsafeIO ()
 main = do let t = toTree [1,8,2,7,9,3] 
           print (toList t)
 

--- a/tutorial/provisional.tex
+++ b/tutorial/provisional.tex
@@ -293,7 +293,7 @@ outputs it in binary.
 
 \begin{SaveVerbatim}{binmain}
 
-main : IO ()
+main : UnsafeIO ()
 main = do putStr "Enter a number: "
           x <- getLine
           print (natToBin (fromInteger (cast x)))

--- a/tutorial/starting.tex
+++ b/tutorial/starting.tex
@@ -37,7 +37,7 @@ text:
 
 module Main
 
-main : IO ()
+main : UnsafeIO ()
 main = putStrLn "Hello world"
 
 \end{SaveVerbatim}
@@ -140,7 +140,7 @@ $ idris hello.idr
 
 Type checking ./hello.idr
 *hello> :t main 
-main : IO ()
+main : UnsafeIO ()
 *hello> :c hello 
 *hello> :q 
 Bye bye

--- a/tutorial/syntax.tex
+++ b/tutorial/syntax.tex
@@ -105,7 +105,7 @@ exampe, a \texttt{for} loop binds a variable on each iteration:
 
 syntax for {x} "in" [xs] ":" [body] = forLoop xs (\x => body)
   
-main : IO ()
+main : UnsafeIO ()
 main = do for x in [1..10]:
               putStrLn ("Number " ++ show x)
           putStrLn "Done!"

--- a/tutorial/typesfuns.tex
+++ b/tutorial/typesfuns.tex
@@ -45,7 +45,7 @@ of indentation as the preceding declaration. Alternatively, declarations
 may be terminated with a semicolon.
 
 A library module \texttt{prelude} is automatically imported by every \Idris{} program,
-including facilities for IO, arithmetic, data structures and various common
+including facilities for UnsafeIO, arithmetic, data structures and various common
 functions. The prelude defines several arithmetic and comparison operators,
 which we can use at the prompt. Evaluating things at the prompt gives an
 answer, and the type of the answer. For example:
@@ -542,25 +542,25 @@ Computer programs are of little use if they do not interact with the user or
 the system in some way. The difficulty in a pure language such as \Idris{} ---
 that is, a language where expressions do not have side-effects --- is that I/O
 is inherently side-effecting. Therefore in \Idris{}, such interactions are
-encapsulated in the type \texttt{IO}:
+encapsulated in the type \texttt{UnsafeIO}:
 
 \begin{SaveVerbatim}{ioty}
 
-data IO a -- IO operation returning a value of type a
+data UnsafeIO a -- UnsafeIO operation returning a value of type a
 
 \end{SaveVerbatim}
 \useverb{ioty}
 
 \noindent
-We'll leave the definition of \texttt{IO} abstract, but effectively it describes what
+We'll leave the definition of \texttt{UnsafeIO} abstract, but effectively it describes what
 the I/O operations to be executed are, rather than how to execute them. The
 resulting operations are executed externally,
-by the run-time system. We've already seen one IO
+by the run-time system. We've already seen one UnsafeIO
 program:
 
 \begin{SaveVerbatim}{main}
 
-main : IO ()
+main : UnsafeIO ()
 main = putStrLn "Hello world"
 
 \end{SaveVerbatim}
@@ -573,8 +573,8 @@ outputs a string without a newline:
 
 \begin{SaveVerbatim}{putstr}
 
-putStrLn : String -> IO ()
-putStr   : String -> IO ()
+putStrLn : String -> UnsafeIO ()
+putStr   : String -> UnsafeIO ()
 
 \end{SaveVerbatim}
 
@@ -582,7 +582,7 @@ We can also read strings from user input:
 
 \begin{SaveVerbatim}{getline}
 
-getLine : IO String
+getLine : UnsafeIO String
 
 \end{SaveVerbatim}
 \useverb{getline}
@@ -596,14 +596,14 @@ writing files, including:
 data File -- abstract
 data Mode = Read | Write | ReadWrite
 
-openFile  : String -> Mode -> IO File
-closeFile : File -> IO ()
+openFile  : String -> Mode -> UnsafeIO File
+closeFile : File -> UnsafeIO ()
 
-fread  : File -> IO String
-fwrite : File -> String -> IO ()
-feof   : File -> IO Bool
+fread  : File -> UnsafeIO String
+fwrite : File -> String -> UnsafeIO ()
+feof   : File -> UnsafeIO Bool
 
-readFile : String -> IO String
+readFile : String -> UnsafeIO String
 
 \end{SaveVerbatim}
 \useverb{fileops}
@@ -613,13 +613,13 @@ readFile : String -> IO String
 \label{sect:do}
 
 I/O programs will typically need to sequence actions, feeding the output of one
-computation into the input of the next. \texttt{IO} is an abstract type, however, so we
+computation into the input of the next. \texttt{UnsafeIO} is an abstract type, however, so we
 can't access the result of a computation directly. Instead, we sequence
 operations with \texttt{do} notation:
 
 \begin{SaveVerbatim}{greet}
 
-greet : IO ()
+greet : UnsafeIO ()
 greet = do putStr "What is your name? "
            name <- getLine
            putStrLn ("Hello " ++ name)
@@ -629,17 +629,17 @@ greet = do putStr "What is your name? "
 
 \noindent
 The syntax \texttt{x <- iovalue} executes the I/O operation \texttt{iovalue}, of type 
-\texttt{IO a}, and
+\texttt{UnsafeIO a}, and
 puts the result, of type \texttt{a} into the variable \texttt{x}. 
-In this case, \texttt{getLine} returns an \texttt{IO String},
+In this case, \texttt{getLine} returns an \texttt{UnsafeIO String},
 so \texttt{name} has type \texttt{String}. Indentation is significant --- each
 statement in the do block must begin in the same column.
-The \texttt{return} operation allows us to inject a value directly into an IO
+The \texttt{return} operation allows us to inject a value directly into an UnsafeIO
 operation:
 
 \begin{SaveVerbatim}{return}
 
-return : a -> IO a
+return : a -> UnsafeIO a
 
 \end{SaveVerbatim}
 \useverb{return}
@@ -957,7 +957,7 @@ the point \texttt{(x,y)} is within the bounds of a 640x480 window:
 inBounds : Int -> Int -> Bool
 inBounds x y = x >= 0 && x < 640 && y >= 0 && y < 480
 
-drawPoint : (x : Int) -> (y : Int) -> so (inBounds x y) -> IO ()
+drawPoint : (x : Int) -> (y : Int) -> so (inBounds x y) -> UnsafeIO ()
 drawPoint x y p = unsafeDrawPoint x y
 
 \end{SaveVerbatim}


### PR DESCRIPTION
I know this introduces more breaking changes.

Rationale:

Bugreports like #185 a.k.a. (the forever-"bug") are issued by many people who expect
haskell-like behavior of IO which is not the case.

This patch proposes a more obvious name for IO and should point people gently 
into the direction of safer solutions for IO (e.g. Effects).

If people wish for an IO Monad they can build it on top of UnsafeIO.
