### PR TITLE
Correct opening brace in implicits in pprinter

### DIFF
--- a/src/Idris/AbsSyntaxTree.hs
+++ b/src/Idris/AbsSyntaxTree.hs
@@ -1133,7 +1133,7 @@ pprintPTerm impl bnd docArgs = prettySe 10 bnd
     prettySe p bnd (PPi (Imp l s _) n ty sc)
       | impl =
           bracket p 2 $
-          lparen <> bindingOf n True <+> colon <+> prettySe 10 bnd ty <> rbrace <+>
+          lbrace <> bindingOf n True <+> colon <+> prettySe 10 bnd ty <> rbrace <+>
           st <> text "->" </> prettySe 10 ((n, True):bnd) sc
       | otherwise = prettySe 10 ((n, True):bnd) sc
       where


### PR DESCRIPTION
Before:
    Prelude.Basics.id : (a : Type} -> (__pi_arg : a) -> a

After:
    Prelude.Basics.id : {a : Type} -> (__pi_arg : a) -> a

Fixes #1096
