### PR TITLE
Make 'parameters' a keyword

### DIFF
--- a/src/Idris/ParseHelpers.hs
+++ b/src/Idris/ParseHelpers.hs
@@ -152,7 +152,7 @@ idrisStyle = IdentifierStyle _styleName _styleStart _styleLetter _styleReserved 
                                       "case", "of", "total", "partial", "mutual",
                                       "infix", "infixl", "infixr", "rewrite",
                                       "where", "with", "syntax", "proof", "postulate",
-                                      "using", "namespace", "class", "instance",
+                                      "using", "namespace", "class", "instance", "parameters",
                                       "public", "private", "abstract", "implicit",
                                       "quoteGoal",
                                       "Int", "Integer", "Float", "Char", "String", "Ptr",


### PR DESCRIPTION
Make 'parameters' a keyword such that parameters block doesn't parse as a function declaration. Fixes idris-lang/Idris-dev#546 .
