### PR TITLE
Fixes a problem with custom tactics using Intro & Induction

### DIFF
--- a/src/Idris/ElabTerm.hs
+++ b/src/Idris/ElabTerm.hs
@@ -1184,8 +1184,8 @@ reifyApp _ t [x]
 reifyApp ist t [l, r] | t == reflm "Seq" = liftM2 TSeq (reify ist l) (reify ist r)
 reifyApp ist t [Constant (Str n), x]
              | t == reflm "GoalType" = liftM (GoalType n) (reify ist x)
-reifyApp _ t [Constant (Str n)]
-           | t == reflm "Intro" = return $ Intro [sUN n]
+reifyApp _ t [n] | t == reflm "Intro" = liftM (Intro . (:[])) (reifyTTName n)
+reifyApp _ t [n] | t == reflm "Induction" = liftM Induction (reifyTTName n)
 reifyApp ist t [t']
              | t == reflm "ApplyTactic" = liftM (ApplyTactic . delab ist) (reifyTT t')
 reifyApp ist t [t']


### PR DESCRIPTION
When making applying a custom tactic using `applyTactic`, there were a few problems.
- `Intro` would previously fail with "Unknown Tactic". The problem appears to have been that the argument of `Intro` is _not_ a string, but rather the application of a constructor like `UN` or `MN`.
- `Induction` was not possible; I have added a line to `reifyApp` accordingly.

I'm unable to run the tests on my machine for some reason (#1109), so perhaps Travis will tell us whether this works. It does indeed some to solve my particular case.
