### PR TITLE
Add Uninhabited to Prelude

### DIFF
--- a/libs/base/Control/Isomorphism.idr
+++ b/libs/base/Control/Isomorphism.idr
@@ -1,7 +1,6 @@
 module Control.Isomorphism
 
 import Syntax.PreorderReasoning
-import Uninhabited
 
 %default total
 

--- a/libs/base/base.ipkg
+++ b/libs/base/base.ipkg
@@ -10,8 +10,6 @@ modules = System,
 
           Decidable.Decidable, Decidable.Order,
 
-          Uninhabited,
-
           Providers,
 
           Language.Reflection, Language.Reflection.Utils, Language.Reflection.Errors,

--- a/libs/prelude/Prelude.idr
+++ b/libs/prelude/Prelude.idr
@@ -20,6 +20,7 @@ import Prelude.Chars
 import Prelude.Traversable
 import Prelude.Bits
 import Prelude.Stream
+import Prelude.Uninhabited
 
 import Decidable.Equality
 

--- a/libs/prelude/Prelude/Uninhabited.idr
+++ b/libs/prelude/Prelude/Uninhabited.idr
@@ -1,4 +1,4 @@
-module Uninhabited
+module Prelude.Uninhabited
 
 class Uninhabited t where
   total uninhabited : t -> _|_

--- a/libs/prelude/prelude.ipkg
+++ b/libs/prelude/prelude.ipkg
@@ -1,13 +1,14 @@
 package prelude
 
 opts = "--nobuiltins --total"
-modules = Builtins, Prelude, IO, 
+modules = Builtins, Prelude, IO,
 
           Prelude.Algebra, Prelude.Basics, Prelude.Bool, Prelude.Cast,
           Prelude.Classes, Prelude.Nat, Prelude.Fin, Prelude.List,
           Prelude.Maybe, Prelude.Monad, Prelude.Applicative, Prelude.Either,
           Prelude.Vect, Prelude.Strings, Prelude.Chars, Prelude.Functor,
           Prelude.Foldable, Prelude.Traversable, Prelude.Bits, Prelude.Stream,
+          Prelude.Uninhabited,
 
           Decidable.Equality
 


### PR DESCRIPTION
Fixes #859.

If there will be another patch-release on 0.9.11, it might be good to wait with this one, as it's slightly backwards-incompatible. Client code need only delete an import to fix itself, but it's an incompatibility nonetheless.
