### PR TITLE
Whitespace cleanup.

### DIFF
--- a/contribs/lib/SQLite3/testunit.idr
+++ b/contribs/lib/SQLite3/testunit.idr
@@ -1,18 +1,18 @@
 module Main
 import Sqlite3
 
-          
+
 testexpr : DB()
 testexpr = do db <- open_db "somedb.db"
               let sql = (evalSQL [] ((SELECT ALL)(TBL ["tbl1"])  (OR (AND (MkCond (Equals (VCol "data")(VStr "data0"))) (MkCond (Equals (VCol "num")(VInt 1))) )  (MkCond (Equals (VCol "num")(VInt 2))))))
-              let x = (fst sql) -- get the string 
+              let x = (fst sql) -- get the string
               let list = (snd sql) -- list of vals
               liftIO(print x) -- use liftIO to turn this into DB type
               stmt <- (prepare_db db x) -- prepare the statement
               bindMulti stmt list  -- bind the values in the list
               exec_db_v2 stmt     -- execute the prepared query
               res <- toList_v1 db  -- toList_v1 to get the result
-              liftIO(print res)    -- print the result  
+              liftIO(print res)    -- print the result
               finalize_db stmt     -- Statment pointer must be finalized in the end
               close_db db         -- close the datbase
               return ()
@@ -24,8 +24,8 @@ testupdate = do db <- open_db "somedb.db"
                 let list = (snd sql)
                 liftIO(print x)
                 stmt <- (prepare_db db x)
-                bindMulti stmt list 
-                exec_db_v2 stmt           
+                bindMulti stmt list
+                exec_db_v2 stmt
                 finalize_db stmt
                 close_db db
                 return ()
@@ -37,12 +37,12 @@ testInsert = do db <- open_db "somedb.db"
                 let list = (snd sql)
                 liftIO(print x)
                 stmt <- (prepare_db db x)
-                bindMulti stmt list 
-                exec_db_v2 stmt          
+                bindMulti stmt list
+                exec_db_v2 stmt
                 finalize_db stmt
                 close_db db
-                return ()  
-                
+                return ()
+
 testNull : DB()
 testNull = do db <- open_db "somedb.db"
               let sql = (evalSQL [] ((SELECT ALL)(TBL ["tbl1"]) (MkCond (MkNULL (VCol "data")))))
@@ -50,15 +50,15 @@ testNull = do db <- open_db "somedb.db"
               let list = (snd sql)
               liftIO(print x)
               stmt <- (prepare_db db x)
-              bindMulti stmt list 
+              bindMulti stmt list
               exec_db_v2 stmt
               res <- toList_v1 db
-              liftIO(print res)           
+              liftIO(print res)
               finalize_db stmt
               close_db db
-              return ()     
+              return ()
 
-                           
+
 testInsertWithCond : DB()
 testInsertWithCond = do db <- open_db "somedb.db"
                         let sql = (evalSQL [] (INSERTC (TBL ["tbl1"]) [(VCol "data"),(VCol "num")] [(VInt 30),(VStr "inserthere")]))
@@ -66,12 +66,12 @@ testInsertWithCond = do db <- open_db "somedb.db"
                         let list = (snd sql)
                         liftIO(print x)
                         stmt <- (prepare_db db x)
-                        bindMulti stmt list 
-                        exec_db_v2 stmt           
+                        bindMulti stmt list
+                        exec_db_v2 stmt
                         finalize_db stmt
                         close_db db
-                        return ()                  
-                                
+                        return ()
+
 -- Nested queries need to have the same column as the outer queries.
 testNestedSel1 : DB()
 testNestedSel1 = do db <- open_db "somedb.db"
@@ -80,13 +80,13 @@ testNestedSel1 = do db <- open_db "somedb.db"
                     let list = (snd sql)
                     liftIO(print x)
                     stmt <- (prepare_db db x)
-                    bindMulti stmt list 
-                    exec_db_v2 stmt 
+                    bindMulti stmt list
+                    exec_db_v2 stmt
                     res <- toList_v1 db
-                    liftIO(print res)           
+                    liftIO(print res)
                     finalize_db stmt
                     close_db db
-                    return ()                                                                                                                                
+                    return ()
 
 -- Testing Create Table
 testCreateTable : DB ()
@@ -96,11 +96,11 @@ testCreateTable =  do db <- open_db "somedb.db"
                       let list = (snd sql)
                       liftIO(print x)
                       stmt <- (prepare_db db x)
-                      bindMulti stmt list 
-                      exec_db_v2 stmt           
+                      bindMulti stmt list
+                      exec_db_v2 stmt
                       finalize_db stmt
                       close_db db
-                      return () 
+                      return ()
 
 -- This may be a bit slow
 testMultiTable : DB ()
@@ -110,14 +110,14 @@ testMultiTable = do db <- open_db "somedb.db"
                     let list = (snd sql)
                     liftIO(print x)
                     stmt <- (prepare_db db x)
-                    bindMulti stmt list 
-                    exec_db_v2 stmt 
+                    bindMulti stmt list
+                    exec_db_v2 stmt
                     res <- toList_v1 db
-                    liftIO(print res)          
+                    liftIO(print res)
                     finalize_db stmt
                     close_db db
                     return ()
-                      
+
 testSelAll : DB ()
 testSelAll = do db <- open_db "somedb.db"
                 let sql = (evalSQL [] ((SELECT ALL )(TBL ["tbl1"]) (Empty) ) )
@@ -125,15 +125,15 @@ testSelAll = do db <- open_db "somedb.db"
                 let list = (snd sql)
                 liftIO(print x)
                 stmt <- (prepare_db db x)
-                bindMulti stmt list 
-                exec_db_v2 stmt 
+                bindMulti stmt list
+                exec_db_v2 stmt
                 res <- toList_v1 db
-                liftIO(print res)          
+                liftIO(print res)
                 finalize_db stmt
                 close_db db
                 return ()
 
-                      
+
 main : IO ()
 main = do x <- runDB (testMultiTable) -- runDB : DB a -> IO a
           --y <- runDB (testNestedSel1)

--- a/effects/Effect/Exception.idr
+++ b/effects/Effect/Exception.idr
@@ -5,7 +5,7 @@ import System
 import Control.IOExcept
 
 data Exception : Type -> Type -> Type -> Type -> Type where
-     Raise : a -> Exception a () () b 
+     Raise : a -> Exception a () () b
 
 instance Handler (Exception a) Maybe where
      handle _ (Raise e) k = Nothing
@@ -21,7 +21,7 @@ instance Handler (Exception a) (Either a) where
      handle _ (Raise e) k = Left e
 
 EXCEPTION : Type -> EFFECT
-EXCEPTION t = MkEff () (Exception t) 
+EXCEPTION t = MkEff () (Exception t)
 
 raise : a -> Eff m [EXCEPTION a] b
 raise err = Raise err

--- a/effects/Effect/File.idr
+++ b/effects/Effect/File.idr
@@ -9,11 +9,11 @@ data OpenFile : Mode -> Type where
 data FileIO : Effect where
      Open  : String -> (m : Mode) -> FileIO () (Either () (OpenFile m)) Bool
      Close :                         FileIO (OpenFile m) () ()
-  
+
      ReadLine  :           FileIO (OpenFile Read)  (OpenFile Read) String
      WriteLine : String -> FileIO (OpenFile Write) (OpenFile Write) ()
      EOF       :           FileIO (OpenFile Read)  (OpenFile Read) Bool
-  
+
 
 instance Handler FileIO IO where
     handle () (Open fname m) k = do h <- openFile fname m
@@ -30,7 +30,7 @@ instance Handler FileIO IO where
                                          k (FH h) e
 
 instance Handler FileIO (IOExcept String) where
-    handle () (Open fname m) k 
+    handle () (Open fname m) k
        = do h <- ioe_lift (openFile fname m)
             valid <- ioe_lift (validFile h)
             if valid then k (Right (FH h)) True
@@ -44,10 +44,10 @@ instance Handler FileIO (IOExcept String) where
                                          k (FH h) e
 
 FILE_IO : Type -> EFFECT
-FILE_IO t = MkEff t FileIO 
+FILE_IO t = MkEff t FileIO
 
 open : Handler FileIO e =>
-       String -> (m : Mode) -> EffM e [FILE_IO ()] 
+       String -> (m : Mode) -> EffM e [FILE_IO ()]
                                       [FILE_IO (Either () (OpenFile m))] Bool
 open f m = Open f m
 

--- a/effects/Effect/Select.idr
+++ b/effects/Effect/Select.idr
@@ -14,7 +14,7 @@ instance Handler Selection Maybe where
 
 instance Handler Selection List where
      handle r (Select xs) k = concatMap (k r) xs
-     
+
 SELECT : EFFECT
 SELECT = MkEff () Selection
 

--- a/effects/Effect/State.idr
+++ b/effects/Effect/State.idr
@@ -17,7 +17,7 @@ STATE : Type -> EFFECT
 STATE t = MkEff t State
 
 get : Eff m [STATE x] x
-get = Get 
+get = Get
 
 put : x -> Eff m [STATE x] ()
 put val = Put val
@@ -26,7 +26,7 @@ putM : y -> EffM m [STATE x] [STATE y] ()
 putM val = Put val
 
 update : (x -> x) -> Eff m [STATE x] ()
-update f = put (f !get) 
+update f = put (f !get)
 
 updateM : (x -> y) -> EffM m [STATE x] [STATE y] ()
 updateM f = putM (f !get)

--- a/effects/Effect/StdIO.idr
+++ b/effects/Effect/StdIO.idr
@@ -9,16 +9,16 @@ data StdIO : Effect where
 
 instance Handler StdIO IO where
     handle () (PutStr s) k = do putStr s; k () ()
-    handle () GetStr     k = do x <- getLine; k () x 
+    handle () GetStr     k = do x <- getLine; k () x
 
 instance Handler StdIO (IOExcept a) where
     handle () (PutStr s) k = do ioe_lift (putStr s); k () ()
-    handle () GetStr     k = do x <- ioe_lift getLine; k () x 
+    handle () GetStr     k = do x <- ioe_lift getLine; k () x
 
 -- Handle effects in a pure way, for simulating IO for unit testing/proof
 
 data IOStream a = MkStream (List String -> (a, List String))
-  
+
 instance Handler StdIO IOStream where
     handle () (PutStr s) k
        = MkStream (\x => case k () () of
@@ -31,7 +31,7 @@ instance Handler StdIO IOStream where
         where
             cont : String -> List String -> (a, List String)
             cont t ts = case k () t of
-                             MkStream f => f ts 
+                             MkStream f => f ts
 
 --- The Effect and associated functions
 
@@ -47,8 +47,8 @@ putStrLn s = putStr (s ++ "\n")
 getStr : Handler StdIO e => Eff e [STDIO] String
 getStr = GetStr
 
-mkStrFn : Env IOStream xs -> 
-          Eff IOStream xs a -> 
+mkStrFn : Env IOStream xs ->
+          Eff IOStream xs a ->
           List String -> (a, List String)
 mkStrFn {a} env p input = case mkStrFn' of
                                MkStream f => f input
@@ -57,4 +57,4 @@ mkStrFn {a} env p input = case mkStrFn' of
         mkStrFn' : IOStream a
         mkStrFn' = runWith injStream env p
 
-  
+

--- a/lib/Builtins.idr
+++ b/lib/Builtins.idr
@@ -39,7 +39,7 @@ believe_me : a -> b -- compiled specially as id, use with care!
 believe_me x = prim__believe_me _ _ x
 
 public %assert_total -- reduces at compile time, use with extreme care!
-really_believe_me : a -> b 
+really_believe_me : a -> b
 really_believe_me x = prim__believe_me _ _ x
 
 namespace Builtins {
@@ -84,7 +84,7 @@ data Dec : Type -> Type where
 
 data Bool = False | True
 
-boolElim : Bool -> |(t : a) -> |(f : a) -> a 
+boolElim : Bool -> |(t : a) -> |(f : a) -> a
 boolElim True  t e = t
 boolElim False t e = e
 
@@ -120,7 +120,7 @@ intToBool 0 = False
 intToBool x = True
 
 boolOp : (a -> a -> Int) -> a -> a -> Bool
-boolOp op x y = intToBool (op x y) 
+boolOp op x y = intToBool (op x y)
 
 class Eq a where
     (==) : a -> a -> Bool
@@ -129,7 +129,7 @@ class Eq a where
     x /= y = not (x == y)
     x == y = not (x /= y)
 
-instance Eq Int where 
+instance Eq Int where
     (==) = boolOp prim__eqInt
 
 instance Eq Integer where
@@ -162,11 +162,11 @@ instance Eq Ordering where
     GT == GT = True
     _  == _  = False
 
-class Eq a => Ord a where 
+class Eq a => Ord a where
     compare : a -> a -> Ordering
 
     (<) : a -> a -> Bool
-    (<) x y with (compare x y) 
+    (<) x y with (compare x y)
         (<) x y | LT = True
         (<) x y | _  = False
 
@@ -188,31 +188,31 @@ class Eq a => Ord a where
     min x y = if (x < y) then x else y
 
 
-instance Ord Int where 
+instance Ord Int where
     compare x y = if (x == y) then EQ else
                   if (boolOp prim__sltInt x y) then LT else
                   GT
 
 
-instance Ord Integer where 
+instance Ord Integer where
     compare x y = if (x == y) then EQ else
                   if (boolOp prim__sltBigInt x y) then LT else
                   GT
 
 
-instance Ord Float where 
+instance Ord Float where
     compare x y = if (x == y) then EQ else
                   if (boolOp prim__sltFloat x y) then LT else
                   GT
 
 
-instance Ord Char where 
+instance Ord Char where
     compare x y = if (x == y) then EQ else
                   if (boolOp prim__sltChar x y) then LT else
                   GT
 
 
-instance Ord String where 
+instance Ord String where
     compare x y = if (x == y) then EQ else
                   if (boolOp prim__ltString x y) then LT else
                   GT
@@ -225,7 +225,7 @@ instance (Ord a, Ord b) => Ord (a, b) where
       else compare xr yr
 
 
-class Num a where 
+class Num a where
     (+) : a -> a -> a
     (-) : a -> a -> a
     (*) : a -> a -> a
@@ -233,7 +233,7 @@ class Num a where
     abs : a -> a
     fromInteger : Integer -> a
 
-instance Num Integer where 
+instance Num Integer where
     (+) = prim__addBigInt
     (-) = prim__subBigInt
     (*) = prim__mulBigInt
@@ -241,7 +241,7 @@ instance Num Integer where
     abs x = if x < 0 then -x else x
     fromInteger = id
 
-instance Num Int where 
+instance Num Int where
     (+) = prim__addInt
     (-) = prim__subInt
     (*) = prim__mulInt
@@ -250,7 +250,7 @@ instance Num Int where
     abs x = if x < (prim__truncBigInt_Int 0) then -x else x
 
 
-instance Num Float where 
+instance Num Float where
     (+) = prim__addFloat
     (-) = prim__subFloat
     (*) = prim__mulFloat

--- a/lib/Control/Monad/Identity.idr
+++ b/lib/Control/Monad/Identity.idr
@@ -2,7 +2,7 @@ module Control.Monad.Identity
 
 import Prelude.Functor
 import Prelude.Applicative
-import Prelude.Monad 
+import Prelude.Monad
 
 public record Identity : Type -> Type where
     Id : (runIdentity : a) -> Identity a
@@ -12,7 +12,7 @@ instance Functor Identity where
 
 instance Applicative Identity where
     pure x = Id x
-    
+
     (Id f) <$> (Id g) = Id (f g)
 
 instance Monad Identity where

--- a/lib/Control/Monad/State.idr
+++ b/lib/Control/Monad/State.idr
@@ -33,7 +33,7 @@ instance Monad m => Monad (StateT s m) where
 
 instance Monad m => MonadState s (StateT s m) where
     get   = ST (\x => return (x, x))
-    put x = ST (\y => return ((), x)) 
+    put x = ST (\y => return ((), x))
 
 modify : MonadState s m => (s -> s) -> m ()
 modify f = do s <- get

--- a/lib/Data/Bits.idr
+++ b/lib/Data/Bits.idr
@@ -33,7 +33,7 @@ bitsUsed n = 8 * (2 `power` n)
 natToBits' : machineTy n -> Nat -> machineTy n
 natToBits' a Z = a
 natToBits' {n=n} a x with (n)
- -- it seems I have to manually recover the value of n here, instead of being able to reference it  
+ -- it seems I have to manually recover the value of n here, instead of being able to reference it
  natToBits' a (S x') | Z           = natToBits' {n=0} (prim__addB8  a (prim__truncInt_B8  1)) x'
  natToBits' a (S x') | S Z         = natToBits' {n=1} (prim__addB16 a (prim__truncInt_B16 1)) x'
  natToBits' a (S x') | S (S Z)     = natToBits' {n=2} (prim__addB32 a (prim__truncInt_B32 1)) x'
@@ -114,7 +114,7 @@ shiftRightLogical' {n=n} x c with (n)
 
 public
 shiftRightLogical : Bits n -> Bits n -> Bits n
