### PR TITLE
Normalise provider types before checking

### DIFF
--- a/src/Idris/ElabDecls.hs
+++ b/src/Idris/ElabDecls.hs
@@ -630,7 +630,7 @@ elabProvider info syn fc n ty tm
 
          -- Elaborate the provider term to TT and check that the type matches
          (e, et) <- elabVal toplevel False tm
-         unless (isProviderOf ty' et) $
+         unless (isProviderOf (normalise ctxt [] ty') et) $
            ifail $ "Expected provider type IO (Provider (" ++
                    show ty' ++ "))" ++ ", got " ++ show et ++ " instead."
 


### PR DESCRIPTION
This ensures, among other things, that:
- Namespaces don't get in the way
- Type synonyms get expanded
