### PR TITLE
Show docs and types in IDESlave

### DIFF
--- a/idris.cabal
+++ b/idris.cabal
@@ -476,6 +476,7 @@ Library
                 , Idris.IdeSlave
                 , Idris.Imports
                 , Idris.Inliner
+                , Idris.Output
                 , Idris.Parser
                 , Idris.ParseHelpers
                 , Idris.ParseOps

--- a/src/Idris/AbsSyntax.hs
+++ b/src/Idris/AbsSyntax.hs
@@ -511,155 +511,15 @@ renderWidth = do iw <- getWidth
                    AutomaticWidth -> runIO getScreenWidth
 
 
-iRender :: Doc a -> Idris (SimpleDoc a)
-iRender d = do w <- getWidth
-               ist <- getIState
-               let ideSlave = case idris_outputmode ist of
-                                IdeSlave _ -> True
-                                _          -> False
-               case w of
-                 InfinitelyWide -> return $ renderPretty 1.0 1000000000 d
-                 ColsWide n -> return $
-                               if n < 1
-                                 then renderPretty 1.0 1000000000 d
-                                 else renderPretty 0.8 n d
-                 AutomaticWidth | ideSlave  -> return $ renderPretty 1.0 1000000000 d
-                                | otherwise -> do width <- runIO getScreenWidth
-                                                  return $ renderPretty 0.8 width d
-
-ihPrintResult :: Handle -> String -> Idris ()
-ihPrintResult h s = do i <- getIState
-                       case idris_outputmode i of
-                         RawOutput -> case s of
-                                        "" -> return ()
-                                        s  -> runIO $ hPutStrLn h s
-                         IdeSlave n ->
-                             let good = SexpList [SymbolAtom "ok", toSExp s] in
-                             runIO $ hPutStrLn h $ convSExp "return" good n
-
--- | Write a pretty-printed term to the console with semantic coloring
-consoleDisplayAnnotated :: Handle -> Doc OutputAnnotation -> Idris ()
-consoleDisplayAnnotated h output = do ist <- getIState
-                                      rendered <- iRender $ output
-                                      runIO . hPutStrLn h .
-                                        displayDecorated (consoleDecorate ist) $
-                                        rendered
-
-
--- | Write pretty-printed output to IDESlave with semantic annotations
-ideSlaveReturnAnnotated :: Integer -> Handle -> Doc OutputAnnotation -> Idris ()
-ideSlaveReturnAnnotated n h out = do ist <- getIState
-                                     (str, spans) <- fmap displaySpans .
-                                                     iRender .
-                                                     fmap (fancifyAnnots ist) $
-                                                     out
-                                     let good = [SymbolAtom "ok", toSExp str, toSExp spans]
-                                     runIO . hPutStrLn h $ convSExp "return" good n
-
-ihPrintTermWithType :: Handle -> Doc OutputAnnotation -> Doc OutputAnnotation -> Idris ()
-ihPrintTermWithType h tm ty = do ist <- getIState
-                                 let output = tm <+> colon <+> ty
-                                 case idris_outputmode ist of
-                                   RawOutput -> consoleDisplayAnnotated h output
-                                   IdeSlave n -> ideSlaveReturnAnnotated n h output
-
--- | Pretty-print a collection of overloadings to REPL or IDESlave - corresponds to :t name
-ihPrintFunTypes :: Handle -> [(Name, Bool)] -> Name -> [(Name, PTerm)] -> Idris ()
-ihPrintFunTypes h bnd n []        = ihPrintError h $ "No such variable " ++ show n
-ihPrintFunTypes h bnd n overloads = do imp <- impShow
-                                       ist <- getIState
-                                       let output = vsep (map (uncurry (ppOverload imp)) overloads)
-                                       case idris_outputmode ist of
-                                         RawOutput -> consoleDisplayAnnotated h output
-                                         IdeSlave n -> ideSlaveReturnAnnotated n h output
-  where fullName n = prettyName True bnd n
-        ppOverload imp n tm = fullName n <+> colon <+> align (pprintPTerm imp bnd [] tm)
-
-ihRenderResult :: Handle -> Doc OutputAnnotation -> Idris ()
-ihRenderResult h d = do ist <- getIState
-                        case idris_outputmode ist of
-                          RawOutput -> consoleDisplayAnnotated h d
-                          IdeSlave n -> ideSlaveReturnAnnotated n h d
-
-fancifyAnnots :: IState -> OutputAnnotation -> OutputAnnotation
-fancifyAnnots ist annot@(AnnName n _ _) =
-  do let ctxt = tt_ctxt ist
-     case () of
-       _ | isDConName    n ctxt -> AnnName n (Just DataOutput) Nothing
-       _ | isFnName      n ctxt -> AnnName n (Just FunOutput) Nothing
-       _ | isTConName    n ctxt -> AnnName n (Just TypeOutput) Nothing
-       _ | isMetavarName n ist  -> AnnName n (Just MetavarOutput) Nothing
-       _ | otherwise            -> annot
-fancifyAnnots _ annot = annot
 
 type1Doc :: Doc OutputAnnotation
 type1Doc = (annotate AnnConstType $ text "Type 1")
 
