### PR TITLE
Set line buffering on stdout in REPL setup

### DIFF
--- a/src/Idris/REPL.hs
+++ b/src/Idris/REPL.hs
@@ -776,6 +776,8 @@ idrisMain opts =
        
        loadInputs inputs
 
+       liftIO $ hSetBuffering stdout LineBuffering
+
        ok <- noErrors
        when ok $ case output of
                     [] -> return ()


### PR DESCRIPTION
The runtime sets stdout to block buffering if it’s not connected to a terminal,
so a program piping from idris or idris --ideslave does not get responses as
they are written.
