### PR TITLE
Prover commands for evaluation and typechecking expressions

### DIFF
--- a/CHANGELOG
+++ b/CHANGELOG
@@ -7,6 +7,8 @@ New in 0.9.12:
 * JavaScript and Node codegen now understand the %include directive
 * Concept up 'null' is now understood in the JavaScript and Node codegen
 * Lots of performance patches for generated JavaScript
+* New commands :eval (:e) and :type (:t) in the prover, which either normalise
+  or show the type of expressions
 
 New in 0.9.11:
 --------------

--- a/src/Idris/AbsSyntax.hs
+++ b/src/Idris/AbsSyntax.hs
@@ -549,16 +549,16 @@ ihPrintTermWithType h tm ty = do ist <- getIState
                                    IdeSlave n -> ideSlaveReturnAnnotated n h output
 
 -- | Pretty-print a collection of overloadings to REPL or IDESlave - corresponds to :t name
-ihPrintFunTypes :: Handle -> Name -> [(Name, PTerm)] -> Idris ()
-ihPrintFunTypes h n []        = ihPrintError h $ "No such variable " ++ show n
-ihPrintFunTypes h n overloads = do imp <- impShow
-                                   ist <- getIState
-                                   let output = vsep (map (uncurry (ppOverload imp)) overloads)
-                                   case idris_outputmode ist of
-                                     RawOutput -> consoleDisplayAnnotated h output
-                                     IdeSlave n -> ideSlaveReturnAnnotated n h output
-  where fullName n = annotate (AnnName n Nothing Nothing) $ text (show n)
-        ppOverload imp n tm = fullName n <+> colon <+> align (prettyImp imp tm)
+ihPrintFunTypes :: Handle -> [(Name, Bool)] -> Name -> [(Name, PTerm)] -> Idris ()
+ihPrintFunTypes h bnd n []        = ihPrintError h $ "No such variable " ++ show n
+ihPrintFunTypes h bnd n overloads = do imp <- impShow
+                                       ist <- getIState
+                                       let output = vsep (map (uncurry (ppOverload imp)) overloads)
+                                       case idris_outputmode ist of
+                                         RawOutput -> consoleDisplayAnnotated h output
+                                         IdeSlave n -> ideSlaveReturnAnnotated n h output
+  where fullName n = prettyName True bnd n
+        ppOverload imp n tm = fullName n <+> colon <+> align (pprintPTerm imp bnd tm)
 
 ihRenderResult :: Handle -> Doc OutputAnnotation -> Idris ()
 ihRenderResult h d = do ist <- getIState

--- a/src/Idris/AbsSyntaxTree.hs
+++ b/src/Idris/AbsSyntaxTree.hs
@@ -697,6 +697,8 @@ data PTactic' t = Intro [Name] | Intros | Focus Name
                 | Reflect t
                 | Fill t
                 | GoalType String (PTactic' t)
+                | TCheck t
+                | TEval t
                 | Qed | Abandon
     deriving (Show, Eq, Functor)
 {-!

--- a/src/Idris/Completion.hs
+++ b/src/Idris/Completion.hs
@@ -45,6 +45,10 @@ tacticArgs = [ ("intro", Nothing) -- FIXME syntax for intro (fresh name)
              , ("fill", Just ExprTArg)
              , ("try", Just AltsTArg)
              , ("induction", Just NameTArg)
+             , (":t", Just ExprTArg)
+             , (":type", Just ExprTArg)
+             , (":e", Just ExprTArg)
+             , (":eval", Just ExprTArg)
              ] ++ map (\x -> (x, Nothing)) [
               "intros", "compute", "trivial", "solve", "attack",
               "state", "term", "undo", "qed", "abandon", ":q"
@@ -168,7 +172,8 @@ replCompletion (prev, next) = case firstWord of
 
 
 completeTactic :: [String] -> String -> CompletionFunc Idris
-completeTactic as tac (prev, next) = fromMaybe completeTacName $ fmap completeArg $ lookup tac tacticArgs
+completeTactic as tac (prev, next) = fromMaybe completeTacName . fmap completeArg $
+                                     lookup tac tacticArgs
     where completeTacName = return $ ("", completeWith tactics tac)
           completeArg Nothing           = noCompletion (prev, next)
           completeArg (Just NameTArg)   = noCompletion (prev, next) -- this is for binding new names!

--- a/src/Idris/ParseExpr.hs
+++ b/src/Idris/ParseExpr.hs
@@ -1173,7 +1173,17 @@ tactic syn = do reserved "intro"; ns <- sepBy (indentPropHolds gtProp *> name) (
           <|> do reserved "undo"; return Undo
           <|> do reserved "qed"; return Qed
           <|> do reserved "abandon"; return Abandon
-          <|> do lchar ':'; reserved "q"; return Abandon
+          <|> do lchar ':';
+                 (    (do reserved "q"; return Abandon)
+                  <|> (do (reserved "e" <|> reserved "eval");
+                          t <- (indentPropHolds gtProp *> expr syn);
+                          i <- get
+                          return $ TEval (desugar syn i t))
+                  <|> (do (reserved "t" <|> reserved "type");
+                          t <- (indentPropHolds gtProp *> expr syn);
+                          i <- get
+                          return $ TCheck (desugar syn i t))
+                  <?> "prover command")
           <?> "tactic"
   where
     imp :: IdrisParser Bool

--- a/src/Idris/REPL.hs
+++ b/src/Idris/REPL.hs
@@ -496,7 +496,7 @@ process h fn (Check (PRef _ n))
             case lookup t (idris_metavars ist) of
                 Just (_, i, _) -> ihRenderResult h . fmap (fancifyAnnots ist) $
                                   showMetavarInfo imp ist n i
-                Nothing -> ihPrintFunTypes h n (map (\n -> (n, delabTy ist n)) ts)
+                Nothing -> ihPrintFunTypes h [] n (map (\n -> (n, delabTy ist n)) ts)
           [] -> ihPrintError h $ "No such variable " ++ show n
   where
     showMetavarInfo imp ist n i


### PR DESCRIPTION
Now, the prover supports two new commands:
- :t, :type gives the type of an expression
- :e, :eval normalises the expression and prints the result

These work within the proof environment, so evaluating expressions that
contain references to hypotheses is allowed.

Fixes #505.
