### PR TITLE
[Issue 590] Added a --nobanner flag to supress the banner 

### DIFF
--- a/src/Idris/AbsSyntax.hs
+++ b/src/Idris/AbsSyntax.hs
@@ -421,6 +421,17 @@ setREPL t = do i <- getIState
                let opt' = opts { opt_repl = t }
                putIState $ i { idris_options = opt' }
 
+setNoBanner :: Bool -> Idris ()
+setNoBanner n = do i <- getIState
+                   let opts = idris_options i
+                   let opt' = opts {opt_nobanner = n}
+                   putIState $ i { idris_options = opt' }
+
+getNoBanner :: Idris Bool
+getNoBanner = do i <- getIState
+                 let opts = idris_options i
+                 return (opt_nobanner opts)
+
 setQuiet :: Bool -> Idris ()
 setQuiet q = do i <- getIState
                 let opts = idris_options i

--- a/src/Idris/AbsSyntaxTree.hs
+++ b/src/Idris/AbsSyntaxTree.hs
@@ -37,6 +37,7 @@ data IOption = IOption { opt_logLevel   :: Int,
                          opt_errContext :: Bool,
                          opt_repl       :: Bool,
                          opt_verbose    :: Bool,
+                         opt_nobanner   :: Bool,
                          opt_quiet      :: Bool,
                          opt_codegen    :: Codegen,
                          opt_outputTy   :: OutputType,
@@ -57,6 +58,7 @@ defaultOpts = IOption { opt_logLevel   = 0
                       , opt_errContext = False
                       , opt_repl       = True
                       , opt_verbose    = True
+                      , opt_nobanner   = False
                       , opt_quiet      = False
                       , opt_codegen    = ViaC
                       , opt_outputTy   = Executable
@@ -256,6 +258,7 @@ data Opt = Filename String
          | Ver
          | Usage
          | Quiet
+         | NoBanner
          | ColourREPL Bool
          | Ideslave
          | ShowLibs

--- a/src/Idris/REPL.hs
+++ b/src/Idris/REPL.hs
@@ -937,6 +937,7 @@ parseCodegen _ = error "unknown codegen" -- FIXME: partial function
 
 parseArgs :: [String] -> [Opt]
 parseArgs [] = []
+parseArgs ("--nobanner":ns)      = NoBanner : (parseArgs ns)
 parseArgs ("--quiet":ns)         = Quiet : (parseArgs ns)
 parseArgs ("--ideslave":ns)      = Ideslave : (parseArgs ns)
 parseArgs ("--client":ns)        = [Client (showSep " " ns)]
@@ -1078,6 +1079,7 @@ idrisMain :: [Opt] -> Idris ()
 idrisMain opts =
     do let inputs = opt getFile opts
        let quiet = Quiet `elem` opts
+       let nobanner = NoBanner `elem` opts
        let idesl = Ideslave `elem` opts
        let runrepl = not (NoREPL `elem` opts)
        let output = opt getOutput opts
@@ -1139,7 +1141,7 @@ idrisMain opts =
                                                 return ()
        when (not (NoPrelude `elem` opts)) $ do x <- loadModule stdout "Prelude"
                                                return ()
-       when (runrepl && not quiet && not idesl && not (isJust script)) $ iputStrLn banner
+       when (runrepl && not quiet && not idesl && not (isJust script) && not nobanner) $ iputStrLn banner
        ist <- getIState
 
        loadInputs stdout inputs


### PR DESCRIPTION
A small fix for [Issue 590](https://github.com/idris-lang/Idris-dev/issues/590), which provides a `--nobanner` flag to the Idris runtime, surpressing the banner at the REPL.
