### PR TITLE
src/Idris/ParseHelpers.hs: workaround build failure against ghc-7.8

### DIFF
--- a/src/Idris/ParseHelpers.hs
+++ b/src/Idris/ParseHelpers.hs
@@ -1,4 +1,5 @@
 {-# LANGUAGE GeneralizedNewtypeDeriving, ConstraintKinds, PatternGuards #-}
+{-# LANGUAGE StandaloneDeriving #-}
 module Idris.ParseHelpers where
 
 import Prelude hiding (pi)
@@ -37,7 +38,9 @@ import System.FilePath
 type IdrisParser = StateT IState IdrisInnerParser
 
 newtype IdrisInnerParser a = IdrisInnerParser { runInnerParser :: Parser a }
-  deriving (Monad, Functor, MonadPlus, Applicative, Alternative, CharParsing, LookAheadParsing, Parsing, DeltaParsing, MarkParsing Delta, Monoid)
+  deriving (Monad, Functor, MonadPlus, Applicative, Alternative, CharParsing, LookAheadParsing{-, Parsing-}, DeltaParsing, MarkParsing Delta, Monoid)
+
+deriving instance Parsing IdrisInnerParser
 
 instance TokenParsing IdrisInnerParser where
   someSpace = many (simpleWhiteSpace <|> singleLineComment <|> multiLineComment) *> pure ()


### PR DESCRIPTION
> [50 of 75] Compiling Idris.ParseHelpers ( src/Idris/ParseHelpers.hs,
> dist/build/Idris/ParseHelpers.o )
> 
> src/Idris/ParseHelpers.hs:40:97:
>     Could not coerce from ‘Monad Parser’ to ‘Monad IdrisInnerParser’
>       because the first type argument of ‘Monad’ has role Nominal,
>       but the arguments ‘Parser’ and ‘IdrisInnerParser’ differ
>       arising from the coercion of the method ‘notFollowedBy’ from type
>                    ‘forall a. (Monad Parser, Show a) => Parser a -> Parser
> ()’ to type
>                    ‘forall a.
>                     (Monad IdrisInnerParser, Show a) =>
>                     IdrisInnerParser a -> IdrisInnerParser ()’
>     Possible fix:
>       use a standalone 'deriving instance' declaration,
>         so you can specify the instance context yourself
>     When deriving the instance for (Parsing IdrisInnerParser)

I'm not sure if it's a ghc-7.8.1-rc2 bug or feature. Looks like standalone
deriving does not try to infer (too tight) context.

Signed-off-by: Sergei Trofimovich slyfox@gentoo.org
