### PR TITLE
Don't check hostname on network connections to REPL from editors.

### DIFF
--- a/src/Idris/REPL.hs
+++ b/src/Idris/REPL.hs
@@ -142,19 +142,11 @@ startServer orig fn_in = do tid <- runIO $ forkOS serverLoop
                   _ -> ""
 
         loop fn ist sock
-            = do (h,host,_) <- accept sock
-                 -- just use the local part of the hostname
-                 -- for the "localhost.localdomain" case
-                 if ((takeWhile (/= '.') host) == "localhost" ||
-                     host == "127.0.0.1")
-                   then do
-                     cmd <- hGetLine h
-                     (ist', fn) <- processNetCmd orig ist h fn cmd
-                     hClose h
-                     loop fn ist' sock
-                   else do
-                     putStrLn $ "Closing connection attempt from non-localhost " ++ host
-                     hClose h
+            = do (h,_,_) <- accept sock
+                 cmd <- hGetLine h
+                 (ist', fn) <- processNetCmd orig ist h fn cmd
+                 hClose h
+                 loop fn ist' sock
 
 processNetCmd :: IState -> IState -> Handle -> FilePath -> String ->
                  IO (IState, FilePath)


### PR DESCRIPTION
It's already restricted to only listening on the 127.0.0.1 interface;
the additional check might just be being paranoid. Doesn't seem like
this kind of thing is a huge security concern, anyways.
Fixes #916.
Think I saw someone else complain about this too, recently.
