### PR TITLE
Prevent duplicate dynamic linking

### DIFF
--- a/src/Idris/REPL.hs
+++ b/src/Idris/REPL.hs
@@ -524,7 +524,10 @@ process fn (DynamicLink l) = do i <- getIState
                                 case handle of
                                   Nothing -> iFail $ "Could not load dynamic lib \"" ++ l ++ "\""
                                   Just x -> do let libs = idris_dynamic_libs i
-                                               putIState $ i { idris_dynamic_libs = x:libs }
+                                               if x `elem` libs
+                                                  then do iLOG ("Tried to load duplicate library " ++ lib_name x)
+                                                          return ()
+                                                  else putIState $ i { idris_dynamic_libs = x:libs }
     where trim = reverse . dropWhile isSpace . reverse . dropWhile isSpace
 process fn ListDynamic = do i <- getIState
                             iputStrLn "Dynamic libraries:"

--- a/src/Util/DynamicLinker.hs
+++ b/src/Util/DynamicLinker.hs
@@ -36,6 +36,9 @@ data DynamicLib = Lib { lib_name :: String
                       , lib_handle :: DL
                       }
 
+instance Eq DynamicLib where
+    (Lib a _) == (Lib b _) = a == b
+
 #ifndef WINDOWS
 tryLoadLib :: String -> IO (Maybe DynamicLib)
 tryLoadLib lib = do exactName <- doesFileExist lib


### PR DESCRIPTION
This fixes a bug where :r would stop type providers from working.
