### PR TITLE
llvm/Makefile: usage of .PHONY was backwards

### DIFF
--- a/llvm/Makefile
+++ b/llvm/Makefile
@@ -14,11 +14,11 @@ $(LIB): $(OBJECTS)
 .c.o:
 	$(CC) -c $(CFLAGS) $< -o $@
 
-install: $(LIB) .PHONY
+install: $(LIB)
 	mkdir -p $(TARGET)
 	install $(LIB) $(TARGET)
 
-clean: .PHONY
+clean:
 	rm -f $(OBJECTS) $(LIB)
 
-.PHONY:
+.PHONY: install clean


### PR DESCRIPTION
Phony targets should be _dependencies_ of `.PHONY`, not the other way round.
