### PR TITLE
Remove "CaseSplit" constructor and implementation which could never

### DIFF
--- a/src/Idris/AbsSyntaxTree.hs
+++ b/src/Idris/AbsSyntaxTree.hs
@@ -239,7 +239,6 @@ data Command = Quit
              | Pattelab PTerm
              | DebugInfo Name
              | Search PTerm
-             | CaseSplit Name PTerm
              | CaseSplitAt Bool Int Name
              | AddClauseFrom Bool Int Name
              | AddProofClauseFrom Bool Int Name

--- a/src/Idris/CaseSplit.hs
+++ b/src/Idris/CaseSplit.hs
@@ -1,6 +1,6 @@
 {-# LANGUAGE PatternGuards #-}
 
-module Idris.CaseSplit(split, splitOnLine, replaceSplits,
+module Idris.CaseSplit(splitOnLine, replaceSplits,
                        getClause, getProofClause,
                        mkWith,
                        getUniq, nameRoot) where

--- a/src/Idris/REPL.hs
+++ b/src/Idris/REPL.hs
@@ -532,9 +532,6 @@ process h fn (Info n)
                               [c] -> classInfo c
                               _ -> iPrintError "Not a class"
 process h fn (Search t) = iPrintError "Not implemented"
-process h fn (CaseSplit n t)
-   = do tms <- split n t
-        iputStrLn (showSep "\n" (map show tms))
 -- FIXME: There is far too much repetition in the cases below!
 process h fn (CaseSplitAt updatefile l n)
    = do src <- runIO $ readFile fn


### PR DESCRIPTION
be called (the REPLParser uses CaseSplitAt). Furhermore, we no longer
need to export "split" from CaseSplit.hs
