### PR TITLE
Stop building packages if there are totality mismatches

### DIFF
--- a/idris.cabal
+++ b/idris.cabal
@@ -444,6 +444,10 @@ Extra-source-files:
                        test/totality006/run
                        test/totality006/*.idr
                        test/totality006/expected
+                       test/totality007/run
+                       test/totality007/*.ipkg
+                       test/totality007/src/*.idr
+                       test/totality007/expected
 
                        test/tutorial001/run
                        test/tutorial001/*.idr

--- a/test/totality007/expected
+++ b/test/totality007/expected
@@ -1,0 +1,3 @@
+Type checking ./Totality.idr
+Totality.idr:4:1:Totality.foo is not total as there are missing cases
+Totality.idr:4:1:Could not build: Totality.foo is not total as there are missing cases

--- a/test/totality007/run
+++ b/test/totality007/run
@@ -1,0 +1,3 @@
+#!/usr/bin/env bash
+idris $@ --build totality.ipkg
+rm -f src/*.ibc

--- a/test/totality007/src/Totality.idr
+++ b/test/totality007/src/Totality.idr
@@ -1,0 +1,4 @@
+module Totality
+
+total foo : Nat -> Nat
+foo Z = Z

--- a/test/totality007/totality.ipkg
+++ b/test/totality007/totality.ipkg
@@ -1,0 +1,7 @@
+package totality
+
+-- totality007
+-- Test that the package builder doesn't allow totality errors in a build
+opts = ""
+sourcedir = src
+modules = Totality


### PR DESCRIPTION
This is to stop libraries from preventing executables to build later.

Fixes #1214.