--- | Show an error with semantic highlighting
-ihRenderError :: Handle -> Doc OutputAnnotation -> Idris ()
-ihRenderError h e = do ist <- getIState
-                       case idris_outputmode ist of
-                         RawOutput -> consoleDisplayAnnotated h e
-                         IdeSlave n -> do
-                           (str, spans) <- fmap displaySpans .
-                                           iRender .
-                                           fmap (fancifyAnnots ist) $
-                                           e
-                           let good = [SymbolAtom "error", toSExp str, toSExp spans]
-                           runIO . hPutStrLn h $ convSExp "return" good n
-
-ihPrintError :: Handle -> String -> Idris ()
-ihPrintError h s = do i <- getIState
-                      case idris_outputmode i of
-                        RawOutput -> case s of
-                                          "" -> return ()
-                                          s  -> runIO $ hPutStrLn h s
-                        IdeSlave n ->
-                          let good = SexpList [SymbolAtom "error", toSExp s] in
-                          runIO . hPutStrLn h $ convSExp "return" good n
-
-ihputStrLn :: Handle -> String -> Idris ()
-ihputStrLn h s = do i <- getIState
-                    case idris_outputmode i of
-                      RawOutput -> runIO $ hPutStrLn h s
-                      IdeSlave n -> runIO . hPutStrLn h $ convSExp "write-string" s n
-
-iputStrLn = ihputStrLn stdout
-iPrintError = ihPrintError stdout
-iPrintResult = ihPrintResult stdout
-iWarn = ihWarn stdout
-
-ideslavePutSExp :: SExpable a => String -> a -> Idris ()
-ideslavePutSExp cmd info = do i <- getIState
-                              case idris_outputmode i of
-                                   IdeSlave n -> runIO . putStrLn $ convSExp cmd info n
-                                   _ -> return ()
-
--- this needs some typing magic and more structured output towards emacs
-iputGoal :: SimpleDoc OutputAnnotation -> Idris ()
-iputGoal g = do i <- getIState
-                case idris_outputmode i of
-                  RawOutput -> runIO $ putStrLn (displayDecorated (consoleDecorate i) g)
-                  IdeSlave n -> runIO . putStrLn $
-                                convSExp "write-goal" (displayS (fmap (fancifyAnnots i) g) "") n
 
 isetPrompt :: String -> Idris ()
 isetPrompt p = do i <- getIState
                   case idris_outputmode i of
                     IdeSlave n -> runIO . putStrLn $ convSExp "set-prompt" p n
