### PR TITLE
Skip obviously  unnecessary coverage checking

### DIFF
--- a/src/Idris/ElabDecls.hs
+++ b/src/Idris/ElabDecls.hs
@@ -988,7 +988,7 @@ elabClauses info fc opts n_in cs = let n = liftname info n_in in
                    simpleCase tcase False reflect CompileTime fc atys pdef
            cov <- coverage
            pmissing <-
-                   if cov
+                   if cov && not (hasDefault cs)
                       then do missing <- genClauses fc n (map getLHS pdef) cs
                               -- missing <- genMissing n scargs sc
                               missing' <- filterM (checkPossible info fc True n) missing
@@ -1091,6 +1091,10 @@ elabClauses info fc opts n_in cs = let n = liftname info n_in in
 
     depat acc (Bind n (PVar t) sc) = depat (n : acc) (instantiate (P Bound n t) sc)
     depat acc x = (acc, x)
+
+    hasDefault cs | (PClause _ _ last _ _ _ :_) <- reverse cs
+                  , (PApp fn s args) <- last = all ((==Placeholder) . getTm) args
+    hasDefault _ = False
 
     getLHS (_, l, _) = l
 


### PR DESCRIPTION
If the last clause in a definition contains only _, we don't need to
coverage check it. This vastly, vastly improves the speed of this defn:

fourTupleElems : TT -> Maybe (TT, (TT, (TT, TT)))
fourTupleElems (App (App (App (App p ty1) ty2) tm1)
                (App (App (App (App p ty3) ty4) tm2)
                 (App (App (App (App p ty1) ty2) tm3) tm4))) = Just (tm1, tm2, tm3, tm4)
fourTupleElems _ = Nothing

The check is perhaps overly conservative, but that can be improved in the future. Right now, it makes the kinds of deep patterns used in reflection programming much more convenient.
