### PR TITLE
changed the first sentence of the readme

### DIFF
--- a/README
+++ b/README
@@ -1,4 +1,4 @@
-Idris (http://idris-lang.org/) is an experimental functional programming 
+Idris (http://idris-lang.org/) is a general-purpose functional programming 
 language with dependent types.
 
 To configure, edit config.mk. The default values should work for most people.


### PR DESCRIPTION
The Idris website says that Idris is a "general-purpose" programming language.  The readme should match that, put the right first impression in people's minds and all that jazz.
