### PR TITLE
 (Temporarily) remove the remaining typecase checks.

### DIFF
--- a/src/Idris/ElabTerm.hs
+++ b/src/Idris/ElabTerm.hs
@@ -162,9 +162,9 @@ elab ist info pattern opts fn tm
 
     elab' ina (PNoImplicits t) = elab' ina t -- skip elabE step
     elab' ina PType           = do apply RType []; solve
-    elab' (_,_,inty) (PConstant c) 
-       | constType c && pattern && not reflect && not inty
-         = lift $ tfail (Msg "Typecase is not allowed") 
+--  elab' (_,_,inty) (PConstant c) 
+--     | constType c && pattern && not reflect && not inty
+--       = lift $ tfail (Msg "Typecase is not allowed") 
     elab' ina (PConstant c)  = do apply (RConstant c) []; solve
     elab' ina (PQuote r)     = do fill r; solve
     elab' ina (PTrue fc)     = try (elab' ina (PRef fc unitCon))
@@ -240,9 +240,9 @@ elab ist info pattern opts fn tm
               trySeq' deferr (x : xs)
                   = try' (elab' ina x) (trySeq' deferr xs) True
     elab' ina (PPatvar fc n) | pattern = patvar n
-    elab' (_, _, inty) (PRef fc f)
-       | isTConName f (tt_ctxt ist) && pattern && not reflect && not inty
-          = lift $ tfail (Msg "Typecase is not allowed") 
+--    elab' (_, _, inty) (PRef fc f)
+--       | isTConName f (tt_ctxt ist) && pattern && not reflect && not inty
+--          = lift $ tfail (Msg "Typecase is not allowed") 
     elab' (ina, guarded, inty) (PRef fc n) | pattern && not (inparamBlock n)
         = do ctxt <- get_context
              let defined = case lookupTy n ctxt of


### PR DESCRIPTION
6e1cac72fd0660cd26beb6bb1f7ed5a1b65ec9bd temporarily disables the
typecase test, but some checks remain and continue to cause undesired
behaviour. This patch temporarily disables the remaining checks.
