### PR TITLE
Convert IO errors into erros in the Idris monad

### DIFF
--- a/src/IRTS/Compiler.hs
+++ b/src/IRTS/Compiler.hs
@@ -67,31 +67,30 @@ compile codegen f tm
         dumpDefun <- getDumpDefun
         case dumpCases of
             Nothing -> return ()
-            Just f -> liftIO $ writeFile f (showCaseTrees tagged)
+            Just f -> runIO $ writeFile f (showCaseTrees tagged)
         case dumpDefun of
             Nothing -> return ()
-            Just f -> liftIO $ writeFile f (dumpDefuns defuns)
+            Just f -> runIO $ writeFile f (dumpDefuns defuns)
         triple <- targetTriple
         cpu <- targetCPU
         optimize <- optLevel
         iLOG "Building output"
         case checked of
-            OK c -> liftIO $ case codegen of
-                                  ViaC ->
-                                    codegenC c f outty hdrs
-                                      (concatMap mkObj objs)
-                                      (concatMap mkLib libs) 
-                                      (concatMap mkFlag flags ++
-                                       concatMap incdir impdirs) NONE
-                                  ViaJava ->
-                                    codegenJava [] c f hdrs libs outty
-                                  ViaJavaScript ->
-                                    codegenJavaScript JavaScript c f outty
-                                  ViaNode ->
-                                    codegenJavaScript Node c f outty
-                                  ViaLLVM -> codegenLLVM c triple cpu optimize f outty
-
-                                  Bytecode -> dumpBC c f
+            OK c -> runIO $ case codegen of
+                              ViaC ->
+                                  codegenC c f outty hdrs
+                                    (concatMap mkObj objs)
+                                    (concatMap mkLib libs) 
+                                    (concatMap mkFlag flags ++
+                                     concatMap incdir impdirs) NONE
+                              ViaJava ->
+                                  codegenJava [] c f hdrs libs outty
+                              ViaJavaScript ->
+                                  codegenJavaScript JavaScript c f outty
+                              ViaNode ->
+                                  codegenJavaScript Node c f outty
+                              ViaLLVM -> codegenLLVM c triple cpu optimize f outty
+                              Bytecode -> dumpBC c f
             Error e -> ierror e
   where checkMVs = do i <- getIState
                       case idris_metavars i \\ primDefs of

--- a/src/Idris/IBC.hs
+++ b/src/Idris/IBC.hs
@@ -62,7 +62,7 @@ initIBC = IBCFile ibcVersion "" [] [] [] [] [] [] [] [] [] [] [] [] [] [] [] [] 
 
 loadIBC :: FilePath -> Idris ()
 loadIBC fp = do iLOG $ "Loading ibc " ++ fp
-                ibcf <- liftIO $ (decodeFile fp :: IO IBCFile)
+                ibcf <- runIO $ (decodeFile fp :: IO IBCFile)
                 process ibcf fp
 
 writeIBC :: FilePath -> FilePath -> Idris ()
@@ -73,8 +73,8 @@ writeIBC src f
                 (_:_) -> ifail "Can't write ibc when there are unsolved metavariables"
                 [] -> return ()
          ibcf <- mkIBC (ibc_write i) (initIBC { sourcefile = src }) 
