### PR TITLE
Fix test reg039 and add it to idris.cabal

### DIFF
--- a/idris.cabal
+++ b/idris.cabal
@@ -227,6 +227,9 @@ Extra-source-files:
                        test/reg038/run
                        test/reg038/*.idr
                        test/reg038/expected
+                       test/reg039/run
+                       test/reg039/*.idr
+                       test/reg039/expected
 
                        test/basic001/run
                        test/basic001/*.idr

--- a/test/reg039/run
+++ b/test/reg039/run
@@ -22,5 +22,11 @@ timeout() {
 
 }
 
-timeout 60 "idris $@ --nocolour reg039.idr --exec go"
+declare -a extraargs
+for arg in "$@"
+do
+    extraargs=("${extraargs[@]}" "'$arg'")
+done
+
+timeout 60 "idris ${extraargs[*]} --nocolour reg039.idr --exec go"
 rm -f reg039 *.ibc


### PR DESCRIPTION
It otherwise broke if more than one additional argument was passed, such as `--codegen llvm` when making `test_llvm`. This went unnoticed because travis only gets what’s in `idris.cabal`.
