### PR TITLE
Show Git revision IDs in pre-release versions

### DIFF
--- a/idris.cabal
+++ b/idris.cabal
@@ -308,6 +308,13 @@ Flag GMP
   Default:      False
   manual:       True
 
+-- This flag determines whether to show Git hashes in version strings
+-- Defaults to True because Hackage is a source release
+Flag release
+  Description:  This is an official release
+  Default:      False
+  manual:       True
+
 Executable idris
   Main-is:        Main.hs
   hs-source-dirs: src

--- a/src/Idris/REPL.hs
+++ b/src/Idris/REPL.hs
@@ -26,6 +26,7 @@ import Idris.CaseSplit
 import Idris.DeepSeq
 
 import Paths_idris
+import Version_idris (gitHash)
 import Util.System
 import Util.DynamicLinker
 import Util.Net (listenOnLocalhost)
@@ -1326,7 +1327,7 @@ getColour _ = Nothing
 opt :: (Opt -> Maybe a) -> [Opt] -> [a]
 opt = mapMaybe
 
-ver = showVersion version
+ver = showVersion version ++ gitHash
 
 banner = "     ____    __     _                                          \n" ++
          "    /  _/___/ /____(_)____                                     \n" ++


### PR DESCRIPTION
A new Cabal flag `release` is added, and is off by default.

When the flag is on, version strings show the version from
idris.cabal. When the flag is off, version strings are given a
prerelease suffix. If the build system can determine the short Git hash
for HEAD, then this is the suffix. If it cannot, then the suffix is a
generic "-PRE" suffix.
