### PR TITLE
Improvement regarding parsing of slices, and addproof syntax

### DIFF
--- a/src/Idris/ParseExpr.hs
+++ b/src/Idris/ParseExpr.hs
@@ -324,7 +324,7 @@ bracketed syn =
                 lchar ')'
                 return (PDPair fc l Placeholder r)
         <|> try(do fc0 <- getFC
-                   l <- simpleExpr syn
+                   l <- expr' syn
                    o <- operator
                    lchar ')'
                    return $ PLam (MN 1000 "ARG") Placeholder

--- a/src/Idris/Prover.hs
+++ b/src/Idris/Prover.hs
@@ -37,9 +37,9 @@ prover lit x =
 
 showProof :: Bool -> Name -> [String] -> String
 showProof lit n ps 
-    = bird ++ show n ++ " = proof {" ++ break ++
-             showSep break (map (\x -> "  " ++ x ++ ";") ps) ++
-                     break ++ "}\n"
+    = bird ++ show n ++ " = proof" ++ break ++
+             showSep break (map (\x -> "  " ++ x) ps) ++
+                     break ++ "\n"
   where bird = if lit then "> " else ""
         break = "\n" ++ bird
 


### PR DESCRIPTION
Changed the way addproof works to indented-block style
Allowed a larger range of expression to work with slices (improves on
idris-lang/Idris-dev#524)
