### PR TITLE
Fix import clash in Setup.hs

### DIFF
--- a/Setup.hs
+++ b/Setup.hs
@@ -106,7 +106,7 @@ idrisConfigure _ flags _ local = do
       -- Put the Git hash into a module for use in the program
       -- For release builds, just put the empty string in the module
       generateVersionModule = do
-        gitHash <- catch (readProcess "git" ["rev-parse", "--short", "HEAD"] "")
+        gitHash <- Control.Exception.catch (readProcess "git" ["rev-parse", "--short", "HEAD"] "")
                          (\e -> let e' = (e :: SomeException) in return "PRE")
         let hash = takeWhile (/= '\n') gitHash
         let versionModulePath = autogenModulesDir local </> "Version_idris" Px.<.> "hs"


### PR DESCRIPTION
`Control.Exception.catch` clashes with `Prelude.catch` on older versions of base.
Newer versions of base don’t have `Prelude.catch`, so it’s probably not possible
to `import Prelude hiding (catch)`.