-
-ihWarn :: Handle -> FC -> Doc OutputAnnotation -> Idris ()
-ihWarn h fc err = do i <- getIState
-                     case idris_outputmode i of
-                       RawOutput ->
-                         do err' <- iRender . fmap (fancifyAnnots i) $
-                                    text (show fc) <> colon <//> err
-                            runIO . hPutStrLn h $ displayDecorated (consoleDecorate i) err'
-                       IdeSlave n ->
-                         do err' <- iRender . fmap (fancifyAnnots i) $ err
-                            let (str, spans) = displaySpans err'
-                            runIO . hPutStrLn h $
-                              convSExp "warning" (fc_fname fc, fc_start fc, fc_end fc, str, spans) n
 
 setLogLevel :: Int -> Idris ()
 setLogLevel l = do i <- getIState

--- a/src/Idris/CaseSplit.hs
+++ b/src/Idris/CaseSplit.hs
@@ -14,6 +14,7 @@ import Idris.ElabTerm
 import Idris.Delaborate
 import Idris.Parser
 import Idris.Error
+import Idris.Output
 
 import Idris.Core.TT
 import Idris.Core.Typecheck

--- a/src/Idris/Core/TT.hs
+++ b/src/Idris/Core/TT.hs
@@ -88,8 +88,10 @@ data NameOutput = TypeOutput | FunOutput | DataOutput | MetavarOutput
 data TextFormatting = BoldText | ItalicText | UnderlineText
 
 -- | Output annotations for pretty-printing
-data OutputAnnotation = AnnName Name (Maybe NameOutput) (Maybe Type)
+data OutputAnnotation = AnnName Name (Maybe NameOutput) (Maybe String) (Maybe String)
+                        -- ^^ The name, classification, docs overview, and pretty-printed type
                       | AnnBoundName Name Bool
+                        -- ^^ The name and whether it is implicit
                       | AnnConstData
                       | AnnConstType
                       | AnnKeyword
@@ -312,11 +314,11 @@ instance Sized Name where
   size _ = 1
 
 instance Pretty Name OutputAnnotation where
-  pretty n@(UN n') = annotate (AnnName n Nothing Nothing) $ text (T.unpack n')
-  pretty n@(NS un s) = annotate (AnnName n Nothing Nothing) . noAnnotate $ pretty un
-  pretty n@(MN i s) = annotate (AnnName n Nothing Nothing) $
+  pretty n@(UN n') = annotate (AnnName n Nothing Nothing Nothing) $ text (T.unpack n')
+  pretty n@(NS un s) = annotate (AnnName n Nothing Nothing Nothing) . noAnnotate $ pretty un
+  pretty n@(MN i s) = annotate (AnnName n Nothing Nothing Nothing) $
                       lbrace <+> text (T.unpack s) <+> (text . show $ i) <+> rbrace
-  pretty n@(SN s) = annotate (AnnName n Nothing Nothing) $ text (show s)
+  pretty n@(SN s) = annotate (AnnName n Nothing Nothing Nothing) $ text (show s)
 
 instance Pretty [Name] OutputAnnotation where
   pretty = encloseSep empty empty comma . map pretty

--- a/src/Idris/Coverage.hs
+++ b/src/Idris/Coverage.hs
@@ -9,6 +9,7 @@ import Idris.Core.CaseTree
 import Idris.AbsSyntax
 import Idris.Delaborate
 import Idris.Error
+import Idris.Output (iputStrLn)
 
 import Data.List
 import Data.Either

