### PR TITLE
Improve parser error messages by removing some backtracking

### DIFF
--- a/test/test039/Main.idr
+++ b/test/test039/Main.idr
@@ -1,0 +1,4 @@
+module Main
+
+s : String
+s = "\u"

--- a/test/test039/expected
+++ b/test/test039/expected
@@ -1,0 +1,4 @@
+[1m./Main.idr[0m:[1m4[0m:[1m7[0m: [91merror[0m: expected: "&",
+    escape code, space
+s = "\u" 
+      [92m^[0m  

--- a/test/test039/run
+++ b/test/test039/run
@@ -1,0 +1,3 @@
+#!/usr/bin/env bash
+idris $@ Main.idr --nocolour --check
+rm -f *.ibc


### PR DESCRIPTION
Fixes #800. Includes a test (`test038` is already taken by another #806) and a little cleanup in the code.

The tests pass, the stdlib builds.