-shiftRightLogical {n} (MkBits x) (MkBits y) 
+shiftRightLogical {n} (MkBits x) (MkBits y)
     = MkBits {n} (shiftRightLogical' {n=nextBytes n} x y)
 
 shiftRightArithmetic' : machineTy (nextBytes n) -> machineTy (nextBytes n) -> machineTy (nextBytes n)

--- a/lib/Data/Morphisms.idr
+++ b/lib/Data/Morphisms.idr
@@ -1,6 +1,6 @@
 module Data.Morphisms
 
-import Prelude 
+import Prelude
 
 %access public
 

--- a/lib/Debug/Trace.idr
+++ b/lib/Debug/Trace.idr
@@ -4,6 +4,6 @@ import Prelude
 import IO
 
 trace : String -> a -> a
-trace x val = unsafePerformIO (do putStrLn x; return val) 
+trace x val = unsafePerformIO (do putStrLn x; return val)
 
 

--- a/lib/Decidable/Equality.idr
+++ b/lib/Decidable/Equality.idr
@@ -109,9 +109,9 @@ lemma_both_neq p_x_not_x' p_y_not_y' refl = p_x_not_x' refl
 lemma_snd_neq : {x : a, y : b, y' : d} -> (x = x) -> (y = y' -> _|_) -> ((x, y) = (x, y') -> _|_)
 lemma_snd_neq refl p refl = p refl
 
-lemma_fst_neq_snd_eq : {x : a, x' : b, y : c, y' : d} -> 
-                       (x = x' -> _|_) -> 
-                       (y = y') -> 
+lemma_fst_neq_snd_eq : {x : a, x' : b, y : c, y' : d} ->
+                       (x = x' -> _|_) ->
+                       (y = y') ->
                        ((x, y) = (x', y) -> _|_)
 lemma_fst_neq_snd_eq p_x_not_x' refl refl = p_x_not_x' refl
 
@@ -133,7 +133,7 @@ lemma_val_not_nil : {x : t, xs : List t} -> ((x :: xs) = Prelude.List.Nil {a = t
 lemma_val_not_nil refl impossible
 
 lemma_x_eq_xs_neq : {x : t, xs : List t, y : t, ys : List t} -> (x = y) -> (xs = ys -> _|_) -> ((x :: xs) = (y :: ys) -> _|_)
-lemma_x_eq_xs_neq refl p refl = p refl 
+lemma_x_eq_xs_neq refl p refl = p refl
 
 lemma_x_neq_xs_eq : {x : t, xs : List t, y : t, ys : List t} -> (x = y -> _|_) -> (xs = ys) -> ((x :: xs) = (y :: ys) -> _|_)
 lemma_x_neq_xs_eq p refl refl = p refl

--- a/lib/Decidable/Order.idr
+++ b/lib/Decidable/Order.idr
@@ -45,7 +45,7 @@ instance Preorder Nat NatLTE where
   transitive = NatLTEIsTransitive
   reflexive  = NatLTEIsReflexive
 
-total NatLTEIsAntisymmetric : (m : Nat) -> (n : Nat) -> 
+total NatLTEIsAntisymmetric : (m : Nat) -> (n : Nat) ->
                               NatLTE m n -> NatLTE n m -> m = n
 NatLTEIsAntisymmetric n n nEqn nEqn = refl
 NatLTEIsAntisymmetric n m nEqn (nLTESm _) impossible

--- a/lib/IO.idr
+++ b/lib/IO.idr
@@ -97,34 +97,34 @@ ForeignTy (t::ts) rt = interpFTy t -> ForeignTy ts rt
 
 
 data Foreign : Type -> Type where
-    FFun : String -> (xs:List FTy) -> (t:FTy) -> 
+    FFun : String -> (xs:List FTy) -> (t:FTy) ->
            Foreign (ForeignTy xs t)
 
 mkForeignPrim : Foreign x -> x
 mkLazyForeignPrim : Foreign x -> x
 -- mkForeign and mkLazyForeign compiled as primitives
 
-abstract 
+abstract
 io_bind : IO a -> (a -> IO b) -> IO b
 io_bind (MkIO fn) k
    = MkIO (\w => prim_io_bind (fn w)
                     (\ b => case k b of
                                  MkIO fkb => fkb w))
 
-abstract 
+abstract
 io_return : a -> IO a
 io_return x = MkIO (\w => prim_io_return x)
 
 liftPrimIO : (World -> PrimIO a) -> IO a
-liftPrimIO f = MkIO (\w => prim_io_bind (f w) 
+liftPrimIO f = MkIO (\w => prim_io_bind (f w)
                          (\x => prim_io_return x))
 
 run__IO : IO () -> PrimIO ()
-run__IO (MkIO f) = prim_io_bind (f TheWorld) 
+run__IO (MkIO f) = prim_io_bind (f TheWorld)
                         (\ b => prim_io_return b)
 
 run__provider : IO a -> PrimIO a
-run__provider (MkIO f) = prim_io_bind (f TheWorld) 
+run__provider (MkIO f) = prim_io_bind (f TheWorld)
                             (\ b => prim_io_return b)
 
 -- io_bind v (\v' => io_return v')
@@ -143,7 +143,7 @@ prim_fread : Ptr -> IO String
 prim_fread h = MkIO (\w => prim_io_return (prim__readString h))
 
 unsafePerformIO : IO a -> a
-unsafePerformIO (MkIO f) = unsafePerformPrimIO 
+unsafePerformIO (MkIO f) = unsafePerformPrimIO
         (prim_io_bind (f TheWorld) (\ b => prim_io_return b))
 
 

--- a/lib/Language/Reflection.idr
+++ b/lib/Language/Reflection.idr
@@ -172,7 +172,7 @@ data Tactic = Try Tactic Tactic
             | Reflect TT
             -- ^ turn a value into its reflected representation
             | Fill Raw
-            -- ^ turn a raw value back into a term 
+            -- ^ turn a raw value back into a term
             | Exact TT
             -- ^ use the given value to conclude the proof
             | Focus TTName

--- a/lib/Network/Cgi.idr
+++ b/lib/Network/Cgi.idr
@@ -33,7 +33,7 @@ instance Functor CGI where
 
 instance Applicative CGI where
     pure v = MkCGI (\s => return (v, s))
-    
+
     (MkCGI a) <$> (MkCGI b) = MkCGI (\s => do (f, i) <- a s
                                               (c, j) <- b i
                                               return (f c, j))
@@ -50,9 +50,9 @@ getInfo : CGI CGIInfo
 getInfo = MkCGI (\s => return (s, s))
 
 abstract
-lift : IO a -> CGI a 
+lift : IO a -> CGI a
 lift op = MkCGI (\st => do { x <- op
-                             return (x, st) } ) 
+                             return (x, st) } )
 
 abstract
 output : String -> CGI ()
@@ -95,10 +95,10 @@ flushHeaders = do o <- getHeaders
 abstract
 flush : CGI ()
 flush = do o <- getOutput
-           lift (putStr o) 
+           lift (putStr o)
 
 getVars : List Char -> String -> List (String, String)
-getVars seps query = mapMaybe readVar (split (\x => elem x seps) query) 
+getVars seps query = mapMaybe readVar (split (\x => elem x seps) query)
   where
     readVar : String -> Maybe (String, String)
     readVar xs with (split (\x => x == '=') xs)
@@ -118,11 +118,11 @@ getContent x = getC x "" where
 getCgiEnv : String -> IO String
 getCgiEnv key = do
   val <- getEnv key
-  return $ maybe "" id val 
+  return $ maybe "" id val
 
 abstract
 runCGI : CGI a -> IO a
-runCGI prog = do 
+runCGI prog = do
     clen_in <- getCgiEnv "CONTENT_LENGTH"
     let clen = prim__fromStrInt clen_in
     content <- getContent clen
@@ -134,8 +134,8 @@ runCGI prog = do
     let post_vars = getVars ['&'] content
     let cookies   = getVars [';'] cookie
 
-    (v, st) <- getAction prog (CGISt get_vars post_vars cookies agent 
-                 "Content-type: text/html\n" 
+    (v, st) <- getAction prog (CGISt get_vars post_vars cookies agent
+                 "Content-type: text/html\n"
                  "")
     putStrLn (Headers st)
     putStr (Output st)

--- a/lib/Prelude.idr
+++ b/lib/Prelude.idr
@@ -23,28 +23,28 @@ import Prelude.Bits
 
 -- Show and instances
 
-class Show a where 
+class Show a where
     partial show : a -> String
 
-instance Show Int where 
+instance Show Int where
     show = prim__toStrInt
 
-instance Show Integer where 
+instance Show Integer where
     show = prim__toStrBigInt
 
-instance Show Float where 
+instance Show Float where
     show = prim__floatToStr
 
-instance Show Char where 
-    show x = strCons x "" 
+instance Show Char where
+    show x = strCons x ""
 
-instance Show String where 
+instance Show String where
     show = id
 
-instance Show Nat where 
+instance Show Nat where
     show n = show (the Integer (cast n))
 
-instance Show Bool where 
+instance Show Bool where
     show True = "True"
     show False = "False"
 
@@ -163,23 +163,23 @@ instance Show Bits64x2 where
         ++ ", " ++ prim__toStrB64 b
         ++ ">"
 
-instance (Show a, Show b) => Show (a, b) where 
+instance (Show a, Show b) => Show (a, b) where
     show (x, y) = "(" ++ show x ++ ", " ++ show y ++ ")"
 
-instance Show a => Show (List a) where 
-    show xs = "[" ++ show' "" xs ++ "]" where 
+instance Show a => Show (List a) where
+    show xs = "[" ++ show' "" xs ++ "]" where
         show' acc []        = acc
         show' acc [x]       = acc ++ show x
         show' acc (x :: xs) = show' (acc ++ show x ++ ", ") xs
 
-instance Show a => Show (Vect n a) where 
-    show xs = "[" ++ show' xs ++ "]" where 
+instance Show a => Show (Vect n a) where
+    show xs = "[" ++ show' xs ++ "]" where
         show' : Vect n a -> String
         show' []        = ""
         show' [x]       = show x
         show' (x :: xs) = show x ++ ", " ++ show' xs
 
-instance Show a => Show (Maybe a) where 
+instance Show a => Show (Maybe a) where
     show Nothing = "Nothing"
     show (Just x) = "Just " ++ show x
 
@@ -191,7 +191,7 @@ instance Functor PrimIO where
 instance Functor IO where
     map f io = io_bind io (\b => io_return (f b))
 
-instance Functor Maybe where 
+instance Functor Maybe where
     map f (Just x) = Just (f x)
     map f Nothing  = Nothing
 
@@ -203,7 +203,7 @@ instance Functor (Either e) where
 
 instance Applicative PrimIO where
     pure = prim_io_return
-    
+
     am <$> bm = prim_io_bind am (\f => prim_io_bind bm (prim_io_return . f))
 
 instance Applicative IO where
@@ -245,18 +245,18 @@ instance Alternative Maybe where
 
 instance Alternative List where
     empty = []
-    
+
     (<|>) = (++)
 
 ---- Monad instances
 
-instance Monad PrimIO where 
+instance Monad PrimIO where
     b >>= k = prim_io_bind b k
 
 instance Monad IO where
     b >>= k = io_bind b k
 
-instance Monad Maybe where 
+instance Monad Maybe where
     Nothing  >>= k = Nothing
     (Just x) >>= k = k x
 
@@ -264,7 +264,7 @@ instance Monad (Either e) where
     (Left n) >>= _ = Left n
     (Right r) >>= f = f r
 
-instance Monad List where 
+instance Monad List where
     m >>= f = concatMap f m
 
 instance Monad (Vect n) where
@@ -347,19 +347,19 @@ partial abstract
 count : (Ord a, Num a) => a -> a -> a -> List a
 count a inc b = if a <= b then a :: count (a + inc) inc b
                           else []
-  
+
 partial abstract
 countFrom : (Ord a, Num a) => a -> a -> List a
 countFrom a inc = a :: lazy (countFrom (a + inc) inc)
-  
-syntax "[" [start] ".." [end] "]" 
-     = count start 1 end 
-syntax "[" [start] "," [next] ".." [end] "]" 
-     = count start (next - start) end 
 
-syntax "[" [start] "..]" 
+syntax "[" [start] ".." [end] "]"
+     = count start 1 end
+syntax "[" [start] "," [next] ".." [end] "]"
+     = count start (next - start) end
+
+syntax "[" [start] "..]"
      = countFrom start 1
-syntax "[" [start] "," [next] "..]" 
+syntax "[" [start] "," [next] "..]"
      = countFrom start (next - start)
 
 ---- More utilities
@@ -410,25 +410,25 @@ getChar = map cast $ mkForeign (FFun "getchar" [] FInt)
 
 ---- some basic file handling
 
-abstract 
+abstract
 data File = FHandle Ptr
 
 partial stdin : File
 stdin = FHandle prim__stdin
 
 do_fopen : String -> String -> IO Ptr
-do_fopen f m 
+do_fopen f m
    = mkForeign (FFun "fileOpen" [FString, FString] FPtr) f m
 
 fopen : String -> String -> IO File
 fopen f m = do h <- do_fopen f m
-               return (FHandle h) 
+               return (FHandle h)
 
 data Mode = Read | Write | ReadWrite
 
 partial
 openFile : String -> Mode -> IO File
-openFile f m = fopen f (modeStr m) where 
+openFile f m = fopen f (modeStr m) where
   modeStr Read  = "r"
   modeStr Write = "w"
   modeStr ReadWrite = "r+"
@@ -454,7 +454,7 @@ fread (FHandle h) = do_fread h
 
 partial
 do_fwrite : Ptr -> String -> IO ()
-do_fwrite h s 
+do_fwrite h s
    = mkForeign (FFun "fputStr" [FPtr, FString] FUnit) h s
 
 partial
@@ -498,7 +498,7 @@ while t b = do v <- t
                if v then do b
                             while t b
                     else return ()
-               
+
 partial -- no error checking!
 readFile : String -> IO String
 readFile fn = do h <- openFile fn Read
@@ -508,7 +508,7 @@ readFile fn = do h <- openFile fn Read
   where
     partial
     readFile' : File -> String -> IO String
-    readFile' h contents = 
+    readFile' h contents =
        do x <- feof h
           if not x then do l <- fread h
                            readFile' h (contents ++ l)

--- a/lib/Prelude/Algebra.idr
+++ b/lib/Prelude/Algebra.idr
@@ -248,8 +248,8 @@ class (VerifiedJoinSemilattice a, VerifiedMeetSemilattice a) => VerifiedLattice 
 class (BoundedJoinSemilattice a, BoundedMeetSemilattice a) => BoundedLattice a where { }
 
 class (VerifiedBoundedJoinSemilattice a, VerifiedBoundedMeetSemilattice a, VerifiedLattice a) => VerifiedBoundedLattice a where { }
-  
-  
+
+
 -- XXX todo:
 --   Fields and vector spaces.
 --   Structures where "abs" make sense.

--- a/lib/Prelude/Applicative.idr
+++ b/lib/Prelude/Applicative.idr
@@ -5,9 +5,9 @@ import Prelude.Functor
 
 ---- Applicative functors/Idioms
 
-infixl 2 <$> 
+infixl 2 <$>
 
-class Functor f => Applicative (f : Type -> Type) where 
+class Functor f => Applicative (f : Type -> Type) where
     pure  : a -> f a
     (<$>) : f (a -> b) -> f a -> f b
 

--- a/lib/Prelude/Chars.idr
+++ b/lib/Prelude/Chars.idr
@@ -9,7 +9,7 @@ isLower : Char -> Bool
 isLower x = x >= 'a' && x <= 'z'
 
 isAlpha : Char -> Bool
-isAlpha x = isUpper x || isLower x 
+isAlpha x = isUpper x || isLower x
 
 isDigit : Char -> Bool
 isDigit x = (x >= '0' && x <= '9')
@@ -23,10 +23,10 @@ isSpace x = x == ' '  || x == '\t' || x == '\r' ||
             x == '\xa0'
 
 isNL : Char -> Bool
-isNL x = x == '\r' || x == '\n' 
+isNL x = x == '\r' || x == '\n'
 
 toUpper : Char -> Char
-toUpper x = if (isLower x) 
+toUpper x = if (isLower x)
                then (prim__intToChar (prim__charToInt x - 32))
                else x
 

--- a/lib/Prelude/Complex.idr
+++ b/lib/Prelude/Complex.idr
@@ -8,7 +8,7 @@ module Prelude.Complex
 import Builtins
 import Prelude
 
------------------------------- Rectangular form 
+------------------------------ Rectangular form
 
 infix 6 :+
 data Complex a = (:+) a a

--- a/lib/Prelude/Either.idr
+++ b/lib/Prelude/Either.idr
@@ -49,7 +49,7 @@ rights (x::xs) =
 
 partitionEithers : List (Either a b) -> (List a, List b)
 partitionEithers l = (lefts l, rights l)
-    
+
 fromEither : Either a a -> a
 fromEither (Left l)  = l
 fromEither (Right r) = r

--- a/lib/Prelude/Fin.idr
+++ b/lib/Prelude/Fin.idr
@@ -58,10 +58,10 @@ integerToFin : Integer -> (n : Nat) -> Maybe (Fin n)
 integerToFin x = natToFin (cast x)
 
 data IsJust : Maybe a -> Type where
-     ItIsJust : IsJust {a} (Just x) 
+     ItIsJust : IsJust {a} (Just x)
 
-fromInteger : (x : Integer) -> 
-        {default (ItIsJust _ _) 
+fromInteger : (x : Integer) ->
+        {default (ItIsJust _ _)
              prf : (IsJust (integerToFin x n))} -> Fin n
 fromInteger {n} x {prf} with (integerToFin x n)
   fromInteger {n} x {prf = ItIsJust} | Just y = y

--- a/lib/Prelude/Functor.idr
+++ b/lib/Prelude/Functor.idr
@@ -1,4 +1,4 @@
 module Prelude.Functor
 
-class Functor (f : Type -> Type) where 
+class Functor (f : Type -> Type) where
     map : (a -> b) -> f a -> f b

--- a/lib/Prelude/Heap.idr
+++ b/lib/Prelude/Heap.idr
@@ -127,7 +127,7 @@ instance Eq a => Eq (MaxiphobicHeap a) where
   (Node ls ll le lr) == (Node rs rl re rr) =
     ls == rs && ll == rl && le == re && lr == rr
   _                  == _                  = False
-   
+
 instance Ord a => Semigroup (MaxiphobicHeap a) where
   (<+>) = merge
 

--- a/lib/Prelude/List.idr
+++ b/lib/Prelude/List.idr
@@ -537,7 +537,7 @@ hasAnyByNilFalse p (x::xs) =
 
 hasAnyNilFalse : Eq a => (l : List a) -> hasAny [] l = False
 hasAnyNilFalse l = ?hasAnyNilFalseBody
-    
+
 --------------------------------------------------------------------------------
 -- Proofs
 --------------------------------------------------------------------------------

--- a/lib/Prelude/Monad.idr
+++ b/lib/Prelude/Monad.idr
@@ -10,7 +10,7 @@ import Prelude.Applicative
 
 infixl 5 >>=
 
-class Applicative m => Monad (m : Type -> Type) where 
+class Applicative m => Monad (m : Type -> Type) where
     (>>=)  : m a -> (a -> m b) -> m b
 
 flatten : Monad m => m (m a) -> m a

--- a/lib/Prelude/Vect.idr
+++ b/lib/Prelude/Vect.idr
@@ -9,7 +9,7 @@ import Prelude.Nat
 %access public
 %default total
 
-infixr 7 :: 
+infixr 7 ::
 
 data Vect : Nat -> Type -> Type where
   Nil  : Vect Z a
@@ -109,7 +109,7 @@ instance Functor (Vect n) where
 -- XXX: causes Idris to enter an infinite loop when type checking in the REPL
 --mapMaybe : (a -> Maybe b) -> Vect n a -> (p ** Vect b p)
 --mapMaybe f []      = (_ ** [])
---mapMaybe f (x::xs) = mapMaybe' (f x) 
+--mapMaybe f (x::xs) = mapMaybe' (f x)
 -- XXX: working around the type restrictions on case statements
 --  where
 --    mapMaybe' : (Maybe b) -> (n ** Vect b n) -> (p ** Vect b p)

--- a/lib/System.idr
+++ b/lib/System.idr
@@ -7,7 +7,7 @@ import Prelude
 
 getArgs : IO (List String)
 getArgs = do n <- numArgs
-             ga' [] 0 n 
+             ga' [] 0 n
   where
     numArgs : IO Int
     numArgs = mkForeign (FFun "idris_numArgs" [FPtr] FInt) prim__vm
@@ -23,7 +23,7 @@ getArgs = do n <- numArgs
 -- Retrieves an value from the environment, if the given key is present,
 -- otherwise it returns Nothing.
 getEnv : String -> IO (Maybe String)
-getEnv key = do 
+getEnv key = do
     str_ptr <- getEnv'
     is_nil  <- nullStr str_ptr
     if is_nil

--- a/lib/System/Concurrency/Process.idr
+++ b/lib/System/Concurrency/Process.idr
@@ -1,4 +1,4 @@
--- WARNING: No guarantees that this works properly yet! 
+-- WARNING: No guarantees that this works properly yet!
 
 module System.Concurrency.Process
 
@@ -6,7 +6,7 @@ import System.Concurrency.Raw
 
 %access public
 
-abstract 
+abstract
 data ProcID msg = MkPID Ptr
 
 -- Type safe message passing programs. Parameterised over the type of
@@ -43,7 +43,7 @@ send (MkPID p) m = lift (sendToThread p (prim__vm, m))
 -- Return whether a message is waiting in the queue
 
 msgWaiting : Process msg Bool
-msgWaiting = lift checkMsgs 
+msgWaiting = lift checkMsgs
 
 -- Receive a message - blocks if there is no message waiting
 
@@ -56,7 +56,7 @@ recv {msg} = do (senderid, m) <- lift get
 -- receive a message, and return with the sender's process ID.
 
 recvWithSender : Process msg (ProcID msg, msg)
-recvWithSender {msg} 
+recvWithSender {msg}
      = do (senderid, m) <- lift get
           return (MkPID senderid, m)
   where get : IO (Ptr, msg)

--- a/lib/System/Concurrency/Raw.idr
+++ b/lib/System/Concurrency/Raw.idr
@@ -1,4 +1,4 @@
--- WARNING: No guarantees that this works properly yet! 
+-- WARNING: No guarantees that this works properly yet!
 
 module System.Concurrency.Raw
 
@@ -9,8 +9,8 @@ import System
 -- Send a message of any type to the thread with the given thread id
 
 sendToThread : (thread_id : Ptr) -> a -> IO ()
-sendToThread {a} dest val 
-   = mkForeign (FFun "idris_sendMessage" 
+sendToThread {a} dest val
+   = mkForeign (FFun "idris_sendMessage"
         [FPtr, FPtr, FAny a] FUnit) prim__vm dest val
 
 checkMsgs : IO Bool
@@ -22,6 +22,6 @@ checkMsgs = do msgs <- mkForeign (FFun "idris_checkMessage"
 -- arrives.
 
 getMsg : IO a
-getMsg {a} = mkForeign (FFun "idris_recvMessage" 
+getMsg {a} = mkForeign (FFun "idris_recvMessage"
                 [FPtr] (FAny a)) prim__vm
 

--- a/samples/binary.idr
+++ b/samples/binary.idr
@@ -21,21 +21,21 @@ instance Show (Binary w k) where
 pattern syntax bitpair [x] [y] = (_ ** (_ ** (x, y, _)))
 term    syntax bitpair [x] [y] = (_ ** (_ ** (x, y, refl)))
 
-addBit : Bit x -> Bit y -> Bit c -> 
+addBit : Bit x -> Bit y -> Bit c ->
           (bx ** (by ** (Bit bx, Bit by, c + x + y = by + 2 * bx)))
 addBit b0 b0 b0 = bitpair b0 b0
-addBit b0 b0 b1 = bitpair b0 b1 
+addBit b0 b0 b1 = bitpair b0 b1
 addBit b0 b1 b0 = bitpair b0 b1
 addBit b0 b1 b1 = bitpair b1 b0
-addBit b1 b0 b0 = bitpair b0 b1 
-addBit b1 b0 b1 = bitpair b1 b0 
-addBit b1 b1 b0 = bitpair b1 b0 
-addBit b1 b1 b1 = bitpair b1 b1 
+addBit b1 b0 b0 = bitpair b0 b1
+addBit b1 b0 b1 = bitpair b1 b0
+addBit b1 b1 b0 = bitpair b1 b0
+addBit b1 b1 b1 = bitpair b1 b1
 
-adc : Binary w x -> Binary w y -> Bit c -> Binary (S w) (c + x + y) 
+adc : Binary w x -> Binary w y -> Bit c -> Binary (S w) (c + x + y)
 adc zero        zero        carry ?= zero # carry
 adc (numx # bx) (numy # by) carry
-   ?= let (bitpair carry0 lsb) = addBit bx by carry in 
+   ?= let (bitpair carry0 lsb) = addBit bx by carry in
           adc numx numy carry0 # lsb
 
 main : IO ()

--- a/samples/interp-alt.idr
+++ b/samples/interp-alt.idr
@@ -26,11 +26,11 @@ using (G : Vect n Ty)
       Val : (x : Int) -> Expr G TyInt
       Lam : Expr (a :: G) t -> Expr G (TyFun a t)
       App : Expr G (TyFun a t) -> Expr G a -> Expr G t
-      Op  : (interpTy a -> interpTy b -> interpTy c) -> Expr G a -> Expr G b -> 
+      Op  : (interpTy a -> interpTy b -> interpTy c) -> Expr G a -> Expr G b ->
             Expr G c
       If  : Expr G TyBool -> Expr G a -> Expr G a -> Expr G a
       Bind : Expr G a -> (interpTy a -> Expr G b) -> Expr G b
-  
+
   interp : Env G -> {static} Expr G t -> interpTy t
   interp env (Var i)     = lookup i env
   interp env (Val x)     = x
@@ -39,7 +39,7 @@ using (G : Vect n Ty)
   interp env (Op op x y) = op (interp env x) (interp env y)
   interp env (If x t e)  = if (interp env x) then (interp env t) else (interp env e)
   interp env (Bind v f)  = interp env (f (interp env v))
- 
+
   eId : Expr G (TyFun TyInt TyInt)
   eId = Lam (Var fZ)
 
@@ -48,13 +48,13 @@ using (G : Vect n Ty)
 
   eAdd : Expr G (TyFun TyInt (TyFun TyInt TyInt))
   eAdd = Lam (Lam (Op prim__addInt (Var fZ) (Var (fS fZ))))
-  
+
 --   eDouble : Expr G (TyFun TyInt TyInt)
 --   eDouble = Lam (App (App (Lam (Lam (Op' (+) (Var fZ) (Var (fS fZ))))) (Var fZ)) (Var fZ))
-  
+
   eDouble : Expr G (TyFun TyInt TyInt)
   eDouble = Lam (App (App eAdd (Var fZ)) (Var fZ))
- 
+
   app : |(f : Expr G (TyFun a t)) -> Expr G a -> Expr G t
   app = \f, a => App f a
 
@@ -63,7 +63,7 @@ using (G : Vect n Ty)
                  (Val 1) (Op (*) (app eFac (Op (-) (Var fZ) (Val 1))) (Var fZ)))
 
   -- Exercise elaborator: Complicated way of doing \x y => x*4 + y*2
-  
+
   eProg : Expr G (TyFun TyInt (TyFun TyInt TyInt))
   eProg = Lam (Lam (Bind (App eDouble (Var (fS fZ)))
               (\x => Bind (App eDouble (Var fZ))

--- a/samples/interp.idr
+++ b/samples/interp.idr
@@ -26,17 +26,17 @@ using (G : Vect n Ty)
       Val : (x : Int) -> Expr G TyInt
       Lam : Expr (a :: G) t -> Expr G (TyFun a t)
       App : Expr G (TyFun a t) -> Expr G a -> Expr G t
-      Op  : (interpTy a -> interpTy b -> interpTy c) -> Expr G a -> Expr G b -> 
+      Op  : (interpTy a -> interpTy b -> interpTy c) -> Expr G a -> Expr G b ->
             Expr G c
       If  : Expr G TyBool -> Expr G a -> Expr G a -> Expr G a
       Bind : Expr G a -> (interpTy a -> Expr G b) -> Expr G b
- 
+
   dsl expr
       lambda      = Lam
       variable    = Var
       index_first = stop
       index_next  = pop
- 
+
   (<$>) : |(f : Expr G (TyFun a t)) -> Expr G a -> Expr G t
   (<$>) = \f, a => App f a
 
@@ -59,7 +59,7 @@ using (G : Vect n Ty)
     abs x = IF (x < 0) THEN (-x) ELSE x
 
     fromInteger = Val . fromInteger
-  
+
   interp : Env G -> {static} Expr G t -> interpTy t
   interp env (Var i)     = lookup i env
   interp env (Val x)     = x
@@ -77,7 +77,7 @@ using (G : Vect n Ty)
 
   eAdd : Expr G (TyFun TyInt (TyFun TyInt TyInt))
   eAdd = expr (\x, y => Op (+) x y)
-  
+
   eDouble : Expr G (TyFun TyInt TyInt)
   eDouble = expr (\x => App (App eAdd x) (Var stop))
 

--- a/samples/named_instance.lidr
+++ b/samples/named_instance.lidr
@@ -21,7 +21,7 @@ instance --- they must not overlap.
 Sort foo using the default comparison operator:
 
 > test1 : List Nat
-> test1 = sort foo 
+> test1 = sort foo
 
 -- which gives [1,2,3,4,5,6,7,8]
 
@@ -29,7 +29,7 @@ Sort foo using the alternative instance. No need for 'sortBy' and other
 such functions. Hoorah!
 
 > test2 : List Nat
-> test2 = sort @{myord} foo 
+> test2 = sort @{myord} foo
 
 -- which gives [8,7,6,5,4,3,2,1]
 

--- a/samples/reflection.idr
+++ b/samples/reflection.idr
@@ -66,7 +66,7 @@ firstEq ((y, Lam yt)::(x, Lam xt)::(_, Let _ f)::Nil) _ = Exact (App (App f (P (
 firstEq xs _ = Exact (TConst (I 0))
 
 -- | Skip 1 argument of the proof context and return the second one which
--- has to be introduced. Used for the tactical dispatch example, which 
+-- has to be introduced. Used for the tactical dispatch example, which
 -- will push dispatch, as first env agrument.
 innerTac : List (TTName, Binder TT) -> TT -> Tactic
 innerTac (_::(x, Lam xt)::_) _ = Exact (P Bound x xt)

--- a/src/Core/Constraints.hs
+++ b/src/Core/Constraints.hs
@@ -25,7 +25,7 @@ type Relations = M.Map UExp [(UConstraint, FC)]
 
 mkRels :: [(UConstraint, FC)] -> Relations -> Relations
 mkRels [] acc = acc
-mkRels ((c, f) : cs) acc 
+mkRels ((c, f) : cs) acc
     | not (ignore c)
        = case M.lookup (lhs c) acc of
               Nothing -> mkRels cs (M.insert (lhs c) [(c,f)] acc)
@@ -38,7 +38,7 @@ mkRels ((c, f) : cs) acc
 
 
 acyclic :: Relations -> [UExp] -> TC ()
-acyclic r cvs = checkCycle (fileFC "root") r [] 0 cvs 
+acyclic r cvs = checkCycle (fileFC "root") r [] 0 cvs
   where
     checkCycle :: FC -> Relations -> [(UExp, FC)] -> Int -> [UExp] -> TC ()
     checkCycle fc r path inc [] = return ()
@@ -50,18 +50,18 @@ acyclic r cvs = checkCycle (fileFC "root") r [] 0 cvs
 
     check fc path inc (UVar x) | x < 0 = return ()
     check fc path inc cv
-        | inc > 0 && cv `elem` map fst path 
+        | inc > 0 && cv `elem` map fst path
             = Error $ At fc UniverseError
                 -- FIXME: Make informative
                 -- e.g. (Msg ("Cycle: " ++ show cv ++ ", " ++ show path))
         -- if we reach a cycle but we're at the same universe level, it's
         -- fine, because they must all be equal, so stop.
         | inc == 0 && cv `elem` map fst path
-            = return () 
+            = return ()
         | otherwise = case M.lookup cv r of
                             Nothing       -> return ()
                             Just cs -> mapM_ (next ((cv, fc):path) inc) cs
-    
+
     next path inc (ULT l r, fc) = check fc path (inc + 1) r
     next path inc (ULE l r, fc) = check fc path inc r
 

--- a/src/Core/CoreParser.hs
+++ b/src/Core/CoreParser.hs
@@ -1,6 +1,6 @@
 {-# LANGUAGE MultiParamTypeClasses, FlexibleInstances #-}
 
-module Core.CoreParser(parseTerm, parseFile, parseDef, pTerm, iName, 
+module Core.CoreParser(parseTerm, parseFile, parseDef, pTerm, iName,
                        idrisLexer, maybeWithNS, pDocComment, opChars) where
 
 import Core.TT
@@ -21,22 +21,22 @@ import Debug.Trace
 
 type TokenParser a = PTok.TokenParser a
 
-idrisDef = haskellDef { 
+idrisDef = haskellDef {
               opStart = iOpStart,
               opLetter = iOpLetter,
               identLetter = identLetter haskellDef <|> lchar '.',
-              reservedOpNames 
+              reservedOpNames
                  = [":", "..", "=", "\\", "|", "<-", "->", "=>", "**"],
-              reservedNames 
-                 = ["let", "in", "data", "codata", "record", "Type", 
-                    "do", "dsl", "import", "impossible", 
+              reservedNames
+                 = ["let", "in", "data", "codata", "record", "Type",
+                    "do", "dsl", "import", "impossible",
                     "case", "of", "total", "partial", "mutual",
                     "infix", "infixl", "infixr", "rewrite",
                     "where", "with", "syntax", "proof", "postulate",
                     "using", "namespace", "class", "instance",
                     "public", "private", "abstract", "implicit",
                     "quoteGoal"]
-           } 
+           }
 
 -- | The characters allowed in operator names
 opChars = ":!#$%&*+./<=>?@\\^|-~"
@@ -46,7 +46,7 @@ iOpLetter = oneOf opChars
 --          <|> letter
 
 idrisLexer :: TokenParser a
-idrisLexer  = idrisMakeTokenParser idrisDef 
+idrisLexer  = idrisMakeTokenParser idrisDef
 
 lexer = idrisLexer
 
@@ -130,14 +130,14 @@ initsEndAt p (x:xs) | p x = [] : x_inits_xs
 -- Create a `Name' from a pair of strings representing a base name and its
 -- namespace.
 mkName :: (String, String) -> Name
-mkName (n, "") = UN n 
+mkName (n, "") = UN n
 mkName (n, ns) = NS (UN n) (reverse (parseNS ns))
   where parseNS x = case span (/= '.') x of
                       (x, "")    -> [x]
                       (x, '.':y) -> x : parseNS y
 
 pDocComment :: Char -> CParser a String
-pDocComment c 
+pDocComment c
    = try (do string ("--")
              char c
              skipMany simpleSpace
@@ -193,13 +193,13 @@ pExp = do lchar '\\'; x <- iName []; lchar ':'; ty <- pTerm
                    lchar '.';
                    sc <- pTerm
                    return (RBind x (Hole ty) sc))
-       <|> try (do lchar '('; 
+       <|> try (do lchar '(';
                    x <- iName []; lchar ':'; ty <- pTerm
                    lchar ')';
                    symbol "->";
                    sc <- pTerm
                    return (RBind x (Pi ty) sc))
-       <|> try (do lchar '('; 
+       <|> try (do lchar '(';
                    t <- pTerm
                    lchar ')'
                    return t)
@@ -209,14 +209,14 @@ pExp = do lchar '\\'; x <- iName []; lchar ':'; ty <- pTerm
                    val <- pTerm
                    sc <- pTerm
                    return (RBind x (Guess ty val) sc))
-       <|> try (do reserved "let"; 
+       <|> try (do reserved "let";
                    x <- iName []; lchar ':'; ty <- pTerm
                    lchar '=';
                    val <- pTerm
                    reserved "in";
                    sc <- pTerm
                    return (RBind x (Let ty val) sc))
-       <|> try (do lchar '_'; 
+       <|> try (do lchar '_';
                    x <- iName []; lchar ':'; ty <- pTerm
                    lchar '.';
                    sc <- pTerm
@@ -236,11 +236,11 @@ pConstructor = do lchar '|'
                   c <- iName []; lchar ':'; ty <- pTerm
                   return (c, ty)
 
------- borrowed from Parsec 
+------ borrowed from Parsec
 -- (c) Daan Leijen 1999-2001, (c) Paolo Martini 2007
 
 idrisMakeTokenParser languageDef
-    = PTok.TokenParser{ 
+    = PTok.TokenParser{
                    PTok.identifier = identifier
                  , PTok.reserved = reserved
                  , PTok.operator = operator

--- a/src/Core/Execute.hs
+++ b/src/Core/Execute.hs
@@ -247,15 +247,15 @@ execApp' env ctxt con@(EP _ (UN "prim_io_return") _) args@(tp:v:rest) =
 
 -- Special cases arising from not having access to the C RTS in the interpreter
 execApp' env ctxt (EP _ (UN "mkForeignPrim") _) (_:fn:EConstant (Str arg):_:rest)
-    | Just (FFun "putStr" _ _) <- foreignFromTT fn 
+    | Just (FFun "putStr" _ _) <- foreignFromTT fn
            = do execIO (putStr arg)
                 execApp' env ctxt ioUnit rest
 execApp' env ctxt (EP _ (UN "mkForeignPrim") _) (_:fn:_:EHandle h:_:rest)
-    | Just (FFun "idris_readStr" _ _) <- foreignFromTT fn 
+    | Just (FFun "idris_readStr" _ _) <- foreignFromTT fn
            = do contents <- execIO $ hGetLine h
                 execApp' env ctxt (EConstant (Str (contents ++ "\n"))) rest
 execApp' env ctxt (EP _ (UN "mkForeignPrim") _) (_:fn:EConstant (Str f):EConstant (Str mode):rest)
-    | Just (FFun "fileOpen" _ _) <- foreignFromTT fn 
+    | Just (FFun "fileOpen" _ _) <- foreignFromTT fn
            = do m <- case mode of
                          "r" -> return ReadMode
                          "w" -> return WriteMode
@@ -268,25 +268,25 @@ execApp' env ctxt (EP _ (UN "mkForeignPrim") _) (_:fn:EConstant (Str f):EConstan
                 execApp' env ctxt (ioWrap (EHandle h)) (tail rest)
 
 execApp' env ctxt (EP _ (UN "mkForeignPrim") _) (_:fn:(EHandle h):rest)
-    | Just (FFun "fileEOF" _ _) <- foreignFromTT fn 
+    | Just (FFun "fileEOF" _ _) <- foreignFromTT fn
            = do eofp <- execIO $ hIsEOF h
                 let res = ioWrap (EConstant (I $ if eofp then 1 else 0))
                 execApp' env ctxt res (tail rest)
 
 execApp' env ctxt (EP _ (UN "mkForeignPrim") _) (_:fn:(EHandle h):rest)
-    | Just (FFun "fileClose" _ _) <- foreignFromTT fn 
+    | Just (FFun "fileClose" _ _) <- foreignFromTT fn
            = do execIO $ hClose h
                 execApp' env ctxt ioUnit (tail rest)
 
 execApp' env ctxt (EP _ (UN "mkForeignPrim") _) (_:fn:(EPtr p):rest)
-    | Just (FFun "isNull" _ _) <- foreignFromTT fn 
+    | Just (FFun "isNull" _ _) <- foreignFromTT fn
            = let res = ioWrap . EConstant . I $
                        if p == nullPtr then 1 else 0
                   in execApp' env ctxt res (tail rest)
 
 -- Throw away the 'World' argument to the foreign function
 
-execApp' env ctxt f@(EP _ (UN "mkForeignPrim") _) args@(ty:fn:xs) 
+execApp' env ctxt f@(EP _ (UN "mkForeignPrim") _) args@(ty:fn:xs)
       | Just (FFun f argTs retT) <- foreignFromTT fn
         , length xs >= length argTs =
     do let (args', xs') = (take (length argTs) xs, -- foreign args

--- a/src/Core/ProofShell.hs
+++ b/src/Core/ProofShell.hs
@@ -15,7 +15,7 @@ import Idris.AbsSyntaxTree (Idris)
 
 import Util.Pretty
 
-data ShellState = ShellState 
+data ShellState = ShellState
                         { ctxt     :: Context,
                           prf      :: Maybe ProofState,
                           deferred :: [(Name, ProofState)],
@@ -25,18 +25,18 @@ data ShellState = ShellState
 initState c = ShellState c Nothing [] False
 
 processCommand :: Command -> ShellState -> (ShellState, String)
-processCommand (Theorem n ty) state 
+processCommand (Theorem n ty) state
     = case check (ctxt state) [] ty of
-              OK (gl, t) -> 
+              OK (gl, t) ->
                  case isType (ctxt state) [] t of
                     OK _ -> (state { prf = Just (newProof n (ctxt state) gl) }, "")
                     _ ->    (state, "Goal is not a type")
               err ->            (state, show err)
 processCommand Quit     state = (state { exitNow = True }, "Bye bye")
-processCommand (Eval t) state = 
+processCommand (Eval t) state =
     case check (ctxt state) [] t of
          OK (val, ty) ->
-            let nf = normalise (ctxt state) [] val 
+            let nf = normalise (ctxt state) [] val
                 tnf = normalise (ctxt state) [] ty in
                 (state, show nf ++ " : " ++ show ty)
          err -> (state, show err)
@@ -44,10 +44,10 @@ processCommand (Print n) state =
     case lookupDef n (ctxt state) of
          [tm] -> (state, show tm)
          _ -> (state, "No such name")
-processCommand (Tac e)  state 
+processCommand (Tac e)  state
     | Just ps <- prf state = case execElab () e ps of
-                                OK (ES (ps', _) resp _) -> 
-                                   if (not (done ps')) 
+                                OK (ES (ps', _) resp _) ->
+                                   if (not (done ps'))
                                       then (state { prf = Just ps' }, resp)
                                       else (state { prf = Nothing,
                                                     ctxt = addToCtxt (thname ps')
@@ -60,10 +60,10 @@ processCommand (Tac e)  state
 runShell :: ShellState -> Idris ShellState
 runShell st = runInputT defaultSettings $ runShell' st
     where
-      runShell' st = do (prompt, parser) <- 
-                            maybe (return ("TT# ", parseCommand)) 
+      runShell' st = do (prompt, parser) <-
+                            maybe (return ("TT# ", parseCommand))
                                       (\st -> do outputStrLn . render . pretty $ st
-                                                 return (show (thname st) ++ "# ", parseTactic)) 
+                                                 return (show (thname st) ++ "# ", parseTactic))
                                       (prf st)
                         x <- getInputLine prompt
                         cmd <- case x of

--- a/src/Core/ShellParser.hs
+++ b/src/Core/ShellParser.hs
@@ -50,7 +50,7 @@ pTactic = do reserved "attack";  return attack
       <|> do reserved "regret";  return regret
       <|> do reserved "exact";   tm <- pTerm; return (exact tm)
       <|> do reserved "fill";    tm <- pTerm; return (fill tm)
-      <|> do reserved "apply";   tm <- pTerm; args <- many pArgType; 
+      <|> do reserved "apply";   tm <- pTerm; args <- many pArgType;
              return (discard (apply tm (map (\x -> (x,0)) args)))
       <|> do reserved "solve";   return solve
       <|> do reserved "compute"; return compute

--- a/src/Core/TT.hs
+++ b/src/Core/TT.hs
@@ -63,8 +63,8 @@ emptyFC = fileFC ""
 fileFC :: String -> FC
 fileFC s = FC s 0 0
 
-{-! 
-deriving instance Binary FC 
+{-!
+deriving instance Binary FC
 !-}
 
 instance Sized FC where
@@ -75,7 +75,7 @@ instance Show FC where
 
 data Err = Msg String
          | InternalMsg String
-         | CantUnify Bool Term Term Err [(Name, Type)] Int 
+         | CantUnify Bool Term Term Err [(Name, Type)] Int
               -- Int is 'score' - how much we did unify
               -- Bool indicates recoverability, True indicates more info may make
               -- unification succeed
@@ -181,8 +181,8 @@ instance Show a => Show (TC a) where
 -- (e.g. Type:Type)
 
 instance Monad TC where
-    return = OK 
-    x >>= k = case x of 
+    return = OK
+    x >>= k = case x of
                 OK v -> k v
                 Error e -> Error e
     fail e = Error (InternalMsg e)
@@ -192,7 +192,7 @@ tfail e = Error e
 
 trun :: FC -> TC a -> TC a
 trun fc (OK a)    = OK a
-trun fc (Error e) = Error (At fc e) 
+trun fc (Error e) = Error (At fc e)
 
 instance MonadPlus TC where
     mzero = fail "Unknown error"
@@ -218,23 +218,23 @@ traceWhen False _  a = a
 -- | Names are hierarchies of strings, describing scope (so no danger of
 -- duplicate names, but need to be careful on lookup).
 data Name = UN String -- ^ User-provided name
-          | NS Name [String] -- ^ Root, namespaces 
+          | NS Name [String] -- ^ Root, namespaces
           | MN Int String -- ^ Machine chosen names
           | NErased -- ^ Name of somethng which is never used in scope
           | SN SpecialName -- ^ Decorated function names
   deriving (Eq, Ord)
-{-! 
-deriving instance Binary Name 
+{-!
+deriving instance Binary Name
 !-}
 
 data SpecialName = WhereN Int Name Name
                  | InstanceN Name [String]
                  | ParentN Name String
-                 | MethodN Name 
+                 | MethodN Name
                  | CaseN Name
   deriving (Eq, Ord)
-{-! 
-deriving instance Binary SpecialName 
+{-!
+deriving instance Binary SpecialName
 !-}
 
 instance Sized Name where
@@ -300,9 +300,9 @@ nsroot n = n
 
 addDef :: Name -> a -> Ctxt a -> Ctxt a
 addDef n v ctxt = case Map.lookup (nsroot n) ctxt of
-                        Nothing -> Map.insert (nsroot n) 
+                        Nothing -> Map.insert (nsroot n)
                                         (Map.insert n v Map.empty) ctxt
-                        Just xs -> Map.insert (nsroot n) 
+                        Just xs -> Map.insert (nsroot n)
                                         (Map.insert n v xs) ctxt
 
 {-| Look up a name in the context, given an optional namespace.
@@ -326,7 +326,7 @@ lookupCtxtName n ctxt = case Map.lookup (nsroot n) ctxt of
                                   Nothing -> []
   where
     filterNS [] = []
-    filterNS ((found, v) : xs) 
+    filterNS ((found, v) : xs)
         | nsmatch n found = (found, v) : filterNS xs
         | otherwise       = filterNS xs
 
@@ -341,9 +341,9 @@ lookupCtxtExact :: Name -> Ctxt a -> [a]
 lookupCtxtExact n ctxt = [ v | (nm, v) <- lookupCtxtName n ctxt, nm == n]
 
 updateDef :: Name -> (a -> a) -> Ctxt a -> Ctxt a
-updateDef n f ctxt 
+updateDef n f ctxt
   = let ds = lookupCtxtName n ctxt in
-        foldr (\ (n, t) c -> addDef n (f t) c) ctxt ds  
+        foldr (\ (n, t) c -> addDef n (f t) c) ctxt ds
 
 toAlist :: Ctxt a -> [(Name, a)]
 toAlist ctxt = let allns = map snd (Map.toList ctxt) in
@@ -390,15 +390,15 @@ intTyWidth ITNative = 8 * sizeOf (0 :: Int)
 intTyWidth ITChar = error "IRTS.Lang.intTyWidth: Characters have platform and backend dependent width"
 intTyWidth ITBig = error "IRTS.Lang.intTyWidth: Big integers have variable width"
 
-data Const = I Int | BI Integer | Fl Double | Ch Char | Str String 
+data Const = I Int | BI Integer | Fl Double | Ch Char | Str String
            | B8 Word8 | B16 Word16 | B32 Word32 | B64 Word64
            | B8V (Vector Word8) | B16V (Vector Word16)
            | B32V (Vector Word32) | B64V (Vector Word64)
            | AType ArithTy | StrType
            | PtrType | VoidType | Forgot
   deriving (Eq, Ord)
-{-! 
-deriving instance Binary Const 
+{-!
+deriving instance Binary Const
 !-}
 
 instance Sized Const where
@@ -439,8 +439,8 @@ instance Sized Raw where
 instance Pretty Raw where
   pretty = text . show
 
-{-! 
-deriving instance Binary Raw 
+{-!
+deriving instance Binary Raw
 !-}
 
 -- | All binding forms are represented in a unform fashion.
@@ -458,8 +458,8 @@ data Binder b = Lam   { binderTy  :: b {-^ type annotation for bound variable-}}
               | PVar  { binderTy  :: b }
               | PVTy  { binderTy  :: b }
   deriving (Show, Eq, Ord, Functor)
-{-! 
-deriving instance Binary Binder 
+{-!
+deriving instance Binary Binder
 !-}
 
 instance Sized a => Sized (Binder a) where
@@ -548,8 +548,8 @@ data NameType = Bound
               | DCon Int Int -- ^ Data constructor; Ints are tag and arity
               | TCon Int Int -- ^ Type constructor; Ints are tag and arity
   deriving (Show, Ord)
-{-! 
-deriving instance Binary NameType 
+{-!
+deriving instance Binary NameType
 !-}
 
 instance Sized NameType where
@@ -576,8 +576,8 @@ data TT n = P NameType n (TT n) -- ^ named references
           | Impossible -- ^ special case for totality checking
           | TType UExp -- ^ the type of types at some level
   deriving (Ord, Functor)
-{-! 
-deriving instance Binary TT 
+{-!
+deriving instance Binary TT
 !-}
 
 class TermSize a where
@@ -588,14 +588,14 @@ instance TermSize a => TermSize [a] where
     termsize n (x : xs) = termsize n x + termsize n xs
 
 instance TermSize (TT Name) where
-    termsize n (P _ x _) 
+    termsize n (P _ x _)
        | x == n = 1000000 -- recursive => really big
        | otherwise = 1
     termsize n (V _) = 1
-    termsize n (Bind n' (Let t v) sc) 
+    termsize n (Bind n' (Let t v) sc)
        = let rn = if n == n' then MN 0 "noname" else n in
              termsize rn v + termsize rn sc
-    termsize n (Bind n' b sc) 
+    termsize n (Bind n' b sc)
        = let rn = if n == n' then MN 0 "noname" else n in
              termsize rn sc
     termsize n (App f a) = termsize n f + termsize n a
@@ -652,7 +652,7 @@ isInjective _                  = False
 vinstances :: Int -> TT n -> Int
 vinstances i (V x) | i == x = 1
 vinstances i (App f a) = vinstances i f + vinstances i a
-vinstances i (Bind x b sc) = instancesB b + vinstances (i + 1) sc 
+vinstances i (Bind x b sc) = instancesB b + vinstances (i + 1) sc
   where instancesB (Let t v) = vinstances i v
         instancesB _ = 0
 vinstances i t = 0
@@ -662,7 +662,7 @@ instantiate e = subst 0 where
     subst i (V x) | i == x = e
     subst i (Bind x b sc) = Bind x (fmap (subst i) b) (subst (i+1) sc)
     subst i (App f a) = App (subst i f) (subst i a)
-    subst i (Proj x idx) = Proj (subst i x) idx 
+    subst i (Proj x idx) = Proj (subst i x) idx
     subst i t = t
 
 substV :: TT n -> TT n -> TT n
@@ -677,7 +677,7 @@ substV x tm = dropV 0 (instantiate x tm) where
 explicitNames :: TT n -> TT n
 explicitNames (Bind x b sc) = let b' = fmap explicitNames b in
                                   Bind x b'
-                                     (explicitNames (instantiate 
+                                     (explicitNames (instantiate
                                         (P Bound x (binderTy b')) sc))
 explicitNames (App f a) = App (explicitNames f) (explicitNames a)
 explicitNames (Proj x idx) = Proj (explicitNames x) idx
@@ -785,15 +785,15 @@ forget tm = fe [] tm
   where
     fe env (P _ n _) = Var n
     fe env (V i)     = Var (env !! i)
-    fe env (Bind n b sc) = RBind n (fmap (fe env) b) 
+    fe env (Bind n b sc) = RBind n (fmap (fe env) b)
                                    (fe (n:env) sc)
     fe env (App f a) = RApp (fe env f) (fe env a)
-    fe env (Constant c) 
+    fe env (Constant c)
                      = RConstant c
     fe env (TType i)   = RType
-    fe env Erased    = RConstant Forgot 
-    
-bindAll :: [(n, Binder (TT n))] -> TT n -> TT n 
+    fe env Erased    = RConstant Forgot
+
+bindAll :: [(n, Binder (TT n))] -> TT n -> TT n
 bindAll [] t =t
 bindAll ((n, b) : bs) t = Bind n b (bindAll bs t)
 
@@ -820,7 +820,7 @@ uniqueBinders ns (Bind n b sc)
           Bind n' (fmap (uniqueBinders (n':ns)) b) (uniqueBinders ns sc)
 uniqueBinders ns (App f a) = App (uniqueBinders ns f) (uniqueBinders ns a)
 uniqueBinders ns t = t
-  
+
 
 nextName (NS x s)    = NS (nextName x) s
 nextName (MN i n)    = MN (i+1) n
@@ -892,7 +892,7 @@ prettyEnv env t = prettyEnv' env t False
       | otherwise     = p
 
     prettySe p env (P nt n t) debug =
-      pretty n <+> 
+      pretty n <+>
         if debug then
           lbrack <+> pretty nt <+> colon <+> prettySe 10 env t debug <+> rbrack
         else
@@ -931,16 +931,16 @@ prettyEnv env t = prettyEnv' env t False
     prettyBv env op sc n t v debug =
       text op <> pretty n <+> colon <+> prettySe 10 env t debug <+> text "=" <+>
         prettySe 10 env v debug <> text sc
-          
+
 
 showEnv' env t dbg = se 10 env t where
-    se p env (P nt n t) = show n 
+    se p env (P nt n t) = show n
                             ++ if dbg then "{" ++ show nt ++ " : " ++ se 10 env t ++ "}" else ""
     se p env (V i) | i < length env && i >= 0
                                     = (show $ fst $ env!!i) ++
                                       if dbg then "{" ++ show i ++ "}" else ""
                    | otherwise = "!!V " ++ show i ++ "!!"
-    se p env (Bind n b@(Pi t) sc)  
+    se p env (Bind n b@(Pi t) sc)
         | noOccurrence n sc && not dbg = bracket p 2 $ se 1 env t ++ " -> " ++ se 10 ((n,b):env) sc
     se p env (Bind n b sc) = bracket p 2 $ sb env n b ++ se 10 ((n,b):env) sc
     se p env (App f a) = bracket p 1 $ se 1 env f ++ " " ++ se 0 env a
@@ -960,8 +960,8 @@ showEnv' env t dbg = se 10 env t where
     sb env n (Guess t v) = showbv env "?? " " in " n t v
 
     showb env op sc n t    = op ++ show n ++ " : " ++ se 10 env t ++ sc
-    showbv env op sc n t v = op ++ show n ++ " : " ++ se 10 env t ++ " = " ++ 
-                             se 10 env v ++ sc 
+    showbv env op sc n t v = op ++ show n ++ " : " ++ se 10 env t ++ " = " ++
+                             se 10 env v ++ sc
 
     bracket outer inner str | inner > outer = "(" ++ str ++ ")"
                             | otherwise = str
@@ -1008,7 +1008,7 @@ orderPats tm = op [] tm
   where
     op ps (Bind n (PVar t) sc) = op ((n, PVar t) : ps) sc
     op ps (Bind n (Hole t) sc) = op ((n, Hole t) : ps) sc
-    op ps sc = bindAll (map (\ (n, t) -> (n, t)) (sortP ps)) sc 
+    op ps sc = bindAll (map (\ (n, t) -> (n, t)) (sortP ps)) sc
 
     sortP ps = pick [] (reverse ps)
 
@@ -1025,7 +1025,7 @@ orderPats tm = op [] tm
 
     insert n t [] = [(n, t)]
     insert n t ((n',t') : ps)
-        | n `elem` (namesIn (binderTy t') ++ 
+        | n `elem` (namesIn (binderTy t') ++
                       concatMap namesIn (map (binderTy . snd) ps))
             = (n', t') : insert n t ps
         | otherwise = (n,t):(n',t'):ps

--- a/src/IRTS/BCImp.hs
+++ b/src/IRTS/BCImp.hs
@@ -1,6 +1,6 @@
 module IRTS.BCImp where
 
--- Bytecode for a register/variable based VM (e.g. for generating code in an 
+-- Bytecode for a register/variable based VM (e.g. for generating code in an
 -- imperative language where we let the language deal with GC)
 
 import IRTS.Lang

--- a/src/IRTS/CodegenLLVM.hs
+++ b/src/IRTS/CodegenLLVM.hs
@@ -216,7 +216,7 @@ initDefs tgt =
                                , G.name = Name $ "__idris_" ++ name
                                , G.basicBlocks = def
                                }
-      
+
       exfun :: String -> Type -> [Type] -> Bool -> Definition
       exfun name rty argtys vari =
           GlobalDefinition $ functionDefaults
@@ -562,7 +562,7 @@ cgCase val alts =
       defExp = getDefExp =<< find isDefCase alts
       constAlts = filter isConstCase alts
       conAlts = filter isConCase alts
-                
+
       isConstCase (SConstCase {}) = True
       isConstCase _ = False
 
@@ -806,7 +806,7 @@ addGlobal' ty val = do
                 , G.initializer = Just val
                 }
   return . C.GlobalReference $ name
-  
+
 
 ensureCDecl :: String -> FType -> [FType] -> Codegen Operand
 ensureCDecl name rty argtys = do
@@ -1110,7 +1110,7 @@ cgStrCat x y = do
   end <- inst $ IntToPtr offj (PointerType (IntegerType 8) (AddrSpace 0)) []
   inst' $ Store False end (ConstantOperand (C.Int 8 0)) Nothing 0 []
   box FString mem
-  
+
 ibin :: IntTy -> Operand -> Operand
      -> (Operand -> Operand -> InstructionMetadata -> Instruction) -> Codegen Operand
 ibin ity x y instCon = do

--- a/src/IRTS/DumpBC.hs
+++ b/src/IRTS/DumpBC.hs
@@ -50,7 +50,7 @@ serializeBC n bc = indent n ++
       CALL x -> "CALL " ++ show x
       TAILCALL x -> "TAILCALL " ++ show x
       FOREIGNCALL r _ ret name args ->
-        "FOREIGNCALL " ++ serializeReg r ++ " \"" ++ name ++ "\" " ++ show ret ++ 
+        "FOREIGNCALL " ++ serializeReg r ++ " \"" ++ name ++ "\" " ++ show ret ++
         " [" ++ interMap args ", " (\(ty, r) -> serializeReg r ++ " : " ++ show ty) ++ "]"
       SLIDE n -> "SLIDE " ++ show n
       REBASE -> "REBASE"

--- a/src/IRTS/Inliner.hs
+++ b/src/IRTS/Inliner.hs
@@ -4,13 +4,13 @@ import Core.TT
 
 import IRTS.Defunctionalise
 
-inline :: DDefs -> DDefs 
+inline :: DDefs -> DDefs
 inline xs = let sep = toAlist xs
                 inls = map (inl xs) sep in
                 addAlist inls emptyContext
 
 inl :: DDefs -> (Name, DDecl) -> (Name, DDecl)
-inl ds d@(n, DFun n' args exp) 
+inl ds d@(n, DFun n' args exp)
     = case evalD ds exp of
            Just exp' -> (n, DFun n' args exp')
            _ -> d

--- a/src/IRTS/LParser.hs
+++ b/src/IRTS/LParser.hs
@@ -31,7 +31,7 @@ type TokenParser a = PTok.TokenParser a
 type LParser = GenParser Char ()
 
 lexer :: TokenParser ()
-lexer  = idrisLexer 
+lexer  = idrisLexer
 
 whiteSpace= PTok.whiteSpace lexer
 lexeme    = PTok.lexeme lexer
@@ -75,7 +75,7 @@ parseFOVM fname = do -- putStrLn $ "Reading " ++ fname
 pProgram :: LParser [(Name, LDecl)]
 pProgram = do fs <- many1 pLDecl
               eof
-              return fs 
+              return fs
 
 pLDecl :: LParser (Name, LDecl)
 pLDecl = do reserved "data"
@@ -91,7 +91,7 @@ pLDecl = do reserved "data"
             def <- pLExp
             return (n, LFun [] n args def)
 
-pLExp = buildExpressionParser optable pLExp' 
+pLExp = buildExpressionParser optable pLExp'
 
 optable = [[binary "*" (\x y -> LOp (LTimes (ATInt ITNative)) [x,y]) AssocLeft,
             binary "/" (\x y -> LOp (LSDiv (ATInt ITNative)) [x,y]) AssocLeft,
@@ -149,9 +149,9 @@ pLExp' = try (do lchar '%'; pCast)
                  lchar '('
                  args <- sepBy pLExp (lchar ',')
                  lchar ')'
-                 if null args 
+                 if null args
                     then if lazy then return (LLazyApp x [])
-                                 else return (LV (Glob x)) 
+                                 else return (LV (Glob x))
                     else if lazy then return (LLazyApp x args)
                                  else return (LApp tc (LV (Glob x)) args))
      <|> do lchar '('; e <- pLExp; lchar ')'; return e
@@ -172,7 +172,7 @@ pLExp' = try (do lchar '%'; pCast)
      <|> pCase
      <|> do x <- iName []
             return (LV (Glob x))
-     
+
 pLang = do reserved "C"; return LANG_C
 
 pType = do reserved "Int"; return (FArith (ATInt ITNative))
@@ -215,10 +215,10 @@ pCast = do reserved "FloatString"; lchar '('; e <- pLExp; lchar ')'
 pPrim :: LParser LExp
 pPrim = do reserved "StrEq"; lchar '(';
            e <- pLExp; lchar ',';
-           e' <- pLExp; lchar ')'; 
+           e' <- pLExp; lchar ')';
            return (LOp LStrEq [e, e'])
     <|> do reserved "StrLt"; lchar '('
-           e <- pLExp; lchar ','; e' <- pLExp; 
+           e <- pLExp; lchar ','; e' <- pLExp;
            lchar ')'
            return (LOp LStrLt [e, e'])
     <|> do reserved "StrLen"; lchar '('; e <- pLExp; lchar ')';
@@ -228,7 +228,7 @@ pPrim = do reserved "StrEq"; lchar '(';
     <|> do reserved "WriteString"; lchar '(';
            e <- pLExp; lchar ')'
            return (LOp LPrintStr [e])
-    <|> do reserved "WriteInt"; lchar '('; 
+    <|> do reserved "WriteInt"; lchar '(';
            e <- pLExp; lchar ')';
            return (LOp LPrintNum [e])
     <|> do reserved "lazy"; lchar '(';
@@ -240,10 +240,10 @@ pPrim = do reserved "StrEq"; lchar '(';
            return (LOp LStrTail [e])
     <|> do reserved "StrRev"; lchar '('; e <- pLExp; lchar ')';
            return (LOp LStrRev [e])
-    <|> do reserved "StrCons"; lchar '('; x <- pLExp; lchar ','; 
+    <|> do reserved "StrCons"; lchar '('; x <- pLExp; lchar ',';
            xs <- pLExp; lchar ')';
            return (LOp LStrCons [x, xs])
-    <|> do reserved "StrIndex"; lchar '('; x <- pLExp; lchar ','; 
+    <|> do reserved "StrIndex"; lchar '('; x <- pLExp; lchar ',';
            i <- pLExp; lchar ')';
            return (LOp LStrIndex [x, i])
 
@@ -269,8 +269,8 @@ pAlt = try (do x <- iName []
 
 pLConst :: LParser LExp
 pLConst = try (do f <- float; return $ LConst (Fl f))
-      <|> try (do i <- natural; lchar ':'; return $ LConst (BI i))     
-      <|> try (do i <- natural; return $ LConst (I (fromInteger i)))     
+      <|> try (do i <- natural; lchar ':'; return $ LConst (BI i))
+      <|> try (do i <- natural; return $ LConst (I (fromInteger i)))
       <|> try (do s <- strlit; return $ LConst (Str s))
       <|> try (do c <- chlit; return $ LConst (Ch c))
 

--- a/src/Idris/AbsSyntax.hs
+++ b/src/Idris/AbsSyntax.hs
@@ -90,7 +90,7 @@ addLangExt ErrorReflection = do i <- getIState
                                 }
 
 addTrans :: (Term, Term) -> Idris ()
-addTrans t = do i <- getIState 
+addTrans t = do i <- getIState
                 putIState $ i { idris_transforms = t : idris_transforms i }
 
 totcheck :: (FC, Name) -> Idris ()
@@ -103,19 +103,19 @@ setFlags :: Name -> [FnOpt] -> Idris ()
 setFlags n fs = do i <- getIState; putIState $ i { idris_flags = addDef n fs (idris_flags i) }
 
 setAccessibility :: Name -> Accessibility -> Idris ()
-setAccessibility n a 
+setAccessibility n a
          = do i <- getIState
               let ctxt = setAccess n a (tt_ctxt i)
               putIState $ i { tt_ctxt = ctxt }
 
 setTotality :: Name -> Totality -> Idris ()
-setTotality n a 
+setTotality n a
          = do i <- getIState
               let ctxt = setTotal n a (tt_ctxt i)
               putIState $ i { tt_ctxt = ctxt }
 
 getTotality :: Name -> Idris Totality
-getTotality n  
+getTotality n
          = do i <- getIState
               case lookupTotal n (tt_ctxt i) of
                 [t] -> return t
@@ -131,13 +131,13 @@ getCoercionsTo i ty =
           findCoercions t (n : ns) =
              let ps = case lookupTy n (tt_ctxt i) of
                          [ty] -> case unApply (getRetTy ty) of
-                                   (t', _) -> 
+                                   (t', _) ->
                                       if t == t' then [n] else []
                          _ -> [] in
                  ps ++ findCoercions t ns
 
 addToCG :: Name -> CGInfo -> Idris ()
-addToCG n cg 
+addToCG n cg
    = do i <- getIState
         putIState $ i { idris_callgraph = addDef n cg (idris_callgraph i) }
 
@@ -146,7 +146,7 @@ addCoercion n = do i <- getIState
                    putIState $ i { idris_coercions = nub $ n : idris_coercions i }
 
 addDocStr :: Name -> String -> Idris ()
-addDocStr n doc 
+addDocStr n doc
    = do i <- getIState
         putIState $ i { idris_docstrings = addDef n doc (idris_docstrings i) }
 
@@ -158,7 +158,7 @@ addToCalledG n ns = return () -- TODO
 -- Dodgy hack 2: put constraint chasers (@@) last
 
 addInstance :: Bool -> Name -> Name -> Idris ()
-addInstance int n i 
+addInstance int n i
     = do ist <- getIState
          case lookupCtxt n (idris_classes ist) of
                 [CI a b c d ins] ->
@@ -178,7 +178,7 @@ addInstance int n i
         chaser _ = False
 
 addClass :: Name -> ClassInfo -> Idris ()
-addClass n i 
+addClass n i
    = do ist <- getIState
         let i' = case lookupCtxt n (idris_classes ist) of
                       [c] -> c { class_instances = class_instances i }
@@ -186,7 +186,7 @@ addClass n i
         putIState $ ist { idris_classes = addDef n i' (idris_classes ist) }
 
 addIBC :: IBCWrite -> Idris ()
-addIBC ibc@(IBCDef n) 
+addIBC ibc@(IBCDef n)
            = do i <- getIState
                 when (notDef (ibc_write i)) $
                   putIState $ i { ibc_write = ibc : ibc_write i }
@@ -249,15 +249,15 @@ getInternalApp fp l = do i <- getIState
                               -- TODO: What if it's not there?
 
 checkUndefined :: FC -> Name -> Idris ()
-checkUndefined fc n 
+checkUndefined fc n
     = do i <- getContext
          case lookupTy n i of
-             (_:_)  -> fail $ show fc ++ ":" ++ 
+             (_:_)  -> fail $ show fc ++ ":" ++
                        show n ++ " already defined"
              _ -> return ()
 
 isUndefined :: FC -> Name -> Idris Bool
-isUndefined fc n 
+isUndefined fc n
     = do i <- getContext
          case lookupTy n i of
              (_:_)  -> return False
@@ -282,10 +282,10 @@ addDeferred = addDeferred' Ref
 addDeferredTyCon = addDeferred' (TCon 0 0)
 
 addDeferred' :: NameType -> [(Name, (Int, Maybe Name, Type))] -> Idris ()
-addDeferred' nt ns 
+addDeferred' nt ns
   = do mapM_ (\(n, (i, _, t)) -> updateContext (addTyDecl n nt (tidyNames [] t))) ns
        i <- getIState
-       putIState $ i { idris_metavars = map (\(n, (i, top, _)) -> (n, (top, i))) ns ++ 
+       putIState $ i { idris_metavars = map (\(n, (i, top, _)) -> (n, (top, i))) ns ++
                                             idris_metavars i }
   where tidyNames used (Bind (MN i x) b sc)
             = let n' = uniqueName (UN x) used in
@@ -297,7 +297,7 @@ addDeferred' nt ns
 
 solveDeferred :: Name -> Idris ()
 solveDeferred n = do i <- getIState
-                     putIState $ i { idris_metavars = 
+                     putIState $ i { idris_metavars =
                                        filter (\(n', _) -> n/=n')
                                           (idris_metavars i) }
 
@@ -607,7 +607,7 @@ bi = fileFC "builtin"
 
 inferTy   = MN 0 "__Infer"
 inferCon  = MN 0 "__infer"
-inferDecl = PDatadecl inferTy 
+inferDecl = PDatadecl inferTy
                       PType
                       [("", inferCon, PPi impl (MN 0 "A") PType (
                                   PPi expl (MN 0 "a") (PRef bi (MN 0 "A"))
@@ -644,7 +644,7 @@ pairDecl  = PDatadecl pairTy (piBind [(n "A", PType), (n "B", PType)] PType)
             [("", pairCon, PPi impl (n "A") PType (
                        PPi impl (n "B") PType (
                        PPi expl (n "a") (PRef bi (n "A")) (
-                       PPi expl (n "b") (PRef bi (n "B"))  
+                       PPi expl (n "b") (PRef bi (n "B"))
                            (PApp bi (PRef bi pairTy) [pexp (PRef bi (n "A")),
                                                 pexp (PRef bi (n "B"))])))), bi)]
     where n a = MN 0 a
@@ -672,10 +672,10 @@ piBind = piBindp expl
 piBindp :: Plicity -> [(Name, PTerm)] -> PTerm -> PTerm
 piBindp p [] t = t
 piBindp p ((n, ty):ns) t = PPi p n ty (piBindp p ns t)
-    
+
 -- Dealing with parameters
 
-expandParams :: (Name -> Name) -> [(Name, PTerm)] -> 
+expandParams :: (Name -> Name) -> [(Name, PTerm)] ->
                 [Name] -> -- all names
                 [Name] -> -- names with no declaration
                 PTerm -> PTerm
@@ -686,7 +686,7 @@ expandParams dec ps ns infs tm = en tm
     -- binding and once to call the lifted functions. So we'll explicitly shadow
     -- it. (Yes, it's a hack. The alternative would be to resolve names earlier
     -- but we didn't...)
-    
+
     mkShadow (UN n) = MN 0 n
     mkShadow (MN i n) = MN (i+1) n
     mkShadow (NS x s) = NS (mkShadow x) s
@@ -696,18 +696,18 @@ expandParams dec ps ns infs tm = en tm
                = let n' = mkShadow n in
                      PLam n' (en t) (en (shadow n n' s))
        | otherwise = PLam n (en t) (en s)
-    en (PPi p n t s) 
+    en (PPi p n t s)
        | n `elem` (map fst ps ++ ns)
                = let n' = mkShadow n in
                      PPi p n' (en t) (en (shadow n n' s))
        | otherwise = PPi p n (en t) (en s)
-    en (PLet n ty v s) 
+    en (PLet n ty v s)
        | n `elem` (map fst ps ++ ns)
                = let n' = mkShadow n in
                      PLet n' (en ty) (en v) (en (shadow n n' s))
        | otherwise = PLet n (en ty) (en v) (en s)
-    -- FIXME: Should only do this in a type signature! 
-    en (PDPair f (PRef f' n) t r) 
+    -- FIXME: Should only do this in a type signature!
+    en (PDPair f (PRef f' n) t r)
        | n `elem` (map fst ps ++ ns) && t /= Placeholder
            = let n' = mkShadow n in
                  PDPair f (PRef f' n') (en t) (en (shadow n n' r))
@@ -724,28 +724,28 @@ expandParams dec ps ns infs tm = en tm
     en (PProof ts)   = PProof (map (fmap en) ts)
     en (PTactics ts) = PTactics (map (fmap en) ts)
 
-    en (PQuote (Var n)) 
+    en (PQuote (Var n))
         | n `nselem` ns = PQuote (Var (dec n))
     en (PApp fc (PInferRef fc' n) as)
-        | n `nselem` ns = PApp fc (PInferRef fc' (dec n)) 
+        | n `nselem` ns = PApp fc (PInferRef fc' (dec n))
                            (map (pexp . (PRef fc)) (map fst ps) ++ (map (fmap en) as))
     en (PApp fc (PRef fc' n) as)
-        | n `elem` infs = PApp fc (PInferRef fc' (dec n)) 
+        | n `elem` infs = PApp fc (PInferRef fc' (dec n))
                            (map (pexp . (PRef fc)) (map fst ps) ++ (map (fmap en) as))
-        | n `nselem` ns = PApp fc (PRef fc' (dec n)) 
+        | n `nselem` ns = PApp fc (PRef fc' (dec n))
                            (map (pexp . (PRef fc)) (map fst ps) ++ (map (fmap en) as))
     en (PAppBind fc (PRef fc' n) as)
-        | n `elem` infs = PAppBind fc (PInferRef fc' (dec n)) 
+        | n `elem` infs = PAppBind fc (PInferRef fc' (dec n))
                            (map (pexp . (PRef fc)) (map fst ps) ++ (map (fmap en) as))
-        | n `nselem` ns = PAppBind fc (PRef fc' (dec n)) 
+        | n `nselem` ns = PAppBind fc (PRef fc' (dec n))
                            (map (pexp . (PRef fc)) (map fst ps) ++ (map (fmap en) as))
     en (PRef fc n)
-        | n `elem` infs = PApp fc (PInferRef fc (dec n)) 
+        | n `elem` infs = PApp fc (PInferRef fc (dec n))
                            (map (pexp . (PRef fc)) (map fst ps))
-        | n `nselem` ns = PApp fc (PRef fc (dec n)) 
+        | n `nselem` ns = PApp fc (PRef fc (dec n))
                            (map (pexp . (PRef fc)) (map fst ps))
     en (PInferRef fc n)
-        | n `nselem` ns = PApp fc (PInferRef fc (dec n)) 
+        | n `nselem` ns = PApp fc (PInferRef fc (dec n))
                            (map (pexp . (PRef fc)) (map fst ps))
     en (PApp fc f as) = PApp fc (en f) (map (fmap en) as)
     en (PAppBind fc f as) = PAppBind fc (en f) (map (fmap en) as)
@@ -759,20 +759,20 @@ expandParams dec ps ns infs tm = en tm
     nseq x y = nsroot x == nsroot y
 
 expandParamsD :: Bool -> -- True = RHS only
-                 IState -> 
+                 IState ->
                  (Name -> Name) -> [(Name, PTerm)] -> [Name] -> PDecl -> PDecl
-expandParamsD rhsonly ist dec ps ns (PTy doc syn fc o n ty) 
+expandParamsD rhsonly ist dec ps ns (PTy doc syn fc o n ty)
     = if n `elem` ns && (not rhsonly)
          then -- trace (show (n, expandParams dec ps ns ty)) $
               PTy doc syn fc o (dec n) (piBindp expl_param ps (expandParams dec ps ns [] ty))
-         else --trace (show (n, expandParams dec ps ns ty)) $ 
+         else --trace (show (n, expandParams dec ps ns ty)) $
               PTy doc syn fc o n (expandParams dec ps ns [] ty)
-expandParamsD rhsonly ist dec ps ns (PPostulate doc syn fc o n ty) 
+expandParamsD rhsonly ist dec ps ns (PPostulate doc syn fc o n ty)
     = if n `elem` ns && (not rhsonly)
          then -- trace (show (n, expandParams dec ps ns ty)) $
-              PPostulate doc syn fc o (dec n) (piBind ps 
+              PPostulate doc syn fc o (dec n) (piBind ps
                             (expandParams dec ps ns [] ty))
-         else --trace (show (n, expandParams dec ps ns ty)) $ 
+         else --trace (show (n, expandParams dec ps ns ty)) $
               PPostulate doc syn fc o n (expandParams dec ps ns [] ty)
 expandParamsD rhsonly ist dec ps ns (PClauses fc opts n cs)
     = let n' = if n `elem` ns then dec n else n in
@@ -782,7 +782,7 @@ expandParamsD rhsonly ist dec ps ns (PClauses fc opts n cs)
         = let -- ps' = updateps True (namesIn ist rhs) (zip ps [0..])
               ps'' = updateps False (namesIn [] ist lhs) (zip ps [0..])
               lhs' = if rhsonly then lhs else (expandParams dec ps'' ns [] lhs)
-              n' = if n `elem` ns then dec n else n 
+              n' = if n `elem` ns then dec n else n
               -- names bound on the lhs should not be expanded on the rhs
               ns' = removeBound lhs ns in
               PClause fc n' lhs'
@@ -793,7 +793,7 @@ expandParamsD rhsonly ist dec ps ns (PClauses fc opts n cs)
         = let -- ps' = updateps True (namesIn ist wval) (zip ps [0..])
               ps'' = updateps False (namesIn [] ist lhs) (zip ps [0..])
               lhs' = if rhsonly then lhs else (expandParams dec ps'' ns [] lhs)
-              n' = if n `elem` ns then dec n else n 
+              n' = if n `elem` ns then dec n else n
               ns' = removeBound lhs ns in
               PWith fc n' lhs'
                           (map (expandParams dec ps'' ns' []) ws)
@@ -812,32 +812,32 @@ expandParamsD rhsonly ist dec ps ns (PClauses fc opts n cs)
     bnames (PDPair _ l Placeholder r) = bnames l ++ bnames r
     bnames _ = []
 
-expandParamsD rhs ist dec ps ns (PData doc syn fc co pd) 
+expandParamsD rhs ist dec ps ns (PData doc syn fc co pd)
     = PData doc syn fc co (expandPData pd)
   where
     -- just do the type decl, leave constructors alone (parameters will be
     -- added implicitly)
-    expandPData (PDatadecl n ty cons) 
+    expandPData (PDatadecl n ty cons)
        = if n `elem` ns
-            then PDatadecl (dec n) (piBind ps (expandParams dec ps ns [] ty)) 
+            then PDatadecl (dec n) (piBind ps (expandParams dec ps ns [] ty))
                            (map econ cons)
             else PDatadecl n (expandParams dec ps ns [] ty) (map econ cons)
-    econ (doc, n, t, fc) 
+    econ (doc, n, t, fc)
        = (doc, dec n, piBindp expl ps (expandParams dec ps ns [] t), fc)
 expandParamsD rhs ist dec ps ns (PParams f params pds)
-   = PParams f (ps ++ map (mapsnd (expandParams dec ps ns [])) params) 
+   = PParams f (ps ++ map (mapsnd (expandParams dec ps ns [])) params)
                (map (expandParamsD True ist dec ps ns) pds)
---                (map (expandParamsD ist dec ps ns) pds) 
+--                (map (expandParamsD ist dec ps ns) pds)
 expandParamsD rhs ist dec ps ns (PMutual f pds)
    = PMutual f (map (expandParamsD rhs ist dec ps ns) pds)
 expandParamsD rhs ist dec ps ns (PClass doc info f cs n params decls)
-   = PClass doc info f 
+   = PClass doc info f
            (map (expandParams dec ps ns []) cs)
            n
            (map (mapsnd (expandParams dec ps ns [])) params)
            (map (expandParamsD rhs ist dec ps ns) decls)
 expandParamsD rhs ist dec ps ns (PInstance info f cs n params ty cn decls)
-   = PInstance info f 
+   = PInstance info f
            (map (expandParams dec ps ns []) cs)
            n
            (map (expandParams dec ps ns []) params)
@@ -855,7 +855,7 @@ mapsnd f (x, t) = (x, f t)
 -- * finally, everything else (3)
 
 getPriority :: IState -> PTerm -> Int
-getPriority i tm = 1 -- pri tm 
+getPriority i tm = 1 -- pri tm
   where
     pri (PRef _ n) =
         case lookupP n (tt_ctxt i) of
@@ -869,9 +869,9 @@ getPriority i tm = 1 -- pri tm
     pri (PRefl _ _) = 1
     pri (PEq _ l r) = max 1 (max (pri l) (pri r))
     pri (PRewrite _ l r _) = max 1 (max (pri l) (pri r))
-    pri (PApp _ f as) = max 1 (max (pri f) (foldr max 0 (map (pri.getTm) as))) 
-    pri (PAppBind _ f as) = max 1 (max (pri f) (foldr max 0 (map (pri.getTm) as))) 
-    pri (PCase _ f as) = max 1 (max (pri f) (foldr max 0 (map (pri.snd) as))) 
+    pri (PApp _ f as) = max 1 (max (pri f) (foldr max 0 (map (pri.getTm) as)))
+    pri (PAppBind _ f as) = max 1 (max (pri f) (foldr max 0 (map (pri.getTm) as)))
+    pri (PCase _ f as) = max 1 (max (pri f) (foldr max 0 (map (pri.snd) as)))
     pri (PTyped l r) = pri l
     pri (PPair _ l r) = max 1 (max (pri l) (pri r))
     pri (PDPair _ l t r) = max 1 (max (pri l) (max (pri t) (pri r)))
@@ -888,7 +888,7 @@ addStatics n tm ptm =
        when (not (null statics)) $
           logLvl 7 $ show n ++ " " ++ show statics ++ "\n" ++ show dynamics
                         ++ "\n" ++ show stnames ++ "\n" ++ show dnames
-       let statics' = nub $ map fst statics ++ 
+       let statics' = nub $ map fst statics ++
                               filter (\x -> not (elem x dnames)) stnames
        let stpos = staticList statics' tm
        i <- getIState
@@ -909,7 +909,7 @@ addStatics n tm ptm =
 -- Add constraint bindings from using block
 
 addUsingConstraints :: SyntaxInfo -> FC -> PTerm -> Idris PTerm
-addUsingConstraints syn fc t 
+addUsingConstraints syn fc t
    = do ist <- get
         let ns = namesIn [] ist t
         let cs = getConstraints t -- check declared constraints
@@ -924,12 +924,12 @@ addUsingConstraints syn fc t
          doAdd [] _ t = t
          -- if all of args in ns, then add it
          doAdd (UConstraint c args : cs) ns t
-             | all (\n -> elem n ns) args 
+             | all (\n -> elem n ns) args
                    = PPi (Constraint False Dynamic "") (MN 0 "cu")
                          (mkConst c args) (doAdd cs ns t)
              | otherwise = doAdd cs ns t
 
-         mkConst c args = PApp fc (PRef fc c) 
+         mkConst c args = PApp fc (PRef fc c)
                              (map (\n -> PExp 0 False (PRef fc n) "") args)
 
          getConstraints (PPi (Constraint _ _ _) _ c sc)
@@ -937,7 +937,7 @@ addUsingConstraints syn fc t
          getConstraints (PPi _ _ c sc) = getConstraints sc
          getConstraints _ = []
 
-         getcapp (PApp _ (PRef _ c) args) 
+         getcapp (PApp _ (PRef _ c) args)
              = do ns <- mapM getName args
                   return (UConstraint c ns)
          getcapp _ = []
@@ -954,7 +954,7 @@ implicit :: SyntaxInfo -> Name -> PTerm -> Idris PTerm
 implicit syn n ptm = implicit' syn [] n ptm
 
 implicit' :: SyntaxInfo -> [Name] -> Name -> PTerm -> Idris PTerm
-implicit' syn ignore n ptm 
+implicit' syn ignore n ptm
     = do i <- getIState
          let (tm', impdata) = implicitise syn ignore i ptm
 --          let (tm'', spos) = findStatics i tm'
@@ -967,12 +967,12 @@ implicit' syn ignore n ptm
 
 implicitise :: SyntaxInfo -> [Name] -> IState -> PTerm -> (PTerm, [PArg])
 implicitise syn ignore ist tm = -- trace ("INCOMING " ++ showImp True tm) $
-      let (declimps, ns') = execState (imps True [] tm) ([], []) 
+      let (declimps, ns') = execState (imps True [] tm) ([], [])
           ns = filter (\n -> implicitable n || elem n (map fst uvars)) $
-                  ns' \\ (map fst pvars ++ no_imp syn ++ ignore) 
+                  ns' \\ (map fst pvars ++ no_imp syn ++ ignore)
           nsOrder = filter (not . inUsing) ns ++ filter inUsing ns in
-          if null ns 
-            then (tm, reverse declimps) 
+          if null ns
+            then (tm, reverse declimps)
             else implicitise syn ignore ist (pibind uvars nsOrder tm)
   where
     uvars = map ipair (filter uimplicit (using syn))
@@ -992,18 +992,18 @@ implicitise syn ignore ist tm = -- trace ("INCOMING " ++ showImp True tm) $
        = do (decls, ns) <- get
             let isn = concatMap (namesIn uvars ist) (map getTm as)
             put (decls, nub (ns ++ (isn `dropAll` (env ++ map fst (getImps decls)))))
-    imps top env (PPi (Imp l _ doc _) n ty sc) 
+    imps top env (PPi (Imp l _ doc _) n ty sc)
         = do let isn = nub (namesIn uvars ist ty) `dropAll` [n]
              (decls , ns) <- get
-             put (PImp (getPriority ist ty) True l n ty doc : decls, 
+             put (PImp (getPriority ist ty) True l n ty doc : decls,
                   nub (ns ++ (isn `dropAll` (env ++ map fst (getImps decls)))))
              imps True (n:env) sc
-    imps top env (PPi (Exp l _ doc _) n ty sc) 
+    imps top env (PPi (Exp l _ doc _) n ty sc)
         = do let isn = nub (namesIn uvars ist ty ++ case sc of
                             (PRef _ x) -> namesIn uvars ist sc `dropAll` [n]
                             _ -> [])
              (decls, ns) <- get -- ignore decls in HO types
-             put (PExp (getPriority ist ty) l ty doc : decls, 
+             put (PExp (getPriority ist ty) l ty doc : decls,
                   nub (ns ++ (isn `dropAll` (env ++ map fst (getImps decls)))))
              imps True (n:env) sc
     imps top env (PPi (Constraint l _ doc) n ty sc)
@@ -1011,7 +1011,7 @@ implicitise syn ignore ist tm = -- trace ("INCOMING " ++ showImp True tm) $
                             (PRef _ x) -> namesIn uvars ist sc `dropAll` [n]
                             _ -> [])
              (decls, ns) <- get -- ignore decls in HO types
-             put (PConstraint 10 l ty doc : decls, 
+             put (PConstraint 10 l ty doc : decls,
                   nub (ns ++ (isn `dropAll` (env ++ map fst (getImps decls)))))
              imps True (n:env) sc
     imps top env (PPi (TacImp l _ scr doc) n ty sc)
@@ -1019,7 +1019,7 @@ implicitise syn ignore ist tm = -- trace ("INCOMING " ++ showImp True tm) $
                             (PRef _ x) -> namesIn uvars ist sc `dropAll` [n]
                             _ -> [])
              (decls, ns) <- get -- ignore decls in HO types
-             put (PTacImplicit 10 l n scr ty doc : decls, 
+             put (PTacImplicit 10 l n scr ty doc : decls,
                   nub (ns ++ (isn `dropAll` (env ++ map fst (getImps decls)))))
              imps True (n:env) sc
     imps top env (PEq _ l r)
@@ -1042,14 +1042,14 @@ implicitise syn ignore ist tm = -- trace ("INCOMING " ++ showImp True tm) $
              put (decls, nub (ns ++ (isn \\ (env ++ map fst (getImps decls)))))
     imps top env (PDPair _ l t r)
         = do (decls, ns) <- get
-             let isn = namesIn uvars ist l ++ namesIn uvars ist t ++ 
+             let isn = namesIn uvars ist l ++ namesIn uvars ist t ++
                        namesIn uvars ist r
              put (decls, nub (ns ++ (isn \\ (env ++ map fst (getImps decls)))))
     imps top env (PAlternative a as)
         = do (decls, ns) <- get
              let isn = concatMap (namesIn uvars ist) as
              put (decls, nub (ns ++ (isn `dropAll` (env ++ map fst (getImps decls)))))
-    imps top env (PLam n ty sc)  
+    imps top env (PLam n ty sc)
         = do imps False env ty
              imps False (n:env) sc
     imps top env (PHidden tm)    = imps False env tm
@@ -1058,10 +1058,10 @@ implicitise syn ignore ist tm = -- trace ("INCOMING " ++ showImp True tm) $
     imps top env _               = return ()
 
     pibind using []     sc = sc
-    pibind using (n:ns) sc 
+    pibind using (n:ns) sc
       = case lookup n using of
             Just ty -> PPi (Imp False Dynamic "" False) n ty (pibind using ns sc)
-            Nothing -> PPi (Imp False Dynamic "" False) n Placeholder 
+            Nothing -> PPi (Imp False Dynamic "" False) n Placeholder
                                    (pibind using ns sc)
 
 -- Add implicit arguments in function calls
@@ -1083,7 +1083,7 @@ addImpl = addImpl' False [] []
 addImpl' :: Bool -> [Name] -> [Name] -> IState -> PTerm -> PTerm
 addImpl' inpat env infns ist ptm = ai (zip env (repeat Nothing)) ptm
   where
-    ai env (PRef fc f)    
+    ai env (PRef fc f)
         | f `elem` infns = PInferRef fc f
         | not (f `elem` map fst env) = handleErr $ aiFn inpat inpat ist fc f []
     ai env (PHidden (PRef fc f))
@@ -1107,16 +1107,16 @@ addImpl' inpat env infns ist ptm = ai (zip env (repeat Nothing)) ptm
                                    PDPair fc l' t' r'
     ai env (PAlternative a as) = let as' = map (ai env) as in
                                      PAlternative a as'
-    ai env (PApp fc (PInferRef _ f) as) 
+    ai env (PApp fc (PInferRef _ f) as)
         = let as' = map (fmap (ai env)) as in
-              PApp fc (PInferRef fc f) as'  
-    ai env (PApp fc ftm@(PRef _ f) as) 
+              PApp fc (PInferRef fc f) as'
+    ai env (PApp fc ftm@(PRef _ f) as)
         | f `elem` infns = ai env (PApp fc (PInferRef fc f) as)
         | not (f `elem` map fst env)
                           = let as' = map (fmap (ai env)) as in
                                 handleErr $ aiFn inpat False ist fc f as'
         | Just (Just ty) <- lookup f env
-                          = let as' = map (fmap (ai env)) as 
+                          = let as' = map (fmap (ai env)) as
                                 arity = getPArity ty in
                                 mkPApp fc arity ftm as'
     ai env (PApp fc f as) = let f' = ai env f
@@ -1158,8 +1158,8 @@ aiFn inpat True ist fc f []
   = case lookupDef f (tt_ctxt ist) of
         [] -> Right $ PPatvar fc f
         alts -> let ialts = lookupCtxtName f (idris_implicits ist) in
-                    -- trace (show f ++ " " ++ show (fc, any (all imp) ialts, ialts, any constructor alts)) $ 
-                    if (not (vname f) || tcname f 
+                    -- trace (show f ++ " " ++ show (fc, any (all imp) ialts, ialts, any constructor alts)) $
+                    if (not (vname f) || tcname f
                            || any (conCaf (tt_ctxt ist)) ialts)
 --                            any constructor alts || any allImp ialts))
                         then aiFn inpat False ist fc f [] -- use it as a constructor
@@ -1187,7 +1187,7 @@ aiFn inpat expat ist fc f as
                     else Right $ mkPApp fc (length as) (PRef fc f) as
             alts -> Right $
                      PAlternative True $
-                       map (\(f', ns) -> mkPApp fc (length ns) (PRef fc f') 
+                       map (\(f', ns) -> mkPApp fc (length ns) (PRef fc f')
                                                    (insertImpl ns as)) alts
   where
     insertImpl :: [PArg] -> [PArg] -> [PArg]
@@ -1204,16 +1204,16 @@ aiFn inpat expat ist fc f as
     insertImpl (PTacImplicit p l n sc ty d : ps) given =
         case find n given [] of
             Just (tm, given') -> PTacImplicit p l n sc tm "" : insertImpl ps given'
-            Nothing -> if inpat 
+            Nothing -> if inpat
                           then PTacImplicit p l n sc Placeholder "" : insertImpl ps given
                           else PTacImplicit p l n sc sc "" : insertImpl ps given
     insertImpl expected [] = []
     insertImpl _        given  = given
 
     find n []               acc = Nothing
-    find n (PImp _ _ _ n' t _ : gs) acc 
+    find n (PImp _ _ _ n' t _ : gs) acc
          | n == n' = Just (t, reverse acc ++ gs)
-    find n (PTacImplicit _ _ n' _ t _ : gs) acc 
+    find n (PTacImplicit _ _ n' _ t _ : gs) acc
          | n == n' = Just (t, reverse acc ++ gs)
     find n (g : gs) acc = find n gs (g : acc)
 
@@ -1222,9 +1222,9 @@ aiFn inpat expat ist fc f as
 -- it is hard to get right!
 
 stripLinear :: IState -> PTerm -> PTerm
-stripLinear i tm = evalState (sl tm) [] where 
+stripLinear i tm = evalState (sl tm) [] where
     sl :: PTerm -> State [Name] PTerm
-    sl (PRef fc f) 
+    sl (PRef fc f)
          | (_:_) <- lookupTy f (tt_ctxt i)
               = return $ PRef fc f
          | otherwise = do ns <- get
@@ -1232,7 +1232,7 @@ stripLinear i tm = evalState (sl tm) [] where
                              then return Placeholder
                              else do put (f : ns)
                                      return (PRef fc f)
-    sl (PPatvar fc f) 
+    sl (PPatvar fc f)
                      = do ns <- get
                           if (f `elem` ns)
                              then return Placeholder
@@ -1245,10 +1245,10 @@ stripLinear i tm = evalState (sl tm) [] where
                                          return $ PImp p m l n t' d
              slA (PExp p l t d) = do t' <- sl t
                                      return $ PExp p l t' d
-             slA (PConstraint p l t d) 
+             slA (PConstraint p l t d)
                                 = do t' <- sl t
                                      return $ PConstraint p l t' d
-             slA (PTacImplicit p l n sc t d) 
+             slA (PTacImplicit p l n sc t d)
                                 = do t' <- sl t
                                      return $ PTacImplicit p l n sc t' d
     sl x = return x
@@ -1261,7 +1261,7 @@ mkPApp fc a f as = let rest = drop a as in
     appRest fc f (a : as) = appRest fc (PApp fc f [a]) as
 
 -- Find 'static' argument positions
--- (the declared ones, plus any names in argument position in the declared 
+-- (the declared ones, plus any names in argument position in the declared
 -- statics)
 -- FIXME: It's possible that this really has to happen after elaboration
 
@@ -1279,7 +1279,7 @@ findStatics ist tm = trace (showImp Nothing True False tm) $
 
         inOne n ns = length (filter id (map (elem n) ns)) == 1
 
-        pos ns ss (PPi p n t sc) 
+        pos ns ss (PPi p n t sc)
             | elem n ss = do sc' <- pos ns ss sc
                              spos <- get
                              put (True : spos)
@@ -1296,16 +1296,16 @@ dumpDecls :: [PDecl] -> String
 dumpDecls [] = ""
 dumpDecls (d:ds) = dumpDecl d ++ "\n" ++ dumpDecls ds
 
-dumpDecl (PFix _ f ops) = show f ++ " " ++ showSep ", " ops 
+dumpDecl (PFix _ f ops) = show f ++ " " ++ showSep ", " ops
 dumpDecl (PTy _ _ _ _ n t) = "tydecl " ++ show n ++ " : " ++ showImp Nothing True False t
 dumpDecl (PClauses _ _ n cs) = "pat " ++ show n ++ "\t" ++ showSep "\n\t" (map (showCImp True) cs)
 dumpDecl (PData _ _ _ _ d) = showDImp True d
 dumpDecl (PParams _ ns ps) = "params {" ++ show ns ++ "\n" ++ dumpDecls ps ++ "}\n"
 dumpDecl (PNamespace n ps) = "namespace {" ++ n ++ "\n" ++ dumpDecls ps ++ "}\n"
 dumpDecl (PSyntax _ syn) = "syntax " ++ show syn
-dumpDecl (PClass _ _ _ cs n ps ds) 
+dumpDecl (PClass _ _ _ cs n ps ds)
     = "class " ++ show cs ++ " " ++ show n ++ " " ++ show ps ++ "\n" ++ dumpDecls ds
-dumpDecl (PInstance _ _ cs n _ t _ ds) 
+dumpDecl (PInstance _ _ cs n _ t _ ds)
     = "instance " ++ show cs ++ " " ++ show n ++ " " ++ show t ++ "\n" ++ dumpDecls ds
 dumpDecl _ = "..."
 -- dumpDecl (PImport i) = "import " ++ i
@@ -1322,7 +1322,7 @@ instance Monad (EitherErr a) where
 toEither (LeftErr e)  = Left e
 toEither (RightOK ho) = Right ho
 
--- syntactic match of a against b, returning pair of variables in a 
+-- syntactic match of a against b, returning pair of variables in a
 -- and what they match. Returns the pair that failed if not a match.
 
 matchClause :: IState -> PTerm -> PTerm -> Either (PTerm, PTerm) [(Name, PTerm)]
@@ -1336,7 +1336,7 @@ matchClause' names i x y = checkRpts $ match (fullApp x) (fullApp y) where
     fullApp x = x
 
     match' x y = match (fullApp x) (fullApp y)
-    match (PApp _ (PRef _ (NS (UN "fromInteger") ["builtins"])) [_,_,x]) x' 
+    match (PApp _ (PRef _ (NS (UN "fromInteger") ["builtins"])) [_,_,x]) x'
         | PConstant (I _) <- getTm x = match (getTm x) x'
     match x' (PApp _ (PRef _ (NS (UN "fromInteger") ["builtins"])) [_,_,x])
         | PConstant (I _) <- getTm x = match (getTm x) x'
@@ -1354,17 +1354,17 @@ matchClause' names i x y = checkRpts $ match (fullApp x) (fullApp y) where
     match xr (PPatvar f n) = match xr (PRef f n)
     match (PApp _ x []) (PRef f n) = match x (PRef f n)
     match (PRef _ n) tm@(PRef _ n')
-        | n == n' && not names && 
+        | n == n' && not names &&
           (not (isConName n (tt_ctxt i)) || tm == Placeholder)
             = return [(n, tm)]
         | n == n' = return []
-    match (PRef _ n) tm 
+    match (PRef _ n) tm
         | not names && (not (isConName n (tt_ctxt i)) || tm == Placeholder)
             = return [(n, tm)]
     match (PEq _ l r) (PEq _ l' r') = do ml <- match' l l'
                                          mr <- match' r r'
                                          return (ml ++ mr)
-    match (PRewrite _ l r _) (PRewrite _ l' r' _) 
+    match (PRewrite _ l r _) (PRewrite _ l' r' _)
                                     = do ml <- match' l l'
                                          mr <- match' r r'
                                          return (ml ++ mr)
@@ -1380,8 +1380,8 @@ matchClause' names i x y = checkRpts $ match (fullApp x) (fullApp y) where
                                                     mt <- match' t t'
                                                     mr <- match' r r'
                                                     return (ml ++ mt ++ mr)
-    match (PAlternative a as) (PAlternative a' as') 
-        = do ms <- zipWithM match' as as' 
+    match (PAlternative a as) (PAlternative a' as')
+        = do ms <- zipWithM match' as as'
              return (concat ms)
     match a@(PAlternative _ as) b
         = do let ms = zipWith match' as (repeat b)
@@ -1421,9 +1421,9 @@ matchClause' names i x y = checkRpts $ match (fullApp x) (fullApp y) where
               | otherwise = LeftErr (a, b)
 
     checkRpts (RightOK ms) = check ms where
-        check ((n,t):xs) 
+        check ((n,t):xs)
             | Just t' <- lookup n xs = if t/=t' && t/=Placeholder && t'/=Placeholder
-                                                then Left (t, t') 
+                                                then Left (t, t')
                                                 else check xs
         check (_:xs) = check xs
         check [] = Right ms
@@ -1434,7 +1434,7 @@ substMatches ms = substMatchesShadow ms []
 
 substMatchesShadow :: [(Name, PTerm)] -> [Name] -> PTerm -> PTerm
 substMatchesShadow [] shs t = t
-substMatchesShadow ((n,tm):ns) shs t 
+substMatchesShadow ((n,tm):ns) shs t
    = substMatchShadow n shs tm (substMatchesShadow ns shs t)
 
 substMatch :: Name -> PTerm -> PTerm -> PTerm
@@ -1444,10 +1444,10 @@ substMatchShadow :: Name -> [Name] -> PTerm -> PTerm -> PTerm
 substMatchShadow n shs tm t = sm shs t where
     sm xs (PRef _ n') | n == n' = tm
     sm xs (PLam x t sc) = PLam x (sm xs t) (sm xs sc)
-    sm xs (PPi p x t sc) 
-         | x `elem` xs 
+    sm xs (PPi p x t sc)
+         | x `elem` xs
              = let x' = nextName x in
-                   PPi p x' (sm (x':xs) (substMatch x (PRef emptyFC x') t)) 
+                   PPi p x' (sm (x':xs) (substMatch x (PRef emptyFC x') t))
                             (sm (x':xs) (substMatch x (PRef emptyFC x') sc))
          | otherwise = PPi p x (sm xs t) (sm (x : xs) sc)
     sm xs (PApp f x as) = fullApp $ PApp f (sm xs x) (map (fmap (sm xs)) as)

--- a/src/Idris/AbsSyntaxTree.hs
+++ b/src/Idris/AbsSyntaxTree.hs
@@ -88,7 +88,7 @@ data IState = IState {
     idris_statics :: Ctxt [Bool],
     idris_classes :: Ctxt ClassInfo,
     idris_dsls :: Ctxt DSL,
-    idris_optimisation :: Ctxt OptInfo, 
+    idris_optimisation :: Ctxt OptInfo,
     idris_datatypes :: Ctxt TypeInfo,
     idris_patdefs :: Ctxt ([([Name], Term, Term)], [PTerm]), -- not exported
       -- ^ list of lhs/rhs, and a list of missing clauses
@@ -100,8 +100,8 @@ data IState = IState {
     idris_log :: String,
     idris_options :: IOption,
     idris_name :: Int,
-    idris_lineapps :: [((FilePath, Int), PTerm)], 
-          -- ^ Full application LHS on source line 
+    idris_lineapps :: [((FilePath, Int), PTerm)],
+          -- ^ Full application LHS on source line
     idris_metavars :: [(Name, (Maybe Name, Int))], -- ^ The currently defined but not proven metavariables
     idris_coercions :: [Name],
     idris_transforms :: [(Term, Term)],
@@ -145,15 +145,15 @@ data CGInfo = CGInfo { argsdef :: [Name],
                        argsused :: [Name],
                        unusedpos :: [Int] }
     deriving Show
-{-! 
-deriving instance Binary CGInfo 
+{-!
+deriving instance Binary CGInfo
 !-}
 
-primDefs = [UN "unsafePerformPrimIO", 
-            UN "mkLazyForeignPrim", 
-            UN "mkForeignPrim", 
+primDefs = [UN "unsafePerformPrimIO",
+            UN "mkLazyForeignPrim",
+            UN "mkForeignPrim",
             UN "FalseElim"]
-             
+
 -- information that needs writing for the current module's .ibc file
 data IBCWrite = IBCFix FixDecl
               | IBCImp Name
@@ -183,13 +183,13 @@ data IBCWrite = IBCFix FixDecl
   deriving Show
 
 idrisInit = IState initContext [] [] emptyContext emptyContext emptyContext
-                   emptyContext emptyContext emptyContext emptyContext 
+                   emptyContext emptyContext emptyContext emptyContext
                    emptyContext emptyContext emptyContext emptyContext
                    [] "" defaultOpts 6 [] [] [] [] [] [] [] [] [] [] [] []
                    [] Nothing Nothing [] [] [] Hidden False [] Nothing [] [] RawOutput
                    True defaultTheme stdout
 
--- | The monad for the main REPL - reading and processing files and updating 
+-- | The monad for the main REPL - reading and processing files and updating
 -- global state (hence the IO inner monad).
 --type Idris = WriterT [Either String (IO ())] (State IState a))
 type Idris = StateT IState (ErrorT Err IO)
@@ -212,9 +212,9 @@ data Command = Quit
              | DocStr Name
              | TotCheck Name
              | Reload
-             | Load FilePath 
+             | Load FilePath
              | ChangeDirectory FilePath
-             | ModImport String 
+             | ModImport String
              | Edit
              | Compile Codegen String
              | Execute
@@ -240,11 +240,11 @@ data Command = Quit
              | DebugInfo Name
              | Search PTerm
              | CaseSplit Name PTerm
-             | CaseSplitAt Bool Int Name 
-             | AddClauseFrom Bool Int Name 
-             | AddProofClauseFrom Bool Int Name 
-             | AddMissing Bool Int Name 
-             | MakeWith Bool Int Name 
+             | CaseSplitAt Bool Int Name
+             | AddClauseFrom Bool Int Name
+             | AddProofClauseFrom Bool Int Name
+             | AddMissing Bool Int Name
+             | MakeWith Bool Int Name
              | DoProofSearch Bool Int Name [Name]
              | SetOpt Opt
              | UnsetOpt Opt
@@ -298,13 +298,13 @@ data Opt = Filename String
 
 -- Parsed declarations
 
-data Fixity = Infixl { prec :: Int } 
+data Fixity = Infixl { prec :: Int }
             | Infixr { prec :: Int }
-            | InfixN { prec :: Int } 
+            | InfixN { prec :: Int }
             | PrefixN { prec :: Int }
     deriving Eq
-{-! 
-deriving instance Binary Fixity 
+{-!
+deriving instance Binary Fixity
 !-}
 
 instance Show Fixity where
@@ -313,14 +313,14 @@ instance Show Fixity where
     show (InfixN i) = "infix " ++ show i
     show (PrefixN i) = "prefix " ++ show i
 
-data FixDecl = Fix Fixity String 
+data FixDecl = Fix Fixity String
     deriving Eq
 
 instance Show FixDecl where
   show (Fix f s) = show f ++ " " ++ s
 
-{-! 
-deriving instance Binary FixDecl 
+{-!
+deriving instance Binary FixDecl
 !-}
 
 instance Ord FixDecl where
@@ -329,8 +329,8 @@ instance Ord FixDecl where
 
 data Static = Static | Dynamic
   deriving (Show, Eq)
-{-! 
-deriving instance Binary Static 
+{-!
+deriving instance Binary Static
 !-}
 
 -- Mark bindings with their explicitness, and laziness
@@ -352,7 +352,7 @@ data Plicity = Imp { plazy :: Bool,
   deriving (Show, Eq)
 
 {-!
-deriving instance Binary Plicity 
+deriving instance Binary Plicity
 !-}
 
 impl = Imp False Dynamic "" False
@@ -363,8 +363,8 @@ tacimpl t = TacImp False Dynamic t ""
 
 data FnOpt = Inlinable -- always evaluate when simplifying
            | TotalFn | PartialFn
-           | Coinductive | AssertTotal 
-           | Dictionary -- type class dictionary, eval only when 
+           | Coinductive | AssertTotal
+           | Dictionary -- type class dictionary, eval only when
                         -- a function argument, and further evaluation resutls
            | Implicit -- implicit coercion
            | CExport String    -- export, with a C name
@@ -395,7 +395,7 @@ data PDecl' t
    | PParams  FC [(Name, t)] [PDecl' t] -- ^ Params block
    | PNamespace String [PDecl' t] -- ^ New namespace
    | PRecord  String SyntaxInfo FC Name t String Name t  -- ^ Record declaration
-   | PClass   String SyntaxInfo FC 
+   | PClass   String SyntaxInfo FC
               [t] -- constraints
               Name
               [(Name, t)] -- parameters
@@ -436,7 +436,7 @@ type ElabD a = Elab' [PDecl] a
 -- 4. The where block (PDecl' t)
 
 data PClause' t = PClause  FC Name t [t] t [PDecl' t] -- ^ A normal top-level definition.
-                | PWith    FC Name t [t] t [PDecl' t]   
+                | PWith    FC Name t [t] t [PDecl' t]
                 | PClauseR FC        [t] t [PDecl' t]
                 | PWithR   FC        [t] t [PDecl' t]
     deriving Functor
@@ -462,7 +462,7 @@ deriving instance Binary PData'
 
 type PDecl   = PDecl' PTerm
 type PData   = PData' PTerm
-type PClause = PClause' PTerm 
+type PClause = PClause' PTerm
 
 -- get all the names declared in a decl
 
@@ -494,7 +494,7 @@ tldeclared (PClauses _ _ n _) = [] -- not a declaration
 tldeclared (PRecord _ _ _ n _ _ c _) = [n, c]
 tldeclared (PData _ _ _ _ (PDatadecl n _ ts)) = n : map fstt ts
    where fstt (_, a, _, _) = a
-tldeclared (PParams _ _ ds) = [] 
+tldeclared (PParams _ _ ds) = []
 tldeclared (PMutual _ ds) = concatMap tldeclared ds
 tldeclared (PNamespace _ ds) = concatMap tldeclared ds
 tldeclared (PClass _ _ _ _ n _ ms) = concatMap tldeclared ms
@@ -528,14 +528,14 @@ updateN _  n = n
 updateNs :: [(Name, Name)] -> PTerm -> PTerm
 updateNs [] t = t
 updateNs ns t = mapPT updateRef t
-  where updateRef (PRef fc f) = PRef fc (updateN ns f) 
+  where updateRef (PRef fc f) = PRef fc (updateN ns f)
         updateRef t = t
 
 -- updateDNs :: [(Name, Name)] -> PDecl -> PDecl
 -- updateDNs [] t = t
 -- updateDNs ns (PTy s f n t)    | Just n' <- lookup n ns = PTy s f n' t
 -- updateDNs ns (PClauses f n c) | Just n' <- lookup n ns = PClauses f n' (map updateCNs c)
---   where updateCNs ns (PClause n l ts r ds) 
+--   where updateCNs ns (PClause n l ts r ds)
 --             = PClause (updateN ns n) (fmap (updateNs ns) l)
 --                                      (map (fmap (updateNs ns)) ts)
 --                                      (fmap (updateNs ns) r)
@@ -579,12 +579,12 @@ data PTerm = PQuote Raw
            | PImpossible -- ^ Special case for declaring when an LHS can't typecheck
            | PCoerced PTerm -- ^ To mark a coerced argument, so as not to coerce twice
            | PUnifyLog PTerm -- ^ dump a trace of unifications when building term
-           | PNoImplicits PTerm -- ^ never run implicit converions on the term 
+           | PNoImplicits PTerm -- ^ never run implicit converions on the term
        deriving Eq
 
 
-{-! 
-deriving instance Binary PTerm 
+{-!
+deriving instance Binary PTerm
 !-}
 
 mapPT :: (PTerm -> PTerm) -> PTerm -> PTerm
@@ -592,7 +592,7 @@ mapPT f t = f (mpt t) where
   mpt (PLam n t s) = PLam n (mapPT f t) (mapPT f s)
   mpt (PPi p n t s) = PPi p n (mapPT f t) (mapPT f s)
   mpt (PLet n ty v s) = PLet n (mapPT f ty) (mapPT f v) (mapPT f s)
-  mpt (PRewrite fc t s g) = PRewrite fc (mapPT f t) (mapPT f s) 
+  mpt (PRewrite fc t s g) = PRewrite fc (mapPT f t) (mapPT f s)
                                  (fmap (mapPT f) g)
   mpt (PApp fc t as) = PApp fc (mapPT f t) (map (fmap (mapPT f)) as)
   mpt (PAppBind fc t as) = PAppBind fc (mapPT f t) (map (fmap (mapPT f)) as)
@@ -613,11 +613,11 @@ mapPT f t = f (mpt t) where
 
 
 data PTactic' t = Intro [Name] | Intros | Focus Name
-                | Refine Name [Bool] | Rewrite t 
+                | Refine Name [Bool] | Rewrite t
                 | Equiv t
-                | MatchRefine Name 
+                | MatchRefine Name
                 | LetTac Name t | LetTacTy Name t t
-                | Exact t | Compute | Trivial 
+                | Exact t | Compute | Trivial
                 | ProofSearch (Maybe Name) Name [Name]
                 | Solve
                 | Attack
@@ -630,8 +630,8 @@ data PTactic' t = Intro [Name] | Intros | Focus Name
                 | GoalType String (PTactic' t)
                 | Qed | Abandon
     deriving (Show, Eq, Functor)
-{-! 
-deriving instance Binary PTactic' 
+{-!
+deriving instance Binary PTactic'
 !-}
 
 instance Sized a => Sized (PTactic' a) where
@@ -665,8 +665,8 @@ data PDo' t = DoExp  FC t
             | DoLet  FC Name t t
             | DoLetP FC t t
     deriving (Eq, Functor)
-{-! 
-deriving instance Binary PDo' 
+{-!
+deriving instance Binary PDo'
 !-}
 
 instance Sized a => Sized (PDo' a) where
@@ -682,7 +682,7 @@ type PDo = PDo' PTerm
 -- things early which will help give a more concrete type to other
 -- variables, e.g. a before (interpTy a).
 
-data PArg' t = PImp { priority :: Int, 
+data PArg' t = PImp { priority :: Int,
                       machine_inf :: Bool, -- true if the machine inferred it
                       lazyarg :: Bool, pname :: Name, getTm :: t,
                       pargdoc :: String }
@@ -693,9 +693,9 @@ data PArg' t = PImp { priority :: Int,
                              lazyarg :: Bool, getTm :: t,
                              pargdoc :: String }
              | PTacImplicit { priority :: Int,
-                              lazyarg :: Bool, pname :: Name, 
+                              lazyarg :: Bool, pname :: Name,
                               getScript :: t,
-                              getTm :: t, 
+                              getTm :: t,
                               pargdoc :: String }
     deriving (Show, Eq, Functor)
 
@@ -705,8 +705,8 @@ instance Sized a => Sized (PArg' a) where
   size (PConstraint p l trm _) = 1 + size trm
   size (PTacImplicit p l nm scr trm _) = 1 + size nm + size scr + size trm
 
-{-! 
-deriving instance Binary PArg' 
+{-!
+deriving instance Binary PArg'
 !-}
 
 pimp n t mach = PImp 1 mach True n t ""
@@ -724,8 +724,8 @@ data ClassInfo = CI { instanceName :: Name,
                       class_params :: [Name],
                       class_instances :: [Name] }
     deriving Show
-{-! 
-deriving instance Binary ClassInfo 
+{-!
+deriving instance Binary ClassInfo
 !-}
 
 data OptInfo = Optimise { collapsible :: Bool,
@@ -733,12 +733,12 @@ data OptInfo = Optimise { collapsible :: Bool,
                           forceable :: [Int], -- argument positions
                           recursive :: [Int] }
     deriving Show
-{-! 
-deriving instance Binary OptInfo 
+{-!
+deriving instance Binary OptInfo
 !-}
 
 
-data TypeInfo = TI { con_names :: [Name], 
+data TypeInfo = TI { con_names :: [Name],
                      codata :: Bool,
                      param_pos :: [Int] }
     deriving Show
@@ -746,7 +746,7 @@ data TypeInfo = TI { con_names :: [Name],
 deriving instance Binary TypeInfo
 !-}
 
--- Syntactic sugar info 
+-- Syntactic sugar info
 
 data DSL' t = DSL { dsl_bind    :: t,
                     dsl_return  :: t,
@@ -767,14 +767,14 @@ type DSL = DSL' PTerm
 
 data SynContext = PatternSyntax | TermSyntax | AnySyntax
     deriving Show
-{-! 
-deriving instance Binary SynContext 
+{-!
+deriving instance Binary SynContext
 !-}
 
 data Syntax = Rule [SSymbol] PTerm SynContext
     deriving Show
-{-! 
-deriving instance Binary Syntax 
+{-!
+deriving instance Binary Syntax
 !-}
 
 data SSymbol = Keyword Name
@@ -783,11 +783,11 @@ data SSymbol = Keyword Name
              | Expr Name
              | SimpleExpr Name
     deriving Show
-{-! 
-deriving instance Binary SSymbol 
+{-!
+deriving instance Binary SSymbol
 !-}
 
-initDSL = DSL (PRef f (UN ">>=")) 
+initDSL = DSL (PRef f (UN ">>="))
               (PRef f (UN "return"))
               (PRef f (UN "<$>"))
               (PRef f (UN "pure"))
@@ -849,29 +849,29 @@ showDeclImp t (PTy _ _ _ _ n ty) = show n ++ " : " ++ showImp Nothing t False ty
 showDeclImp t (PPostulate _ _ _ _ n ty) = show n ++ " : " ++ showImp Nothing t False ty
 showDeclImp _ (PClauses _ _ n c) = showSep "\n" (map show c)
 showDeclImp _ (PData _ _ _ _ d) = show d
-showDeclImp _ (PParams f ns ps) = "parameters " ++ show ns ++ "\n" ++ 
+showDeclImp _ (PParams f ns ps) = "parameters " ++ show ns ++ "\n" ++
                                     showSep "\n" (map show ps)
 
 
 showCImp :: Bool -> PClause -> String
-showCImp impl (PClause _ n l ws r w) 
+showCImp impl (PClause _ n l ws r w)
    = showImp Nothing impl False l ++ showWs ws ++ " = " ++ showImp Nothing impl False r
-             ++ " where " ++ show w 
+             ++ " where " ++ show w
   where
     showWs [] = ""
     showWs (x : xs) = " | " ++ showImp Nothing impl False x ++ showWs xs
-showCImp impl (PWith _ n l ws r w) 
+showCImp impl (PWith _ n l ws r w)
    = showImp Nothing impl False l ++ showWs ws ++ " with " ++ showImp Nothing impl False r
-             ++ " { " ++ show w ++ " } " 
+             ++ " { " ++ show w ++ " } "
   where
     showWs [] = ""
     showWs (x : xs) = " | " ++ showImp Nothing impl False x ++ showWs xs
 
 
 showDImp :: Bool -> PData -> String
-showDImp impl (PDatadecl n ty cons) 
+showDImp impl (PDatadecl n ty cons)
    = "data " ++ show n ++ " : " ++ showImp Nothing impl False ty ++ " where\n\t"
-     ++ showSep "\n\t| " 
+     ++ showSep "\n\t| "
             (map (\ (_, n, t, _) -> show n ++ " : " ++ showImp Nothing impl False t) cons)
 
 getImps :: [PArg] -> [(Name, PTerm)]
@@ -890,7 +890,7 @@ getConsts (PConstraint _ _ tm _ : xs) = tm : getConsts xs
 getConsts (_ : xs) = getConsts xs
 
 getAll :: [PArg] -> [PTerm]
-getAll = map getTm 
+getAll = map getTm
 
 -- | Pretty-print a high-level Idris term
 prettyImp :: Bool -- ^^ whether to show implicits
@@ -1135,7 +1135,7 @@ showImp ist impl colour tm = se 10 [] tm where
         | Just num <- snat p e  = perhapsColourise colouriseData (show num)
     se p bnd (PRef fc n) = showName ist bnd impl colour n
     se p bnd (PLam n ty sc) = bracket p 2 $ "\\ " ++ perhapsColourise colouriseBound (show n) ++
-                              (if impl then " : " ++ se 10 bnd ty else "") ++ " => " 
+                              (if impl then " : " ++ se 10 bnd ty else "") ++ " => "
                               ++ se 10 ((n, False):bnd) sc
     se p bnd (PLet n ty v sc) = bracket p 2 $ "let " ++ perhapsColourise colouriseBound (show n) ++
                                 " = " ++ se 10 bnd v ++
@@ -1145,7 +1145,7 @@ showImp ist impl colour tm = se 10 [] tm where
                                   = bracket p 2 $
                                     (if l then "|(" else "(") ++
                                     perhapsColourise colouriseBound (show n) ++ " : " ++ se 10 bnd ty ++
-                                    ") " ++ 
+                                    ") " ++
                                     (if (impl && param) then "P" else "") ++
                                     st ++
                                     "-> " ++ se 10 ((n, False):bnd) sc
@@ -1155,7 +1155,7 @@ showImp ist impl colour tm = se 10 [] tm where
                     _ -> ""
     se p bnd (PPi (Imp l s _ _) n ty sc)
         | impl = bracket p 2 $ (if l then "|{" else "{") ++
-                               perhapsColourise colouriseBound (show n) ++ " : " ++ se 10 bnd ty ++ 
+                               perhapsColourise colouriseBound (show n) ++ " : " ++ se 10 bnd ty ++
                                "} " ++ st ++ "-> " ++ se 10 ((n, True):bnd) sc
         | otherwise = se 10 ((n, True):bnd) sc
       where st = case s of
@@ -1173,12 +1173,12 @@ showImp ist impl colour tm = se 10 [] tm where
     se p bnd (PAppBind _ hd@(PRef _ f) [])
         | not impl = "!" ++ se p bnd hd
     se p bnd (PApp _ op@(PRef _ (UN (f:_))) args)
-        | length (getExps args) == 2 && not impl && not (isAlpha f) 
+        | length (getExps args) == 2 && not impl && not (isAlpha f)
             = let [l, r] = getExps args in
               bracket p 1 $ se 1 bnd l ++ " " ++ se p bnd op ++ " " ++ se 0 bnd r
     se p bnd (PApp _ f as)
         = -- let args = getExps as in
-              bracket p 1 $ se 1 bnd f ++ 
+              bracket p 1 $ se 1 bnd f ++
                   if impl then concatMap (sArg bnd) as
                           else concatMap (suiArg impl bnd) as
     se p bnd (PAppBind _ f as)
@@ -1257,16 +1257,16 @@ showImp ist impl colour tm = se 10 [] tm where
     sArg bnd (PTacImplicit _ _ n _ tm _) = stiArg bnd (n, tm)
 
     -- show argument, implicits given by the user also shown
-    suiArg impl bnd (PImp _ mi _ n tm _) 
+    suiArg impl bnd (PImp _ mi _ n tm _)
         | impl || not mi = siArg bnd (n, tm)
     suiArg impl bnd (PExp _ _ tm _) = seArg bnd tm
     suiArg impl bnd _ = ""
 
     seArg bnd arg      = " " ++ se 0 bnd arg
-    siArg bnd (n, val) = 
+    siArg bnd (n, val) =
         let n' = show n
             val' = se 10 bnd val in
-            if (n' == val') 
+            if (n' == val')
                then " {" ++ n' ++ "}"
                else " {" ++ n' ++ " = " ++ val' ++ "}"
     scArg bnd val = " {{" ++ se 10 bnd val ++ "}}"
@@ -1316,9 +1316,9 @@ getPArity _ = 0
 -- Return all names, free or globally bound, in the given term.
 
 allNamesIn :: PTerm -> [Name]
-allNamesIn tm = nub $ ni [] tm 
+allNamesIn tm = nub $ ni [] tm
   where
-    ni env (PRef _ n)        
+    ni env (PRef _ n)
         | not (n `elem` env) = [n]
     ni env (PApp _ f as)   = ni env f ++ concatMap (ni env) (map getTm as)
     ni env (PAppBind _ f as)   = ni env f ++ concatMap (ni env) (map getTm as)
@@ -1340,10 +1340,10 @@ allNamesIn tm = nub $ ni [] tm
 -- Return names which are free in the given term.
 
 namesIn :: [(Name, PTerm)] -> IState -> PTerm -> [Name]
-namesIn uvars ist tm = nub $ ni [] tm 
+namesIn uvars ist tm = nub $ ni [] tm
   where
-    ni env (PRef _ n)        
-        | not (n `elem` env) 
+    ni env (PRef _ n)
+        | not (n `elem` env)
             = case lookupTy n (tt_ctxt ist) of
                 [] -> [n]
                 _ -> if n `elem` (map fst uvars) then [n] else []
@@ -1367,10 +1367,10 @@ namesIn uvars ist tm = nub $ ni [] tm
 -- Return which of the given names are used in the given term.
 
 usedNamesIn :: [Name] -> IState -> PTerm -> [Name]
-usedNamesIn vars ist tm = nub $ ni [] tm 
+usedNamesIn vars ist tm = nub $ ni [] tm
   where
-    ni env (PRef _ n)        
-        | n `elem` vars && not (n `elem` env) 
+    ni env (PRef _ n)
+        | n `elem` vars && not (n `elem` env)
             = case lookupTy n (tt_ctxt ist) of
                 [] -> [n]
                 _ -> []

--- a/src/Idris/CaseSplit.hs
+++ b/src/Idris/CaseSplit.hs
@@ -276,10 +276,10 @@ getProofClause :: Int -> -- ^ Line type is declared on
                   Name -> -- ^ Function name
                   FilePath -> -- ^ Source file name
                   Idris String
-getProofClause l fn fp 
+getProofClause l fn fp
                   = do ty <- getInternalApp fp l
                        return (mkApp ty ++ " = ?" ++ show fn ++ "_rhs")
-   where mkApp (PPi _ _ _ sc) = mkApp sc 
+   where mkApp (PPi _ _ _ sc) = mkApp sc
          mkApp rt = "(" ++ show rt ++ ") <== " ++ show fn
 
 -- Purely syntactic - turn a pattern match clause into a with and a new

--- a/src/Idris/Chaser.hs
+++ b/src/Idris/Chaser.hs
@@ -51,7 +51,7 @@ getModuleFiles ts = nub $ execState (modList ts) [] where
 
    ibc (IBC _ _) = True
    ibc _ = False
- 
+
    chkReload False p = p
    chkReload True (IBC fn src) = chkReload True src
    chkReload True p = p
@@ -74,19 +74,19 @@ buildTree built fp = idrisCatch (btree [] fp)
                         (\e -> do now <- runIO $ getCurrentTime
                                   return [MTree (IDR fp) True now []])
  where
-  btree done f = 
+  btree done f =
     do i <- getIState
        let file = takeWhile (/= ' ') f
        iLOG $ "CHASING " ++ show file
        ibcsd <- valIBCSubDir i
-       ids <- allImportDirs 
+       ids <- allImportDirs
        fp <- runIO $ findImport ids ibcsd file
        mt <- runIO $ getIModTime fp
-       if (file `elem` built) 
+       if (file `elem` built)
           then return [MTree fp False mt []]
-          else if file `elem` done 
+          else if file `elem` done
                   then return []
-                  else mkChildren fp 
+                  else mkChildren fp
 
     where mkChildren (LIDR fn) = do ms <- children True fn (f:done)
                                     mt <- runIO $ getModificationTime fn
@@ -94,7 +94,7 @@ buildTree built fp = idrisCatch (btree [] fp)
           mkChildren (IDR fn) = do ms <- children False fn (f:done)
                                    mt <- runIO $ getModificationTime fn
                                    return [MTree (IDR fn) True mt ms]
-          mkChildren (IBC fn src) 
+          mkChildren (IBC fn src)
               = do srcexist <- runIO $ doesFileExist (getSrcFile src)
                    ms <- if srcexist then
                                do [MTree _ _ _ ms'] <- mkChildren src
@@ -119,7 +119,7 @@ buildTree built fp = idrisCatch (btree [] fp)
                              if exist then do
                                  ibct <- runIO $ getModificationTime ibc
                                  srct <- runIO $ getModificationTime src
-                                 return (srct > ibct) 
+                                 return (srct > ibct)
                                else return False
 
   children :: Bool -> FilePath -> [FilePath] -> Idris [ModuleTree]
@@ -129,7 +129,7 @@ buildTree built fp = idrisCatch (btree [] fp)
             file_in <- runIO $ readFile f
             file <- if lit then tclift $ unlit f file_in else return file_in
             (_, modules, _) <- parseImports f file
-            ms <- mapM (btree done) modules 
+            ms <- mapM (btree done) modules
             return (concat ms)
            else return []) -- IBC with no source available
     (\c -> return []) -- error, can't chase modules here

--- a/src/Idris/DSL.hs
+++ b/src/Idris/DSL.hs
@@ -13,7 +13,7 @@ import Control.Monad.State
 import Debug.Trace
 
 debindApp :: SyntaxInfo -> PTerm -> PTerm
-debindApp syn t = debind (dsl_bind (dsl_info syn)) t 
+debindApp syn t = debind (dsl_bind (dsl_info syn)) t
 
 desugar :: SyntaxInfo -> IState -> PTerm -> PTerm
 desugar syn i t = let t' = expandDo (dsl_info syn) t in
@@ -21,7 +21,7 @@ desugar syn i t = let t' = expandDo (dsl_info syn) t in
 
 expandDo :: DSL -> PTerm -> PTerm
 expandDo dsl (PLam n ty tm)
-    | Just lam <- dsl_lambda dsl 
+    | Just lam <- dsl_lambda dsl
         = let sc = PApp (fileFC "(dsl)") lam [pexp (var dsl n tm 0)] in
               expandDo dsl sc
 expandDo dsl (PLam n ty tm) = PLam n (expandDo dsl ty) (expandDo dsl tm)
@@ -33,13 +33,13 @@ expandDo dsl (PLet n ty v tm) = PLet n (expandDo dsl ty) (expandDo dsl v) (expan
 expandDo dsl (PPi p n ty tm) = PPi p n (expandDo dsl ty) (expandDo dsl tm)
 expandDo dsl (PApp fc t args) = PApp fc (expandDo dsl t)
                                         (map (fmap (expandDo dsl)) args)
-expandDo dsl (PAppBind fc t args) = PAppBind fc (expandDo dsl t) 
-                                                (map (fmap (expandDo dsl)) args) 
+expandDo dsl (PAppBind fc t args) = PAppBind fc (expandDo dsl t)
+                                                (map (fmap (expandDo dsl)) args)
 expandDo dsl (PCase fc s opts) = PCase fc (expandDo dsl s)
                                         (map (pmap (expandDo dsl)) opts)
 expandDo dsl (PEq fc l r) = PEq fc (expandDo dsl l) (expandDo dsl r)
 expandDo dsl (PPair fc l r) = PPair fc (expandDo dsl l) (expandDo dsl r)
-expandDo dsl (PDPair fc l t r) = PDPair fc (expandDo dsl l) (expandDo dsl t) 
+expandDo dsl (PDPair fc l t r) = PDPair fc (expandDo dsl l) (expandDo dsl t)
                                            (expandDo dsl r)
 expandDo dsl (PAlternative a as) = PAlternative a (map (expandDo dsl) as)
 expandDo dsl (PHidden t) = PHidden (expandDo dsl t)
@@ -50,15 +50,15 @@ expandDo dsl (PRewrite fc r t ty)
     = PRewrite fc r (expandDo dsl t) ty
 expandDo dsl (PGoal fc r n sc)
     = PGoal fc (expandDo dsl r) n (expandDo dsl sc)
-expandDo dsl (PDoBlock ds) 
+expandDo dsl (PDoBlock ds)
     = expandDo dsl $ debind (dsl_bind dsl) (block (dsl_bind dsl) ds)
   where
-    block b [DoExp fc tm] = tm 
+    block b [DoExp fc tm] = tm
     block b [a] = PElabError (Msg "Last statement in do block must be an expression")
     block b (DoBind fc n tm : rest)
         = PApp fc b [pexp tm, pexp (PLam n Placeholder (block b rest))]
     block b (DoBindP fc p tm : rest)
-        = PApp fc b [pexp tm, pexp (PLam (MN 0 "bpat") Placeholder 
+        = PApp fc b [pexp tm, pexp (PLam (MN 0 "bpat") Placeholder
                                    (PCase fc (PRef fc (MN 0 "bpat"))
                                              [(p, block b rest)]))]
     block b (DoLet fc n ty tm : rest)
@@ -66,8 +66,8 @@ expandDo dsl (PDoBlock ds)
     block b (DoLetP fc p tm : rest)
         = PCase fc tm [(p, block b rest)]
     block b (DoExp fc tm : rest)
-        = PApp fc b 
-            [pexp tm, 
+        = PApp fc b
+            [pexp tm,
              pexp (PLam (MN 0 "bindx") Placeholder (block b rest))]
     block b _ = PElabError (Msg "Invalid statement in do block")
 
@@ -76,7 +76,7 @@ expandDo dsl t = t
 
 var :: DSL -> Name -> PTerm -> Int -> PTerm
 var dsl n t i = v' i t where
-    v' i (PRef fc x) | x == n = 
+    v' i (PRef fc x) | x == n =
         case dsl_var dsl of
             Nothing -> PElabError (Msg "No 'variable' defined in dsl")
             Just v -> PApp fc v [pexp (mkVar fc i)]
@@ -107,7 +107,7 @@ var dsl n t i = v' i t where
                    Just f  -> f
     mkVar fc n = case index_next dsl of
                    Nothing -> PElabError (Msg "No index_next defined")
-                   Just f -> PApp fc f [pexp (mkVar fc (n-1))] 
+                   Just f -> PApp fc f [pexp (mkVar fc (n-1))]
 
 unIdiom :: PTerm -> PTerm -> FC -> PTerm -> PTerm
 unIdiom ap pure fc e@(PApp _ _ _) = let f = getFn e in
@@ -150,7 +150,7 @@ debind b tm = let (tm', (bs, _)) = runState (db' tm) ([], 0) in
     db' (PDPair fc l t r) = do l' <- db' l
                                r' <- db' r
                                return (PDPair fc l' t r')
-    db' t = return t 
+    db' t = return t
 
     dbArg a = do t' <- db' (getTm a)
                  return (a { getTm = t' })

--- a/src/Idris/Delaborate.hs
+++ b/src/Idris/Delaborate.hs
@@ -17,7 +17,7 @@ delab :: IState -> Term -> PTerm
 delab i tm = delab' i tm False
 
 delabTy :: IState -> Name -> PTerm
-delabTy i n 
+delabTy i n
     = case lookupTy n (tt_ctxt i) of
            (ty:_) -> case lookupCtxt n (idris_implicits i) of
                          (imps:_) -> delabTy' i imps ty False
@@ -43,17 +43,17 @@ delabTy' ist imps tm fullname = de [] imps tm
                             = case lookup n (idris_metavars ist) of
                                   Just (Just _, mi) -> mkMVApp (dens n) []
                                   _ -> PRef un (dens n)
-    de env _ (Bind n (Lam ty) sc) 
+    de env _ (Bind n (Lam ty) sc)
           = PLam n (de env [] ty) (de ((n,n):env) [] sc)
-    de env (PImp _ _ _ _ _ _:is) (Bind n (Pi ty) sc) 
+    de env (PImp _ _ _ _ _ _:is) (Bind n (Pi ty) sc)
           = PPi impl n (de env [] ty) (de ((n,n):env) is sc)
-    de env (PConstraint _ _ _ _:is) (Bind n (Pi ty) sc) 
+    de env (PConstraint _ _ _ _:is) (Bind n (Pi ty) sc)
           = PPi constraint n (de env [] ty) (de ((n,n):env) is sc)
-    de env (PTacImplicit _ _ _ tac _ _:is) (Bind n (Pi ty) sc) 
+    de env (PTacImplicit _ _ _ tac _ _:is) (Bind n (Pi ty) sc)
           = PPi (tacimpl tac) n (de env [] ty) (de ((n,n):env) is sc)
-    de env _ (Bind n (Pi ty) sc) 
+    de env _ (Bind n (Pi ty) sc)
           = PPi expl n (de env [] ty) (de ((n,n):env) [] sc)
-    de env _ (Bind n (Let ty val) sc) 
+    de env _ (Bind n (Let ty val) sc)
         = PLet n (de env [] ty) (de env [] val) (de ((n,n):env) [] sc)
     de env _ (Bind n (Hole ty) sc) = de ((n, UN "[__]"):env) [] sc
     de env _ (Bind n (Guess ty val) sc) = de ((n, UN "[__]"):env) [] sc
@@ -61,7 +61,7 @@ delabTy' ist imps tm fullname = de [] imps tm
     de env _ (Constant i) = PConstant i
     de env _ Erased = Placeholder
     de env _ Impossible = Placeholder
-    de env _ (TType i) = PType 
+    de env _ (TType i) = PType
 
     dens x | fullname = x
     dens ns@(NS n _) = case lookupCtxt n (idris_implicits ist) of
@@ -71,31 +71,31 @@ delabTy' ist imps tm fullname = de [] imps tm
     dens n = n
 
     deFn env (App f a) args = deFn env f (a:args)
-    deFn env (P _ n _) [l,r]     
+    deFn env (P _ n _) [l,r]
          | n == pairTy    = PPair un (de env [] l) (de env [] r)
          | n == eqCon     = PRefl un (de env [] r)
          | n == UN "lazy" = de env [] r
     deFn env (P _ n _) [ty, Bind x (Lam _) r]
-         | n == UN "Exists" 
+         | n == UN "Exists"
                = PDPair un (PRef un x) (de env [] ty)
                            (de ((x,x):env) [] (instantiate (P Bound x ty) r))
-    deFn env (P _ n _) [_,_,l,r] 
+    deFn env (P _ n _) [_,_,l,r]
          | n == pairCon = PPair un (de env [] l) (de env [] r)
          | n == eqTy    = PEq un (de env [] l) (de env [] r)
          | n == UN "Ex_intro" = PDPair un (de env [] l) Placeholder
                                           (de env [] r)
-    deFn env (P _ n _) args 
+    deFn env (P _ n _) args
          = case lookup n (idris_metavars ist) of
-                Just (Just _, mi) -> 
+                Just (Just _, mi) ->
                      mkMVApp (dens n) (drop mi (map (de env []) args))
                 _ -> mkPApp (dens n) (map (de env []) args)
     deFn env f args = PApp un (de env [] f) (map pexp (map (de env []) args))
 
     mkMVApp n []
             = PMetavar n
-    mkMVApp n args 
+    mkMVApp n args
             = PApp un (PMetavar n) (map pexp args)
-    mkPApp n args 
+    mkPApp n args
         | [imps] <- lookupCtxt n (idris_implicits ist)
             = PApp un (PRef un n) (zipWith imp (imps ++ repeat (pexp undefined)) args)
         | otherwise = PApp un (PRef un n) (map pexp args)
@@ -113,7 +113,7 @@ indented text = boxIt '\n' $ unlines $ map ('\t':) $ lines text where
 
 pshow :: IState -> Err -> String
 pshow i (Msg s) = s
-pshow i (InternalMsg s) = "INTERNAL ERROR: " ++ show s ++ 
+pshow i (InternalMsg s) = "INTERNAL ERROR: " ++ show s ++
    "\nThis is probably a bug, or a missing error message.\n" ++
    "Please consider reporting at " ++ bugaddr
 pshow i (CantUnify _ x y e sc s)
@@ -152,11 +152,11 @@ pshow i (CantIntroduce ty)
       let colour = idris_colourRepl i in
           "Can't use lambda here: type is " ++ showImp (Just i) imps colour (delab i ty)
 pshow i (InfiniteUnify x tm env)
-    = "Unifying " ++ showbasic x ++ " and " ++ show (delab i tm) ++ 
+    = "Unifying " ++ showbasic x ++ " and " ++ show (delab i tm) ++
       " would lead to infinite value" ++
                  if (opt_errContext (idris_options i)) then showSc i env else ""
 pshow i (NotInjective p x y) = "Can't verify injectivity of " ++ show (delab i p) ++
-                               " when unifying " ++ show (delab i x) ++ " and " ++ 
+                               " when unifying " ++ show (delab i x) ++ " and " ++
                                                     show (delab i y)
 pshow i (CantResolve c) = "Can't resolve type class " ++ show (delab i c)
 pshow i (CantResolveAlts as) = "Can't disambiguate name: " ++ showSep ", " as
@@ -166,13 +166,13 @@ pshow i (IncompleteTerm t) = "Incomplete term " ++ showImp Nothing True False (d
 pshow i UniverseError = "Universe inconsistency"
 pshow i ProgramLineComment = "Program line next to comment"
 pshow i (Inaccessible n) = show n ++ " is not an accessible pattern variable"
-pshow i (NonCollapsiblePostulate n) 
+pshow i (NonCollapsiblePostulate n)
     = "The return type of postulate " ++ show n ++ " is not collapsible"
 pshow i (AlreadyDefined n) = show n ++ " is already defined"
 pshow i (ProofSearchFail e) = pshow i e
 pshow i (NoRewriting tm) = "rewrite did not change type " ++ show (delab i tm)
 pshow i (At f e) = show f ++ ":" ++ pshow i e
-pshow i (Elaborating s n e) = "When elaborating " ++ s ++ 
+pshow i (Elaborating s n e) = "When elaborating " ++ s ++
                                showqual i n ++ ":\n" ++ pshow i e
 pshow i (ProviderError msg) = "Type provider error: " ++ msg
 pshow i (LoadingFailed fn e) = "Loading " ++ fn ++ " failed: " ++ pshow i e

--- a/src/Idris/Docs.hs
+++ b/src/Idris/Docs.hs
@@ -11,7 +11,7 @@ import Data.List
 
 -- TODO: Only include names with public/abstract accessibility
 
-data FunDoc = Doc Name String 
+data FunDoc = Doc Name String
                   [(Name, PArg)] -- args
                   PTerm -- function type
                   (Maybe Fixity)
@@ -23,7 +23,7 @@ data Doc = FunDoc FunDoc
                     [FunDoc] -- method docs
 
 showDoc "" = ""
-showDoc x = "  -- " ++ x 
+showDoc x = "  -- " ++ x
 
 instance Show FunDoc where
    show (Doc n doc args ty f)
@@ -35,7 +35,7 @@ instance Show FunDoc where
                else ""
 
     where showArg (n, arg@(PExp _ _ _ _))
-             = Just $ showName n ++ show (getTm arg) ++ 
+             = Just $ showName n ++ show (getTm arg) ++
                       showDoc (pargdoc arg) ++ "\n"
           showArg (n, arg@(PConstraint _ _ _ _))
              = Just $ "Class constraint " ++
@@ -44,7 +44,7 @@ instance Show FunDoc where
           showArg (n, arg@(PImp _ _ _ _ _ doc))
            | not (null doc)
              = Just $ "(implicit) " ++
-                      show n ++ " : " ++ show (getTm arg) 
+                      show n ++ " : " ++ show (getTm arg)
                       ++ showDoc (pargdoc arg) ++ "\n"
           showArg (n, _) = Nothing
 
@@ -57,13 +57,13 @@ instance Show Doc where
     show (DataDoc t args) = "Data type " ++ show t ++
        "\nConstructors:\n\n" ++
        showSep "\n" (map show args)
-    show (ClassDoc n doc meths) 
+    show (ClassDoc n doc meths)
        = "Type class " ++ show n ++ -- parameters?
          "\nMethods:\n\n" ++
          showSep "\n" (map show meths)
 
 getDocs :: Name -> Idris Doc
-getDocs n 
+getDocs n
    = do i <- getIState
         case lookupCtxt n (idris_classes i) of
              [ci] -> docClass n ci
@@ -73,7 +73,7 @@ getDocs n
                                return (FunDoc fd)
 
 docData :: Name -> TypeInfo -> Idris Doc
-docData n ti 
+docData n ti
   = do tdoc <- docFun n
        cdocs <- mapM docFun (con_names ti)
        return (DataDoc tdoc cdocs)
@@ -103,7 +103,7 @@ docFun n
        let fixdecls = filter (\(Fix _ x) -> x == funName n) infixes
        let f = case fixdecls of
                     []          -> Nothing
-                    (Fix x _:_) -> Just x 
+                    (Fix x _:_) -> Just x
 
        return (Doc n docstr args (delab i ty) f)
        where funName :: Name -> String

--- a/src/Idris/ElabDecls.hs
+++ b/src/Idris/ElabDecls.hs
@@ -31,9 +31,9 @@ import Data.List
 import Data.Maybe
 import Debug.Trace
 
-recheckC fc env t 
+recheckC fc env t
     = do -- t' <- applyOpts (forget t) (doesn't work, or speed things up...)
-         ctxt <- getContext 
+         ctxt <- getContext
          (tm, ty, cs) <- tclift $ case recheck ctxt env (forget t) t of
                                    Error e -> tfail (At fc e)
                                    OK x -> return x
@@ -47,7 +47,7 @@ checkDef fc ns = do ctxt <- getContext
 -- | Elaborate a top-level type declaration - for example, "foo : Int -> Int".
 elabType :: ElabInfo -> SyntaxInfo -> String ->
             FC -> FnOpts -> Name -> PTerm -> Idris ()
-elabType info syn doc fc opts n ty' = {- let ty' = piBind (params info) ty_in 
+elabType info syn doc fc opts n ty' = {- let ty' = piBind (params info) ty_in
                                       n  = liftname info n_in in    -}
       do checkUndefined fc n
          ctxt <- getContext
@@ -59,12 +59,12 @@ elabType info syn doc fc opts n ty' = {- let ty' = piBind (params info) ty_in
 
          let ty = addImpl i ty'
          logLvl 2 $ show n ++ " type " ++ showImp Nothing True False ty
-         ((tyT, defer, is), log) <- 
+         ((tyT, defer, is), log) <-
                tclift $ elaborate ctxt n (TType (UVal 0)) []
                         (errAt "type of " n (erun fc (build i info False n ty)))
          ds <- checkDef fc defer
          addDeferred ds
-         mapM_ (elabCaseBlock info opts) is 
+         mapM_ (elabCaseBlock info opts) is
          ctxt <- getContext
          logLvl 5 $ "Rechecking"
          logLvl 6 $ show tyT
@@ -147,7 +147,7 @@ elabData info syn doc fc codata (PDatadecl n t_in dcons)
          i <- getIState
          t_in <- implicit syn n t_in
          let t = addImpl i t_in
-         ((t', defer, is), log) <- 
+         ((t', defer, is), log) <-
              tclift $ elaborate ctxt n (TType (UVal 0)) []
                   (errAt "data declaration " n (erun fc (build i info False n t)))
          def' <- checkDef fc defer
@@ -156,11 +156,11 @@ elabData info syn doc fc codata (PDatadecl n t_in dcons)
          (cty, _)  <- recheckC fc [] t'
          logLvl 2 $ "---> " ++ show cty
          -- temporary, to check cons
-         when undef $ updateContext (addTyDecl n (TCon 0 0) cty) 
+         when undef $ updateContext (addTyDecl n (TCon 0 0) cty)
          cons <- mapM (elabCon info syn n codata) dcons
          ttag <- getName
          i <- getIState
-         let as = map (const Nothing) (getArgTys cty) 
+         let as = map (const Nothing) (getArgTys cty)
          let params = findParams  (map snd cons)
          logLvl 2 $ "Parameters : " ++ show params
          putIState (i { idris_datatypes = addDef n (TI (map fst cons) codata params)
@@ -172,7 +172,7 @@ elabData info syn doc fc codata (PDatadecl n t_in dcons)
          collapseCons n cons
          updateContext (addDatatype (Data n ttag cty cons))
          mapM_ (checkPositive n) cons
-  where 
+  where
         -- parameters are names which are unchanged across the structure,
         -- which appear exactly once in the return type of a constructor
 
@@ -184,14 +184,14 @@ elabData info syn doc fc codata (PDatadecl n t_in dcons)
                             paramPos allapps
 
         paramPos [] = []
-        paramPos (args : rest) 
+        paramPos (args : rest)
               = dropNothing $ keepSame (zip [0..] args) rest
 
         dropNothing [] = []
         dropNothing ((x, Nothing) : ts) = dropNothing ts
         dropNothing ((x, _) : ts) = x : dropNothing ts
 
-        keepSame :: [(Int, Maybe Name)] -> [[Maybe Name]] -> 
+        keepSame :: [(Int, Maybe Name)] -> [[Maybe Name]] ->
                     [(Int, Maybe Name)]
         keepSame as [] = as
         keepSame as (args : rest) = keepSame (update as args) rest
@@ -211,14 +211,14 @@ elabData info syn doc fc codata (PDatadecl n t_in dcons)
         getDataApp _ = []
 
         -- keep the arguments which are single names, which don't appear
-        -- elsewhere 
+        -- elsewhere
 
         mParam args [] = []
         mParam args (P Bound n _ : rest)
-               | count n args == 1 
+               | count n args == 1
                   = Just n : mParam args rest
             where count n [] = 0
-                  count n (t : ts) 
+                  count n (t : ts)
                        | n `elem` freeNames t = 1 + count n ts
                        | otherwise = count n ts
         mParam args (_ : rest) = Nothing : mParam args rest
@@ -253,7 +253,7 @@ elabPrims = do mapM_ (elabDecl EAll toplevel)
           believeTy = Bind (UN "a") (Pi (TType (UVar (-2))))
                        (Bind (UN "b") (Pi (TType (UVar (-2))))
                          (Bind (UN "x") (Pi (V 1)) (V 1)))
-          elabBelieveMe 
+          elabBelieveMe
              = do let prim__believe_me = (UN "prim__believe_me")
                   updateContext (addOperator prim__believe_me believeTy 3 p_believeMe)
                   setTotality prim__believe_me (Partial NotCovering)
@@ -279,7 +279,7 @@ elabPrims = do mapM_ (elabDecl EAll toplevel)
                        (Bind (UN "y") (Pi (V 1))
                          (mkApp nMaybe [mkApp (P (TCon 0 4) eqTy Erased)
                                                [V 3, V 2, V 1, V 0]]))))
-          elabSynEq 
+          elabSynEq
              = do let synEq = UN "prim__syntactic_eq"
 
                   updateContext (addOperator synEq synEqTy 4 p_synEq)
@@ -375,10 +375,10 @@ elabTransform info fc safe lhs_in rhs_in
          addIBC (IBCTrans (clhs_tm, crhs_tm))
 
 
-elabRecord :: ElabInfo -> SyntaxInfo -> String -> FC -> Name -> 
+elabRecord :: ElabInfo -> SyntaxInfo -> String -> FC -> Name ->
               PTerm -> String -> Name -> PTerm -> Idris ()
 elabRecord info syn doc fc tyn ty cdoc cn cty
-    = do elabData info syn doc fc False (PDatadecl tyn ty [(cdoc, cn, cty, fc)]) 
+    = do elabData info syn doc fc False (PDatadecl tyn ty [(cdoc, cn, cty, fc)])
          cty' <- implicit syn cn cty
          i <- getIState
          cty <- case lookupTy cn (tt_ctxt i) of
@@ -408,8 +408,8 @@ elabRecord info syn doc fc tyn ty cdoc cn cty
         = do i <- getIState
              idrisCatch (do elabDecl' EAll info ty
                             elabDecl' EAll info val)
-                        (\v -> do iputStrLn $ show fc ++ 
-                                      ":Warning - can't generate setter for " ++ 
+                        (\v -> do iputStrLn $ show fc ++
+                                      ":Warning - can't generate setter for " ++
                                       show fn ++ " (" ++ show ty ++ ")"
                                   putIState i)
 
@@ -459,9 +459,9 @@ elabRecord info syn doc fc tyn ty cdoc cn cty
              let lhs = PApp fc (PRef fc pn)
                         [pexp (PApp fc (PRef fc cn) iargs)]
              let rhs = PRef fc (mkp pn)
-             let pclause = PClause fc pn lhs [] rhs [] 
+             let pclause = PClause fc pn lhs [] rhs []
              return [pfnTy, PClauses fc [] pn [pclause]]
-          
+
     implicitise (pa, t) = pa { getTm = t }
 
     mkUpdate recty k num ((pn, pty), pos)
@@ -484,7 +484,7 @@ elabRecord info syn doc fc tyn ty cdoc cn cty
                                                       (map pexp rhsArgs)) []
             return (pn, pfnTy, PClauses fc [] setname [pclause])
 
-elabCon :: ElabInfo -> SyntaxInfo -> Name -> Bool -> 
+elabCon :: ElabInfo -> SyntaxInfo -> Name -> Bool ->
            (String, Name, PTerm, FC) -> Idris (Name, Type)
 elabCon info syn tn codata (doc, n, t_in, fc)
     = do checkUndefined fc n
@@ -493,7 +493,7 @@ elabCon info syn tn codata (doc, n, t_in, fc)
          t_in <- implicit syn n (if codata then mkLazy t_in else t_in)
          let t = addImpl i t_in
          logLvl 2 $ show fc ++ ":Constructor " ++ show n ++ " : " ++ showImp Nothing True False t
-         ((t', defer, is), log) <- 
+         ((t', defer, is), log) <-
               tclift $ elaborate ctxt n (TType (UVal 0)) []
                        (errAt "constructor " n (erun fc (build i info False n t)))
          logLvl 2 $ "Rechecking " ++ show t'
@@ -512,8 +512,8 @@ elabCon info syn tn codata (doc, n, t_in, fc)
          return (n, cty')
   where
     tyIs (Bind n b sc) = tyIs sc
-    tyIs t | (P _ n' _, _) <- unApply t 
-        = if n' /= tn then tclift $ tfail (At fc (Msg (show n' ++ " is not " ++ show tn))) 
+    tyIs t | (P _ n' _, _) <- unApply t
+        = if n' /= tn then tclift $ tfail (At fc (Msg (show n' ++ " is not " ++ show tn)))
              else return ()
     tyIs t = tclift $ tfail (At fc (Msg (show t ++ " is not " ++ show tn)))
 
@@ -523,7 +523,7 @@ elabCon info syn tn codata (doc, n, t_in, fc)
 -- | Elaborate a collection of left-hand and right-hand pairs - that is, a
 -- top-level definition.
 elabClauses :: ElabInfo -> FC -> FnOpts -> Name -> [PClause] -> Idris ()
-elabClauses info fc opts n_in cs = let n = liftname info n_in in  
+elabClauses info fc opts n_in cs = let n = liftname info n_in in
       do ctxt <- getContext
          -- Check n actually exists, with no definition yet
          let tys = lookupTy n ctxt
@@ -535,7 +535,7 @@ elabClauses info fc opts n_in cs = let n = liftname info n_in in
                     -- question: CAFs in where blocks?
                     tclift $ tfail $ At fc (NoTypeDecl n)
               [ty] -> return ty
-           pats_in <- mapM (elabClause info opts) 
+           pats_in <- mapM (elabClause info opts)
                            (zip [0..] cs)
            logLvl 3 $ "Elaborated patterns:\n" ++ show pats_in
 
@@ -553,9 +553,9 @@ elabClauses info fc opts n_in cs = let n = liftname info n_in in
                               _ -> False
            solveDeferred n
            ist <- getIState
-           when doNothing $ 
+           when doNothing $
               case lookupCtxt n (idris_optimisation ist) of
-                 [oi] -> do let opts = addDef n (oi { collapsible = True }) 
+                 [oi] -> do let opts = addDef n (oi { collapsible = True })
                                            (idris_optimisation ist)
                             putIState (ist { idris_optimisation = opts })
                  _ -> do let opts = addDef n (Optimise True False [] [])
@@ -563,10 +563,10 @@ elabClauses info fc opts n_in cs = let n = liftname info n_in in
                          putIState (ist { idris_optimisation = opts })
                          addIBC (IBCOpt n)
            ist <- getIState
-           let pats = doTransforms ist pats_in 
+           let pats = doTransforms ist pats_in
 
-  --          logLvl 3 (showSep "\n" (map (\ (l,r) -> 
-  --                                         show l ++ " = " ++ 
+  --          logLvl 3 (showSep "\n" (map (\ (l,r) ->
+  --                                         show l ++ " = " ++
   --                                         show r) pats))
            let tcase = opt_typecase (idris_options ist)
 
@@ -583,7 +583,7 @@ elabClauses info fc opts n_in cs = let n = liftname info n_in in
            -- This will get further optimised for run-time, and, separately,
            -- further inlined to help with totality checking.
            let pdef = map debind $ map (simple_lhs (tt_ctxt ist)) pats
-           
+
            logLvl 5 $ "Initial typechecked patterns:\n" ++ show pdef
 
            -- TODO: Inlining on initial definition happens here.
@@ -600,7 +600,7 @@ elabClauses info fc opts n_in cs = let n = liftname info n_in in
 
            -- patterns after collapsing optimisation applied
            -- (i.e. check if the function should do nothing at run time)
-           optpats <- if doNothing 
+           optpats <- if doNothing
                          then return $ [Right (mkApp (P Bound n Erased)
                                                     (take numArgs (repeat Erased)), Erased)]
                          else stripCollapsed pats
@@ -610,22 +610,22 @@ elabClauses info fc opts n_in cs = let n = liftname info n_in in
                 _ -> return ()
 
            let optpdef = map debind $ map (simple_lhs (tt_ctxt ist)) optpats
-           tree@(CaseDef scargs sc _) <- tclift $ 
+           tree@(CaseDef scargs sc _) <- tclift $
                    simpleCase tcase False reflect CompileTime fc pdef
            cov <- coverage
            pmissing <-
-                   if cov  
+                   if cov
                       then do missing <- genClauses fc n (map getLHS pdef) cs
-                              -- missing <- genMissing n scargs sc  
+                              -- missing <- genMissing n scargs sc
                               missing' <- filterM (checkPossible info fc True n) missing
                               let clhs = map getLHS pdef
-                              logLvl 2 $ "Must be unreachable:\n" ++ 
+                              logLvl 2 $ "Must be unreachable:\n" ++
                                           showSep "\n" (map (showImp Nothing True False) missing') ++
                                          "\nAgainst: " ++
                                           showSep "\n" (map (\t -> showImp Nothing True False (delab ist t)) (map getLHS pdef))
                               -- filter out anything in missing' which is
                               -- matched by any of clhs. This might happen since
-                              -- unification may force a variable to take a 
+                              -- unification may force a variable to take a
                               -- particular form, rather than force a case
                               -- to be impossible.
                               return (filter (noMatch ist clhs) missing')
@@ -633,7 +633,7 @@ elabClauses info fc opts n_in cs = let n = liftname info n_in in
            let pcover = null pmissing
 
            -- pdef' is the version that gets compiled for run-time
-           pdef' <- applyOpts optpdef 
+           pdef' <- applyOpts optpdef
            logLvl 5 $ "After data structure transformations:\n" ++ show pdef'
 
            ist <- getIState
@@ -641,8 +641,8 @@ elabClauses info fc opts n_in cs = let n = liftname info n_in in
            let tot = if pcover || AssertTotal `elem` opts
                       then Unchecked -- finish checking later
                       else Partial NotCovering -- already know it's not total
-  --          case lookupCtxt (namespace info) n (idris_flags ist) of 
-  --             [fs] -> if TotalFn `elem` fs 
+  --          case lookupCtxt (namespace info) n (idris_flags ist) of
+  --             [fs] -> if TotalFn `elem` fs
   --                       then case tot of
   --                               Total _ -> return ()
   --                               t -> tclift $ tfail (At fc (Msg (show n ++ " is " ++ show t)))
@@ -652,7 +652,7 @@ elabClauses info fc opts n_in cs = let n = liftname info n_in in
                CaseDef _ _ [] -> return ()
                CaseDef _ _ xs -> mapM_ (\x ->
                    iputStrLn $ show fc ++
-                                ":warning - Unreachable case: " ++ 
+                                ":warning - Unreachable case: " ++
                                    show (delab ist x)) xs
            let knowncovering = (pcover && cov) || AssertTotal `elem` opts
 
@@ -662,12 +662,12 @@ elabClauses info fc opts n_in cs = let n = liftname info n_in in
            logLvl 3 $ "Optimised: " ++ show tree'
            ctxt <- getContext
            ist <- getIState
-           putIState (ist { idris_patdefs = addDef n (pdef', pmissing) 
+           putIState (ist { idris_patdefs = addDef n (pdef', pmissing)
                                                 (idris_patdefs ist) })
            let caseInfo = CaseInfo (inlinable opts) (dictionary opts)
            case lookupTy n ctxt of
                [ty] -> do updateContext (addCasedef n caseInfo
-                                                       tcase knowncovering 
+                                                       tcase knowncovering
                                                        reflect
                                                        (AssertTotal `elem` opts)
                                                        pats
@@ -698,14 +698,14 @@ elabClauses info fc opts n_in cs = let n = liftname info n_in in
   where
     noMatch i cs tm = all (\x -> case matchClause i (delab' i x True) tm of
                                       Right _ -> False
-                                      Left miss -> True) cs 
+                                      Left miss -> True) cs
 
     checkUndefined n ctxt = case lookupDef n ctxt of
                                  [] -> return ()
                                  [TyDecl _ _] -> return ()
                                  _ -> tclift $ tfail (At fc (AlreadyDefined n))
 
-    debind (Right (x, y)) = let (vs, x') = depat [] x 
+    debind (Right (x, y)) = let (vs, x') = depat [] x
                                 (_, y') = depat [] y in
                                 (vs, x', y')
     debind (Left x)       = let (vs, x') = depat [] x in
@@ -713,26 +713,26 @@ elabClauses info fc opts n_in cs = let n = liftname info n_in in
 
     depat acc (Bind n (PVar t) sc) = depat (n : acc) (instantiate (P Bound n t) sc)
     depat acc x = (acc, x)
-    
+
     getLHS (_, l, _) = l
 
-    simple_lhs ctxt (Right (x, y)) = Right (normalise ctxt [] x, y) 
+    simple_lhs ctxt (Right (x, y)) = Right (normalise ctxt [] x, y)
     simple_lhs ctxt t = t
 
     specNames [] = Nothing
     specNames (Specialise ns : _) = Just ns
     specNames (_ : xs) = specNames xs
 
-    sameLength ((_, x, _) : xs) 
+    sameLength ((_, x, _) : xs)
         = do l <- sameLength xs
              let (f, as) = unApply x
              if (null xs || l == length as) then return (length as)
                 else tfail (At fc (Msg "Clauses have differing numbers of arguments "))
     sameLength [] = return 0
 
-    -- apply all transformations (just specialisation for now, add 
+    -- apply all transformations (just specialisation for now, add
     -- user defined transformation rules later)
-    doTransforms ist pats = 
+    doTransforms ist pats =
            case specNames opts of
                             Nothing -> pats
                             Just ns -> partial_eval (tt_ctxt ist) ns pats
@@ -750,14 +750,14 @@ elabValBind info aspat tm_in
         --    * ordinary elaboration
         --    * elaboration as a Type
         --    * elaboration as a function a -> b
-        
-        ((tm', defer, is), _) <- 
---             tctry (elaborate ctxt (MN 0 "val") (TType (UVal 0)) []                         
+
+        ((tm', defer, is), _) <-
+--             tctry (elaborate ctxt (MN 0 "val") (TType (UVal 0)) []
 --                        (build i info aspat (MN 0 "val") tm))
                 tclift (elaborate ctxt (MN 0 "val") infP []
                         (build i info aspat (MN 0 "val") (infTerm tm)))
         let vtm = orderPats (getInferTerm tm')
-        let bargs = getPBtys vtm 
+        let bargs = getPBtys vtm
 
         def' <- checkDef (fileFC "(input)") defer
         addDeferred def'
@@ -796,7 +796,7 @@ checkPossible info fc tcgen fname lhs_in
 --                   trace (show (delab' i lhs_tm True) ++ "\n" ++ show lhs) $ return (not b)
             err@(Error _) -> return False
 
-elabClause :: ElabInfo -> FnOpts -> (Int, PClause) -> 
+elabClause :: ElabInfo -> FnOpts -> (Int, PClause) ->
               Idris (Either Term (Term, Term))
 elabClause info opts (_, PClause fc fname lhs_in [] PImpossible [])
    = do let tcgen = Dictionary `elem` opts
@@ -805,7 +805,7 @@ elabClause info opts (_, PClause fc fname lhs_in [] PImpossible [])
             True -> ifail $ show fc ++ ":" ++ show lhs_in ++ " is a possible case"
             False -> do ptm <- mkPatTm lhs_in
                         return (Left ptm)
-elabClause info opts (cnum, PClause fc fname lhs_in withs rhs_in whereblock) 
+elabClause info opts (cnum, PClause fc fname lhs_in withs rhs_in whereblock)
    = do let tcgen = Dictionary `elem` opts
         ctxt <- getContext
 
@@ -818,15 +818,15 @@ elabClause info opts (cnum, PClause fc fname lhs_in withs rhs_in whereblock)
                          _ -> error "Can't happen (elabClause function type)"
         let fn_is = case lookupCtxt fname (idris_implicits i) of
                          [t] -> t
-                         _ -> [] 
+                         _ -> []
         let params = getParamsInType i [] fn_is fn_ty
         let lhs = addImplPat i (propagateParams params (stripLinear i lhs_in))
         logLvl 5 ("LHS: " ++ show fc ++ " " ++ showImp Nothing True False lhs)
         logLvl 4 ("Fixed parameters: " ++ show params ++ " from " ++ show (fn_ty, fn_is))
 
-        ((lhs', dlhs, []), _) <- 
+        ((lhs', dlhs, []), _) <-
             tclift $ elaborate ctxt (MN 0 "patLHS") infP []
-                     (errAt "left hand side of " fname 
+                     (errAt "left hand side of " fname
                        (erun fc (buildTC i info True tcgen fname (infTerm lhs))))
         let lhs_tm = orderPats (getInferTerm lhs')
         let lhs_ty = getInferType lhs'
@@ -848,7 +848,7 @@ elabClause info opts (cnum, PClause fc fname lhs_in withs rhs_in whereblock)
         let defs = nub (decls ++ concatMap defined whereblock)
         let newargs = pvars ist lhs_tm
         let wb = map (expandParamsD False ist decorate newargs defs) whereblock
-        
+
         -- Split the where block into declarations with a type, and those
         -- without
         -- Elaborate those with a type *before* RHS, those without *after*
@@ -864,12 +864,12 @@ elabClause info opts (cnum, PClause fc fname lhs_in withs rhs_in whereblock)
         logLvl 2 $ "RHS: " ++ showImp Nothing True False rhs
         ctxt <- getContext -- new context with where block added
         logLvl 5 "STARTING CHECK"
-        ((rhs', defer, is), _) <- 
+        ((rhs', defer, is), _) <-
            tclift $ elaborate ctxt (MN 0 "patRHS") clhsty []
                     (do pbinds lhs_tm
-                        (_, _, is) <- errAt "right hand side of " fname 
+                        (_, _, is) <- errAt "right hand side of " fname
                                         (erun fc (build i info False fname rhs))
-                        errAt "right hand side of " fname 
+                        errAt "right hand side of " fname
                               (erun fc $ psolve lhs_tm)
                         tt <- get_term
                         let (tm, ds) = runState (collectDeferred (Just fname) tt) []
@@ -897,10 +897,10 @@ elabClause info opts (cnum, PClause fc fname lhs_in withs rhs_in whereblock)
         checkInferred fc (delab' i crhs True) rhs
         return $ Right (clhs, crhs)
   where
-    decorate (NS x ns) 
-       = NS (SN (WhereN cnum fname x)) ns -- ++ [show cnum]) 
+    decorate (NS x ns)
+       = NS (SN (WhereN cnum fname x)) ns -- ++ [show cnum])
 --        = NS (UN ('#':show x)) (ns ++ [show cnum, show fname])
-    decorate x 
+    decorate x
        = SN (WhereN cnum fname x)
 --        = NS (SN (WhereN cnum fname x)) [show cnum]
 --        = NS (UN ('#':show x)) [show cnum, show fname]
@@ -909,18 +909,18 @@ elabClause info opts (cnum, PClause fc fname lhs_in withs rhs_in whereblock)
       sepBlocks' ns (d@(PTy _ _ _ _ n t) : bs)
             = let (bf, af) = sepBlocks' (n : ns) bs in
                   (d : bf, af)
-      sepBlocks' ns (d@(PClauses _ _ n _) : bs) 
+      sepBlocks' ns (d@(PClauses _ _ n _) : bs)
          | not (n `elem` ns) = let (bf, af) = sepBlocks' ns bs in
                                    (bf, d : af)
       sepBlocks' ns (b : bs) = let (bf, af) = sepBlocks' ns bs in
                                    (b : bf, af)
       sepBlocks' ns [] = ([], [])
 
-    pinfo ns ps i 
+    pinfo ns ps i
           = let ds = concatMap declared ps
                 newps = params info ++ ns
                 dsParams = map (\n -> (n, map fst newps)) ds
-                newb = addAlist dsParams (inblock info) 
+                newb = addAlist dsParams (inblock info)
                 l = liftname info in
                 info { params = newps,
                        inblock = newb,
@@ -929,24 +929,24 @@ elabClause info opts (cnum, PClause fc fname lhs_in withs rhs_in whereblock)
                                      --      _ -> MN i (show n)) . l
                     }
 
-    getParamsInType i env (PExp _ _ _ _ : is) (Bind n (Pi t) sc) 
+    getParamsInType i env (PExp _ _ _ _ : is) (Bind n (Pi t) sc)
         = getParamsInType i env is (instantiate (P Bound n t) sc)
-    getParamsInType i env (_ : is) (Bind n (Pi t) sc) 
+    getParamsInType i env (_ : is) (Bind n (Pi t) sc)
         = getParamsInType i (n : env) is (instantiate (P Bound n t) sc)
     getParamsInType i env is tm@(App f a)
-        | (P _ tn _, args) <- unApply tm 
+        | (P _ tn _, args) <- unApply tm
            = case lookupCtxt tn (idris_datatypes i) of
                 [t] -> nub $ paramNames args env (param_pos t) ++
-                             getParamsInType i env is f ++ 
+                             getParamsInType i env is f ++
                              getParamsInType i env is a
-                [] -> nub $ getParamsInType i env is f ++ 
+                [] -> nub $ getParamsInType i env is f ++
                             getParamsInType i env is a
-        | otherwise = nub $ getParamsInType i env is f ++ 
+        | otherwise = nub $ getParamsInType i env is f ++
                             getParamsInType i env is a
     getParamsInType i _ _ _ = []
 
     paramNames args env [] = []
-    paramNames args env (p : ps) 
+    paramNames args env (p : ps)
        | length args > p = case args!!p of
                               P _ n _ -> if n `elem` env
                                             then n : paramNames args env ps
@@ -964,7 +964,7 @@ elabClause info opts (cnum, PClause fc fname lhs_in withs rhs_in whereblock)
          = PApp fc (PRef fc n) (map (\x -> pimp x (PRef fc x) True) ps)
     propagateParams ps x = x
 
-elabClause info opts (_, PWith fc fname lhs_in withs wval_in withblock) 
+elabClause info opts (_, PWith fc fname lhs_in withs wval_in withblock)
    = do let tcgen = Dictionary `elem` opts
         ctxt <- getContext
         -- Build the LHS as an "Infer", and pull out its type and
@@ -972,7 +972,7 @@ elabClause info opts (_, PWith fc fname lhs_in withs wval_in withblock)
         i <- getIState
         let lhs = addImplPat i lhs_in
         logLvl 5 ("LHS: " ++ showImp Nothing True False lhs)
-        ((lhs', dlhs, []), _) <- 
+        ((lhs', dlhs, []), _) <-
             tclift $ elaborate ctxt (MN 0 "patLHS") infP []
               (errAt "left hand side of with in " fname
                 (erun fc (buildTC i info True tcgen fname (infTerm lhs))) )
@@ -986,12 +986,12 @@ elabClause info opts (_, PWith fc fname lhs_in withs wval_in withblock)
         let wval = addImplBound i (map fst bargs) wval_in
         logLvl 5 ("Checking " ++ showImp Nothing True False wval)
         -- Elaborate wval in this context
-        ((wval', defer, is), _) <- 
-            tclift $ elaborate ctxt (MN 0 "withRHS") 
+        ((wval', defer, is), _) <-
+            tclift $ elaborate ctxt (MN 0 "withRHS")
                         (bindTyArgs PVTy bargs infP) []
                         (do pbinds lhs_tm
                             -- TODO: may want where here - see winfo abpve
-                            (_', d, is) <- errAt "with value in " fname 
+                            (_', d, is) <- errAt "with value in " fname
                               (erun fc (build i info False fname (infTerm wval)))
                             erun fc $ psolve lhs_tm
                             tt <- get_term
@@ -1008,18 +1008,18 @@ elabClause info opts (_, PWith fc fname lhs_in withs wval_in withblock)
         -- rather than a de Bruijn index.
         let pdeps = usedNamesIn pvars i (delab i cwvalty)
         let (bargs_pre, bargs_post) = split pdeps bargs []
-        logLvl 10 ("With type " ++ show (getRetTy cwvaltyN) ++ 
+        logLvl 10 ("With type " ++ show (getRetTy cwvaltyN) ++
                   " depends on " ++ show pdeps ++ " from " ++ show pvars)
         logLvl 10 ("Pre " ++ show bargs_pre ++ "\nPost " ++ show bargs_post)
         windex <- getName
         -- build a type declaration for the new function:
-        -- (ps : Xs) -> (withval : cwvalty) -> (ps' : Xs') -> ret_ty 
+        -- (ps : Xs) -> (withval : cwvalty) -> (ps' : Xs') -> ret_ty
         let wargval = getRetTy cwvalN
         let wargtype = getRetTy cwvaltyN
         logLvl 5 ("Abstract over " ++ show wargval)
-        let wtype = bindTyArgs Pi (bargs_pre ++ 
-                     (MN 0 "warg", wargtype) : 
-                     map (abstract (MN 0 "warg") wargval wargtype) bargs_post) 
+        let wtype = bindTyArgs Pi (bargs_pre ++
+                     (MN 0 "warg", wargtype) :
+                     map (abstract (MN 0 "warg") wargval wargtype) bargs_post)
                      (substTerm wargval (P Bound (MN 0 "warg") wargtype) ret_ty)
         logLvl 3 ("New function type " ++ show wtype)
         let wname = MN windex (show fname)
@@ -1041,8 +1041,8 @@ elabClause info opts (_, PWith fc fname lhs_in withs wval_in withblock)
         mapM_ (elabDecl EAll info) wb
 
         -- rhs becomes: fname' ps wval
-        let rhs = PApp fc (PRef fc wname) 
-                    (map (pexp . (PRef fc) . fst) bargs_pre ++ 
+        let rhs = PApp fc (PRef fc wname)
+                    (map (pexp . (PRef fc) . fst) bargs_pre ++
                         pexp wval :
                     (map (pexp . (PRef fc) . fst) bargs_post))
         logLvl 5 ("New RHS " ++ showImp Nothing True False rhs)
@@ -1074,25 +1074,25 @@ elabClause info opts (_, PWith fc fname lhs_in withs wval_in withblock)
     mkAux wname toplhs ns ns' (PClause fc n tm_in (w:ws) rhs wheres)
         = do i <- getIState
              let tm = addImplPat i tm_in
-             logLvl 2 ("Matching " ++ showImp Nothing True False tm ++ " against " ++ 
+             logLvl 2 ("Matching " ++ showImp Nothing True False tm ++ " against " ++
                                       showImp Nothing True False toplhs)
              case matchClause i toplhs tm of
                 Left (a,b) -> trace ("matchClause: " ++ show a ++ " =/= " ++ show b) (ifail $ show fc ++ ":with clause does not match top level")
-                Right mvars -> 
+                Right mvars ->
                     do logLvl 3 ("Match vars : " ++ show mvars)
                        lhs <- updateLHS n wname mvars ns ns' (fullApp tm) w
                        return $ PClause fc wname lhs ws rhs wheres
     mkAux wname toplhs ns ns' (PWith fc n tm_in (w:ws) wval withs)
         = do i <- getIState
              let tm = addImplPat i tm_in
-             logLvl 2 ("Matching " ++ showImp Nothing True False tm ++ " against " ++ 
+             logLvl 2 ("Matching " ++ showImp Nothing True False tm ++ " against " ++
                                       showImp Nothing True False toplhs)
              withs' <- mapM (mkAuxC wname toplhs ns ns') withs
              case matchClause i toplhs tm of
                 Left (a,b) -> trace ("matchClause: " ++ show a ++ " =/= " ++ show b) (ifail $ show fc ++ "with clause does not match top level")
-                Right mvars -> 
+                Right mvars ->
                     do lhs <- updateLHS n wname mvars ns ns' (fullApp tm) w
-                       return $ PWith fc wname lhs ws wval withs' 
+                       return $ PWith fc wname lhs ws wval withs'
     mkAux wname toplhs ns ns' c
         = ifail $ show fc ++ "badly formed with clause"
 
@@ -1102,11 +1102,11 @@ elabClause info opts (_, PWith fc fname lhs_in withs wval_in withblock)
     updateLHS n wname mvars ns_in ns_in' (PApp fc (PRef fc' n') args) w
         = let ns = map (keepMvar (map fst mvars) fc') ns_in
               ns' = map (keepMvar (map fst mvars) fc') ns_in' in
-              return $ substMatches mvars $ 
-                  PApp fc (PRef fc' wname) 
+              return $ substMatches mvars $
+                  PApp fc (PRef fc' wname)
                       (map pexp ns ++ pexp w : (map pexp ns'))
-    updateLHS n wname mvars ns ns' tm w 
-        = ifail $ "Not implemented match " ++ show tm 
+    updateLHS n wname mvars ns ns' tm w
+        = ifail $ "Not implemented match " ++ show tm
 
     keepMvar mvs fc v | v `elem` mvs = PRef fc v
                       | otherwise = Placeholder
@@ -1118,16 +1118,16 @@ elabClause info opts (_, PWith fc fname lhs_in withs wval_in withblock)
     split deps ((n, ty) : rest) pre
           | n `elem` deps = split (deps \\ [n]) rest ((n, ty) : pre)
           | otherwise = split deps rest ((n, ty) : pre)
-    split deps [] pre = (reverse pre, []) 
+    split deps [] pre = (reverse pre, [])
 
     abstract wn wv wty (n, argty) = (n, substTerm wv (P Bound wn wty) argty)
 
 data MArgTy = IA | EA | CA deriving Show
 
 elabClass :: ElabInfo -> SyntaxInfo -> String ->
-             FC -> [PTerm] -> 
+             FC -> [PTerm] ->
              Name -> [(Name, PTerm)] -> [PDecl] -> Idris ()
-elabClass info syn doc fc constraints tn ps ds 
+elabClass info syn doc fc constraints tn ps ds
     = do let cn = UN ("instance" ++ show tn) -- MN 0 ("instance" ++ show tn)
          let tty = pibind ps PType
          let constraint = PApp fc (PRef fc tn)
@@ -1137,20 +1137,20 @@ elabClass info syn doc fc constraints tn ps ds
          let mnames = map getMName mdecls
          logLvl 2 $ "Building methods " ++ show mnames
          ims <- mapM (tdecl mnames) mdecls
-         defs <- mapM (defdecl (map (\ (x,y,z) -> z) ims) constraint) 
+         defs <- mapM (defdecl (map (\ (x,y,z) -> z) ims) constraint)
                       (filter clause ds)
-         let (methods, imethods) 
+         let (methods, imethods)
               = unzip (map (\ ( x,y,z) -> (x, y)) ims)
          let defaults = map (\ (x, (y, z)) -> (x,y)) defs
-         addClass tn (CI cn (map nodoc imethods) defaults (map fst ps) []) 
+         addClass tn (CI cn (map nodoc imethods) defaults (map fst ps) [])
          -- build instance constructor type
          -- decorate names of functions to ensure they can't be referred
          -- to elsewhere in the class declaration
          -- TODO: Remove mdec to make it a dependent record, which would
          -- allow dependent type classes, but building instances will
          -- then need some attention.
-         let cty = impbind ps $ conbind constraints 
-                      $ pibind (map (\ (n, ty) -> (mdec n, ty)) methods) 
+         let cty = impbind ps $ conbind constraints
+                      $ pibind (map (\ (n, ty) -> (mdec n, ty)) methods)
                                constraint
          let cons = [("", cn, cty, fc)]
          let ddecl = PDatadecl tn tty cons
@@ -1158,7 +1158,7 @@ elabClass info syn doc fc constraints tn ps ds
          elabData info (syn { no_imp = no_imp syn ++ mnames }) doc fc False ddecl
          -- for each constraint, build a top level function to chase it
          logLvl 5 $ "Building functions"
-         let usyn = syn { using = map (\ (x,y) -> UImplicit x y) ps 
+         let usyn = syn { using = map (\ (x,y) -> UImplicit x y) ps
                                       ++ using syn }
          fns <- mapM (cfun cn constraint usyn (map fst imethods)) constraints
          mapM_ (elabDecl EAll info) (concat fns)
@@ -1172,19 +1172,19 @@ elabClass info syn doc fc constraints tn ps ds
   where
     nodoc (n, (_, o, t)) = (n, (o, t))
     pibind [] x = x
-    pibind ((n, ty): ns) x = PPi expl n ty (pibind ns x) 
+    pibind ((n, ty): ns) x = PPi expl n ty (pibind ns x)
 
     mdec (UN n) = SN (MethodN (UN n))
     mdec (NS x n) = NS (mdec x) n
     mdec x = x
 
     impbind [] x = x
-    impbind ((n, ty): ns) x = PPi impl n ty (impbind ns x) 
+    impbind ((n, ty): ns) x = PPi impl n ty (impbind ns x)
     conbind (ty : ns) x = PPi constraint (MN 0 "class") ty (conbind ns x)
     conbind [] x = x
 
     getMName (PTy _ _ _ _ n _) = nsroot n
-    tdecl allmeths (PTy doc syn _ o n t) 
+    tdecl allmeths (PTy doc syn _ o n t)
            = do t' <- implicit' syn allmeths n t
                 logLvl 5 $ "Method " ++ show n ++ " : " ++ showImp Nothing True False t'
                 return ( (n, (toExp (map fst ps) Exp t')),
@@ -1192,12 +1192,12 @@ elabClass info syn doc fc constraints tn ps ds
                          (n, (syn, o, t) ) )
     tdecl _ _ = ifail "Not allowed in a class declaration"
 
-    -- Create default definitions 
+    -- Create default definitions
     defdecl mtys c d@(PClauses fc opts n cs) =
         case lookup n mtys of
             Just (syn, o, ty) -> do let ty' = insertConstraint c ty
                                     let ds = map (decorateid defaultdec)
-                                                 [PTy "" syn fc [] n ty', 
+                                                 [PTy "" syn fc [] n ty',
                                                   PClauses fc (o ++ opts) n cs]
                                     iLOG (show ds)
                                     return (n, ((defaultdec n, ds!!1), ds))
@@ -1214,7 +1214,7 @@ elabClass info syn doc fc constraints tn ps ds
 
     -- Generate a function for chasing a dictionary constraint
     cfun cn c syn all con
-        = do let cfn = UN ('@':'@':show cn ++ "#" ++ show con) 
+        = do let cfn = UN ('@':'@':show cn ++ "#" ++ show con)
                        -- SN (ParentN cn (show con))
              let mnames = take (length all) $ map (\x -> MN x "meth") [0..]
              let capp = PApp fc (PRef fc cn) (map (pexp . PRef fc) mnames)
@@ -1238,7 +1238,7 @@ elabClass info syn doc fc constraints tn ps ds
 
     -- Generate a top level function which looks up a method in a given
     -- dictionary (this is inlinable, always)
-    tfun cn c syn all (m, (doc, o, ty)) 
+    tfun cn c syn all (m, (doc, o, ty))
         = do let ty' = insertConstraint c ty
              let mnames = take (length all) $ map (\x -> MN x "meth") [0..]
              let capp = PApp fc (PRef fc cn) (map (pexp . PRef fc) mnames)
@@ -1260,13 +1260,13 @@ elabClass info syn doc fc constraints tn ps ds
     getMeth (m:ms) (a:as) x | x == a = PRef fc m
                             | otherwise = getMeth ms as x
 
-    lhsArgs (EA : xs) (n : ns) = pexp (PRef fc n) : lhsArgs xs ns 
-    lhsArgs (IA : xs) ns = lhsArgs xs ns 
+    lhsArgs (EA : xs) (n : ns) = pexp (PRef fc n) : lhsArgs xs ns
+    lhsArgs (IA : xs) ns = lhsArgs xs ns
     lhsArgs (CA : xs) ns = lhsArgs xs ns
     lhsArgs [] _ = []
 
-    rhsArgs (EA : xs) (n : ns) = pexp (PRef fc n) : rhsArgs xs ns 
-    rhsArgs (IA : xs) ns = pexp Placeholder : rhsArgs xs ns 
+    rhsArgs (EA : xs) (n : ns) = pexp (PRef fc n) : rhsArgs xs ns
+    rhsArgs (IA : xs) ns = pexp Placeholder : rhsArgs xs ns
     rhsArgs (CA : xs) ns = pconst (PResolveTC fc) : rhsArgs xs ns
     rhsArgs [] _ = []
 
@@ -1281,43 +1281,43 @@ elabClass info syn doc fc constraints tn ps ds
     toExp ns e (PPi p n ty sc) = PPi p n ty (toExp ns e sc)
     toExp ns e sc = sc
 
-elabInstance :: ElabInfo -> SyntaxInfo -> 
+elabInstance :: ElabInfo -> SyntaxInfo ->
                 FC -> [PTerm] -> -- constraints
-                Name -> -- the class 
-                [PTerm] -> -- class parameters (i.e. instance) 
+                Name -> -- the class
+                [PTerm] -> -- class parameters (i.e. instance)
                 PTerm -> -- full instance type
                 Maybe Name -> -- explicit name
                 [PDecl] -> Idris ()
 elabInstance info syn fc cs n ps t expn ds
-    = do i <- getIState 
+    = do i <- getIState
          (n, ci) <- case lookupCtxtName n (idris_classes i) of
                        [c] -> return c
                        _ -> ifail $ show fc ++ ":" ++ show n ++ " is not a type class"
          let constraint = PApp fc (PRef fc n) (map pexp ps)
          let iname = case expn of
-                         Nothing -> SN (InstanceN n (map show ps)) 
+                         Nothing -> SN (InstanceN n (map show ps))
                           -- UN ('@':show n ++ "$" ++ show ps)
                          Just nm -> nm
          -- if the instance type matches any of the instances we have already,
          -- and it's not a named instance, then it's overlapping, so report an error
          case expn of
-            Nothing -> do mapM_ (checkNotOverlapping i t) (class_instances ci) 
+            Nothing -> do mapM_ (checkNotOverlapping i t) (class_instances ci)
                           addInstance intInst n iname
-            Just _ -> addInstance intInst n iname 
+            Just _ -> addInstance intInst n iname
          elabType info syn "" fc [] iname t
          let ips = zip (class_params ci) ps
          let ns = case n of
                     NS n ns' -> ns'
                     _ -> []
-         -- get the implicit parameters that need passing through to the 
+         -- get the implicit parameters that need passing through to the
          -- where block
          wparams <- mapM (\p -> case p of
                                   PApp _ _ args -> getWParams args
                                   _ -> return []) ps
          let pnames = map pname (concat (nub wparams))
-         let mtys = map (\ (n, (op, t)) -> 
+         let mtys = map (\ (n, (op, t)) ->
                              let t' = substMatchesShadow ips pnames t in
-                                 (decorate ns iname n, 
+                                 (decorate ns iname n,
                                      op, coninsert cs t', t'))
                         (class_methods ci)
          logLvl 3 (show (mtys, ips))
@@ -1329,12 +1329,12 @@ elabInstance info syn fc cs n ps t expn ds
          let wbVals = map (decorateid (decorate ns iname)) ds'
          let wb = wbTys ++ wbVals
          logLvl 3 $ "Method types " ++ showSep "\n" (map (showDeclImp True . mkTyDecl) mtys)
-         logLvl 3 $ "Instance is " ++ show ps ++ " implicits " ++ 
+         logLvl 3 $ "Instance is " ++ show ps ++ " implicits " ++
                                       show (concat (nub wparams))
          let lhs = PRef fc iname
          let rhs = PApp fc (PRef fc (instanceName ci))
                            (map (pexp . mkMethApp) mtys)
-         let idecls = [PClauses fc [Dictionary] iname 
+         let idecls = [PClauses fc [Dictionary] iname
                                  [PClause fc iname lhs [] rhs wb]]
          iLOG (show idecls)
          mapM (elabDecl EAll info) idecls
@@ -1360,23 +1360,23 @@ elabInstance info syn fc cs n ps t expn ds
                                 Right _ -> overlapping tret tret'
                                 Left _ -> return ()
             _ -> return ()
-    overlapping t t' = tclift $ tfail (At fc (Msg $ 
+    overlapping t t' = tclift $ tfail (At fc (Msg $
                             "Overlapping instance: " ++ show t' ++ " already defined"))
     getRetType (PPi _ _ _ sc) = getRetType sc
     getRetType t = t
 
-    mkMethApp (n, _, _, ty) 
+    mkMethApp (n, _, _, ty)
           = lamBind 0 ty (papp fc (PRef fc n) (methArgs 0 ty))
-    lamBind i (PPi (Constraint _ _ _) _ _ sc) sc' 
+    lamBind i (PPi (Constraint _ _ _) _ _ sc) sc'
           = PLam (MN i "meth") Placeholder (lamBind (i+1) sc sc')
-    lamBind i (PPi _ n ty sc) sc' 
+    lamBind i (PPi _ n ty sc) sc'
           = PLam (MN i "meth") Placeholder (lamBind (i+1) sc sc')
     lamBind i _ sc = sc
-    methArgs i (PPi (Imp _ _ _ _) n ty sc) 
+    methArgs i (PPi (Imp _ _ _ _) n ty sc)
         = PImp 0 True False n (PRef fc (MN i "meth")) "" : methArgs (i+1) sc
-    methArgs i (PPi (Exp _ _ _ _) n ty sc) 
+    methArgs i (PPi (Exp _ _ _ _) n ty sc)
         = PExp 0 False (PRef fc (MN i "meth")) "" : methArgs (i+1) sc
-    methArgs i (PPi (Constraint _ _ _) n ty sc) 
+    methArgs i (PPi (Constraint _ _ _) n ty sc)
         = PConstraint 0 False (PResolveTC fc) "" : methArgs (i+1) sc
     methArgs i _ = []
 
@@ -1384,8 +1384,8 @@ elabInstance info syn fc cs n ps t expn ds
     papp fc f as = PApp fc f as
 
     getWParams [] = return []
-    getWParams (p : ps) 
-      | PRef _ n <- getTm p 
+    getWParams (p : ps)
+      | PRef _ n <- getTm p
         = do ps' <- getWParams ps
              ctxt <- getContext
              case lookupP n ctxt of
@@ -1405,16 +1405,16 @@ elabInstance info syn fc cs n ps t expn ds
     coninsert cs sc = conbind cs sc
 
     insertDefaults :: IState -> Name ->
-                      [(Name, (Name, PDecl))] -> [String] -> 
+                      [(Name, (Name, PDecl))] -> [String] ->
                       [PDecl] -> [PDecl]
     insertDefaults i iname [] ns ds = ds
-    insertDefaults i iname ((n,(dn, clauses)) : defs) ns ds 
+    insertDefaults i iname ((n,(dn, clauses)) : defs) ns ds
        = insertDefaults i iname defs ns (insertDef i n dn clauses ns iname ds)
 
     insertDef i meth def clauses ns iname decls
         | null $ filter (clauseFor meth iname ns) decls
             = let newd = expandParamsD False i (\n -> meth) [] [def] clauses in
-                  -- trace (show newd) $ 
+                  -- trace (show newd) $
                   decls ++ [newd]
         | otherwise = decls
 
@@ -1425,12 +1425,12 @@ elabInstance info syn fc cs n ps t expn ds
 
     checkInClass ns meth
         | not (null (filter (eqRoot meth) ns)) = return ()
-        | otherwise = tclift $ tfail (At fc (Msg $ 
+        | otherwise = tclift $ tfail (At fc (Msg $
                                 show meth ++ " not a method of class " ++ show n))
 
     eqRoot x y = nsroot x == nsroot y
 
-    clauseFor m iname ns (PClauses _ _ m' _) 
+    clauseFor m iname ns (PClauses _ _ m' _)
        = decorate ns iname m == decorate ns iname m'
     clauseFor m iname ns _ = False
 
@@ -1460,17 +1460,17 @@ elabInstance info syn fc cs n ps t expn ds
 -}
 
 decorateid decorate (PTy doc s f o n t) = PTy doc s f o (decorate n) t
-decorateid decorate (PClauses f o n cs) 
+decorateid decorate (PClauses f o n cs)
    = PClauses f o (decorate n) (map dc cs)
     where dc (PClause fc n t as w ds) = PClause fc (decorate n) (dappname t) as w ds
-          dc (PWith   fc n t as w ds) 
-                 = PWith fc (decorate n) (dappname t) as w 
+          dc (PWith   fc n t as w ds)
+                 = PWith fc (decorate n) (dappname t) as w
                             (map (decorateid decorate) ds)
           dappname (PApp fc (PRef fc' n) as) = PApp fc (PRef fc' (decorate n)) as
           dappname t = t
 
 
-pbinds (Bind n (PVar t) sc) = do attack; patbind n 
+pbinds (Bind n (PVar t) sc) = do attack; patbind n
                                  pbinds sc
 pbinds tm = return ()
 
@@ -1495,8 +1495,8 @@ elabDecls info ds = do mapM_ (elabDecl EAll info) ds
 --                       mapM_ (elabDecl EDefns info) ds
 
 elabDecl :: ElabWhat -> ElabInfo -> PDecl -> Idris ()
-elabDecl what info d 
-    = idrisCatch (elabDecl' what info d) 
+elabDecl what info d
+    = idrisCatch (elabDecl' what info d)
                  (\e -> do setErrLine (getErrLine e)
                            ist <- getIState
                            let h = idris_outh ist
@@ -1504,24 +1504,24 @@ elabDecl what info d
 
 elabDecl' _ info (PFix _ _ _)
      = return () -- nothing to elaborate
-elabDecl' _ info (PSyntax _ p) 
+elabDecl' _ info (PSyntax _ p)
      = return () -- nothing to elaborate
-elabDecl' what info (PTy doc s f o n ty)    
+elabDecl' what info (PTy doc s f o n ty)
   | what /= EDefns
     = do iLOG $ "Elaborating type decl " ++ show n ++ show o
          elabType info s doc f o n ty
-elabDecl' what info (PPostulate doc s f o n ty)    
+elabDecl' what info (PPostulate doc s f o n ty)
   | what /= EDefns
     = do iLOG $ "Elaborating postulate " ++ show n ++ show o
          elabPostulate info s doc f o n ty
-elabDecl' what info (PData doc s f co d)    
+elabDecl' what info (PData doc s f co d)
   | what /= ETypes
     = do iLOG $ "Elaborating " ++ show (d_name d)
          elabData info s doc f co d
-  | otherwise 
+  | otherwise
     = do iLOG $ "Elaborating [type of] " ++ show (d_name d)
          elabData info s doc f co (PLaterdecl (d_name d) (d_tcon d))
-elabDecl' what info d@(PClauses f o n ps) 
+elabDecl' what info d@(PClauses f o n ps)
   | what /= ETypes
     = do iLOG $ "Elaborating clause " ++ show n
          i <- getIState -- get the type options too
@@ -1529,7 +1529,7 @@ elabDecl' what info d@(PClauses f o n ps)
                     [fs] -> fs
                     [] -> []
          elabClauses info f (o ++ o') n ps
-elabDecl' what info (PMutual f ps) 
+elabDecl' what info (PMutual f ps)
     = do mapM_ (elabDecl ETypes info) ps
          mapM_ (elabDecl EDefns info) ps
          -- Do totality checking after entire mutual block
@@ -1541,32 +1541,32 @@ elabDecl' what info (PMutual f ps)
          mapM_ checkDeclTotality (idris_totcheck i)
          clear_totcheck
 
-elabDecl' what info (PParams f ns ps) 
+elabDecl' what info (PParams f ns ps)
     = do i <- getIState
          iLOG $ "Expanding params block with " ++ show ns ++ " decls " ++
                 show (concatMap tldeclared ps)
          let nblock = pblock i
-         mapM_ (elabDecl' what info) nblock 
+         mapM_ (elabDecl' what info) nblock
   where
     pinfo = let ds = concatMap tldeclared ps
                 newps = params info ++ ns
                 dsParams = map (\n -> (n, map fst newps)) ds
-                newb = addAlist dsParams (inblock info) in 
+                newb = addAlist dsParams (inblock info) in
                 info { params = newps,
                        inblock = newb }
-    pblock i = map (expandParamsD False i id ns 
+    pblock i = map (expandParamsD False i id ns
                       (concatMap tldeclared ps)) ps
 
 elabDecl' what info (PNamespace n ps) = mapM_ (elabDecl' what ninfo) ps
   where
     ninfo = case namespace info of
                 Nothing -> info { namespace = Just [n] }
-                Just ns -> info { namespace = Just (n:ns) } 
-elabDecl' what info (PClass doc s f cs n ps ds) 
+                Just ns -> info { namespace = Just (n:ns) }
+elabDecl' what info (PClass doc s f cs n ps ds)
   | what /= EDefns
     = do iLOG $ "Elaborating class " ++ show n
          elabClass info (s { syn_params = [] }) doc f cs n ps ds
-elabDecl' what info (PInstance s f cs n ps t expn ds) 
+elabDecl' what info (PInstance s f cs n ps t expn ds)
   | what /= ETypes
     = do iLOG $ "Elaborating instance " ++ show n
          elabInstance info s f cs n ps t expn ds
@@ -1574,27 +1574,27 @@ elabDecl' what info (PRecord doc s f tyn ty cdoc cn cty)
   | what /= ETypes
     = do iLOG $ "Elaborating record " ++ show tyn
          elabRecord info s doc f tyn ty cdoc cn cty
-  | otherwise 
+  | otherwise
     = do iLOG $ "Elaborating [type of] " ++ show tyn
          elabData info s doc f False (PLaterdecl tyn ty)
 elabDecl' _ info (PDSL n dsl)
     = do i <- getIState
-         putIState (i { idris_dsls = addDef n dsl (idris_dsls i) }) 
+         putIState (i { idris_dsls = addDef n dsl (idris_dsls i) })
          addIBC (IBCDSL n)
-elabDecl' what info (PDirective i) 
+elabDecl' what info (PDirective i)
   | what /= EDefns = i
 elabDecl' what info (PProvider syn fc n tp tm)
   | what /= EDefns
     = do iLOG $ "Elaborating type provider " ++ show n
          elabProvider info syn fc n tp tm
 elabDecl' what info (PTransform fc safety old new)
-    = elabTransform info fc safety old new 
-elabDecl' _ _ _ = return () -- skipped this time 
+    = elabTransform info fc safety old new
+elabDecl' _ _ _ = return () -- skipped this time
 
-elabCaseBlock info opts d@(PClauses f o n ps) 
+elabCaseBlock info opts d@(PClauses f o n ps)
         = do addIBC (IBCDef n)
              logLvl 6 $ "CASE BLOCK: " ++ show (n, d)
-             elabDecl' EAll info (PClauses f (nub (o ++ opts)) n ps ) 
+             elabDecl' EAll info (PClauses f (nub (o ++ opts)) n ps )
 
 -- elabDecl' info (PImport i) = loadModule i
 
@@ -1608,9 +1608,9 @@ checkInferred fc inf user =
                                      showImp Nothing True False user
         logLvl 10 $ "Checking match"
         i <- getIState
-        tclift $ case matchClause' True i user inf of 
+        tclift $ case matchClause' True i user inf of
             _ -> return ()
---             Left (x, y) -> tfail $ At fc 
+--             Left (x, y) -> tfail $ At fc
 --                                     (Msg $ "The type-checked term and given term do not match: "
 --                                            ++ show x ++ " and " ++ show y)
         logLvl 10 $ "Checked match"
@@ -1624,7 +1624,7 @@ inferredDiff fc inf user =
      do i <- getIState
         logLvl 6 $ "Checked to\n" ++ showImp Nothing True False inf ++ "\n" ++
                                      showImp Nothing True False user
-        tclift $ case matchClause' True i user inf of 
+        tclift $ case matchClause' True i user inf of
             Right vs -> return False
             Left (x, y) -> return True
 

--- a/src/Idris/Error.hs
+++ b/src/Idris/Error.hs
@@ -32,7 +32,7 @@ showErr e = getIState >>= return . flip pshow e
 
 report :: IOError -> String
 report e
-    | isUserError e = ioeGetErrorString e 
+    | isUserError e = ioeGetErrorString e
     | otherwise     = show e
 
 --idrisCatch :: Idris a -> (SomeException -> Idris a) -> Idris a
@@ -54,7 +54,7 @@ tclift (Error err@(At (FC f l c) e)) = do setErrLine l ; throwError err
 tclift (Error err) = throwError err
 
 tctry :: TC a -> TC a -> Idris a
-tctry tc1 tc2 
+tctry tc1 tc2
     = case tc1 of
            OK v -> return v
            Error err -> tclift tc2

--- a/src/Idris/IBC.hs
+++ b/src/Idris/IBC.hs
@@ -54,8 +54,8 @@ data IBCFile = IBCFile { ver :: Word8,
                          ibc_lineapps :: [(FilePath, Int, PTerm)]
                        }
    deriving Show
-{-! 
-deriving instance Binary IBCFile 
+{-!
+deriving instance Binary IBCFile
 !-}
 
 initIBC :: IBCFile
@@ -67,13 +67,13 @@ loadIBC fp = do iLOG $ "Loading ibc " ++ fp
                 process ibcf fp
 
 writeIBC :: FilePath -> FilePath -> Idris ()
-writeIBC src f 
+writeIBC src f
     = do iLOG $ "Writing ibc " ++ show f
          i <- getIState
          case (Data.List.map fst (idris_metavars i)) \\ primDefs of
                 (_:_) -> ifail "Can't write ibc when there are unsolved metavariables"
                 [] -> return ()
-         ibcf <- mkIBC (ibc_write i) (initIBC { sourcefile = src }) 
+         ibcf <- mkIBC (ibc_write i) (initIBC { sourcefile = src })
          idrisCatch (do runIO $ createDirectoryIfMissing True (dropFileName f)
                         runIO $ encodeFile f ibcf
                         iLOG "Written")
@@ -88,25 +88,25 @@ mkIBC (i:is) f = do ist <- getIState
                     mkIBC is f'
 
 ibc :: IState -> IBCWrite -> IBCFile -> Idris IBCFile
-ibc i (IBCFix d) f = return f { ibc_fixes = d : ibc_fixes f } 
+ibc i (IBCFix d) f = return f { ibc_fixes = d : ibc_fixes f }
 ibc i (IBCImp n) f = case lookupCtxt n (idris_implicits i) of
                         [v] -> return f { ibc_implicits = (n,v): ibc_implicits f     }
                         _ -> ifail "IBC write failed"
-ibc i (IBCStatic n) f 
+ibc i (IBCStatic n) f
                    = case lookupCtxt n (idris_statics i) of
                         [v] -> return f { ibc_statics = (n,v): ibc_statics f     }
                         _ -> ifail "IBC write failed"
-ibc i (IBCClass n) f 
+ibc i (IBCClass n) f
                    = case lookupCtxt n (idris_classes i) of
                         [v] -> return f { ibc_classes = (n,v): ibc_classes f     }
                         _ -> ifail "IBC write failed"
-ibc i (IBCInstance int n ins) f 
+ibc i (IBCInstance int n ins) f
                    = return f { ibc_instances = (int,n,ins): ibc_instances f     }
-ibc i (IBCDSL n) f 
+ibc i (IBCDSL n) f
                    = case lookupCtxt n (idris_dsls i) of
                         [v] -> return f { ibc_dsls = (n,v): ibc_dsls f     }
                         _ -> ifail "IBC write failed"
-ibc i (IBCData n) f 
+ibc i (IBCData n) f
                    = case lookupCtxt n (idris_datatypes i) of
                         [v] -> return f { ibc_datatypes = (n,v): ibc_datatypes f     }
                         _ -> ifail "IBC write failed"
@@ -135,7 +135,7 @@ ibc i (IBCAccess n a) f = return f { ibc_access = (n,a) : ibc_access f }
 ibc i (IBCFlags n a) f = return f { ibc_flags = (n,a) : ibc_flags f }
 ibc i (IBCTotal n a) f = return f { ibc_total = (n,a) : ibc_total f }
 ibc i (IBCTrans t) f = return f { ibc_transforms = t : ibc_transforms f }
-ibc i (IBCLineApp fp l t) f 
+ibc i (IBCLineApp fp l t) f
      = return f { ibc_lineapps = (fp,l,t) : ibc_lineapps f }
 
 process :: IBCFile -> FilePath -> Idris ()
@@ -181,7 +181,7 @@ timestampOlder src ibc = do srct <- getModificationTime src
                                else return ()
 
 pImports :: [FilePath] -> Idris ()
-pImports fs 
+pImports fs
   = do mapM_ (\f -> do i <- getIState
                        ibcsd <- valIBCSubDir i
                        ids <- allImportDirs
@@ -189,18 +189,18 @@ pImports fs
                        if (f `elem` imported i)
                         then iLOG $ "Already read " ++ f
                         else do putIState (i { imported = f : imported i })
-                                case fp of 
+                                case fp of
                                     LIDR fn -> do iLOG $ "Failed at " ++ fn
                                                   ifail "Must be an ibc"
                                     IDR fn -> do iLOG $ "Failed at " ++ fn
                                                  ifail "Must be an ibc"
-                                    IBC fn src -> loadIBC fn) 
+                                    IBC fn src -> loadIBC fn)
              fs
 
 pImps :: [(Name, [PArg])] -> Idris ()
-pImps imps = mapM_ (\ (n, imp) -> 
+pImps imps = mapM_ (\ (n, imp) ->
                         do i <- getIState
-                           putIState (i { idris_implicits 
+                           putIState (i { idris_implicits
                                             = addDef n imp (idris_implicits i) }))
                    imps
 
@@ -216,7 +216,7 @@ pStatics ss = mapM_ (\ (n, s) ->
                     ss
 
 pClasses :: [(Name, ClassInfo)] -> Idris ()
-pClasses cs = mapM_ (\ (n, c) -> 
+pClasses cs = mapM_ (\ (n, c) ->
                         do i <- getIState
                            -- Don't lose instances from previous IBCs, which
                            -- could have loaded in any order
@@ -283,11 +283,11 @@ pHdrs :: [(Codegen, String)] -> Idris ()
 pHdrs hs = mapM_ (uncurry addHdr) hs
 
 pDefs :: [(Name, Def)] -> Idris ()
-pDefs ds = mapM_ (\ (n, d) -> 
+pDefs ds = mapM_ (\ (n, d) ->
                      do i <- getIState
                         logLvl 5 $ "Added " ++ show (n, d)
                         putIState (i { tt_ctxt = addCtxtDef n d (tt_ctxt i) }))
-                 ds       
+                 ds
 
 pDocs :: [(Name, String)] -> Idris ()
 pDocs ds = mapM_ (\ (n, a) -> addDocStr n a) ds
@@ -363,7 +363,7 @@ instance Binary FC where
                x3 <- get
                return (FC x1 x2 x3)
 
- 
+
 instance Binary Name where
         put x
           = case x of
@@ -508,7 +508,7 @@ instance Binary Const where
 
                    _ -> error "Corrupted binary data for Const"
 
- 
+
 instance Binary Raw where
         put x
           = case x of
@@ -545,7 +545,7 @@ instance Binary Raw where
                            return (RForce x1)
                    _ -> error "Corrupted binary data for Raw"
 
- 
+
 instance (Binary b) => Binary (Binder b) where
         put x
           = case x of
@@ -598,7 +598,7 @@ instance (Binary b) => Binary (Binder b) where
                            return (PVTy x1)
                    _ -> error "Corrupted binary data for Binder"
 
- 
+
 instance Binary NameType where
         put x
           = case x of
@@ -626,7 +626,7 @@ instance Binary NameType where
 
 instance {-(Binary n) =>-} Binary (TT Name) where
         put x
-          = {-# SCC "putTT" #-} 
+          = {-# SCC "putTT" #-}
             case x of
                 P x1 x2 x3 -> do putWord8 0
                                  put x1
@@ -705,12 +705,12 @@ instance Binary SC where
                    3 -> do x1 <- get
                            return (UnmatchedCase x1)
                    4 -> return ImpossibleCase
-                   _ -> error "Corrupted binary data for SC" 
+                   _ -> error "Corrupted binary data for SC"
 
- 
+
 instance Binary CaseAlt where
         put x
-          = {-# SCC "putCaseAlt" #-} 
+          = {-# SCC "putCaseAlt" #-}
             case x of
                 ConCase x1 x2 x3 x4 -> do putWord8 0
                                           put x1
@@ -769,10 +769,10 @@ instance Binary CaseInfo where
         get = do x1 <- get
                  x2 <- get
                  return (CaseInfo x1 x2)
- 
+
 instance Binary Def where
         put x
-          = {-# SCC "putDef" #-} 
+          = {-# SCC "putDef" #-}
             case x of
                 Function x1 x2 -> do putWord8 0
                                      put x1
@@ -871,7 +871,7 @@ instance Binary Totality where
 
 instance Binary IBCFile where
         put x@(IBCFile x1 x2 x3 x4 x5 x6 x7 x8 x9 x10 x11 x12 x13 x14 x15 x16 x17 x18 x19 x20 x21 x22 x23 x24 x25 x26 x27)
-         = {-# SCC "putIBCFile" #-} 
+         = {-# SCC "putIBCFile" #-}
             do put x1
                put x2
                put x3
@@ -901,7 +901,7 @@ instance Binary IBCFile where
                put x27
         get
           = do x1 <- get
-               if x1 == ibcVersion then 
+               if x1 == ibcVersion then
                  do x2 <- get
                     x3 <- get
                     x4 <- get
@@ -930,7 +930,7 @@ instance Binary IBCFile where
                     x27 <- get
                     return (IBCFile x1 x2 x3 x4 x5 x6 x7 x8 x9 x10 x11 x12 x13 x14 x15 x16 x17 x18 x19 x20 x21 x22 x23 x24 x25 x26 x27)
                   else return (initIBC { ver = x1 })
- 
+
 instance Binary FnOpt where
         put x
           = case x of
@@ -983,7 +983,7 @@ instance Binary Fixity where
                            return (PrefixN x1)
                    _ -> error "Corrupted binary data for Fixity"
 
- 
+
 instance Binary FixDecl where
         put (Fix x1 x2)
           = do put x1
@@ -993,7 +993,7 @@ instance Binary FixDecl where
                x2 <- get
                return (Fix x1 x2)
 
- 
+
 instance Binary Static where
         put x
           = case x of
@@ -1006,28 +1006,28 @@ instance Binary Static where
                    1 -> return Dynamic
                    _ -> error "Corrupted binary data for Static"
 
- 
+
 instance Binary Plicity where
         put x
           = case x of
-                Imp x1 x2 x3 x4 -> 
+                Imp x1 x2 x3 x4 ->
                              do putWord8 0
                                 put x1
                                 put x2
                                 put x3
                                 put x4
-                Exp x1 x2 x3 x4 -> 
+                Exp x1 x2 x3 x4 ->
                              do putWord8 1
                                 put x1
                                 put x2
                                 put x3
                                 put x4
-                Constraint x1 x2 x3 -> 
+                Constraint x1 x2 x3 ->
                                     do putWord8 2
                                        put x1
                                        put x2
                                        put x3
-                TacImp x1 x2 x3 x4 -> 
+                TacImp x1 x2 x3 x4 ->
                                    do putWord8 3
                                       put x1
                                       put x2
@@ -1057,7 +1057,7 @@ instance Binary Plicity where
                            return (TacImp x1 x2 x3 x4)
                    _ -> error "Corrupted binary data for Plicity"
 
- 
+
 instance (Binary t) => Binary (PDecl' t) where
         put x
           = case x of
@@ -1078,7 +1078,7 @@ instance (Binary t) => Binary (PDecl' t) where
                                            put x2
                                            put x3
                                            put x4
-                PData x1 x2 x3 x4 x5 -> 
+                PData x1 x2 x3 x4 x5 ->
                                      do putWord8 3
                                         put x1
                                         put x2
@@ -1092,7 +1092,7 @@ instance (Binary t) => Binary (PDecl' t) where
                 PNamespace x1 x2 -> do putWord8 5
                                        put x1
                                        put x2
-                PRecord x1 x2 x3 x4 x5 x6 x7 x8 -> 
+                PRecord x1 x2 x3 x4 x5 x6 x7 x8 ->
                                              do putWord8 6
                                                 put x1
                                                 put x2
@@ -1575,7 +1575,7 @@ instance (Binary t) => Binary (PTactic' t) where
                 Reflect x1 -> do putWord8 17
                                  put x1
                 Fill x1 -> do putWord8 18
-                              put x1                
+                              put x1
         get
           = do i <- getWord8
                case i of
@@ -1668,7 +1668,7 @@ instance (Binary t) => Binary (PDo' t) where
 instance (Binary t) => Binary (PArg' t) where
         put x
           = case x of
-                PImp x1 x2 x3 x4 x5 x6 -> 
+                PImp x1 x2 x3 x4 x5 x6 ->
                                     do putWord8 0
                                        put x1
                                        put x2
@@ -1676,19 +1676,19 @@ instance (Binary t) => Binary (PArg' t) where
                                        put x4
                                        put x5
                                        put x6
-                PExp x1 x2 x3 x4 -> 
+                PExp x1 x2 x3 x4 ->
                                  do putWord8 1
                                     put x1
                                     put x2
                                     put x3
                                     put x4
-                PConstraint x1 x2 x3 x4 -> 
+                PConstraint x1 x2 x3 x4 ->
                                         do putWord8 2
                                            put x1
                                            put x2
                                            put x3
                                            put x4
-                PTacImplicit x1 x2 x3 x4 x5 x6 -> 
+                PTacImplicit x1 x2 x3 x4 x5 x6 ->
                                                do putWord8 3
                                                   put x1
                                                   put x2
@@ -1725,7 +1725,7 @@ instance (Binary t) => Binary (PArg' t) where
                            return (PTacImplicit x1 x2 x3 x4 x5 x6)
                    _ -> error "Corrupted binary data for PArg'"
 
- 
+
 instance Binary ClassInfo where
         put (CI x1 x2 x3 x4 _)
           = do put x1
@@ -1775,7 +1775,7 @@ instance Binary SynContext where
                    2 -> return AnySyntax
                    _ -> error "Corrupted binary data for SynContext"
 
- 
+
 instance Binary Syntax where
         put (Rule x1 x2 x3)
           = do put x1
@@ -1809,7 +1809,7 @@ instance (Binary t) => Binary (DSL' t) where
                x8 <- get
                x9 <- get
                return (DSL x1 x2 x3 x4 x5 x6 x7 x8 x9)
- 
+
 instance Binary SSymbol where
         put x
           = case x of

--- a/src/Idris/Imports.hs
+++ b/src/Idris/Imports.hs
@@ -9,7 +9,7 @@ import System.FilePath
 import System.Directory
 import Control.Monad.State
 
-data IFileType = IDR FilePath | LIDR FilePath | IBC FilePath IFileType 
+data IFileType = IDR FilePath | LIDR FilePath | IBC FilePath IFileType
     deriving (Show, Eq)
 
 srcPath :: FilePath -> FilePath
@@ -60,7 +60,7 @@ findImport (d:ds) ibcsd fp = do let fp_full = d </> fp
                                            else IDR idrp
                                 if ibc
                                   then return (IBC ibcp isrc)
-                                  else if (idr || lidr) 
+                                  else if (idr || lidr)
                                        then return isrc
                                        else findImport ds ibcsd fp
 

--- a/src/Idris/Inliner.hs
+++ b/src/Idris/Inliner.hs
@@ -15,13 +15,13 @@ inlineDef ist ds = map (\ (ns, lhs, rhs) -> (ns, lhs, inlineTerm ist rhs)) ds
 --        (Dictionaries are inlinable in an argument, not otherwise)
 --      - If so, try inlining without reducing its arguments
 --        + If successful, then continue on the result (top level)
---        + If not, reduce the arguments (argument level) and try again 
+--        + If not, reduce the arguments (argument level) and try again
 --      - If not, inline all the arguments (top level)
 
 inlineTerm :: IState -> Term -> Term
 inlineTerm ist tm = inl tm where
   inl orig@(P _ n _) = inlApp n [] orig
-  inl orig@(App f a) 
+  inl orig@(App f a)
       | (P _ fn _, args) <- unApply orig = inlApp fn args orig
   inl (Bind n (Let t v) sc) = Bind n (Let t (inl v)) (inl sc)
   inl (Bind n b sc) = Bind n b (inl sc)

--- a/src/Idris/ParseData.hs
+++ b/src/Idris/ParseData.hs
@@ -38,7 +38,7 @@ Record ::=
     DocComment Accessibility? 'record' FnName TypeSig 'where' OpenBlock Constructor KeepTerminator CloseBlock;
 -}
 record :: SyntaxInfo -> IdrisParser PDecl
-record syn = do (doc, acc) <- try (do 
+record syn = do (doc, acc) <- try (do
                       doc <- option "" (docComment '|')
                       acc <- optional accessibility
                       reserved "record"

--- a/src/Idris/ParseExpr.hs
+++ b/src/Idris/ParseExpr.hs
@@ -313,7 +313,7 @@ bracketed syn =
         <|>
         try (do l <- expr syn
                 lchar ')'
-                return l) 
+                return l)
         <|>  do (l, fc) <- try (do
                      l <- expr syn
                      fc <- getFC

--- a/src/Idris/ParseHelpers.hs
+++ b/src/Idris/ParseHelpers.hs
@@ -487,9 +487,9 @@ collect (c@(PClauses _ o _ _) : ds)
 collect (PParams f ns ps : ds) = PParams f ns (collect ps) : collect ds
 collect (PMutual f ms : ds) = PMutual f (collect ms) : collect ds
 collect (PNamespace ns ps : ds) = PNamespace ns (collect ps) : collect ds
-collect (PClass doc f s cs n ps ds : ds') 
+collect (PClass doc f s cs n ps ds : ds')
     = PClass doc f s cs n ps (collect ds) : collect ds'
-collect (PInstance f s cs n ps t en ds : ds') 
+collect (PInstance f s cs n ps t en ds : ds')
     = PInstance f s cs n ps t en (collect ds) : collect ds'
 collect (d : ds) = d : collect ds
 collect [] = []

--- a/src/Idris/Parser.hs
+++ b/src/Idris/Parser.hs
@@ -1,5 +1,5 @@
 {-# LANGUAGE GeneralizedNewtypeDeriving, ConstraintKinds, PatternGuards #-}
-module Idris.Parser(module Idris.Parser, 
+module Idris.Parser(module Idris.Parser,
                     module Idris.ParseExpr,
                     module Idris.ParseData,
                     module Idris.ParseHelpers,
@@ -262,7 +262,7 @@ fnDecl syn
   ;
 -}
 fnDecl' :: SyntaxInfo -> IdrisParser PDecl
-fnDecl' syn = do (doc, fc, opts', n, acc) <- try (do 
+fnDecl' syn = do (doc, fc, opts', n, acc) <- try (do
                         doc <- option "" (docComment '|')
                         pushIndent
                         ist <- get
@@ -443,7 +443,7 @@ Class ::=
   ;
 -}
 class_ :: SyntaxInfo -> IdrisParser [PDecl]
-class_ syn = do (doc, acc) <- try (do 
+class_ syn = do (doc, acc) <- try (do
                   doc <- option "" (docComment '|')
                   acc <- optional accessibility
                   return (doc, acc))
@@ -645,7 +645,7 @@ clause syn
               ist <- get
               put (ist { lastParse = Just n })
               return $ PClause fc n capp [] r wheres
-       <|> do (l, op) <- try (do 
+       <|> do (l, op) <- try (do
                 pushIndent
                 l <- argExpr syn
                 op <- operator

--- a/src/Idris/PartialEval.hs
+++ b/src/Idris/PartialEval.hs
@@ -7,7 +7,7 @@ import Core.Evaluate
 
 import Debug.Trace
 
-partial_eval :: Context -> [(Name, Maybe Int)] -> 
+partial_eval :: Context -> [(Name, Maybe Int)] ->
                 [Either Term (Term, Term)] ->
                 [Either Term (Term, Term)]
 partial_eval ctxt ns tms = map peClause tms where

--- a/src/Idris/Primitives.hs
+++ b/src/Idris/Primitives.hs
@@ -131,7 +131,7 @@ primitives =
      (1, LFloatStr) total,
 
    Prim (UN "prim__floatExp") (ty [(AType ATFloat)] (AType ATFloat)) 1 (p_floatExp)
-     (1, LFExp) total, 
+     (1, LFExp) total,
    Prim (UN "prim__floatLog") (ty [(AType ATFloat)] (AType ATFloat)) 1 (p_floatLog)
      (1, LFLog) total,
    Prim (UN "prim__floatSin") (ty [(AType ATFloat)] (AType ATFloat)) 1 (p_floatSin)
@@ -191,7 +191,7 @@ intSCmps ity =
 
 intCmps :: IntTy -> [Prim]
 intCmps ITNative = intSCmps ITNative
-intCmps ity = 
+intCmps ity =
     intSCmps ity ++
     [ iCmp ity "lt" False (bCmp ity (cmpOp ity (<))) LLt total
     , iCmp ity "lte" False (bCmp ity (cmpOp ity (<=))) LLe total

--- a/src/Idris/ProofSearch.hs
+++ b/src/Idris/ProofSearch.hs
@@ -24,7 +24,7 @@ trivial elab ist = try' (do elab (PRefl (fileFC "prf") Placeholder)
                             return ()) True
       where
         tryAll []     = fail "No trivial solution"
-        tryAll ((x, b):xs) 
+        tryAll ((x, b):xs)
            = do -- if type of x has any holes in it, move on
                 hs <- get_holes
                 g <- goal
@@ -35,10 +35,10 @@ trivial elab ist = try' (do elab (PRefl (fileFC "prf") Placeholder)
 
 proofSearch :: (PTerm -> ElabD ()) -> Maybe Name -> Name -> [Name] ->
                IState -> ElabD ()
-proofSearch elab fn nroot hints ist = psRec maxDepth 
+proofSearch elab fn nroot hints ist = psRec maxDepth
   where
     maxDepth = 6
-  
+
     psRec 0 = do attack; defer nroot; solve --fail "Maximum depth reached"
     psRec d = try' (trivial elab ist)
                    (try' (try' (resolveByCon (d - 1)) (resolveByLocals (d - 1))
@@ -50,7 +50,7 @@ proofSearch elab fn nroot hints ist = psRec maxDepth
     getFn d (Just f) | d < maxDepth-1 = [f]
                      | otherwise = []
 
-    resolveByCon d 
+    resolveByCon d
         = do t <- goal
              let (f, _) = unApply t
              case f of
@@ -71,7 +71,7 @@ proofSearch elab fn nroot hints ist = psRec maxDepth
 
     tryCons d [] = fail "Constructors failed"
     tryCons d (c : cs) = try' (tryCon d c) (tryCons d cs) True
-   
+
     tryLocal d n t = do let a = getPArity (delab ist (binderTy t))
                         tryLocalArg d n a
 
@@ -80,7 +80,7 @@ proofSearch elab fn nroot hints ist = psRec maxDepth
                                    (psRec d) "proof search local apply"
 
     -- Like type class resolution, but searching with constructors
-    tryCon d n = 
+    tryCon d n =
          do let imps = case lookupCtxtName n (idris_implicits ist) of
                             [] -> []
                             [args] -> map isImp (snd args)
@@ -93,7 +93,7 @@ proofSearch elab fn nroot hints ist = psRec maxDepth
                                   psRec d)
                   (filter (\ (x, y) -> not x) (zip (map fst imps) args))
             solve
-    
+
     isImp (PImp p _ _ _ _ _) = (True, p)
     isImp arg = (False, priority arg)
 

--- a/src/Idris/Prover.hs
+++ b/src/Idris/Prover.hs
@@ -36,7 +36,7 @@ prover lit x =
                   _ -> fail "No such metavariable"
 
 showProof :: Bool -> Name -> [String] -> String
-showProof lit n ps 
+showProof lit n ps
     = bird ++ show n ++ " = proof" ++ break ++
              showSep break (map (\x -> "  " ++ x) ps) ++
                      break ++ "\n"
@@ -105,7 +105,7 @@ dumpState ist ps@(PS nm (h:hs) _ _ tm _ _ _ _ _ _ problems i _ _ ctxy _ _ _) = d
     prettyPs ((n, Let t v) : bs) =
       nest nestingSize (pretty n <+> text "=" <+> tPretty v <> colon <+>
         tPretty t $$ prettyPs bs)
-    prettyPs ((n, b) : bs) = 
+    prettyPs ((n, b) : bs) =
       pretty n <+> colon <+> tPretty (binderTy b) $$ prettyPs bs
 
     prettyG (Guess t v) = tPretty t <+> text "=?=" <+> tPretty v

--- a/src/Idris/REPLParser.hs
+++ b/src/Idris/REPLParser.hs
@@ -65,29 +65,29 @@ pCmd = do P.whiteSpace; try (do cmd ["q", "quit"]; eof; return Quit)
               <|> try (do cmd ["set"]; o <-pOption; return (SetOpt o))
               <|> try (do cmd ["unset"]; o <-pOption; return (UnsetOpt o))
               <|> try (do cmd ["s", "search"]; P.whiteSpace; t <- P.fullExpr defaultSyntax; return (Search t))
-              <|> try (do cmd ["cs", "casesplit"]; P.whiteSpace; 
+              <|> try (do cmd ["cs", "casesplit"]; P.whiteSpace;
                           upd <- option False (do P.lchar '!'; return True)
-                          l <- P.natural; n <- P.name; 
+                          l <- P.natural; n <- P.name;
                           return (CaseSplitAt upd (fromInteger l) n))
-              <|> try (do cmd ["apc", "addproofclause"]; P.whiteSpace; 
+              <|> try (do cmd ["apc", "addproofclause"]; P.whiteSpace;
                           upd <- option False (do P.lchar '!'; return True)
-                          l <- P.natural; n <- P.name; 
+                          l <- P.natural; n <- P.name;
                           return (AddProofClauseFrom upd (fromInteger l) n))
-              <|> try (do cmd ["ac", "addclause"]; P.whiteSpace; 
+              <|> try (do cmd ["ac", "addclause"]; P.whiteSpace;
                           upd <- option False (do P.lchar '!'; return True)
-                          l <- P.natural; n <- P.name; 
+                          l <- P.natural; n <- P.name;
                           return (AddClauseFrom upd (fromInteger l) n))
-              <|> try (do cmd ["am", "addmissing"]; P.whiteSpace; 
+              <|> try (do cmd ["am", "addmissing"]; P.whiteSpace;
                           upd <- option False (do P.lchar '!'; return True)
-                          l <- P.natural; n <- P.name; 
+                          l <- P.natural; n <- P.name;
                           return (AddMissing upd (fromInteger l) n))
-              <|> try (do cmd ["mw", "makewith"]; P.whiteSpace; 
+              <|> try (do cmd ["mw", "makewith"]; P.whiteSpace;
                           upd <- option False (do P.lchar '!'; return True)
-                          l <- P.natural; n <- P.name; 
+                          l <- P.natural; n <- P.name;
                           return (MakeWith upd (fromInteger l) n))
-              <|> try (do cmd ["ps", "proofsearch"]; P.whiteSpace; 
+              <|> try (do cmd ["ps", "proofsearch"]; P.whiteSpace;
                           upd <- option False (do P.lchar '!'; return True)
-                          l <- P.natural; n <- P.name; 
+                          l <- P.natural; n <- P.name;
                           hints <- many P.name
                           return (DoProofSearch upd (fromInteger l) n hints))
               <|> try (do cmd ["p", "prove"]; n <- P.name; eof; return (Prove n))

--- a/src/Idris/Transforms.hs
+++ b/src/Idris/Transforms.hs
@@ -40,7 +40,7 @@ instance Transform CaseAlt where
 natTrans = [TermTrans zero, TermTrans suc, CaseTrans natcase]
 
 zname = NS (UN "Z") ["Nat","Prelude"]
-sname = NS (UN "S") ["Nat","Prelude"] 
+sname = NS (UN "S") ["Nat","Prelude"]
 
 zero :: TT Name -> TT Name
 zero (P _ n _) | n == zname
@@ -53,5 +53,5 @@ suc (App (P _ s _) a) | s == sname
 suc x = x
 
 natcase :: SC -> SC
-natcase = undefined 
+natcase = undefined
 

--- a/src/Idris/Unlit.hs
+++ b/src/Idris/Unlit.hs
@@ -15,7 +15,7 @@ ulLine ('>':' ':xs)        = (Prog, xs)
 ulLine ('>':xs)            = (Prog, xs)
 ulLine xs | all isSpace xs = (Blank, "")
 -- make sure it's not a doc comment
-          | otherwise      = (Comm, '-':'-':' ':'>':xs) 
+          | otherwise      = (Comm, '-':'-':' ':'>':xs)
 
 check :: FilePath -> Int -> [(LineType, String)] -> TC ()
 check f l (a:b:cs) = do chkAdj f l (fst a) (fst b)

--- a/src/Idris/UnusedArgs.hs
+++ b/src/Idris/UnusedArgs.hs
@@ -13,18 +13,18 @@ findUnusedArgs :: [Name] -> Idris ()
 findUnusedArgs ns = mapM_ traceUnused ns
 
 traceUnused :: Name -> Idris ()
-traceUnused n 
+traceUnused n
    = do i <- getIState
-        case lookupCtxt n (idris_callgraph i) of 
+        case lookupCtxt n (idris_callgraph i) of
           [CGInfo args calls scg usedns _] ->
                 do let argpos = zip args [0..]
                    let fargs = concatMap (getFargpos calls) argpos
                    logLvl 3 $ show n ++ " used TRACE: " ++ show fargs
-                   recused <- mapM (\ (argn, i, (g, j)) -> 
+                   recused <- mapM (\ (argn, i, (g, j)) ->
                                         do u <- used [(n, i)] g j
                                            return (argn, u)) fargs
                    let fused = nub $ usedns ++ map fst (filter snd recused)
-                   logLvl 1 $ show n ++ " used args: " ++ show fused 
+                   logLvl 1 $ show n ++ " used args: " ++ show fused
                    let unusedpos = mapMaybe (getUnused fused) (zip [0..] args)
                    logLvl 1 $ show n ++ " unused args: " ++ show (args, unusedpos)
                    addToCG n (CGInfo args calls scg usedns unusedpos) -- updates
@@ -34,14 +34,14 @@ traceUnused n
                           | otherwise = Just i
 
 used :: [(Name, Int)] -> Name -> Int -> Idris Bool
-used path g j 
+used path g j
    | (g, j) `elem` path = return False -- cycle, never used on the way
-   | otherwise 
-       = do logLvl 5 $ (show ((g, j) : path)) 
+   | otherwise
+       = do logLvl 5 $ (show ((g, j) : path))
             i <- getIState
             case lookupCtxt g (idris_callgraph i) of
                [CGInfo args calls scg usedns unused] ->
-                  if (j >= length args) 
+                  if (j >= length args)
                     then -- overapplied, assume used
                          return True
                     else do let directuse = args!!j `elem` usedns
@@ -50,7 +50,7 @@ used path g j
                             recused <- mapM (\ (argn, j, (g', j')) ->
                                            used ((g,j):path) g' j') garg
                             -- used on any route from here, or not used recursively
-                            return (directuse || null recused || or recused) 
+                            return (directuse || null recused || or recused)
                _ -> return True -- no definition, assume used
 
 getFargpos :: [(Name, [[Name]])] -> (Name, Int) -> [(Name, Int, (Name, Int))]

--- a/src/Pkg/PParser.hs
+++ b/src/Pkg/PParser.hs
@@ -58,10 +58,10 @@ parseDesc fp = do p <- readFile fp
                        Right x -> return x
 
 pPkg :: PParser PkgDesc
-pPkg = do reserved "package"; p <- identifier 
+pPkg = do reserved "package"; p <- identifier
           st <- getState
           setState (st { pkgname = p })
-          many1 pClause 
+          many1 pClause
           st <- getState
           return st
 
@@ -84,7 +84,7 @@ pClause = do reserved "executable"; lchar '=';
              let args = parseArgs (words opts)
              setState (st { idris_opts = args })
       <|> do reserved "modules"; lchar '=';
-             ms <- sepBy1 (iName []) (lchar ',') 
+             ms <- sepBy1 (iName []) (lchar ',')
              st <- getState
              setState (st { modules = modules st ++ ms })
       <|> do reserved "libs"; lchar '=';
@@ -99,4 +99,4 @@ pClause = do reserved "executable"; lchar '=';
              mk <- iName []
              st <- getState
              setState (st { makefile = Just (show mk) })
-  
+

--- a/src/Pkg/Package.hs
+++ b/src/Pkg/Package.hs
@@ -30,7 +30,7 @@ import Paths_idris (getDataDir)
 -- * install everything into datadir/pname, if install flag is set
 
 buildPkg :: Bool -> (Bool, FilePath) -> IO ()
-buildPkg warnonly (install, fp) 
+buildPkg warnonly (install, fp)
      = do pkgdesc <- parseDesc fp
           ok <- mapM (testLib warnonly (pkgname pkgdesc)) (libdeps pkgdesc)
           when (and ok) $
@@ -42,17 +42,17 @@ buildPkg warnonly (install, fp)
                                     (modules pkgdesc)
                    Just o -> do let exec = dir </> o
                                 buildMods
-                                    (NoREPL : Verbose : Output exec : idris_opts pkgdesc) 
+                                    (NoREPL : Verbose : Output exec : idris_opts pkgdesc)
                                     [idris_main pkgdesc]
                setCurrentDirectory dir
                when install $ installPkg pkgdesc
 
 cleanPkg :: FilePath -> IO ()
-cleanPkg fp 
+cleanPkg fp
      = do pkgdesc <- parseDesc fp
           dir <- getCurrentDirectory
           setCurrentDirectory $ dir </> sourcedir pkgdesc
-          clean (makefile pkgdesc) 
+          clean (makefile pkgdesc)
           mapM_ rmIBC (modules pkgdesc)
           case execout pkgdesc of
                Nothing -> return ()
@@ -75,7 +75,7 @@ buildMods opts ns = do let f = map (toPath . show) ns
     where toPath n = foldl1' (</>) $ splitOn "." n
 
 testLib :: Bool -> String -> String -> IO Bool
-testLib warn p f 
+testLib warn p f
     = do d <- getDataDir
          gcc <- getCC
          (tmpf, tmph) <- tempfile
@@ -84,15 +84,15 @@ testLib warn p f
          e <- system $ gcc ++ " " ++ libtest ++ " -l" ++ f ++ " -o " ++ tmpf
          case e of
             ExitSuccess -> return True
-            _ -> do if warn 
-                       then do putStrLn $ "Not building " ++ p ++ 
+            _ -> do if warn
+                       then do putStrLn $ "Not building " ++ p ++
                                           " due to missing library " ++ f
                                return False
                        else fail $ "Missing library " ++ f
 
 rmIBC :: Name -> IO ()
-rmIBC m = rmFile $ toIBCFile m 
-             
+rmIBC m = rmFile $ toIBCFile m
+
 toIBCFile (UN n) = n ++ ".ibc"
 toIBCFile (NS n ns) = foldl1' (</>) (reverse (toIBCFile n : ns))
 

--- a/src/Util/LLVMStubs.hs
+++ b/src/Util/LLVMStubs.hs
@@ -1,6 +1,6 @@
-{-- 
+{--
 
-Things needed to build without LLVM 
+Things needed to build without LLVM
 Replaces stuff from LLVM.General.Target and IRTS.CodegenLLVM.
 
 --}

--- a/src/Util/System.hs
+++ b/src/Util/System.hs
@@ -48,17 +48,17 @@ tempfile = do dir <- getTemporaryDirectory
               openTempFile (normalise dir) "idris"
 
 withTempdir :: String -> (FilePath -> IO a) -> IO a
-withTempdir subdir callback 
+withTempdir subdir callback
   = do dir <- getTemporaryDirectory
        let tmpDir = (normalise dir) </> subdir
        removeLater <- catchIO (createDirectoryIfMissing True tmpDir >> return True)
-                              (\ ioError -> if isAlreadyExistsError ioError then return False 
+                              (\ ioError -> if isAlreadyExistsError ioError then return False
                                             else throw ioError
                               )
        result <- callback tmpDir
        when removeLater $ removeDirectoryRecursive tmpDir
        return result
-                       
+
 environment :: String -> IO (Maybe String)
 environment x = catchIO (do e <- getEnv x
                             return (Just e))
@@ -70,13 +70,13 @@ getTargetDir = environment "TARGET" >>= maybe getDataDir return
 rmFile :: FilePath -> IO ()
 rmFile f = do putStrLn $ "Removing " ++ f
               catchIO (removeFile f)
-                      (\ioerr -> putStrLn $ "WARNING: Cannot remove file " 
+                      (\ioerr -> putStrLn $ "WARNING: Cannot remove file "
                                  ++ f ++ ", Error msg:" ++ show ioerr)
 
-	
+
 getLibFlags = do dir <- getDataDir
                  return $ "-L" ++ (dir </> "rts") ++ " -lidris_rts -lgmp -lpthread"
-                 
+
 getIdrisLibDir = do dir <- getDataDir
                     return $ addTrailingPathSeparator dir
 

--- a/test/mktest.pl
+++ b/test/mktest.pl
@@ -2,7 +2,7 @@
 
 if ($#ARGV>=0) {
     $test=shift(@ARGV);
-} else { 
+} else {
     print "What's its name?\n";
     exit;
 }

--- a/test/reg001/reg001.idr
+++ b/test/reg001/reg001.idr
@@ -1,10 +1,10 @@
 apply : (a -> b) -> a -> b
 apply f x = f x
 
-class Functor f => VerifiedFunctor (f : Type -> Type) where 
-   identity : (fa : f a) -> map id fa = fa 
+class Functor f => VerifiedFunctor (f : Type -> Type) where
+   identity : (fa : f a) -> map id fa = fa
 
-data Imp : Type where 
+data Imp : Type where
    MkImp : {any : Type} -> any -> Imp
 
 testVal : Imp

--- a/test/reg002/reg002.idr
+++ b/test/reg002/reg002.idr
@@ -2,7 +2,7 @@ module Main
 
 %default total
 
-data CoNat 
+data CoNat
     = Co Nat
     | Infinity
 
@@ -11,7 +11,7 @@ S (Co n)   = Co (S n)
 S Infinity = Infinity
 
 Sn_notzero : Main.S n = Co 0 -> _|_
-Sn_notzero = believe_me 
+Sn_notzero = believe_me
 
 S_Co_not_Inf : Main.S (Co n) = Infinity -> _|_
 S_Co_not_Inf = believe_me

--- a/test/reg003/reg003.idr
+++ b/test/reg003/reg003.idr
@@ -7,7 +7,7 @@ mutual
 
   namespace Odd
     data OddList : Type where
-        (::) : Nat -> EvenList -> OddList                                                                                                                                                 
+        (::) : Nat -> EvenList -> OddList
 
 test : EvenList
 test = [1, 2, 3, 4, 5, 6]

--- a/test/reg003/reg003a.idr
+++ b/test/reg003/reg003a.idr
@@ -4,7 +4,7 @@ data EvenList : Type where
     ECons : Nat -> OddList -> EvenList
 
 data OddList : Type where
-    OCons : Nat -> EvenList -> OddList                                                                                                                                                 
+    OCons : Nat -> EvenList -> OddList
 
 test : EvenList
-test = ECons 1 ENil 
+test = ECons 1 ENil

--- a/test/reg003/run
+++ b/test/reg003/run
@@ -1,4 +1,4 @@
 #!/bin/bash
-idris --check reg003.idr 
-idris --check reg003a.idr 
+idris --check reg003.idr
+idris --check reg003a.idr
 rm -f *.ibc

--- a/test/reg005/reg005.idr
+++ b/test/reg005/reg005.idr
@@ -7,7 +7,7 @@ rep (S k) x = x :: rep k x
 data RLE : Vect n Char -> Type where
      REnd  : RLE []
      RChar : {xs : Vect k Char} ->
-             (n : Nat) -> (x : Char) -> RLE xs -> 
+             (n : Nat) -> (x : Char) -> RLE xs ->
              RLE (rep (S n) x ++ xs)
 
 eq : (x : Char) -> (y : Char) -> Maybe (x = y)
@@ -22,13 +22,13 @@ rle (x :: xs) with (rle xs)
    rle (x :: rep (S n) yvar ++ ys) | RChar n yvar rs with (eq x yvar)
      rle (x :: rep (S n) x ++ ys) | RChar n x rs | Just refl
            = RChar (S n) x rs
-     rle (x :: rep (S n) y ++ ys) | RChar n y rs | Nothing 
+     rle (x :: rep (S n) y ++ ys) | RChar n y rs | Nothing
            = RChar Z x (RChar n y rs)
 
 compress : Vect n Char -> String
 compress xs with (rle xs)
   compress Nil                 | REnd         = ""
-  compress (rep (S n) x ++ xs) | RChar _ _ rs 
+  compress (rep (S n) x ++ xs) | RChar _ _ rs
          = let ni : Integer = cast (S n) in
                show ni ++ show x ++ compress xs
 

--- a/test/reg006/reg006.idr
+++ b/test/reg006/reg006.idr
@@ -1,17 +1,17 @@
 module RBTree
- 
+
 data Colour = Red | Black
 
 data RBTree : Type -> Type -> Nat -> Colour -> Type where
   Leaf : RBTree k v Z Black
   RedBranch : k -> v -> RBTree k v n Black -> RBTree k v n Black -> RBTree k v n Red
   BlackBranch : k -> v -> RBTree k v n x -> RBTree k v n y -> RBTree k v (S n) Black
- 
+
 toBlack : RBTree k v n c -> (m ** (RBTree k v m Black, Either (m = n) (m = (S n))))
 toBlack (RedBranch k v l r) = (_ ** (BlackBranch k v l r, Right refl))
 toBlack Leaf = (_ ** (Leaf, Left refl))
 toBlack (BlackBranch k v l r) = (_ ** (BlackBranch k v l r, Left refl))
- 
+
 total
 lookup : Ord k => k -> RBTree k v n Black -> Maybe v
 lookup k Leaf = Nothing
@@ -23,5 +23,5 @@ lookup k (BlackBranch k0 v0 l r) =
             lookup k t
     GT =>
       let (_ ** (t, _)) = toBlack r in
-            lookup k t 
+            lookup k t
 

--- a/test/reg007/run
+++ b/test/reg007/run
@@ -1,3 +1,3 @@
 #!/bin/bash
-idris --check $@ reg007.lidr 
+idris --check $@ reg007.lidr
 rm -f *.ibc

--- a/test/reg009/reg009.lidr
+++ b/test/reg009/reg009.lidr
@@ -2,15 +2,15 @@
 > isAnyBy _ (_ ** Nil) = False
 > isAnyBy p (_ ** (a :: as)) = p a || isAnyBy p (_ ** as)
 
-> filterTagP : (p  : alpha -> Bool) -> 
->              (as : Vect n alpha) -> 
+> filterTagP : (p  : alpha -> Bool) ->
+>              (as : Vect n alpha) ->
 >              so (isAnyBy p (n ** as)) ->
 >              (m : Nat ** (Vect m (a : alpha ** so (p a)), so (m > Z)))
 > filterTagP {n = S m} p (a :: as) q with (p a)
 >   | True  = (_
->              ** 
->              ((a ** believe_me oh) 
->               :: 
+>              **
+>              ((a ** believe_me oh)
+>               ::
 >               (fst (getProof (filterTagP p as (believe_me oh)))),
 >               oh
 >              )

--- a/test/reg011/reg011.idr
+++ b/test/reg011/reg011.idr
@@ -1,9 +1,9 @@
-vfoldl : (P : Nat -> Type) -> 
+vfoldl : (P : Nat -> Type) ->
          ((x : Nat) -> P x -> a -> P (S x)) -> P Z
        -> Vect m a -> P m
--- vfoldl P cons nil []        
+-- vfoldl P cons nil []
 --     = nil
-vfoldl P cons nil (x :: xs) 
+vfoldl P cons nil (x :: xs)
     = vfoldl (\k => P (S k)) (\ n => cons (S n)) (cons Z nil x) xs
--- vfoldl P cons nil (x :: xs) 
+-- vfoldl P cons nil (x :: xs)
 --     = vfoldl (\n => P (S n)) (\ n => cons _) (cons _ nil x) xs

--- a/test/reg012/reg012.lidr
+++ b/test/reg012/reg012.lidr
@@ -13,22 +13,22 @@
 > soTrue                  :  so b -> b = True
 > soTrue {b = False} x    =  soFalseElim x
 > soTrue {b = True}  x    =  refl
-                             
+
 > class Eq alpha => ReflEqEq alpha where
 >   reflexive_eqeq : (a : alpha) -> so (a == a)
 
-> modifyFun : (Eq alpha) => 
->             (alpha -> beta) -> 
->             (alpha, beta) -> 
+> modifyFun : (Eq alpha) =>
+>             (alpha -> beta) ->
+>             (alpha, beta) ->
 >             (alpha -> beta)
 > modifyFun f (a, b) a' = if a' == a then b else f a'
 
-> modifyFunLemma : (ReflEqEq alpha) => 
+> modifyFunLemma : (ReflEqEq alpha) =>
 >                  (f : alpha -> beta) ->
 >                  (ab : (alpha, beta)) ->
 >                  modifyFun f ab (fst ab) = snd ab
-> modifyFunLemma f (a,b) = 
+> modifyFunLemma f (a,b) =
 >   rewrite soTrue (reflexive_eqeq a) in refl
 
-   replace {P = \ z => boolElim (a == a) b (f a) = boolElim z b (f a)} 
+   replace {P = \ z => boolElim (a == a) b (f a) = boolElim z b (f a)}
            (soTrue (reflexive_eqeq a)) refl

--- a/test/reg014/reg014.idr
+++ b/test/reg014/reg014.idr
@@ -6,7 +6,7 @@ Matrix a n m = Vect n (Vect m a)
 transpose : Matrix a (S n) (S m) -> Matrix a (S m) (S n)
 transpose ((x:: []) :: []) = [[x]]
 transpose [x :: y :: xs] = [x] :: (transpose [y :: xs])
-transpose (x :: y :: xs) 
-    = let tx = transpose [x] in 
+transpose (x :: y :: xs)
+    = let tx = transpose [x] in
       let ux = transpose (y :: xs) in zipWith (++) tx ux
 

--- a/test/reg018/reg018b.idr
+++ b/test/reg018/reg018b.idr
@@ -1,4 +1,4 @@
-module A 
+module A
 
 %default total
 
@@ -8,7 +8,7 @@ showB : B -> String
 showB (I x) = "I" ++ showB x
 showB (Z x) = "Z" ++ showB x
 
-instance Show B where show = showB 
+instance Show B where show = showB
 
 os : B
 os = Z os

--- a/test/reg018/reg018c.idr
+++ b/test/reg018/reg018c.idr
@@ -2,7 +2,7 @@ module CodataTest
 %default total
 
 codata InfStream a = (::) a (InfStream a)
--- 
+--
 -- natStream : InfStream Nat
 -- natStream = natFromStream 0 where
 --   natFromStream : Nat -> InfStream Nat

--- a/test/reg019/reg019.idr
+++ b/test/reg019/reg019.idr
@@ -1,4 +1,4 @@
-m_add : Maybe (Either Bool Int) -> Maybe (Either Bool Int) -> 
+m_add : Maybe (Either Bool Int) -> Maybe (Either Bool Int) ->
         Maybe (Either Bool Int)
 m_add x y = do x' <- x -- Extract value from x
                y' <- y -- Extract value from y

--- a/test/reg022/reg022.idr
+++ b/test/reg022/reg022.idr
@@ -9,7 +9,7 @@ instance Functor (Result str) where
 ParserT : (Type -> Type) -> Type -> Type -> Type
 ParserT m str a = str -> m (Result str a)
 
-ap : Monad m => ParserT m str (a -> b) -> ParserT m str a -> 
+ap : Monad m => ParserT m str (a -> b) -> ParserT m str a ->
                 ParserT m str b
 ap f x = \s => do f' <- f s
                   case f' of

--- a/test/runtest.pl
+++ b/test/runtest.pl
@@ -24,7 +24,7 @@ sub runtest {
     $got =~ s/\r\n/\n/g;
     $exp =~ s/\r\n/\n/g;
 
-    # Normalize paths in $got and $exp, so the expected outcomes don't 
+    # Normalize paths in $got and $exp, so the expected outcomes don't
     # change between platforms
     while($got =~ /(^|.*?\n)(.*?)\\(.*?):(\d+):(.*)/ms) {
         $got = "$1$2/$3:$4:$5";
@@ -35,7 +35,7 @@ sub runtest {
 
     if ($got eq $exp) {
     	print "Ran $test...success\n";
-    } 
+    }
     else {
         if ($update == 0) {
             $exitstatus = 1;
@@ -66,7 +66,7 @@ if ($#ARGV>=0) {
 	    push @tests, $test;
     }
     @opts = @ARGV;
-} 
+}
 else {
     print "Give a test name, or 'all' to run all.\n";
     exit;

--- a/test/test001/test001.idr
+++ b/test/test001/test001.idr
@@ -27,11 +27,11 @@ using (G : Vect n Ty)
       Val : (x : Int) -> Expr G TyInt
       Lam : Expr (a :: G) t -> Expr G (TyFun a t)
       App : Expr G (TyFun a t) -> Expr G a -> Expr G t
-      Op  : (interpTy a -> interpTy b -> interpTy c) -> Expr G a -> Expr G b -> 
+      Op  : (interpTy a -> interpTy b -> interpTy c) -> Expr G a -> Expr G b ->
             Expr G c
       If  : Expr G TyBool -> Expr G a -> Expr G a -> Expr G a
       Bind : Expr G a -> (interpTy a -> Expr G b) -> Expr G b
- 
+
   dsl expr
       lambda = Lam
       variable = Var
@@ -46,7 +46,7 @@ using (G : Vect n Ty)
   interp env (Op op x y) = op (interp env x) (interp env y)
   interp env (If x t e)  = if interp env x then interp env t else interp env e
   interp env (Bind v f)  = interp env (f (interp env v))
- 
+
   eId : Expr G (TyFun TyInt TyInt)
   eId = expr (\x => x)
 
@@ -55,25 +55,25 @@ using (G : Vect n Ty)
 
   eAdd : Expr G (TyFun TyInt (TyFun TyInt TyInt))
   eAdd = expr (\x, y => Op (+) x y)
-  
+
 --   eDouble : Expr G (TyFun TyInt TyInt)
 --   eDouble = Lam (App (App (Lam (Lam (Op' (+) (Var fZ) (Var (fS fZ))))) (Var fZ)) (Var fZ))
-  
+
   eDouble : Expr G (TyFun TyInt TyInt)
   eDouble = expr (\x => App (App eAdd x) (Var stop))
- 
+
   app : |(f : Expr G (TyFun a t)) -> Expr G a -> Expr G t
   app = \f, a => App f a
 
   eFac : Expr G (TyFun TyInt TyInt)
   eFac = expr (\x => If (Op (==) x (Val 0))
-                 (Val 1) 
+                 (Val 1)
                  (Op (*) (app eFac (Op (-) x (Val 1))) x))
 
   -- Exercise elaborator: Complicated way of doing \x y => x*4 + y*2
-  
+
   eProg : Expr G (TyFun TyInt (TyFun TyInt TyInt))
-  eProg = Lam (Lam 
+  eProg = Lam (Lam
                     (Bind (App eDouble (Var (pop stop)))
               (\x => Bind (App eDouble (Var stop))
               (\y => Bind (App eDouble (Val x))

--- a/test/test003/Lit.lidr
+++ b/test/test003/Lit.lidr
@@ -4,14 +4,14 @@ Test some string primitives while we're at it
 
 > st : String
 > st = "abcdefg"
-  
+
 Literate main program
 
 > main : IO ()
 > main = do { putStrLn (show (strHead st))
 >             putStrLn (show (strIndex st 3))
 >             putStrLn (strCons 'z' st)
->             putStrLn (reverse st) 
+>             putStrLn (reverse st)
 >             let x = unpack st
 >             putStrLn (show (reverse x))
 >             putStrLn (pack x)

--- a/test/test004/test004.idr
+++ b/test/test004/test004.idr
@@ -20,10 +20,10 @@ main : IO ()
 main = do { h <- openFile "testfile" Write
             fwrite h "Hello!\nWorld!\n...\n3\n4\nLast line\n"
             closeFile h
-            putStrLn "Reading testfile" 
+            putStrLn "Reading testfile"
             f <- readFile "testfile"
             putStrLn f
-            putStrLn "---" 
+            putStrLn "---"
             dumpFile "testfile"
             putStrLn "---"
           }

--- a/test/test007/test007.idr
+++ b/test/test007/test007.idr
@@ -16,7 +16,7 @@ fetch x = MkEval (\e => fetchVal e) where
 instance Functor Eval where
     map f (MkEval g) = MkEval (\e => map f (g e))
 
-instance Applicative Eval where 
+instance Applicative Eval where
     pure x = MkEval (\e => Just x)
 
     (<$>) (MkEval f) (MkEval g) = MkEval (\x => appAux (f x) (g x)) where

--- a/test/test008/test008.idr
+++ b/test/test008/test008.idr
@@ -14,7 +14,7 @@ foo = (4, "foo")
 
 
 ioVals : IO (String, String)
-ioVals = do { return ("First", "second") } 
+ioVals = do { return ("First", "second") }
 
 main : IO ()
 main = do (a, b) <- ioVals

--- a/test/test009/test009.idr
+++ b/test/test009/test009.idr
@@ -6,4 +6,4 @@ pythag n = [ (x, y, z) | z <- [1..n], y <- [1..z], x <- [1..y],
 
 main : IO ()
 main = putStrLn (show (pythag 50))
-      
+

--- a/test/test011/test011.idr
+++ b/test/test011/test011.idr
@@ -16,7 +16,7 @@ person : Person
 person = MkPerson "Fred" 30
 
 main : IO ()
-main = do let x = record { name = "foo", 
+main = do let x = record { name = "foo",
                            more_things = reverse ["a","b"] } testFoo
           print $ name x
           print $ name person

--- a/test/test012/test012a.idr
+++ b/test/test012/test012a.idr
@@ -1,10 +1,10 @@
 module Main
-  
+
 f : Nat -> Nat
 f x = x + 1
-        
+
 foo : Nat -> Nat
 foo (f x) = x
-              
+
 main : IO ()
 main = putStrLn (show (foo 1))

--- a/test/test013/test013.idr
+++ b/test/test013/test013.idr
@@ -9,7 +9,7 @@ syntax for {x} "in" [xs] ":" [body] = forLoop xs (\x => body)
 
 main : IO ()
 main = do putStrLn "Counting:"
-          for x in [1..10]: 
+          for x in [1..10]:
               putStrLn $ "Number " ++ show x
           putStrLn "Done!"
 

--- a/test/test014/test014.idr
+++ b/test/test014/test014.idr
@@ -16,7 +16,7 @@ syntax ifM [test] then [t] else [e]
 
 open : String -> (p:Purpose) -> Creator (Either () (FILE p))
 open fn p = ioc (do h <- fopen fn (pstring p)
-                    ifM validFile h 
+                    ifM validFile h
                         then return (Right (OpenH h))
                         else return (Left ()))
 

--- a/test/test015/test015.idr
+++ b/test/test015/test015.idr
@@ -24,7 +24,7 @@ instance Show (Binary w k) where
      show (bin # bit) = show bin ++ show bit
 
 pad : Binary w n -> Binary (S w) n
-pad zero = zero # b0 
+pad zero = zero # b0
 pad (num # x) = pad num # x
 
 natToBin : (width : Nat) -> (n : Nat) ->
@@ -47,21 +47,21 @@ testBin = natToBin _ _
 pattern syntax bitpair [x] [y] = (_ ** (_ ** (x, y, _)))
 term    syntax bitpair [x] [y] = (_ ** (_ ** (x, y, refl)))
 
-addBit : Bit x -> Bit y -> Bit c -> 
+addBit : Bit x -> Bit y -> Bit c ->
           (bX ** (bY ** (Bit bX, Bit bY, c + x + y = bY + 2 * bX)))
 addBit b0 b0 b0 = bitpair b0 b0
-addBit b0 b0 b1 = bitpair b0 b1 
+addBit b0 b0 b1 = bitpair b0 b1
 addBit b0 b1 b0 = bitpair b0 b1
 addBit b0 b1 b1 = bitpair b1 b0
-addBit b1 b0 b0 = bitpair b0 b1 
-addBit b1 b0 b1 = bitpair b1 b0 
-addBit b1 b1 b0 = bitpair b1 b0 
-addBit b1 b1 b1 = bitpair b1 b1 
+addBit b1 b0 b0 = bitpair b0 b1
+addBit b1 b0 b1 = bitpair b1 b0
+addBit b1 b1 b0 = bitpair b1 b0
+addBit b1 b1 b1 = bitpair b1 b1
 
-adc : Binary w x -> Binary w y -> Bit c -> Binary (S w) (c + x + y) 
+adc : Binary w x -> Binary w y -> Bit c -> Binary (S w) (c + x + y)
 adc zero        zero        carry ?= zero # carry
 adc (numx # bX) (numy # bY) carry
-   ?= let (bitpair carry0 lsb) = addBit bX bY carry in 
+   ?= let (bitpair carry0 lsb) = addBit bX bY carry in
           adc numx numy carry0 # lsb
 
 readNum : IO Nat
@@ -82,7 +82,7 @@ main = do let Just bin1 = natToBin 8 42
 
 
 
-    
+
 ---------- Proofs ----------
 
 Main.ntbOdd = proof {

--- a/test/test017/test017.idr
+++ b/test/test017/test017.idr
@@ -13,7 +13,7 @@ ordElim : (x : Ord) ->
           (P : Ord -> Type) ->
           (P Zero) ->
           ((x : Ord) -> P x -> P (Suc x)) ->
-          ((f : Nat -> Ord) -> ((n : Nat) -> P (f n)) -> 
+          ((f : Nat -> Ord) -> ((n : Nat) -> P (f n)) ->
              P (Sup f)) -> P x
 ordElim Zero P mZ mSuc mSup = mZ
 ordElim (Suc o) P mZ mSuc mSup = mSuc o (ordElim o P mZ mSuc mSup)
@@ -56,7 +56,7 @@ even (S k) = odd k
 ack : Nat -> Nat -> Nat
 ack Z     n     = S n
 ack (S m) Z     = ack m (S Z)
-ack (S m) (S n) = ack m (ack (S m) n) 
+ack (S m) (S n) = ack m (ack (S m) n)
 
 data Bin = eps | c0 Bin | c1 Bin
 

--- a/test/test018/test018.idr
+++ b/test/test018/test018.idr
@@ -17,10 +17,10 @@ ping : Ptr -> IO ()
 ping thread = sendToThread thread (prim__vm, "Hello!")
 
 pingpong : IO ()
-pingpong 
+pingpong
      = do th <- fork pong
           putStrLn "Sending"
-          ping th 
+          ping th
           reply <- getMsg
           putStrLn reply
           usleep 100000

--- a/test/test018/test018a.idr
+++ b/test/test018/test018a.idr
@@ -3,7 +3,7 @@ module Main
 import System.Concurrency.Process
 
 ping : ProcID String -> ProcID String -> Process String ()
-ping main proc 
+ping main proc
    = do lift (usleep 1000)
         send proc "Hello!"
         lift (putStrLn "Sent ping")
@@ -14,7 +14,7 @@ ping main proc
 pong : Process String ()
 pong = do -- lift (putStrLn "Waiting for message")
           (sender, m) <- recvWithSender
-          lift $ putStrLn ("Received " ++ m) 
+          lift $ putStrLn ("Received " ++ m)
           send sender ("Hello back!")
 
 mainProc : Process String ()
@@ -27,7 +27,7 @@ mainProc = do mainID <- myID
 repeatIO : Int -> IO ()
 repeatIO 0 = return ()
 repeatIO n = do print n
-                run mainProc 
+                run mainProc
                 repeatIO (n - 1)
 
 main : IO ()

--- a/test/test020/test020.idr
+++ b/test/test020/test020.idr
@@ -1,10 +1,10 @@
 module Main
 
-implicit 
+implicit
 natInt : Nat -> Integer
 natInt x = cast x
 
-implicit 
+implicit
 forget : Vect n a -> List a
 forget [] = []
 forget (x :: xs) = x :: forget xs

--- a/test/test020/test020a.idr
+++ b/test/test020/test020a.idr
@@ -1,6 +1,6 @@
 module Main
 
-implicit 
+implicit
 forget : Vect n a -> List a
 forget [] = []
 forget (x :: xs) = x :: forget xs

--- a/test/test021/test021.idr
+++ b/test/test021/test021.idr
@@ -1,4 +1,4 @@
-module Main 
+module Main
 
 import Effect.File
 import Effect.State
@@ -8,20 +8,20 @@ import Control.IOExcept
 data FName = Count | NotCount
 
 FileIO : Type -> Type -> Type
-FileIO st t 
+FileIO st t
    = Eff (IOExcept String) [FILE_IO st, STDIO, Count ::: STATE Int] t
 
 readFile : FileIO (OpenFile Read) (List String)
 readFile = readAcc [] where
-    readAcc : List String -> FileIO (OpenFile Read) (List String) 
+    readAcc : List String -> FileIO (OpenFile Read) (List String)
     readAcc acc = do e <- eof
-                     if (not e) 
+                     if (not e)
                         then do str <- readLine
                                 Count :- put (!(Count :- get) + 1)
                                 readAcc (str :: acc)
                         else return (reverse acc)
 
-testFile : FileIO () () 
+testFile : FileIO () ()
 testFile = do open "testFile" Read
               if_valid then do putStrLn (show !readFile)
                                close

--- a/test/test021/test021a.idr
+++ b/test/test021/test021a.idr
@@ -14,7 +14,7 @@ Env : Type
 Env = List (String, Integer)
 
 -- Evaluator : Type -> Type
--- Evaluator t 
+-- Evaluator t
 --    = Eff m [EXCEPTION String, RND, STATE Env] t
 
 eval : Expr -> Eff IO [EXCEPTION String, STDIO, RND, STATE Env] Integer

--- a/test/test025/test025.idr
+++ b/test/test025/test025.idr
@@ -26,7 +26,7 @@ testMemory = do Src :- allocate 5
                 res <- Dst :- peek 1 (S(S(S(S Z)))) oh
                 Dst :- free
                 return (map (prim__zextB8_Int) res)
-               
+
 main : IO ()
 main = do ioe_run (run [Dst := (), Src := ()] testMemory)
                   (\err => print err) (\ok => print ok)

--- a/test/test029/test029.idr
+++ b/test/test029/test029.idr
@@ -1,10 +1,10 @@
-module simple 
+module simple
 
 plus_comm : (n : Nat) -> (m : Nat) -> (n + m = m + n)
 
 -- Base case
 (Z + m = m + Z) <== plus_comm =
-    rewrite ((m + Z = m) <== plusZeroRightNeutral) ==> 
+    rewrite ((m + Z = m) <== plusZeroRightNeutral) ==>
             (Z + m = m) in refl
 
 -- Step case

--- a/test/test030/Reflect.idr
+++ b/test/test030/Reflect.idr
@@ -41,7 +41,7 @@ using (xs : List a, ys : List a, G : List (List a))
   expr_r (App ex ey) = let (xl ** (xr, xprf)) = expr_r ex in
                        let (yl ** (yr, yprf)) = expr_r ey in
                            appRExpr _ _ xr yr xprf yprf
-    where 
+    where
       appRExpr : (xs', ys' : List a) ->
                  RExpr G xs -> RExpr G ys -> (xs' = xs) -> (ys' = ys) ->
                  (ws' ** (RExpr G ws', xs' ++ ys' = ws'))
@@ -80,13 +80,13 @@ using (xs : List a, ys : List a, G : List (List a))
 
   buildProof : {xs : List a} -> {ys : List a} ->
                Expr G ln -> Expr G rn ->
-               (xs = ln) -> (ys = rn) -> Maybe (xs = ys) 
+               (xs = ln) -> (ys = rn) -> Maybe (xs = ys)
   buildProof e e' lp rp with (eqExpr e e')
     buildProof e e lp rp  | Just refl = ?bp1
     buildProof e e' lp rp | Nothing = Nothing
 
   testEq : Expr G xs -> Expr G ys -> Maybe (xs = ys)
-  testEq l r = let (ln ** (l', lPrf)) = reduce l in 
+  testEq l r = let (ln ** (l', lPrf)) = reduce l in
                let (rn ** (r', rPrf)) = reduce r in
                    buildProof l' r' lPrf rPrf
 
@@ -129,7 +129,7 @@ using (xs : List a, ys : List a, G : List (List a))
 -- reduction will work the right way.
 
 %reflection
-reflectList : (G : List (List a)) -> 
+reflectList : (G : List (List a)) ->
           (xs : List a) -> (G' ** Expr (G' ++ G) xs)
 reflectList G [] = ([] ** ENil)
 
@@ -140,7 +140,7 @@ reflectList G (x :: xs) with (reflectList G xs)
 
 reflectList G (xs ++ ys) with (reflectList G xs)
      | (G' ** xs') with (reflectList (G' ++ G) ys)
-         | (G'' ** ys') = ((G'' ++ G') ** 
+         | (G'' ** ys') = ((G'' ++ G') **
                               rewrite (sym (appendAssociative G'' G' G)) in
                                  App (weaken G'' xs') ys')
 reflectList G t with (isElem t G)
@@ -157,7 +157,7 @@ reflectList G t with (isElem t G)
 
 %reflection
 reflectEq : (a : Type) -> (G : List (List a)) -> (P : Type) -> (G' ** ListEq (G' ++ G) P)
-reflectEq a G (the (List a) xs = the (List a) ys) with (reflectList G xs) 
+reflectEq a G (the (List a) xs = the (List a) ys) with (reflectList G xs)
      | (G' ** xs')  with (reflectList (G' ++ G) ys)
         | (G'' ** ys') = ((G'' ++ G') **
                            rewrite (sym (appendAssociative G'' G' G)) in
@@ -197,7 +197,7 @@ Reflect.bp1 = proof {
 -- The effect is to bind x to p applied to the current goal. If 'p' is a
 -- reflection function (which is the most likely thing to be useful...)
 -- then we can feed the result to the above 'prove' function and pull out
--- the proof, if it exists. 
+-- the proof, if it exists.
 
 -- The syntax declaration below just gives us an easy way to invoke the
 -- prover.

--- a/test/test030/test030.idr
+++ b/test/test030/test030.idr
@@ -7,7 +7,7 @@ testReflect0 : (xs, ys : List a) -> ((xs ++ (ys ++ xs)) = ((xs ++ ys) ++ xs))
 testReflect0 {a} xs ys = AssocProof a
 
 total
-testReflect1 : (xs, ys : List a) -> 
+testReflect1 : (xs, ys : List a) ->
                ((xs ++ (x :: ys ++ xs)) = ((xs ++ [x]) ++ (ys ++ xs)))
-testReflect1 {a} xs ys = AssocProof a 
+testReflect1 {a} xs ys = AssocProof a
 

--- a/test/test030/test030a.idr
+++ b/test/test030/test030a.idr
@@ -7,7 +7,7 @@ testReflect0 : (xs, ys : List a) -> ((xs ++ (ys ++ xs)) = ((xs ++ ys) ++ xs))
 testReflect0 {a} xs ys = AssocProof a
 
 total
-testReflect1 : (xs, ys : List a) -> 
+testReflect1 : (xs, ys : List a) ->
                ((ys ++ (x :: ys ++ xs)) = ((xs ++ [x]) ++ (ys ++ xs)))
-testReflect1 {a} xs ys = AssocProof a 
+testReflect1 {a} xs ys = AssocProof a
 

--- a/test/test032/expected
+++ b/test/test032/expected
@@ -2,8 +2,8 @@ Type checking ./test032.idr
 isElem x [] = ?isElem_rhs_1
 isElem x (_ :: _) = ?isElem_rhs_3
 
-   localZipWith f (_ :: _) ys = ?localZipWith_rhs_1 
-   localZipWith f (_ :: _) ys = ?localZipWith_rhs_2 
+   localZipWith f (_ :: _) ys = ?localZipWith_rhs_1
+   localZipWith f (_ :: _) ys = ?localZipWith_rhs_2
 
 f x :: (map f xs)
 isElem2 x (y :: ys) with (_)

--- a/test/test032/test032.idr
+++ b/test/test032/test032.idr
@@ -14,7 +14,7 @@ vadd : Num a => Vect n a -> Vect n a -> Vect n a
 vadd xs ys = localZipWith (+) xs ys where
    localZipWith : (a -> b -> c) -> Vect n a -> Vect n b -> Vect n c
    localZipWith f [] [] = []
-   localZipWith f (_ :: _) ys = ?localZipWith_rhs 
+   localZipWith f (_ :: _) ys = ?localZipWith_rhs
 
 map : (a -> b) -> Vect n a -> Vect n b
 map f [] = []

--- a/tutorial/examples/bmain.idr
+++ b/tutorial/examples/bmain.idr
@@ -3,6 +3,6 @@ module Main
 import btree
 
 main : IO ()
-main = do let t = toTree [1,8,2,7,9,3] 
+main = do let t = toTree [1,8,2,7,9,3]
           print (btree.toList t)
 

--- a/tutorial/examples/classes.idr
+++ b/tutorial/examples/classes.idr
@@ -1,7 +1,7 @@
 m_add : Maybe Int -> Maybe Int -> Maybe Int
 m_add x y = do x' <- x -- Extract value from x
                y' <- y -- Extract value from y
-               return (x' + y') -- Add them 
+               return (x' + y') -- Add them
 
 m_add' : Maybe Int -> Maybe Int -> Maybe Int
 m_add' x y = [ x' + y' | x' <- x, y' <- y ]

--- a/tutorial/examples/foo.idr
+++ b/tutorial/examples/foo.idr
@@ -6,5 +6,5 @@ namespace x
 
 namespace y
   test : String -> String
-  test x = x ++ x 
+  test x = x ++ x
 

--- a/tutorial/examples/idiom.idr
+++ b/tutorial/examples/idiom.idr
@@ -16,7 +16,7 @@ fetch x = MkEval (\e => fetchVal e) where
 instance Functor Eval where
     map f (MkEval g) = MkEval (\e => map f (g e))
 
-instance Applicative Eval where 
+instance Applicative Eval where
     pure x = MkEval (\e => Just x)
 
     (<$>) (MkEval f) (MkEval g) = MkEval (\x => app (f x) (g x)) where

--- a/tutorial/examples/interp.idr
+++ b/tutorial/examples/interp.idr
@@ -7,7 +7,7 @@ interpTy TyInt       = Int
 interpTy TyBool      = Bool
 interpTy (TyFun s t) = interpTy s -> interpTy t
 
-using (G : Vect n Ty) 
+using (G : Vect n Ty)
 
   data Env : Vect n Ty -> Type where
       Nil  : Env Nil
@@ -26,17 +26,17 @@ using (G : Vect n Ty)
       Val : (x : Int) -> Expr G TyInt
       Lam : Expr (a :: G) t -> Expr G (TyFun a t)
       App : Expr G (TyFun a t) -> Expr G a -> Expr G t
-      Op  : (interpTy a -> interpTy b -> interpTy c) -> Expr G a -> Expr G b -> 
+      Op  : (interpTy a -> interpTy b -> interpTy c) -> Expr G a -> Expr G b ->
             Expr G c
       If  : Expr G TyBool -> Expr G a -> Expr G a -> Expr G a
-  
+
   interp : Env G -> {static} Expr G t -> interpTy t
   interp env (Var i)     = lookup i env
   interp env (Val x)     = x
   interp env (Lam sc)    = \x => interp (x :: env) sc
   interp env (App f s)   = interp env f (interp env s)
   interp env (Op op x y) = op (interp env x) (interp env y)
-  interp env (If x t e)  = if interp env x then interp env t 
+  interp env (If x t e)  = if interp env x then interp env t
                                            else interp env e
 
   eId : Expr G (TyFun TyInt TyInt)
@@ -47,10 +47,10 @@ using (G : Vect n Ty)
 
   eEq : Expr G (TyFun TyInt (TyFun TyInt TyBool))
   eEq = Lam (Lam (Op (==) (Var stop) (Var (pop stop))))
-  
+
   eDouble : Expr G (TyFun TyInt TyInt)
   eDouble = Lam (App (App eAdd (Var stop)) (Var stop))
- 
+
   app : |(f : Expr G (TyFun a t)) -> Expr G a -> Expr G t
   app = \f, a => App f a
 
@@ -67,5 +67,5 @@ unitTestFac = oh
 main : IO ()
 main = do putStr "Enter a number: "
           x <- getLine
-          print (interp [] fact (cast x)) 
+          print (interp [] fact (cast x))
 

--- a/tutorial/examples/wheres.idr
+++ b/tutorial/examples/wheres.idr
@@ -1,10 +1,10 @@
 module wheres
 
-even : Nat -> Bool 
+even : Nat -> Bool
 even Z = True
-even (S k) = odd k where 
+even (S k) = odd k where
   odd Z = False
-  odd (S k) = even k 
+  odd (S k) = even k
 
 test : List Nat
 test = [c (S 1), c Z, d (S Z)]


### PR DESCRIPTION
Take 2. Supersedes #572.

```
$ find . -type f -name '*.idr' -exec sed --in-place 's/[[:space:]]\+$//' {} \+
$ find . -type f -name '*.hs' -exec sed --in-place 's/[[:space:]]\+$//' {} \+
$ find . -type f -name '*.lidr' -exec sed --in-place 's/[[:space:]]\+$//' {} \+
$ find test/ -type f -name '*' -exec sed --in-place 's/[[:space:]]\+$//' {} \+
```
