### PR TITLE
Implement type-of ideslave command, which uses Check in the background

### DIFF
--- a/src/Idris/IdeSlave.hs
+++ b/src/Idris/IdeSlave.hs
@@ -97,6 +97,7 @@ data IdeSlaveCommand = REPLCompletions String
                      | TypeOf String
                      | CaseSplit Int String
                      | AddClause Int String
+                     | AddProofClause Int String
                      | AddMissing Int String
                      | MakeWithBlock Int String
                      | ProofSearch Int String [String]
@@ -111,6 +112,7 @@ sexpToCommand (SexpList [SymbolAtom "load-file", StringAtom filename])          
 sexpToCommand (SexpList [SymbolAtom "type-of", StringAtom name])                        = Just (TypeOf name)
 sexpToCommand (SexpList [SymbolAtom "case-split", IntegerAtom line, StringAtom name])   = Just (CaseSplit (fromInteger line) name)
 sexpToCommand (SexpList [SymbolAtom "add-clause", IntegerAtom line, StringAtom name])   = Just (AddClause (fromInteger line) name)
+sexpToCommand (SexpList [SymbolAtom "add-proof-clause", IntegerAtom line, StringAtom name])   = Just (AddProofClause (fromInteger line) name)
 sexpToCommand (SexpList [SymbolAtom "add-missing", IntegerAtom line, StringAtom name])  = Just (AddMissing (fromInteger line) name)
 sexpToCommand (SexpList [SymbolAtom "make-with", IntegerAtom line, StringAtom name])    = Just (MakeWithBlock (fromInteger line) name)
 sexpToCommand (SexpList [SymbolAtom "proof-search", IntegerAtom line, StringAtom name, SexpList hintexp]) | Just hints <- getHints hintexp = Just (ProofSearch (fromInteger line) name hints)

--- a/src/Idris/REPL.hs
+++ b/src/Idris/REPL.hs
@@ -239,6 +239,8 @@ ideslave orig mods
                  process stdout fn (CaseSplitAt False line (UN name))
                Just (IdeSlave.AddClause line name) ->
                  process stdout fn (AddClauseFrom False line (UN name))
+               Just (IdeSlave.AddProofClause line name) ->
+                 process stdout fn (AddProofClauseFrom False line (UN name))
                Just (IdeSlave.AddMissing line name) ->
                  process stdout fn (AddMissing False line (UN name))
                Just (IdeSlave.MakeWithBlock line name) ->


### PR DESCRIPTION
Furthermore, instead of printing with iputStrLn, use iPrintResult to
indicate that the command finished successfully
