### PR TITLE
More descriptive error message on failure to unzip .ibc

### DIFF
--- a/idris.cabal
+++ b/idris.cabal
@@ -412,6 +412,7 @@ Library
                   Util.Pretty
                 , Util.System
                 , Util.Net
+                , Util.Zlib
 
                 , Pkg.PParser
 

--- a/src/Util/Zlib.hs
+++ b/src/Util/Zlib.hs
@@ -1,0 +1,15 @@
+module Util.Zlib (decompressEither) where
+
+-- From http://stackoverflow.com/questions/10043102/how-to-catch-the-decompress-ioerror/10045963#10045963
+import Codec.Compression.Zlib.Internal
+import Data.ByteString.Lazy (ByteString, fromChunks)
+import Control.Arrow (right)
+
+decompressEither :: ByteString -> Either (DecompressError, String) ByteString
+decompressEither = finalise
+                            . foldDecompressStream cons nil err
+                            . decompressWithErrors zlibFormat defaultDecompressParams
+  where err errorCode errorString = Left (errorCode, errorString)
+        nil = Right []
+        cons chunk = right (chunk :)
+        finalise = right fromChunks


### PR DESCRIPTION
To give more guidance on errors like
https://github.com/edwinb/SDL-idris/issues/2

The DecompressError can be one of three things:
http://hackage.haskell.org/package/zlib-0.5.4.1/docs/Codec-Compression-Zlib-Internal.html#t:DecompressError
There's not a show instance for it, though.
When I try to unzip "/etc/passwd" with this, the text of that error
message returned is "incorrect header check".
