### PR TITLE
Fix filename case in test run scripts

### DIFF
--- a/test/dsl002/run
+++ b/test/dsl002/run
@@ -1,4 +1,4 @@
 #!/usr/bin/env bash
 idris $@ test014.idr -o test014
 ./test014
-rm -f test014 resimp.ibc test014.ibc
+rm -f test014 Resimp.ibc test014.ibc

--- a/test/proof003/run
+++ b/test/proof003/run
@@ -1,4 +1,4 @@
 #!/usr/bin/env bash
 idris $@ test015.idr -o test015
 ./test015
-rm -f test015 parity.ibc test015.ibc
+rm -f test015 Parity.ibc test015.ibc


### PR DESCRIPTION
This causes them to properly clean up IBC files after them on
case-sensitive filesystems.

Fixes #866.
