### PR TITLE
Allow the use of the default foreground colour. Make it the colour of the prompt.

### DIFF
--- a/src/Idris/Colours.hs
+++ b/src/Idris/Colours.hs
@@ -9,7 +9,7 @@ module Idris.Colours (
 
 import System.Console.ANSI
 
-data IdrisColour = IdrisColour { colour    :: Color
+data IdrisColour = IdrisColour { colour    :: Maybe Color
                                , vivid     :: Bool
                                , underline :: Bool
                                , bold      :: Bool
@@ -18,7 +18,7 @@ data IdrisColour = IdrisColour { colour    :: Color
                    deriving (Eq, Show)
 
 mkColour :: Color -> IdrisColour
-mkColour c = IdrisColour c True False False False
+mkColour c = IdrisColour (Just c) True False False False
 
 data ColourTheme = ColourTheme { keywordColour  :: IdrisColour
                                , boundVarColour :: IdrisColour
@@ -31,22 +31,24 @@ data ColourTheme = ColourTheme { keywordColour  :: IdrisColour
                    deriving (Eq, Show)
 
 defaultTheme :: ColourTheme
-defaultTheme = ColourTheme { keywordColour = IdrisColour Black True True True False
+defaultTheme = ColourTheme { keywordColour = IdrisColour Nothing True True True False
                            , boundVarColour = mkColour Magenta
-                           , implicitColour = IdrisColour Magenta True True False False
+                           , implicitColour = IdrisColour (Just Magenta) True True False False
                            , functionColour = mkColour Green
                            , typeColour = mkColour Blue
                            , dataColour = mkColour Red
-                           , promptColour = IdrisColour Black True False True False
+                           , promptColour = IdrisColour Nothing True False True False
                            }
 
 -- Set the colour of a string using POSIX escape codes
 colourise :: IdrisColour -> String -> String
 colourise (IdrisColour c v u b i) str = setSGRCode sgr ++ str ++ setSGRCode [Reset]
-    where sgr = [SetColor Foreground (if v then Vivid else Dull) c] ++
+    where sgr = fg c ++
                 (if u then [SetUnderlining SingleUnderline] else []) ++
                 (if b then [SetConsoleIntensity BoldIntensity] else []) ++
                 (if i then [SetItalicized True] else [])
+          fg Nothing = []
+          fg (Just c) = [SetColor Foreground (if v then Vivid else Dull) c]
 
 colouriseKwd :: ColourTheme -> String -> String
 colouriseKwd t = colourise (keywordColour t)

--- a/src/Idris/REPLParser.hs
+++ b/src/Idris/REPLParser.hs
@@ -107,18 +107,19 @@ pOption = do discard (P.symbol "errorcontext"); return ErrContext
       <|> do discard (P.symbol "showimplicits"); return ShowImpl
 
 
-colours :: [(String, Color)]
-colours = [ ("black", Black)
-          , ("red", Red)
-          , ("green", Green)
-          , ("yellow", Yellow)
-          , ("blue", Blue)
-          , ("magenta", Magenta)
-          , ("cyan", Cyan)
-          , ("white", White)
+colours :: [(String, Maybe Color)]
+colours = [ ("black", Just Black)
+          , ("red", Just Red)
+          , ("green", Just Green)
+          , ("yellow", Just Yellow)
+          , ("blue", Just Blue)
+          , ("magenta", Just Magenta)
+          , ("cyan", Just Cyan)
+          , ("white", Just White)
+          , ("default", Nothing)
           ]
 
-pColour :: P.IdrisParser Color
+pColour :: P.IdrisParser (Maybe Color)
 pColour = doColour colours
     where doColour [] = fail "Unknown colour"
           doColour ((s, c):cs) = (try (P.symbol s) >> return c) <|> doColour cs
@@ -156,7 +157,7 @@ pColourType = doColourType colourTypes
 
 pSetColourCmd :: P.IdrisParser Command
 pSetColourCmd = (do c <- pColourType
-                    let defaultColour = IdrisColour Black True False False False
+                    let defaultColour = IdrisColour Nothing True False False False
                     opts <- sepBy pColourMod (P.whiteSpace)
                     let colour = foldr ($) defaultColour $ reverse opts
                     return $ SetColour c colour)


### PR DESCRIPTION
Fixes #633.
