### PR TITLE
Allow newer versions of parsers and trifecta.

### DIFF
--- a/idris.cabal
+++ b/idris.cabal
@@ -396,14 +396,14 @@ Executable idris
                 , language-java >= 0.2.6
                 , mtl
                 --, parsec >= 3
-                , parsers == 0.9
+                , parsers >= 0.9
                 , pretty
                 , process
                 , split
                 , text
                 , time >= 1.4
                 , transformers
-                , trifecta == 1.1
+                , trifecta >= 1.1
                 , unordered-containers
                 , utf8-string
                 , vector


### PR DESCRIPTION
I've been running locally with the latest versions of these libs. No one
has died, false has not been proven (yet), and the tests all pass.
