### PR TITLE
Make assert_smaller : a -> b -> b

### DIFF
--- a/libs/prelude/Builtins.idr
+++ b/libs/prelude/Builtins.idr
@@ -90,7 +90,7 @@ trace_malloc x = x -- compiled specially
 ||| x (which is typically a pattern argument)
 ||| @ x the larger value (typically a pattern argument)
 ||| @ y the smaller value (typically an argument to a recursive call)
-assert_smaller : (x, y : a) -> a
+assert_smaller : (x : a) -> (y : b) -> b
 assert_smaller x y = y
 
 ||| Assert to the totality checker than the given expression will always

--- a/src/IRTS/Compiler.hs
+++ b/src/IRTS/Compiler.hs
@@ -221,7 +221,7 @@ irTerm vs env tm@(App f a) = case unApply tm of
         | l == txt "Force"
         -> LForce <$> irTerm vs env arg
 
-    (P _ (UN a) _, [_, _, arg])
+    (P _ (UN a) _, [_, _, _, arg])
         | a == txt "assert_smaller"
         -> irTerm vs env arg
 

--- a/src/Idris/Coverage.hs
+++ b/src/Idris/Coverage.hs
@@ -517,7 +517,7 @@ buildSCG' ist pats args = nub $ concatMap scgPat pats where
       -- find which argument in pargs <a> is smaller than, if any
       checkSize a (p : ps) i
           | a == p = Just (i, Same)
-          | (P _ (UN as) _, [_,arg,_]) <- unApply a,
+          | (P _ (UN as) _, [_,_,arg,_]) <- unApply a,
             as == txt "assert_smaller" && arg == p
                   = Just (i, Smaller)
           | smaller Nothing a (p, Nothing) = Just (i, Smaller)


### PR DESCRIPTION
Allow second argument of assert_smaller to be of different type than first argument since this could be useful for functions that arewritten with Universe-style pattern matching, i.e., where the rhs
pattern has different type than the lhs expression.
