### PR TITLE
Add HPC files to .gitignore

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -11,6 +11,8 @@ cabal.sandbox.config
 *.swp
 *~
 .DS_Store
+.hpc
+*.tix
 custom.mk
 test/output
 test/test???/output


### PR DESCRIPTION
HPC is used for coverage checking Haskell code
