### PR TITLE
Adds support for triple-quoted possibly multi-line verbatim string literals

### DIFF
--- a/src/Idris/ParseExpr.hs
+++ b/src/Idris/ParseExpr.hs
@@ -1015,8 +1015,8 @@ VerbatimString_t ::=
 @
  -}
 verbatimStringLiteral :: MonadicParsing m => m String
-verbatimStringLiteral = do string "\"\"\""
-                           manyTill anyChar $ try (string "\"\"\"")
+verbatimStringLiteral = token $ do string "\"\"\""
+                                   manyTill anyChar $ try (string "\"\"\"")
 
 {- | Parses a static modifier
 


### PR DESCRIPTION
This is a simple parser addition that provides support for verbatim literals, which could be useful
when writing expressions that need escaping like file-paths, regular expressions, xml or longer text.

Example:

``` Idris
filePath : String
filePath = """C:\Users\TestUser\Desktop\Test.xml"""

xmlTest : String
xmlTest = """
<person id="12">
   <name>Test User</name>
   <number>+2 3 4</number>
</person>
"""
```

Hopefully, you will find this useful too.
