### PR TITLE
Improved the parsing of `-XExtension` flags.

### DIFF
--- a/src/Idris/REPL.hs
+++ b/src/Idris/REPL.hs
@@ -1019,8 +1019,11 @@ parseArgs ("--dumpcases":n:ns)   = DumpCases n : (parseArgs ns)
 parseArgs ("--codegen":n:ns)     = UseCodegen (parseCodegen n) : (parseArgs ns)
 parseArgs ["--exec"]             = InterpretScript "Main.main" : []
 parseArgs ("--exec":expr:ns)     = InterpretScript expr : parseArgs ns
-parseArgs ("-XTypeProviders":ns) = Extension TypeProviders : (parseArgs ns)
-parseArgs ("-XErrorReflection":ns) = Extension ErrorReflection : (parseArgs ns)
+parseArgs (('-':'X':extName):ns) = case maybeRead extName of
+  Just ext -> Extension ext : parseArgs ns
+  -- Not sure what to do for the Nothing case
+  Nothing -> error ("Unknown extension " ++ extName)
+  where maybeRead = fmap fst . listToMaybe . reads
 parseArgs ("-O3":ns)             = OptLevel 3 : parseArgs ns
 parseArgs ("-O2":ns)             = OptLevel 2 : parseArgs ns
 parseArgs ("-O1":ns)             = OptLevel 1 : parseArgs ns


### PR DESCRIPTION
The `Read LanguageExt` instance is now used to convert strings into
`LanguageExt`s, and passing -XNonexistentExtension results in an error
instead of attempting to load the file "-XNonexistentExtension".

I couldn't think of a better way to handle this than calling haskell's `error` function without making sweeping changes in many places, but if `error` is undesirable, I would be happy to consider or devise alternatives.