-         idrisCatch (do liftIO $ createDirectoryIfMissing True (dropFileName f)
-                        liftIO $ encodeFile f ibcf
+         idrisCatch (do runIO $ createDirectoryIfMissing True (dropFileName f)
+                        runIO $ encodeFile f ibcf
                         iLOG "Written")
             (\c -> do iLOG $ "Failed " ++ show c)
          return ()
@@ -140,8 +140,8 @@ process i fn
    | ver i /= ibcVersion = do iLOG "ibc out of date"
                               ifail "Incorrect ibc version --- please rebuild"
    | otherwise =
-            do srcok <- liftIO $ doesFileExist (sourcefile i)
-               when srcok $ liftIO $ timestampOlder (sourcefile i) fn
+            do srcok <- runIO $ doesFileExist (sourcefile i)
+               when srcok $ runIO $ timestampOlder (sourcefile i) fn
                v <- verbose
                quiet <- getQuiet
 --                when (v && srcok && not quiet) $ iputStrLn $ "Skipping " ++ sourcefile i
@@ -181,7 +181,7 @@ pImports fs
   = do mapM_ (\f -> do i <- getIState
                        ibcsd <- valIBCSubDir i
                        ids <- allImportDirs
-                       fp <- liftIO $ findImport ids ibcsd f
+                       fp <- runIO $ findImport ids ibcsd f
                        if (f `elem` imported i)
                         then iLOG $ "Already read " ++ f
                         else do putIState (i { imported = f : imported i })
@@ -259,7 +259,7 @@ pKeywords k = do i <- getIState
 
 pObjs :: [(Codegen, FilePath)] -> Idris ()
 pObjs os = mapM_ (\ (cg, obj) -> do dirs <- allImportDirs
-                                    o <- liftIO $ findInPath dirs obj
+                                    o <- runIO $ findInPath dirs obj
                                     addObjectFile cg o) os
 
 pLibs :: [(Codegen, String)] -> Idris ()

--- a/src/Idris/Parser.hs
+++ b/src/Idris/Parser.hs
@@ -975,7 +975,7 @@ loadSource lidr f
              = do iLOG ("Reading " ++ f)
                   i <- getIState
                   let def_total = default_total i
-                  file_in <- liftIO $ readFile f
+                  file_in <- runIO $ readFile f
                   file <- if lidr then tclift $ unlit f file_in else return file_in
                   (mname, modules, pos) <- parseImports f file
                   i <- getIState

--- a/src/Idris/Prover.hs
+++ b/src/Idris/Prover.hs
@@ -136,7 +136,7 @@ lifte st e = do (v, _) <- elabStep st e
 receiveInput :: ElabState [PDecl] -> Idris (Maybe String)
 receiveInput e =
   do i <- getIState
-     l <- liftIO $ getLine
+     l <- runIO $ getLine
      let (sexp, id) = parseMessage l
      putIState $ i { idris_outputmode = (IdeSlave id) }
      case sexpToCommand sexp of

--- a/src/Main.hs
+++ b/src/Main.hs
@@ -10,7 +10,6 @@ import Data.Maybe
 import Data.Version
 import Control.Monad.Trans.Error ( ErrorT(..) )
 import Control.Monad.Trans.State.Strict ( execStateT, get, put )
-import Control.Monad.Trans ( liftIO )
 import Control.Monad ( when )
 
 import Core.CoreParser
@@ -45,18 +44,18 @@ main = do xs <- getArgs
 
 runIdris :: [Opt] -> Idris ()
 runIdris opts = do
-       when (Ver `elem` opts) $ liftIO showver
-       when (Usage `elem` opts) $ liftIO usage
-       when (ShowIncs `elem` opts) $ liftIO showIncs
-       when (ShowLibs `elem` opts) $ liftIO showLibs
-       when (ShowLibdir `elem` opts) $ liftIO showLibdir
+       when (Ver `elem` opts) $ runIO showver
+       when (Usage `elem` opts) $ runIO usage
+       when (ShowIncs `elem` opts) $ runIO showIncs
+       when (ShowLibs `elem` opts) $ runIO showLibs
+       when (ShowLibdir `elem` opts) $ runIO showLibdir
        case opt getPkgClean opts of
            [] -> return ()
-           fs -> do liftIO $ mapM_ cleanPkg fs
-                    liftIO $ exitWith ExitSuccess
+           fs -> do runIO $ mapM_ cleanPkg fs
+                    runIO $ exitWith ExitSuccess
        case opt getPkg opts of
            [] -> idrisMain opts -- in Idris.REPL
-           fs -> liftIO $ mapM_ (buildPkg (WarnOnly `elem` opts)) fs
+           fs -> runIO $ mapM_ (buildPkg (WarnOnly `elem` opts)) fs
 
 usage = do putStrLn usagemsg
            exitWith ExitSuccess


### PR DESCRIPTION
Introduces a variant of liftIO, called runIO, that converts IO errors into
Idris errors with the Msg constructor.

Fixes #543.
