### PR TITLE
Fix travis

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,6 +1,6 @@
 language: haskell
 before_install:
-  - sudo add-apt-repository ppa:h-rayflood/llvm
+  - sudo add-apt-repository --yes ppa:h-rayflood/llvm
   - sudo apt-get update -qq
   - sudo apt-get install -qq libgc-dev llvm-3.3
 before_script:


### PR DESCRIPTION
The LLVM project recently removed llvm-3.3 packages from their hosted ubuntu repositories. This switches travis over to using an Ubuntu-hosted PPA, and incidentally removes some redundancy to improve build times.
