### PR TITLE
Turn off optimisations when compiling parser

### DIFF
--- a/src/Idris/ParseExpr.hs
+++ b/src/Idris/ParseExpr.hs
@@ -1,4 +1,5 @@
 {-# LANGUAGE GeneralizedNewtypeDeriving, ConstraintKinds, PatternGuards #-}
+{-# OPTIONS_GHC -O0 #-}
 module Idris.ParseExpr where
 
 import Prelude hiding (pi)

--- a/src/Idris/Parser.hs
+++ b/src/Idris/Parser.hs
@@ -1,4 +1,5 @@
 {-# LANGUAGE GeneralizedNewtypeDeriving, ConstraintKinds, PatternGuards #-}
+{-# OPTIONS_GHC -O0 #-}
 module Idris.Parser(module Idris.Parser,
                     module Idris.ParseExpr,
                     module Idris.ParseData,


### PR DESCRIPTION
Disabling optimisations in Parser and ParserExpr solves the problem of huge compilation time and memory usage of these two modules. Now they compile in a matter of seconds. I measured compilation time of the largest Idris source files I was able to find in base and it looks that this change doesn't impact performance of the compiler (which is kinda expected - most of compilation time for Idris program probably goes into typechecking).
