### PR TITLE
Fix .PHONY targets in Makefiles

### DIFF
--- a/examples/Makefile
+++ b/examples/Makefile
@@ -1,8 +1,8 @@
-check: .PHONY
+check:
 	rm -f *.ibc
 	for x in *.idr ; do \
 	echo "Checking $$x"; \
 	idris --check $$x; \
 	done
 	
-.PHONY:
+.PHONY: check

--- a/libs/Makefile
+++ b/libs/Makefile
@@ -1,20 +1,20 @@
-build: .PHONY
+build:
 	$(MAKE) -C prelude build
 	$(MAKE) -C base build
 	$(MAKE) -C effects build
 	$(MAKE) -C javascript build
 
 
-install: .PHONY
+install:
 	$(MAKE) -C prelude install
 	$(MAKE) -C base install
 	$(MAKE) -C effects install
 	$(MAKE) -C javascript install
 
-clean: .PHONY
+clean:
 	$(MAKE) -C prelude clean
 	$(MAKE) -C base clean
 	$(MAKE) -C effects clean
 	$(MAKE) -C javascript clean
         
-.PHONY:
+.PHONY: build install clean

--- a/libs/base/Makefile
+++ b/libs/base/Makefile
@@ -1,17 +1,17 @@
 IDRIS := idris
 
-build: .PHONY
+build:
 	$(IDRIS) --build base.ipkg
 
 install: 
 	$(IDRIS) --install base.ipkg
 
-clean: .PHONY
+clean:
 	$(IDRIS) --clean base.ipkg
 
 rebuild: clean build
 
-linecount: .PHONY
+linecount:
 	find . -name '*.idr' | xargs wc -l
 
-.PHONY:
+.PHONY: build install clean rebuild linecount

--- a/libs/effects/Makefile
+++ b/libs/effects/Makefile
@@ -1,9 +1,9 @@
 IDRIS     := idris
 
-build: .PHONY
+build:
 	$(IDRIS) --build effects.ipkg
 
-clean: .PHONY
+clean:
 	$(IDRIS) --clean effects.ipkg
 
 install:
@@ -11,4 +11,4 @@ install:
 
 rebuild: clean build
 
-.PHONY:
+.PHONY: build clean install rebuild

--- a/libs/javascript/Makefile
+++ b/libs/javascript/Makefile
@@ -1,14 +1,14 @@
 IDRIS := idris
 
-build: .PHONY
+build:
 	$(IDRIS) --build javascript.ipkg
 
 install:
 	$(IDRIS) --install javascript.ipkg
 
-clean: .PHONY
+clean:
 	$(IDRIS) --clean javascript.ipkg
 
 rebuild: clean build
 
-.PHONY:
+.PHONY: build install clean rebuild

--- a/libs/prelude/Makefile
+++ b/libs/prelude/Makefile
@@ -1,17 +1,17 @@
 IDRIS := idris
 
-build: .PHONY
+build:
 	$(IDRIS) --build prelude.ipkg
 
 install: 
 	$(IDRIS) --install prelude.ipkg
 
-clean: .PHONY
+clean:
 	$(IDRIS) --clean prelude.ipkg
 
 rebuild: clean build
 
-linecount: .PHONY
+linecount:
 	find . -name '*.idr' | xargs wc -l
 
-.PHONY:
+.PHONY: build install clean rebuild linecount

--- a/llvm/Makefile
+++ b/llvm/Makefile
@@ -14,11 +14,11 @@ $(LIB): $(OBJECTS)
 .c.o:
 	$(CC) -c $(CFLAGS) $< -o $@
 
-install: $(LIB) .PHONY
+install: $(LIB)
 	mkdir -p $(TARGET)
 	install $(LIB) $(TARGET)
 
-clean: .PHONY
+clean:
 	rm -f $(OBJECTS) $(LIB)
 
-.PHONY:
+.PHONY: build install clean

--- a/papers/impl-paper/Makefile
+++ b/papers/impl-paper/Makefile
@@ -1,6 +1,6 @@
 PAPER = impldtp
 
-all: ${PAPER}.pdf .PHONY
+all: ${PAPER}.pdf
 
 TEXFILES = ${PAPER}.tex intro.tex conclusions.tex hll.tex\
            typechecking.tex elaboration.tex delab.tex \
@@ -28,16 +28,16 @@ ${PAPER}.dvi: $(SOURCES)
 	-latex ${PAPER}
 	-latex ${PAPER}
 
-progress: .PHONY
+progress:
 	wc -w ${TEXFILES}
 
 %.png : %.diag
 	$(DITAA) -o -E $<
 
-todropbox: .PHONY
+todropbox:
 	cp ${SOURCES} ~/Dropbox/TeX/ImplDTP/
 
-fromdropbox: .PHONY
+fromdropbox:
 	cp ~/Dropbox/TeX/ImplDTP/* .
 
-.PHONY:
+.PHONY: all progress todropbox fromdropbox

--- a/rts/Makefile
+++ b/rts/Makefile
@@ -15,13 +15,13 @@ $(LIBTARGET) : $(OBJS)
 	ar r $(LIBTARGET) $(OBJS)
 	ranlib $(LIBTARGET)
 
-install : .PHONY
+install :
 	mkdir -p $(TARGET)
 	install $(LIBTARGET) $(HDRS) $(TARGET)
 
-clean : .PHONY
+clean :
 	rm -f $(OBJS) $(LIBTARGET) $(DYLIBTARGET)
 
 idris_rts.o: idris_rts.h
 
-.PHONY:
+.PHONY: build install clean

--- a/support/Makefile
+++ b/support/Makefile
@@ -12,4 +12,4 @@ install: check
 	install $(LIBTARGET) $(TARGET)
 	install $(HDRS) $(TARGET)
 
-.PHONY:
+.PHONY: check install

--- a/test/Makefile
+++ b/test/Makefile
@@ -105,4 +105,4 @@ distclean:
 	rm -f *~
 	rm -f */output
 
-.phony: test test_java test_js update diff distclean $(TESTS)
+.PHONY: test test_java test_js update diff distclean $(TESTS)


### PR DESCRIPTION
Phony targets should be dependencies of .PHONY, not the other way around.

[Sorry about the other PR just now, the 'Edit' button on Github is just too inviting and I didn't think to check the other makefiles until it was too late. :(]
