### PR TITLE
Parser warnings; especially for invalid doc comments

### DIFF
--- a/src/Idris/AbsSyntaxTree.hs
+++ b/src/Idris/AbsSyntaxTree.hs
@@ -133,6 +133,7 @@ data IState = IState {
     idris_hdrs :: [(Codegen, String)],
     proof_list :: [(Name, [String])],
     errLine :: Maybe Int,
+    parserWarnings :: [(FC, Err)],
     lastParse :: Maybe Name,
     indent_stack :: [Int],
     brace_stack :: [Maybe Int],
@@ -219,7 +220,7 @@ idrisInit = IState initContext [] [] emptyContext emptyContext emptyContext
                    emptyContext emptyContext emptyContext emptyContext
                    emptyContext emptyContext
                    [] [] defaultOpts 6 [] [] [] [] [] [] [] [] [] [] [] [] []
-                   [] Nothing Nothing [] [] [] Hidden False [] Nothing [] [] RawOutput
+                   [] Nothing [] Nothing [] [] [] Hidden False [] Nothing [] [] RawOutput
                    True defaultTheme stdout [] (0, emptyContext) emptyContext M.empty
                    AutomaticWidth
 

--- a/src/Idris/Chaser.hs
+++ b/src/Idris/Chaser.hs
@@ -132,6 +132,8 @@ buildTree built fp = btree [] fp
             file_in <- runIO $ readFile f
             file <- if lit then tclift $ unlit f file_in else return file_in
             (_, modules, _) <- parseImports f file
+            -- The chaser should never report warnings from sub-modules
+            clearParserWarnings
             ms <- mapM (btree done) [realName | (realName, alias, fc) <- modules]
             return (concat ms)
            else return [] -- IBC with no source available

--- a/src/Idris/ParseExpr.hs
+++ b/src/Idris/ParseExpr.hs
@@ -78,8 +78,8 @@ expr' syn = doexpr' syn
 
 doexpr' :: SyntaxInfo -> IdrisParser PTerm
 doexpr' syn =     try (externalExpr syn)
-            <|> internalExpr syn
-            <?> "expression"
+              <|> internalExpr syn
+              <?> "expression"
 
 {- | Parses a user-defined expression -}
 externalExpr :: SyntaxInfo -> IdrisParser PTerm
@@ -204,7 +204,7 @@ internalExpr syn =
      <|> quoteGoal syn
      <|> let_ syn
      <|> rewriteTerm syn
-     <|> try(pi syn)
+     <|> try (pi syn)
      <|> doBlock syn
      <|> caseExpr syn
      <|> simpleExpr syn
@@ -785,7 +785,7 @@ pi syn =
                 -- else return []
                 return []
         st <- static
-        (do try(lchar '('); xt <- typeDeclList syn; lchar ')'
+        (do try (lchar '('); xt <- typeDeclList syn; lchar ')'
             doc <- option "" (docComment '^')
             symbol "->"
             sc <- expr syn


### PR DESCRIPTION
This patch adds:
- A facility for non-fatal parser warnings
- A convenient way to add specific warnings for invalid documentation
  comments
- Warnings for module doc comments (which are not currently supported)

This doesn't totally take care of #912, because I still need to insert more warning locations, but it's a good start. In particular, it gives a nice error message for @walkie's issue.
