### PR TITLE
Fix #1015

### DIFF
--- a/src/Idris/Core/Elaborate.hs
+++ b/src/Idris/Core/Elaborate.hs
@@ -64,7 +64,7 @@ loadState :: Elab' aux ()
 loadState = do (ES p s e) <- get
                case e of
                   Just st -> put st
-                  _ -> fail "Nothing to undo"
+                  _ -> lift $ Error . Msg $ "Nothing to undo"
 
 getNameFrom :: Name -> Elab' aux Name
 getNameFrom n = do (ES (p, a) s e) <- get

--- a/src/Idris/Core/ProofState.hs
+++ b/src/Idris/Core/ProofState.hs
@@ -872,7 +872,7 @@ processTactic QED ps = case holes ps of
                            _  -> fail "Still holes to fill."
 processTactic ProofState ps = return (ps, showEnv [] (pterm ps))
 processTactic Undo ps = case previous ps of
-                            Nothing -> fail "Nothing to undo."
+                            Nothing -> Error . Msg $ "Nothing to undo."
                             Just pold -> return (pold, "")
 processTactic EndUnify ps
     = let (h, ns_in) = unified ps


### PR DESCRIPTION
Issuing 'undo' in the prover when there is
nothing to undo should result in a less
scary looking error message.
