### PR TITLE
Show terms more prettily

### DIFF
--- a/src/Idris/AbsSyntaxTree.hs
+++ b/src/Idris/AbsSyntaxTree.hs
@@ -1432,7 +1432,9 @@ showName ist bnd impl colour n = case ist of
 showTm :: IState -- ^^ the Idris state, for information about identifiers and colours
        -> PTerm  -- ^^ the term to show
        -> String
-showTm ist = displayDecorated (consoleDecorate ist) . renderCompact . prettyImp (opt_showimp (idris_options ist))
+showTm ist = displayDecorated (consoleDecorate ist) .
+             renderPretty 0.8 100000 .
+             prettyImp (opt_showimp (idris_options ist))
 
 -- | Show a term with implicits, no colours
 showTmImpls :: PTerm -> String


### PR DESCRIPTION
Now, a different pretty-print renderer is used for showTm. This should
improve display in various places in the code that don't yet work with
pretty-printer documents natively.

RE #1019 , this seems to fix the printing problem but not the IBC problem.
