### PR TITLE
Allow the big startup banner to be disabled

### DIFF
--- a/CHANGELOG
+++ b/CHANGELOG
@@ -12,6 +12,7 @@ New in 0.9.13:
 * New (first class) nested record update/access syntax:
   record { a->b->c = val } x -- sets field accessed by c (b (a x)) to val
   record { a->b->c } x -- accesses field, equivalent to c (b (a x))
+* The banner at startup can be suppressed by adding :set nobanner to the initialisation script.
 
 Internal changes
 

--- a/src/Idris/Completion.hs
+++ b/src/Idris/Completion.hs
@@ -112,6 +112,7 @@ completeOption = completeWord Nothing " \t" completeOpt
                                               , "showimplicits"
                                               , "originalerrors"
                                               , "autosolve"
+                                              , "nobanner"
                                               ]
 
 completeConsoleWidth :: CompletionFunc Idris

--- a/src/Idris/REPL.hs
+++ b/src/Idris/REPL.hs
@@ -1031,6 +1031,8 @@ process h fn (SetOpt ShowOrigErr)   = setShowOrigErr True
 process h fn (UnsetOpt ShowOrigErr) = setShowOrigErr False
 process h fn (SetOpt AutoSolve)     = setAutoSolve True
 process h fn (UnsetOpt AutoSolve)   = setAutoSolve False
+process h fn (SetOpt NoBanner)      = setNoBanner True
+process h fn (UnsetOpt NoBanner)    = setNoBanner False
 
 process h fn (SetOpt _) = iPrintError "Not a valid option"
 process h fn (UnsetOpt _) = iPrintError "Not a valid option"
@@ -1353,6 +1355,7 @@ idrisMain opts =
        setVerbose verbose
        setCmdLine opts
        setOutputTy outty
+       setNoBanner nobanner
        setCodegen cgn
        setTargetTriple trpl
        setTargetCPU tcpu
@@ -1367,6 +1370,8 @@ idrisMain opts =
          (d:_) -> setIBCSubDir d
        setImportDirs importdirs
 
+       setNoBanner nobanner
+
        when (not (NoBasePkgs `elem` opts)) $ do
            addPkgDir "prelude"
            addPkgDir "base"
@@ -1376,6 +1381,11 @@ idrisMain opts =
                                                 return ()
        when (not (NoPrelude `elem` opts)) $ do x <- loadModule stdout "Prelude"
                                                return ()
+
+       when (runrepl && not idesl) initScript
+
+       nobanner <- getNoBanner
+
        when (runrepl &&
              not quiet &&
              not idesl &&
@@ -1426,7 +1436,6 @@ idrisMain opts =
 
        when (runrepl && not idesl) $ do
 --          clearOrigPats
-         initScript
          startServer orig inputs
          runInputT (replSettings (Just historyFile)) $ repl orig inputs
        when (idesl) $ ideslaveStart orig inputs

--- a/src/Idris/REPLParser.hs
+++ b/src/Idris/REPLParser.hs
@@ -119,6 +119,7 @@ pOption = do discard (P.symbol "errorcontext"); return ErrContext
       <|> do discard (P.symbol "showimplicits"); return ShowImpl
       <|> do discard (P.symbol "originalerrors"); return ShowOrigErr
       <|> do discard (P.symbol "autosolve"); return AutoSolve
+      <|> do discard (P.symbol "nobanner") ; return NoBanner
 
 codegenOption :: P.IdrisParser Codegen
 codegenOption = do discard (P.symbol "javascript"); return ViaJavaScript


### PR DESCRIPTION
This is done by adding `:set nobanner` to the init script.

Fixes #590.