--- a/src/Idris/Delaborate.hs
+++ b/src/Idris/Delaborate.hs
@@ -1,5 +1,5 @@
 {-# LANGUAGE PatternGuards #-}
-module Idris.Delaborate (bugaddr, delab, delab', delabMV, delabTy, delabTy', pshow, pprintErr) where
+module Idris.Delaborate (bugaddr, delab, delab', delabMV, delabTy, delabTy', pprintErr) where
 
 -- Convert core TT back into high level syntax, primarily for display
 -- purposes.
@@ -140,11 +140,6 @@ pprintTerm ist = pprintTerm' ist []
 pprintTerm' :: IState -> [(Name, Bool)] -> PTerm -> Doc OutputAnnotation
 pprintTerm' ist bnd tm = pprintPTerm (opt_showimp (idris_options ist)) bnd [] tm
 
-pshow :: IState -> Err -> String
-pshow ist err = displayDecorated (consoleDecorate ist) .
-                renderPretty 1.0 80 .
-                fmap (fancifyAnnots ist) $ pprintErr ist err
-
 pprintErr :: IState -> Err -> Doc OutputAnnotation
 pprintErr i err = pprintErr' i (fmap (errReverse i) err)
 
@@ -261,7 +256,7 @@ annName :: Name -> Doc OutputAnnotation
 annName n = annName' n (showbasic n)
 
 annName' :: Name -> String -> Doc OutputAnnotation
-annName' n str = annotate (AnnName n Nothing Nothing) (text str)
+annName' n str = annotate (AnnName n Nothing Nothing Nothing) (text str)
 
 showSc :: IState -> [(Name, Term)] -> Doc OutputAnnotation
 showSc i [] = empty

--- a/src/Idris/ElabDecls.hs
+++ b/src/Idris/ElabDecls.hs
@@ -16,6 +16,7 @@ import Idris.Primitives
 import Idris.Inliner
 import Idris.PartialEval
 import Idris.DeepSeq
+import Idris.Output (iputStrLn, pshow, iWarn)
 import IRTS.Lang
 import Paths_idris
 

--- a/src/Idris/ElabTerm.hs
+++ b/src/Idris/ElabTerm.hs
@@ -7,6 +7,7 @@ import Idris.DSL
 import Idris.Delaborate
 import Idris.Error
 import Idris.ProofSearch
+import Idris.Output (pshow)
 
 import Idris.Core.Elaborate hiding (Tactic(..))
 import Idris.Core.TT

--- a/src/Idris/Error.hs
+++ b/src/Idris/Error.hs
@@ -5,6 +5,7 @@ module Idris.Error where
 import Prelude hiding (catch)
 import Idris.AbsSyntax
 import Idris.Delaborate
+import Idris.Output
 
 import Idris.Core.TT
 import Idris.Core.Typecheck

--- a/src/Idris/IBC.hs
+++ b/src/Idris/IBC.hs
@@ -10,6 +10,7 @@ import Idris.Imports
 import Idris.Error
 import Idris.Delaborate
 import Idris.Docstrings
+import Idris.Output
 
 import qualified Cheapskate.Types as CT
 

--- a/src/Idris/IdeSlave.hs
+++ b/src/Idris/IdeSlave.hs
@@ -79,12 +79,16 @@ instance SExpable NameOutput where
   toSExp DataOutput    = SymbolAtom "data"
   toSExp MetavarOutput = SymbolAtom "metavar"
 
+maybeProps :: SExpable a => [(String, Maybe a)] -> [(SExp, SExp)]
+maybeProps [] = []
+maybeProps ((n, Just p):ps) = (SymbolAtom n, toSExp p) : maybeProps ps
+maybeProps ((n, Nothing):ps) = maybeProps ps
+
 instance SExpable OutputAnnotation where
-  toSExp (AnnName n Nothing   _) = toSExp [(SymbolAtom "name", StringAtom (show n)),
-                                           (SymbolAtom "implicit", BoolAtom False)]
-  toSExp (AnnName n (Just ty) _) = toSExp [(SymbolAtom "name", StringAtom (show n)),
-                                           (SymbolAtom "decor", toSExp ty),
-                                           (SymbolAtom "implicit", BoolAtom False)]
+  toSExp (AnnName n ty d t) = toSExp $ [(SymbolAtom "name", StringAtom (show n)),
+                                        (SymbolAtom "implicit", BoolAtom False)] ++
+                                       maybeProps [("decor", ty)] ++
+                                       maybeProps [("doc-overview", d), ("type", t)]
   toSExp (AnnBoundName n imp)    = toSExp [(SymbolAtom "name", StringAtom (show n)),
                                            (SymbolAtom "decor", SymbolAtom "bound"),
                                            (SymbolAtom "implicit", BoolAtom imp)]

--- a/src/Idris/Output.hs
+++ b/src/Idris/Output.hs
@@ -1,0 +1,173 @@
+module Idris.Output where
+
+import Idris.Core.TT
+import Idris.Core.Evaluate (isDConName, isTConName, isFnName)
+
+import Idris.AbsSyntax
+import Idris.Delaborate
+import Idris.Docstrings
+import Idris.IdeSlave
+
+import Util.Pretty
+import Util.ScreenSize (getScreenWidth)
+
+import System.IO (stdout, Handle, hPutStrLn)
+
+pshow :: IState -> Err -> String
+pshow ist err = displayDecorated (consoleDecorate ist) .
+                renderPretty 1.0 80 .
+                fmap (fancifyAnnots ist) $ pprintErr ist err
+
+ihWarn :: Handle -> FC -> Doc OutputAnnotation -> Idris ()
+ihWarn h fc err = do i <- getIState
+                     case idris_outputmode i of
+                       RawOutput ->
+                         do err' <- iRender . fmap (fancifyAnnots i) $
+                                    text (show fc) <> colon <//> err
+                            runIO . hPutStrLn h $ displayDecorated (consoleDecorate i) err'
+                       IdeSlave n ->
+                         do err' <- iRender . fmap (fancifyAnnots i) $ err
+                            let (str, spans) = displaySpans err'
+                            runIO . hPutStrLn h $
+                              convSExp "warning" (fc_fname fc, fc_start fc, fc_end fc, str, spans) n
+
+iRender :: Doc a -> Idris (SimpleDoc a)
+iRender d = do w <- getWidth
+               ist <- getIState
+               let ideSlave = case idris_outputmode ist of
+                                IdeSlave _ -> True
+                                _          -> False
+               case w of
+                 InfinitelyWide -> return $ renderPretty 1.0 1000000000 d
+                 ColsWide n -> return $
+                               if n < 1
+                                 then renderPretty 1.0 1000000000 d
+                                 else renderPretty 0.8 n d
+                 AutomaticWidth | ideSlave  -> return $ renderPretty 1.0 1000000000 d
+                                | otherwise -> do width <- runIO getScreenWidth
+                                                  return $ renderPretty 0.8 width d
+
+ihPrintResult :: Handle -> String -> Idris ()
+ihPrintResult h s = do i <- getIState
+                       case idris_outputmode i of
+                         RawOutput -> case s of
+                                        "" -> return ()
+                                        s  -> runIO $ hPutStrLn h s
+                         IdeSlave n ->
+                             let good = SexpList [SymbolAtom "ok", toSExp s] in
+                             runIO $ hPutStrLn h $ convSExp "return" good n
+
+-- | Write a pretty-printed term to the console with semantic coloring
+consoleDisplayAnnotated :: Handle -> Doc OutputAnnotation -> Idris ()
+consoleDisplayAnnotated h output = do ist <- getIState
+                                      rendered <- iRender $ output
+                                      runIO . hPutStrLn h .
+                                        displayDecorated (consoleDecorate ist) $
+                                        rendered
+
+
+-- | Write pretty-printed output to IDESlave with semantic annotations
+ideSlaveReturnAnnotated :: Integer -> Handle -> Doc OutputAnnotation -> Idris ()
+ideSlaveReturnAnnotated n h out = do ist <- getIState
+                                     (str, spans) <- fmap displaySpans .
+                                                     iRender .
+                                                     fmap (fancifyAnnots ist) $
+                                                     out
+                                     let good = [SymbolAtom "ok", toSExp str, toSExp spans]
+                                     runIO . hPutStrLn h $ convSExp "return" good n
+
+ihPrintTermWithType :: Handle -> Doc OutputAnnotation -> Doc OutputAnnotation -> Idris ()
+ihPrintTermWithType h tm ty = do ist <- getIState
+                                 let output = tm <+> colon <+> ty
+                                 case idris_outputmode ist of
+                                   RawOutput -> consoleDisplayAnnotated h output
+                                   IdeSlave n -> ideSlaveReturnAnnotated n h output
+
+-- | Pretty-print a collection of overloadings to REPL or IDESlave - corresponds to :t name
+ihPrintFunTypes :: Handle -> [(Name, Bool)] -> Name -> [(Name, PTerm)] -> Idris ()
+ihPrintFunTypes h bnd n []        = ihPrintError h $ "No such variable " ++ show n
+ihPrintFunTypes h bnd n overloads = do imp <- impShow
+                                       ist <- getIState
+                                       let output = vsep (map (uncurry (ppOverload imp)) overloads)
+                                       case idris_outputmode ist of
+                                         RawOutput -> consoleDisplayAnnotated h output
+                                         IdeSlave n -> ideSlaveReturnAnnotated n h output
+  where fullName n = prettyName True bnd n
+        ppOverload imp n tm = fullName n <+> colon <+> align (pprintPTerm imp bnd [] tm)
+
+ihRenderResult :: Handle -> Doc OutputAnnotation -> Idris ()
+ihRenderResult h d = do ist <- getIState
+                        case idris_outputmode ist of
+                          RawOutput -> consoleDisplayAnnotated h d
+                          IdeSlave n -> ideSlaveReturnAnnotated n h d
+
+fancifyAnnots :: IState -> OutputAnnotation -> OutputAnnotation
+fancifyAnnots ist annot@(AnnName n _ _ _) =
+  do let ctxt = tt_ctxt ist
+         docs = docOverview ist n
+         ty   = Just (getTy ist n)
+     case () of
+       _ | isDConName    n ctxt -> AnnName n (Just DataOutput) docs ty
+       _ | isFnName      n ctxt -> AnnName n (Just FunOutput) docs ty
+       _ | isTConName    n ctxt -> AnnName n (Just TypeOutput) docs ty
+       _ | isMetavarName n ist  -> AnnName n (Just MetavarOutput) docs ty
+       _ | otherwise            -> annot
+  where docOverview :: IState -> Name -> Maybe String -- pretty-print first paragraph of docs
+        docOverview ist n = do docs <- lookupCtxtExact n (idris_docstrings ist)
+                               let o   = overview (fst docs)
+                                   -- TODO make width configurable
+                                   out = displayS . renderPretty 1.0 50 $ renderDocstring o
+                               return (out "")
+        getTy :: IState -> Name -> String -- fails if name not already extant!
+        getTy ist n = let theTy = pprintPTerm (opt_showimp (idris_options ist)) [] [] $
+                                  delabTy ist n
+                      in (displayS . renderPretty 1.0 50 $ theTy) ""
+fancifyAnnots _ annot = annot
+
+-- | Show an error with semantic highlighting
+ihRenderError :: Handle -> Doc OutputAnnotation -> Idris ()
+ihRenderError h e = do ist <- getIState
+                       case idris_outputmode ist of
+                         RawOutput -> consoleDisplayAnnotated h e
+                         IdeSlave n -> do
+                           (str, spans) <- fmap displaySpans .
+                                           iRender .
+                                           fmap (fancifyAnnots ist) $
+                                           e
+                           let good = [SymbolAtom "error", toSExp str, toSExp spans]
+                           runIO . hPutStrLn h $ convSExp "return" good n
+
+ihPrintError :: Handle -> String -> Idris ()
+ihPrintError h s = do i <- getIState
+                      case idris_outputmode i of
+                        RawOutput -> case s of
+                                          "" -> return ()
+                                          s  -> runIO $ hPutStrLn h s
+                        IdeSlave n ->
+                          let good = SexpList [SymbolAtom "error", toSExp s] in
+                          runIO . hPutStrLn h $ convSExp "return" good n
+
+ihputStrLn :: Handle -> String -> Idris ()
+ihputStrLn h s = do i <- getIState
+                    case idris_outputmode i of
+                      RawOutput -> runIO $ hPutStrLn h s
+                      IdeSlave n -> runIO . hPutStrLn h $ convSExp "write-string" s n
+
+iputStrLn = ihputStrLn stdout
+iPrintError = ihPrintError stdout
+iPrintResult = ihPrintResult stdout
+iWarn = ihWarn stdout
+
+ideslavePutSExp :: SExpable a => String -> a -> Idris ()
+ideslavePutSExp cmd info = do i <- getIState
+                              case idris_outputmode i of
+                                   IdeSlave n -> runIO . putStrLn $ convSExp cmd info n
+                                   _ -> return ()
+
+-- this needs some typing magic and more structured output towards emacs
+iputGoal :: SimpleDoc OutputAnnotation -> Idris ()
+iputGoal g = do i <- getIState
+                case idris_outputmode i of
+                  RawOutput -> runIO $ putStrLn (displayDecorated (consoleDecorate i) g)
+                  IdeSlave n -> runIO . putStrLn $
+                                convSExp "write-goal" (displayS (fmap (fancifyAnnots i) g) "") n

--- a/src/Idris/ParseHelpers.hs
+++ b/src/Idris/ParseHelpers.hs
@@ -17,6 +17,7 @@ import Idris.Core.TT
 import Idris.Core.Evaluate
 import Idris.Delaborate (pprintErr)
 import Idris.Docstrings
+import Idris.Output (ihWarn)
 
 import qualified Util.Pretty as Pretty (text)
 

--- a/src/Idris/Parser.hs
+++ b/src/Idris/Parser.hs
@@ -29,6 +29,7 @@ import Idris.Coverage
 import Idris.IBC
 import Idris.Unlit
 import Idris.Providers
+import Idris.Output
 
 import Idris.ParseHelpers
 import Idris.ParseOps

--- a/src/Idris/Prover.hs
+++ b/src/Idris/Prover.hs
@@ -15,6 +15,7 @@ import Idris.Error
 import Idris.DataOpts
 import Idris.Completion
 import Idris.IdeSlave
+import Idris.Output
 
 import Text.Trifecta.Result(Result(..))
 

--- a/src/Idris/REPL.hs
+++ b/src/Idris/REPL.hs
@@ -27,6 +27,7 @@ import Idris.Colours hiding (colourise)
 import Idris.Inliner
 import Idris.CaseSplit
 import Idris.DeepSeq
+import Idris.Output
 
 import Paths_idris
 import Version_idris (gitHash)
@@ -532,7 +533,7 @@ process h fn (Check (PRef _ n))
     putTy imp ist _ bnd sc = putGoal imp ist ((n,False):bnd) sc
     putGoal imp ist bnd g
                = text "--------------------------------------" <$>
-                 annotate (AnnName n Nothing Nothing) (text $ show n) <+> colon <+>
+                 annotate (AnnName n Nothing Nothing Nothing) (text $ show n) <+> colon <+>
                  align (tPretty bnd ist g)
 
     tPretty bnd ist t = pprintPTerm (opt_showimp (idris_options ist)) bnd [] t

--- a/src/Pkg/Package.hs
+++ b/src/Pkg/Package.hs
@@ -17,6 +17,7 @@ import Data.List.Split(splitOn)
 import Idris.Core.TT
 import Idris.REPL
 import Idris.AbsSyntax
+import Idris.Output
 
 import IRTS.System
 


### PR DESCRIPTION
IDESlave now decorates names with their type signatures and the first paragraph of their documentation strings. This is used in Emacs to show docs and types in tooltips on identifiers.
