### PR TITLE
* Use cc as C compiler, instead of hardcoding gcc.

### DIFF
--- a/config.mk
+++ b/config.mk
@@ -1,4 +1,4 @@
-CC              :=gcc
+CC              :=cc
 CABAL           :=cabal
 CFLAGS          :=-O2 -Wall $(CFLAGS)
 #CABALFLAGS	:=

--- a/rts/Makefile
+++ b/rts/Makefile
@@ -5,9 +5,7 @@ OBJS = idris_rts.o idris_heap.o idris_gc.o idris_gmp.o idris_stdfgn.o \
 HDRS = idris_rts.h idris_heap.h idris_gc.h idris_gmp.h idris_stdfgn.h \
        idris_bitstring.h idris_opts.h idris_stats.h
 CFLAGS:=-fPIC $(CFLAGS)
-ifneq ($(GMP_INCLUDE_DIR),)
-	CFLAGS += -isystem $(GMP_INCLUDE_DIR)
-endif
+CFLAGS += $(GMP_INCLUDE_DIR)
 
 LIBTARGET = libidris_rts.a
 

--- a/rts/idris_opts.c
+++ b/rts/idris_opts.c
@@ -6,7 +6,7 @@
 #include <string.h>
 
 
-char usage[] = 
+const char usage[] =
     "\n"                                                        \
     "Usage: <prog> [+RTS <rtsopts> -RTS] <args>\n\n"            \
     "Options:\n\n"                                              \
@@ -26,7 +26,7 @@ int read_size(char * str) {
 
     int r = sscanf(str, "%u%c", &size, &mult);
 
-    if (r == 1) 
+    if (r == 1)
         return size;
 
     if (r == 2) {
@@ -34,8 +34,8 @@ int read_size(char * str) {
         case 'K': size = size << 10; break;
         case 'M': size = size << 20; break;
         case 'G': size = size << 30; break;
-        default: 
-            fprintf(stderr, 
+        default:
+            fprintf(stderr,
                     "RTS Opts: Unable to recognize size suffix `%c'.\n" \
                     "          Possible suffixes are K or M or G.\n",
                     mult);
@@ -58,7 +58,7 @@ int parse_args(RTSOpts * opts, int argc, char *argv[])
 
     if (strcmp(argv[0], "+RTS") != 0)
         return 0;
-    
+
     int i;
     for (i = 1; i < argc; i++) {
         if (strcmp(argv[i], "-RTS") == 0) {


### PR DESCRIPTION
- Do not use -isystem (not needed, and breaks building the runtime with clang)
- Make clang happier when building the runtime
