### PR TITLE
Change 'iota' syntax to allow spaces

### DIFF
--- a/libs/prelude/Prelude.idr
+++ b/libs/prelude/Prelude.idr
@@ -412,9 +412,9 @@ syntax "[" [start] ".." [end] "]"
 syntax "[" [start] "," [next] ".." [end] "]"
      = enumFromThenTo start (next - start) end
 
-syntax "[" [start] "..]"
+syntax "[" [start] ".." "]"
      = enumFrom start
-syntax "[" [start] "," [next] "..]"
+syntax "[" [start] "," [next] ".." "]"
      = enumFromThen start (next - start)
 
 ---- More utilities


### PR DESCRIPTION
For example, [ 1 ..] is allowed but not [ 1 .. ]. That is, "..]" is a token, instead of a ".." token followed by a "]" token. This patch does the latter.
