### PR TITLE
New Parser in Trifecta

### DIFF
--- a/src/Idris/Parser.hs
+++ b/src/Idris/Parser.hs
@@ -2562,7 +2562,7 @@ parseTactic :: IState -> String -> Result PTactic
 parseTactic st = parseString (evalStateT (fullTactic defaultSyntax) st) (Directed (UTF8.fromString "(input)") 0 0 0 0)
 
 -- | Parse module header and imports
-parseImports :: FilePath -> String -> Idris ([String], [String], Delta)
+parseImports :: FilePath -> String -> Idris ([String], [String], Maybe Delta)
 parseImports fname input
     = do i <- getIState
          case parseString (evalStateT imports i) (Directed (UTF8.fromString fname) 0 0 0 0) input of
@@ -2570,18 +2570,22 @@ parseImports fname input
               Success (x, i) -> do -- Discard state updates (there should be
                                    -- none anyway)
                                    return x
-  where imports :: IdrisParser (([String], [String], Delta), IState)
+  where imports :: IdrisParser (([String], [String], Maybe Delta), IState)
         imports = do whiteSpace
                      mname <- moduleHeader
                      ps    <- many import_
                      mrk   <- mark
+                     isEof <- lookAheadMatches eof
+                     let mrk' = if isEof
+                                   then Nothing
+                                   else Just mrk
                      i     <- get
-                     return ((mname, ps, mrk), i)
+                     return ((mname, ps, mrk'), i)
 
 
 -- | A program is a list of declarations, possibly with associated
 -- documentation strings.
-parseProg :: SyntaxInfo -> FilePath -> String -> Delta ->
+parseProg :: SyntaxInfo -> FilePath -> String -> Maybe Delta ->
              Idris [PDecl]
 parseProg syn fname input mrk
     = do i <- getIState
@@ -2595,10 +2599,13 @@ parseProg syn fname input mrk
             Success (x, i)  -> do putIState i
                                   return $ collect x
   where mainProg :: IdrisParser ([PDecl], IState)
-        mainProg = do release mrk
-                      ds <- prog syn
-                      i' <- get
-                      return (ds, i')
+        mainProg = case mrk of
+                        Nothing -> do i <- get; return ([], i)
+                        Just mrk -> do
+                          release mrk
+                          ds <- prog syn
+                          i' <- get
+                          return (ds, i')
 
 -- | Collect 'PClauses' with the same function name
 collect :: [PDecl] -> [PDecl]


### PR DESCRIPTION
Refactoring of old parser to Trifecta, documenting and updating some items/fixing some issues.
New features:
- Using Trifecta now for better built-in diagnostics, and support for better custom diagnostics in the future
- Grammar extracted and added to parser comments
- Every function has type declaration and every top-level function is documented with haddock
- Adding of <?> to most choices to get better error messages when expecting something
- Fixed some line number error with regard to parsing references to functions
- Should support the following now (will write the tests later):
1. proof and tactics as blocks similar to do e.g.
   
   ``` Idris
   proof intros
           compute
           trivial
   ```
2. Documentation comments in comments e.g.
   
   ``` Idris
   {-
      Commented method:
      {-| Converts a boolean to integer -}
      toInt :: Bool -> Int
   
      toInt False = 0
   
      toInt True  = 1 
   -}
   ```
3. Where is optional on empty instances e.g.

``` Idris
instance Eq MyTree
```

instead of requiring

``` Idris
instance Eq MyTree where
```
1. A tactic sequence can hold more than two tactics
   e.g.

``` Idris
{ compute; { intros; trivial } }
```

can now be written as

``` Idris
{ compute; intros; trivial }
```
1. using/params blocks can be empty e.g.

``` Idris
using (x : List a)
{- 
   dup : x -> x
   dup l = l ++ l
-}
```
1. should check for paranthesis closure before eof i.e.

``` Idris
main : IO ()
main = do { return 2;
```

should now fail
1. Other small fixes

Test 002 commented because of temporary disabling of TT quotation
support (as we discussed on mailing list).

Regression Test 003 and Test 020 have updated expected values (which
fixes previously erranous line number report from old parser).
