### PR TITLE
Add instance Uninhabited _|_

### DIFF
--- a/libs/prelude/Prelude/Uninhabited.idr
+++ b/libs/prelude/Prelude/Uninhabited.idr
@@ -8,6 +8,9 @@ class Uninhabited t where
   ||| @ t the uninhabited type
   total uninhabited : t -> _|_
 
+instance Uninhabited _|_ where
+  uninhabited a = a
+
 ||| Use an absurd assumption to discharge a proof obligation
 ||| @ t some empty type
 ||| @ a the goal type


### PR DESCRIPTION
I'm playing around but seems like I should be able to write this:

```
false : _|_ -> a
false = absurd
```

But we don't have an `Uninhabited` instance for `_|_` - the easiest one:

```
instance Uninhabited _|_ where
  uninhabited a = a
```

The implementation is just `id`!
