### PR TITLE
Correct documentation for --cpu

### DIFF
--- a/src/Main.hs
+++ b/src/Main.hs
@@ -101,6 +101,6 @@ usagemsg = "Idris version " ++ ver ++ "\n" ++
            "\t--codegen [cg]    Select code generator: C, Java, bytecode, javascript,\n" ++
            "\t                  node or llvm\n" ++
            "\t--target [triple] Select target triple (for LLVM codegen)\n" ++
-           "\t--cpu [cpu]       Select target architecture (for LLVM codegen)\n"
+           "\t--cpu [cpu]       Select target CPU (e.g. corei7 or cortex-m3) (for LLVM codegen)\n"
 
 


### PR DESCRIPTION
Target architecture is described by the triple. --cpu specifies a specific CPU within an architecture.
