### PR TITLE
Add -D_GNU_SOURCE flag to RTS CFLAGS

### DIFF
--- a/rts/Makefile
+++ b/rts/Makefile
@@ -4,7 +4,7 @@ OBJS = idris_rts.o idris_heap.o idris_gc.o idris_gmp.o idris_bitstring.o \
        idris_opts.o idris_stats.o mini-gmp.o
 HDRS = idris_rts.h idris_heap.h idris_gc.h idris_gmp.h idris_bitstring.h \
        idris_opts.h idris_stats.h mini-gmp.h
-CFLAGS:=-fPIC $(CFLAGS)
+CFLAGS:=-fPIC -D_GNU_SOURCE $(CFLAGS)
 CFLAGS += $(GMP_INCLUDE_DIR) $(GMP)
 
 ifeq ($(OS), windows)


### PR DESCRIPTION
This should fix Ubuntu 10.04 and allow Try Idris to be upgraded.

Unsure of portability but still compiles on Mac OS X 10.9 Mavericks.

This fixes #1059!
