### PR TITLE
Fix unmatching braces in pretty printed types

### DIFF
--- a/src/Idris/AbsSyntaxTree.hs
+++ b/src/Idris/AbsSyntaxTree.hs
@@ -1174,7 +1174,7 @@ pprintPTerm impl bnd docArgs = prettySe 10 bnd
     prettySe p bnd (PPi (Imp l s _) n ty sc)
       | impl =
           bracket p 2 $
-          lparen <> bindingOf n True <+> colon <+> prettySe 10 bnd ty <> rbrace <+>
+          lbrace <> bindingOf n True <+> colon <+> prettySe 10 bnd ty <> rbrace <+>
           st <> text "->" </> prettySe 10 ((n, True):bnd) sc
       | otherwise = prettySe 10 ((n, True):bnd) sc
       where


### PR DESCRIPTION
The left brace of an implicit argument was a parenthesis:

```
Idris> :doc range
Prelude.Vect.range : (n : Prelude.Nat.Nat} -> Prelude.Vect.Vect n (Prelude.Fin.Fin n)
```
