### PR TITLE
Treat Int as unsigned in C codegen when zero-extending to Integer

### DIFF
--- a/src/IRTS/CodegenC.hs
+++ b/src/IRTS/CodegenC.hs
@@ -364,8 +364,6 @@ doOp v (LSRem (ATInt (ITFixed ty))) [x, y] = bitOp v "SRem" ty [x, y]
 
 doOp v (LSExt (ITFixed from) ITBig) [x]
     = v ++ "MKBIGSI(vm, (" ++ signedTy from ++ ")" ++ creg x ++ "->info.bits" ++ show (nativeTyWidth from) ++ ")"
-doOp v (LZExt ITNative ITBig) [x]
-    = v ++ "MKBIGSI(vm, GETINT(" ++ creg x ++ "))"
 doOp v (LSExt ITNative (ITFixed to)) [x]
     = v ++ "idris_b" ++ show (nativeTyWidth to) ++ "const(vm, GETINT(" ++ creg x ++ "))"
 doOp v (LSExt ITChar (ITFixed to)) [x]
@@ -386,8 +384,8 @@ doOp v (LZExt (ITFixed from) ITChar) [x]
     = doOp v (LZExt (ITFixed from) ITNative) [x]
 doOp v (LZExt (ITFixed from) ITBig) [x]
     = v ++ "MKBIGUI(vm, " ++ creg x ++ "->info.bits" ++ show (nativeTyWidth from) ++ ")"
--- doOp v (LZExt ITNative ITBig) [x]
---     = v ++ "MKBIGUI(vm, (uintptr_t)GETINT(" ++ creg x ++ "))"
+doOp v (LZExt ITNative ITBig) [x]
+    = v ++ "MKBIGUI(vm, (uintptr_t)GETINT(" ++ creg x ++ "))"
 doOp v (LZExt (ITFixed from) (ITFixed to)) [x]
     | nativeTyWidth from < nativeTyWidth to = bitCoerce v "Z" from to x
 doOp v (LTrunc ITNative (ITFixed to)) [x]


### PR DESCRIPTION
This brings behavior into line with zext to fixed width integers and zext in the LLVM codegen, and ensures that cases where an Int wraps a size_t lose a minimum of information.
