### PR TITLE
Fix broken build caused by 3fdf1a03

### DIFF
--- a/idris.cabal
+++ b/idris.cabal
@@ -93,8 +93,6 @@ Extra-source-files:
                        javascript/Makefile
                        javascript/javascript.ipkg
 
-                       js/*.js
-
                        llvm/*.c
                        llvm/Makefile
 


### PR DESCRIPTION
It's unclear if there are missing files or this line was just left in by mistake, but regardless it's breaking things.
