### PR TITLE
Pretty-print fixes

### DIFF
--- a/idris.cabal
+++ b/idris.cabal
@@ -235,6 +235,8 @@ Extra-source-files:
                        test/reg042/run
                        test/reg042/*.idr
                        test/reg042/expected
+                       test/reg043/run
+                       test/reg043/expected
 
                        test/basic001/run
                        test/basic001/*.idr

--- a/src/Idris/AbsSyntaxTree.hs
+++ b/src/Idris/AbsSyntaxTree.hs
@@ -1193,7 +1193,7 @@ pprintPTerm ppo bnd docArgs infixes = prettySe 10 bnd
           st <> text "->" <$> prettySe 10 ((n, False):bnd) sc
       | otherwise                      =
           bracket p 2 . group $
-          group (prettySe 0 bnd ty <+> st) <> text "->" <$> group (prettySe 10 ((n, False):bnd) sc)
+          group (prettySe 1 bnd ty <+> st) <> text "->" <$> group (prettySe 10 ((n, False):bnd) sc)
       where
         st =
           case s of
@@ -1253,7 +1253,7 @@ pprintPTerm ppo bnd docArgs infixes = prettySe 10 bnd
       | PConstant (Idris.Core.TT.Str str) <- getTm tm,
         f == sUN "Symbol_" = annotate AnnConstType $
                                char '\'' <> prettySe 10 bnd (PRef fc (sUN str))
-    prettySe p bnd (PApp _ f as) =
+    prettySe p bnd (PApp _ f as) = -- Normal prefix applications
       let args = getExps as
           fp   = prettySe 1 bnd f
       in

--- a/test/reg041/expected
+++ b/test/reg041/expected
@@ -1,3 +1,3 @@
 Type checking ./ott.idr
-?prf : (x : Bool) -> (x1 : Bool) -> (El (EQ two x two x1)) -> El (EQ two x two x1)
+?prf : (x : Bool) -> (x1 : Bool) -> El (EQ two x two x1) -> El (EQ two x two x1)
 Z

--- a/test/reg043/expected
+++ b/test/reg043/expected
@@ -1,0 +1,1 @@
+take : (m : Fin 3) -> Vect 2 Nat -> Vect (finToNat m) Nat

--- a/test/reg043/run
+++ b/test/reg043/run
@@ -1,0 +1,3 @@
+#!/usr/bin/env bash
+idris $@ --nocolour -e "Vect.take {n=2} {a=Nat}"
+


### PR DESCRIPTION
- Slightly better docs
- Show 'symbols as types in semantic highlighting (because they are)
- Better parenthesization of arrows
