### PR TITLE
Add semantic highlighting info for metavariables

### DIFF
--- a/src/Idris/AbsSyntax.hs
+++ b/src/Idris/AbsSyntax.hs
@@ -490,6 +490,12 @@ getUndefined :: Idris [Name]
 getUndefined = do i <- getIState
                   return (map fst (idris_metavars i) \\ primDefs)
 
+isMetavarName :: Name -> IState -> Bool
+isMetavarName n ist
+     = case lookupNames n (tt_ctxt ist) of
+            (t:_) -> isJust $ lookup t (idris_metavars ist)
+            _     -> False
+
 getWidth :: Idris ConsoleWidth
 getWidth = fmap idris_consolewidth getIState
 
@@ -579,10 +585,11 @@ fancifyAnnots :: IState -> OutputAnnotation -> OutputAnnotation
 fancifyAnnots ist annot@(AnnName n _ _) =
   do let ctxt = tt_ctxt ist
      case () of
-       _ | isDConName n ctxt -> AnnName n (Just DataOutput) Nothing
-       _ | isFnName   n ctxt -> AnnName n (Just FunOutput) Nothing
-       _ | isTConName n ctxt -> AnnName n (Just TypeOutput) Nothing
-       _ | otherwise         -> annot
+       _ | isDConName    n ctxt -> AnnName n (Just DataOutput) Nothing
+       _ | isFnName      n ctxt -> AnnName n (Just FunOutput) Nothing
+       _ | isTConName    n ctxt -> AnnName n (Just TypeOutput) Nothing
+       _ | isMetavarName n ist  -> AnnName n (Just MetavarOutput) Nothing
+       _ | otherwise            -> annot
 fancifyAnnots _ annot = annot
 
 type1Doc :: Doc OutputAnnotation

--- a/src/Idris/Core/TT.hs
+++ b/src/Idris/Core/TT.hs
@@ -82,7 +82,7 @@ instance Show FC where
                                      | otherwise            = show sl ++ ":" ++ show sc ++ "-" ++ show el ++ ":" ++ show ec
 
 -- | Output annotation for pretty-printed name - decides colour
-data NameOutput = TypeOutput | FunOutput | DataOutput
+data NameOutput = TypeOutput | FunOutput | DataOutput | MetavarOutput
 
 -- | Text formatting output
 data TextFormatting = BoldText | ItalicText | UnderlineText

--- a/src/Idris/IdeSlave.hs
+++ b/src/Idris/IdeSlave.hs
@@ -74,9 +74,10 @@ instance (SExpable a, SExpable b, SExpable c, SExpable d, SExpable e) =>
    toSExp (l, m, n, o, p) = SexpList [toSExp l, toSExp m, toSExp n, toSExp o, toSExp p]
 
 instance SExpable NameOutput where
-  toSExp TypeOutput = SymbolAtom "type"
-  toSExp FunOutput  = SymbolAtom "function"
-  toSExp DataOutput = SymbolAtom "data"
+  toSExp TypeOutput    = SymbolAtom "type"
+  toSExp FunOutput     = SymbolAtom "function"
+  toSExp DataOutput    = SymbolAtom "data"
+  toSExp MetavarOutput = SymbolAtom "metavar"
 
 instance SExpable OutputAnnotation where
   toSExp (AnnName n Nothing   _) = toSExp [(SymbolAtom "name", StringAtom (show n)),


### PR DESCRIPTION
This will enable the appropriate fonts to be used in IDEs such as idris-mode

Fixes #949.
