### PR TITLE
Inserted a newline which seemed to be missing in the usage message.

### DIFF
--- a/main/Main.hs
+++ b/main/Main.hs
@@ -100,7 +100,7 @@ usagemsg = usagemsghdr ++ "\n" ++
            "\t    --clean IPKG            Clean package\n" ++
            "\t    --build IPKG            Build package\n" ++
            "\t    --mkdoc IPKG            Generate IdrisDoc for package\n" ++
-           "\t -e --eval EXPR             Evaluate an expression without loading the REPL" ++
+           "\t -e --eval EXPR             Evaluate an expression without loading the REPL\n" ++
            "\t    --exec EXPR             Execute as idris\n" ++
            "\t    --libdir                Display library directory\n" ++
            "\t    --link                  Display link flags\n" ++


### PR DESCRIPTION
Idris reported the help descriptions of '--eval' and '--exec' on the same line, when executing 'idris --help'
This file change simply reinserts a newline to fix the display issue.
