### PR TITLE
Fix LLVM codegen of negative integer literals

### DIFF
--- a/src/IRTS/CodegenLLVM.hs
+++ b/src/IRTS/CodegenLLVM.hs
@@ -776,7 +776,8 @@ cgConst c@(TT.Str s) = do
   str <- addGlobal' (ArrayType (1 + fromIntegral (length s)) (IntegerType 8)) (cgConst' c)
   box FString (ConstantOperand $ C.GetElementPtr True str [C.Int 32 0, C.Int 32 0])
 cgConst c@(TT.BI i) = do
-  str <- addGlobal' (ArrayType (1 + fromInteger (numDigits 10 i)) (IntegerType 8)) (cgConst' c)
+  let stringRepLen = (if i < 0 then 2 else 1) + fromInteger (numDigits 10 i)
+  str <- addGlobal' (ArrayType stringRepLen (IntegerType 8)) (cgConst' c)
   mpz <- alloc mpzTy
   inst $ simpleCall "__gmpz_init_set_str" [mpz
                                           , ConstantOperand $ C.GetElementPtr True str [ C.Int 32 0, C.Int 32 0]


### PR DESCRIPTION
The LLVM codegen currently uses strings to represent big integer constants. Previously, it allocated enough space for one character per digit, plus a terminating null character. This lead to a failure when compiling negative integer constants, which need additional space for the negative sign.
