### PR TITLE
Colourise some error messages

### DIFF
--- a/src/Idris/AbsSyntaxTree.hs
+++ b/src/Idris/AbsSyntaxTree.hs
@@ -1068,7 +1068,10 @@ showName ist bnd impl colour n = if colour then colourise n else showbasic n
                                     | isDConName n ctxt -> colouriseData name
                                     | isFnName n ctxt   -> colouriseFun name
                                     | isTConName n ctxt -> colouriseType name
-                                    | otherwise         -> name
+                                    -- The assumption is that if a name is not bound and does not exist in the
+                                    -- global context, then we're somewhere in which implicit info has been lost
+                                    -- (like error messages). Thus, unknown vars are colourised as implicits.
+                                    | otherwise         -> colouriseImplicit name
 
 -- | Show Idris term
 showImp :: Maybe IState -- ^^ the Idris state, for information about identifiers

--- a/src/Idris/Delaborate.hs
+++ b/src/Idris/Delaborate.hs
@@ -98,35 +98,40 @@ pshow i (Msg s) = s
 pshow i (InternalMsg s) = "INTERNAL ERROR: " ++ show s ++ 
    "\nThis is probably a bug, or a missing error message.\n" ++
    "Please consider reporting at " ++ bugaddr
-pshow i (CantUnify _ x y e sc s) 
+pshow i (CantUnify _ x y e sc s)
     = let imps = opt_showimp (idris_options i) in
-        "Can't unify " ++ showImp Nothing imps False (delab i x)
-          ++ " with " ++ showImp Nothing imps False (delab i y) ++
+      let colour = idris_colourRepl i in
+        "Can't unify " ++ showImp (Just i) imps colour (delab i x)
+          ++ " with " ++ showImp (Just i) imps colour (delab i y) ++
 --         " (" ++ show x ++ " and " ++ show y ++ ") " ++
         case e of
             Msg "" -> ""
-            _ -> "\n\nSpecifically:\n\t" ++ pshow i e ++ 
+            _ -> "\n\nSpecifically:\n\t" ++ pshow i e ++
                  if (opt_errContext (idris_options i)) then showSc i sc else ""
-pshow i (CantConvert x y env) 
+pshow i (CantConvert x y env)
     = let imps = opt_showimp (idris_options i) in
-          "Can't convert " ++ showImp Nothing imps False (delab i x) ++ " with " 
-                 ++ showImp Nothing imps False (delab i y) ++
+      let colour = idris_colourRepl i in
+          "Can't convert " ++ showImp (Just i) imps colour (delab i x) ++ " with "
+                 ++ showImp (Just i) imps colour (delab i y) ++
                  if (opt_errContext (idris_options i)) then showSc i env else ""
-pshow i (UnifyScope n out tm env) 
+pshow i (UnifyScope n out tm env)
     = let imps = opt_showimp (idris_options i) in
-          "Can't unify " ++ show n ++ " with " 
-                 ++ showImp Nothing imps False (delab i tm) ++ " as " ++ show out ++
+      let colour = idris_colourRepl i in
+          "Can't unify " ++ show n ++ " with "
+                 ++ showImp (Just i) imps colour (delab i tm) ++ " as " ++ show out ++
                  " is not in scope" ++
                  if (opt_errContext (idris_options i)) then showSc i env else ""
 pshow i (CantInferType t)
     = "Can't infer type for " ++ t
 pshow i (NonFunctionType f ty)
     = let imps = opt_showimp (idris_options i) in
-          showImp Nothing imps False (delab i f) ++ " does not have a function type ("
-            ++ showImp Nothing imps False (delab i ty) ++ ")"
+      let colour = idris_colourRepl i in
+          showImp (Just i) imps colour (delab i f) ++ " does not have a function type ("
+            ++ showImp (Just i) imps colour (delab i ty) ++ ")"
 pshow i (CantIntroduce ty)
     = let imps = opt_showimp (idris_options i) in
-          "Can't use lambda here: type is " ++ showImp Nothing imps False (delab i ty)
+      let colour = idris_colourRepl i in
+          "Can't use lambda here: type is " ++ showImp (Just i) imps colour (delab i ty)
 pshow i (InfiniteUnify x tm env)
     = "Unifying " ++ showbasic x ++ " and " ++ show (delab i tm) ++ 
       " would lead to infinite value" ++

--- a/test/reg010/run
+++ b/test/reg010/run
@@ -1,2 +1,2 @@
 #!/bin/bash
-idris $@ reg010.idr --check
+idris $@ reg010.idr --check --nocolour

--- a/test/test020/run
+++ b/test/test020/run
@@ -1,5 +1,5 @@
 #!/bin/bash
 idris $@ test020.idr -o test020
-idris $@ test020a.idr --check
+idris $@ test020a.idr --check --nocolor
 ./test020
 rm -f test020 *.ibc

--- a/test/test030/run
+++ b/test/test030/run
@@ -1,4 +1,4 @@
 #!/bin/bash
-idris $@ test030.idr --check
-idris $@ test030a.idr --check
+idris $@ test030.idr --check --nocolour
+idris $@ test030a.idr --check --nocolour
 rm -f *.ibc


### PR DESCRIPTION
Some error messages are now colourised as well. We assume that all unbound
names are implicit arguments, as the error message doesn't have sufficient
context otherwise.
