### PR TITLE
Add a function for dealing with absurdity

### DIFF
--- a/libs/base/Uninhabited.idr
+++ b/libs/base/Uninhabited.idr
@@ -10,3 +10,6 @@ instance Uninhabited (Fin Z) where
 instance Uninhabited (Z = S n) where
   uninhabited refl impossible
 
+-- | Use an absurd assumption to discharge a proof obligation
+absurd : Uninhabited t => t -> a
+absurd t = FalseElim (uninhabited t)


### PR DESCRIPTION
Now, if a type is known to be uninhabited, `absurd` will immediately
find the proof of uninhabitedness and apply `FalseElim` to it. This can
inhabit any type.

Example:

```
foo : Fin Z -> String
foo f = absurd f
```
