### PR TITLE
Future-proof the TC' monad

### DIFF
--- a/src/Idris/Core/TC.hs
+++ b/src/Idris/Core/TC.hs
@@ -2,6 +2,7 @@
 
 module Idris.Core.TC(TC'(..)) where
 
+import Control.Applicative
 import Control.Monad
 import Control.Monad.Trans.Error(Error(..))
 
@@ -26,3 +27,11 @@ instance Error e => MonadPlus (TC' e) where
     _ `mplus` (OK y) = OK y
     err `mplus` _    = err
 
+
+instance Error e => Applicative (TC' e) where
+    pure = return
+    (<*>) = ap
+
+instance Error e => Alternative (TC' e) where
+    empty = mzero
+    (<|>) = mplus


### PR DESCRIPTION
In GHC 7.10 Monad instances will need to implement Applicative
and MonadPlus instances Alternative.

Just reuse the corresponding functions on the Monad/MonadPlus instances.

Fixes #1181
