### PR TITLE
ipkg: Fix parsing of module names containing reserved words

### DIFF
--- a/src/Core/CoreParser.hs
+++ b/src/Core/CoreParser.hs
@@ -1,6 +1,6 @@
 {-# LANGUAGE MultiParamTypeClasses, FlexibleInstances #-}
 
-module Core.CoreParser(parseTerm, parseFile, parseDef, pTerm, iName, 
+module Core.CoreParser(parseTerm, parseFile, parseDef, pTerm, iName, iModuleName,
                        idrisLexer, maybeWithNS, pDocComment, opChars) where
 
 import Core.TT
@@ -92,6 +92,9 @@ operator  = PTok.operator lexer
 reservedOp= PTok.reservedOp lexer
 strlit    = PTok.stringLiteral lexer
 lchar = lexeme.char
+modulename= liftM2 (:) (satisfy isAlpha) (many $ satisfy isIdent)
+  where
+    isIdent c = isAlphaNum c || c == '_'
 
 type CParser a = GenParser Char a
 
@@ -105,6 +108,9 @@ pTestFile = do p <- many1 pDef ; eof
 
 iName :: [String] -> CParser a Name
 iName bad = maybeWithNS identifier False bad
+
+iModuleName :: [String] -> CParser a Name
+iModuleName bad = maybeWithNS modulename False bad
 
 -- Enhances a given parser to accept an optional namespace.  All possible
 -- namespace prefixes are tried in ascending / descending order, and

--- a/src/Pkg/PParser.hs
+++ b/src/Pkg/PParser.hs
@@ -67,11 +67,11 @@ pPkg = do reserved "package"; p <- identifier
 
 pClause :: PParser ()
 pClause = do reserved "executable"; lchar '=';
-             exec <- iName []
+             exec <- iModuleName []
              st <- getState
              setState (st { execout = Just (show exec) })
       <|> do reserved "main"; lchar '=';
-             main <- iName []
+             main <- iModuleName []
              st <- getState
              setState (st { idris_main = main })
       <|> do reserved "sourcedir"; lchar '=';
@@ -84,7 +84,7 @@ pClause = do reserved "executable"; lchar '=';
              let args = parseArgs (words opts)
              setState (st { idris_opts = args })
       <|> do reserved "modules"; lchar '=';
-             ms <- sepBy1 (iName []) (lchar ',') 
+             ms <- sepBy1 (iModuleName []) (lchar ',')
              st <- getState
              setState (st { modules = modules st ++ ms })
       <|> do reserved "libs"; lchar '=';

--- a/test/test032/Test/String.idr
+++ b/test/test032/Test/String.idr
@@ -1,0 +1,4 @@
+module Test.String
+
+foo : a -> a
+foo x = x

--- a/test/test032/expected
+++ b/test/test032/expected
@@ -1,0 +1,3 @@
+Type checking ./Test/String.idr
+Removing Test/String.ibc
+String.ibc does not exist.

--- a/test/test032/run
+++ b/test/test032/run
@@ -1,0 +1,12 @@
+#!/bin/bash
+
+idris --build test.ibc
+idris --clean test.ibc
+
+if [ -f "Test/String.ibc" ]; then
+	echo "String.ibc still exists!"
+else
+	echo "String.ibc does not exist."
+fi
+
+rm -f Test/String.ibc


### PR DESCRIPTION
The current ipkg parser incorrectly parses module names that contain reserved words, such as "Foo.String". This prevents `idris --clean pkg.ipkg` and `idris --install pkg.ipkg` from functioning correctly. (For example, `idris --clean` would attempt to delete `Foo.String.ibc` instead of `Foo/String.ibc`.) The reason is that inter-dot components of module names are parsed using the identifier parser, which excludes reserved words.

This patch replaces the inter-dot module name component parser with a simple parser corresponding to the regex [A-Za-z][A-Za-z0-9_]*.

This patch also adds test031, which fails on the master branch of Idris, while all tests pass after applying this fix.
