### PR TITLE
Broaden localhost checking

### DIFF
--- a/idris.cabal
+++ b/idris.cabal
@@ -357,6 +357,7 @@ Executable idris
                 , Util.Pretty
                 , Util.System
                 , Util.DynamicLinker
+                , Util.Net
 
                 , Pkg.Package
                 , Pkg.PParser

--- a/src/Idris/REPL.hs
+++ b/src/Idris/REPL.hs
@@ -27,6 +27,7 @@ import Idris.CaseSplit
 import Paths_idris
 import Util.System
 import Util.DynamicLinker
+import Util.Net (listenOnLocalhost)
 
 import Core.Evaluate
 import Core.Execute (execute)
@@ -111,7 +112,7 @@ startServer orig stvar fn_in = do tid <- runIO $ forkOS serverLoop
   where serverLoop :: IO ()
         -- TODO: option for port number
         serverLoop = withSocketsDo $ 
-                              do sock <- listenOn $ PortNumber 4294
+                              do sock <- listenOnLocalhost $ PortNumber 4294
                                  i <- readMVar stvar
                                  loop fn i sock
 

--- a/src/Util/Net.hs
+++ b/src/Util/Net.hs
@@ -1,0 +1,22 @@
+module Util.Net (listenOnLocalhost) where
+
+import Network
+import Network.Socket hiding (sClose, PortNumber)
+import Network.BSD (getProtocolNumber)
+import Control.Exception (bracketOnError)
+
+-- Copied from upstream impl of listenOn
+-- bound to localhost interface instead of iNADDR_ANY
+listenOnLocalhost (PortNumber port) = do
+    proto <- getProtocolNumber "tcp"
+    localhost <- inet_addr "127.0.0.1"
+    bracketOnError
+      (socket AF_INET Stream proto)
+      (sClose)
+      (\sock -> do
+          setSocketOption sock ReuseAddr 1
+          bindSocket sock (SockAddrInet port localhost)
+          listen sock maxListenQueue
+          return sock
+      )
+


### PR DESCRIPTION
- Broaden the check introduced in 229975d to account for
  "localhost.localdomain" patterns.

Perhaps `isPrefixOf "localhost"` would be desireable, instead?
- Only bind to the localhost interface from REPL network socket.
  Copied 'n pasted impl of
  http://hackage.haskell.org/package/network-2.2.1.7/docs/Network.html#v:listenOn
  modified to listen on localhost instead of iNADDR_ANY

Tested w/ netcat that I can connect when `host` is "localhost.localdomain", and that I can't when I try a non-127.0.0.1 interface on my local computer.
