### PR TITLE
add backend selection flags.

### DIFF
--- a/idris.cabal
+++ b/idris.cabal
@@ -465,6 +465,21 @@ Flag LLVM
   Default:      False
   manual:       True
 
+Flag Cee
+  Description:  Build the C backend
+  Default:      True
+  manual:       True
+
+Flag Java
+  Description:  Build the Java backend
+  Default:      False
+  manual:       True
+
+Flag JavaScript
+  Description:  Build the JavaScript backend
+  Default:      False
+  manual:       True
+
 Flag FFI
   Description:  Build support for libffi
   Default:      False
@@ -547,18 +562,11 @@ Library
 
                 , IRTS.BCImp
                 , IRTS.Bytecode
-                , IRTS.CodegenC
                 , IRTS.CodegenCommon
-                , IRTS.CodegenJava
-                , IRTS.CodegenJavaScript
                 , IRTS.Compiler
                 , IRTS.Defunctionalise
                 , IRTS.DumpBC
                 , IRTS.Inliner
-                , IRTS.Java.ASTBuilding
-                , IRTS.Java.JTypes
-                , IRTS.Java.Mangling
-                , IRTS.Java.Pom
                 , IRTS.Lang
                 , IRTS.Simplified
                 , IRTS.System
@@ -594,7 +602,6 @@ Library
                 , directory >= 1.2
                 , filepath
                 , haskeline >= 0.7
-                , language-java >= 0.2.6
                 , lens >= 4.1.1
                 , mtl
                 , parsers >= 0.9
@@ -644,6 +651,20 @@ Library
                   , llvm-general-pure == 3.3.8.*
   else
      other-modules: Util.LLVMStubs
+  if flag(Cee)
+     exposed-modules: IRTS.CodegenC
+     cpp-options:     -DIDRIS_CEE
+  if flag(Java)
+     exposed-modules: IRTS.CodegenJava
+                    , IRTS.Java.ASTBuilding
+                    , IRTS.Java.JTypes
+                    , IRTS.Java.Mangling
+                    , IRTS.Java.Pom
+     build-depends:   language-java >= 0.2.6
+     cpp-options:     -DIDRIS_JAVA
+  if flag(JavaScript)
+     exposed-modules: IRTS.CodegenJavaScript
+     cpp-options:     -DIDRIS_JAVASCRIPT
   if flag(FFI)
      build-depends: libffi
      cpp-options:   -DIDRIS_FFI

--- a/src/IRTS/Compiler.hs
+++ b/src/IRTS/Compiler.hs
@@ -6,10 +6,20 @@ import IRTS.Lang
 import IRTS.Defunctionalise
 import IRTS.Simplified
 import IRTS.CodegenCommon
+#ifdef IDRIS_CEE
 import IRTS.CodegenC
+#endif
+
+#ifdef IDRIS_JAVA
 import IRTS.CodegenJava
+#endif
+
 import IRTS.DumpBC
+
+#ifdef IDRIS_JAVASCRIPT
 import IRTS.CodegenJavaScript
+#endif
+
 #ifdef IDRIS_LLVM
 import IRTS.CodegenLLVM
 #else
@@ -48,6 +58,23 @@ import System.Environment
 import System.FilePath ((</>), addTrailingPathSeparator)
 
 import Paths_idris
+
+codegenFail :: String -> CodeGenerator
+codegenFail backend _ = fail msg
+    where msg = "This Idris was compiled without the " ++ backend ++ " backend."
+
+#ifndef IDRIS_CEE
+codegenC = codegenFail "C"
+#endif
+
+#ifndef IDRIS_JAVA
+codegenJava = codegenFail "Java"
+#endif
+
+#ifndef IDRIS_JAVASCRIPT
+codegenJavaScript = codegenFail "JavaScript"
+codegenNode = codegenFail "JavaScript"
+#endif
 
 compile :: Codegen -> FilePath -> Term -> Idris ()
 compile codegen f tm


### PR DESCRIPTION
Only the C codegen is included by default, which means hefty stuff like `language-java` doesn't get pulled in unless you really want it. To enable the rest:

``` bash
cabal configure -fJava -fJavaScript
...
```
