### PR TITLE
Improvement/refactorpis

### DIFF
--- a/src/Idris/ParseExpr.hs
+++ b/src/Idris/ParseExpr.hs
@@ -801,7 +801,7 @@ pi syn =
                  <|> (do x <- opExpr syn
                          (do symbol "->"
                              sc <- expr syn
-                             return (PPi (Exp opts st False) (sMN 0 "__pi_arg") x sc))
+                             return (PPi (Exp opts st False) (sUN "__pi_arg") x sc))
                           <|> return x)
   <?> "dependent type signature"
 

--- a/src/Idris/ParseOps.hs
+++ b/src/Idris/ParseOps.hs
@@ -38,8 +38,7 @@ table fixes
        ++ toTable (reverse fixes) ++
       [[backtick],
        [binary "$" (\fc x y -> flatten $ PApp fc x [pexp y]) AssocRight],
-       [binary "="  PEq AssocLeft]] --,
-     --  [binary "->" (\fc x y -> PPi expl (sUN "__pi_arg") x y) AssocRight]]
+       [binary "="  PEq AssocLeft]]
   where
     flatten :: PTerm -> PTerm -- flatten application
     flatten (PApp fc (PApp _ f as) bs) = flatten (PApp fc f (as ++ bs))


### PR DESCRIPTION
This PR refactors the grammar of dependent type signatures, such as to minimise lookahead and improve error reporting.

Before this PR, any error in the type signature would result in an error location at the start of the signature, while now it should behave a bit more sensibly.
