### PR TITLE
Fix building without LLVM

### DIFF
--- a/src/Util/LLVMStubs.hs
+++ b/src/Util/LLVMStubs.hs
@@ -11,6 +11,7 @@ import qualified Core.TT as TT
 import IRTS.Simplified
 import IRTS.CodegenCommon
 
+import Data.Word (Word)
 
 getDefaultTargetTriple :: IO String
 getDefaultTargetTriple = return ""
@@ -22,7 +23,7 @@ getHostCPUName = return ""
 codegenLLVM :: [(TT.Name, SDecl)] ->
                String -> -- target triple
                String -> -- target CPU
-               Int -> -- Optimization degree
+               Word -> -- Optimization degree
                FilePath -> -- output file name
                OutputType ->
                IO ()


### PR DESCRIPTION
This changes the LLVM stubs to conform to the interface of actual llvm-general, which recently changed. This thereby fixes `cabal install -f -LLVM`, which was erroring as reported by @nicolabotta in the comments of issue #460.
