### PR TITLE
Adding several functions to interact with environment variables.

### DIFF
--- a/lib/Prelude.idr
+++ b/lib/Prelude.idr
@@ -480,7 +480,7 @@ nullPtr p = do ok <- mkForeign (FFun "isNull" [FPtr] FInt) p
 
 partial
 nullStr : String -> IO Bool
-nullStr p = do ok <- mkForeign (FFun "isNullString" [FString] FInt) p
+nullStr p = do ok <- mkForeign (FFun "isNull" [FString] FInt) p
                return (ok /= 0);
 
 partial

--- a/llvm/defs.c
+++ b/llvm/defs.c
@@ -1,8 +1,11 @@
+#include <stdlib.h>
 #include <stdio.h>
 #include <gmp.h>
 #include <gc.h>
 #include <string.h>
 #include <inttypes.h>
+
+extern char** environ;
 
 void putStr(const char *str) {
   fputs(str, stdout);
@@ -119,8 +122,8 @@ int isNull(void* ptr) {
   return ptr==NULL;
 }
 
-int isNullString(char* str) {
-  return str==NULL;
+char* getEnvPair(int i) {
+    return *(environ + i);
 }
 
 void idris_memset(void* ptr, size_t offset, uint8_t c, size_t size) {

--- a/rts/idris_stdfgn.c
+++ b/rts/idris_stdfgn.c
@@ -1,6 +1,8 @@
 #include "idris_stdfgn.h"
 #include "idris_rts.h"
 
+extern char** environ;
+
 void putStr(char* str) {
     printf("%s", str);
 }
@@ -34,10 +36,10 @@ int isNull(void* ptr) {
     return ptr==NULL;
 }
 
-int isNullString(char* str) {
-    return str==NULL;
-}
-
 void* idris_stdin() {
     return (void*)stdin;
+}
+
+char* getEnvPair(int i) {
+    return *(environ + i);
 }

--- a/rts/idris_stdfgn.h
+++ b/rts/idris_stdfgn.h
@@ -13,7 +13,8 @@ int fileError(void* h);
 void fputStr(void*h, char* str);
 
 int isNull(void* ptr);
-int isNullString(char* str);
 void* idris_stdin();
+
+char* getEnvPair(int i);
 
 #endif


### PR DESCRIPTION
In addition to removing the superfluous 'isNullString' function,
now that I understand the FFI a bit better, there is a new
'getEnvPair' function that looks into the 'const char*\* environ'.
Setting, unsetting, and listing all of the environment variables is
now supported.

A test program that nearly mimics the standard Unix `env` utility is:

```
module Main

import System

mapM_ : (Monad m) => (a -> m b) -> List a -> m ()
mapM_ f xs = sequence_ (map f xs)

toEntry : (String, String) -> IO ()
toEntry (k, v) = do
  putStr k
  putStr "="
  putStrLn v

main : IO ()
main = getEnvironment >>= mapM_ toEntry
```

Potential problems:
- I'm not so happy with the `splitEq` function in `getEnvironment`. I feel that there is a more elegant solution that I'm missing, given my unfamiliarity with the language.
- The `getEnvPair` C-function is in multiple places. Should I keep them in these locations or is it possible to refactor them out to some common place?
