### PR TITLE
incremented max allowed blaze markup version

### DIFF
--- a/idris.cabal
+++ b/idris.cabal
@@ -594,7 +594,7 @@ Library
                 , ansi-wl-pprint
                 , binary
                 , blaze-html >= 0.6.1.3
-                , blaze-markup >= 0.5.2.1 && < 0.6.0.0
+                , blaze-markup >= 0.5.2.1 && < 0.7.0.0
                 , bytestring
                 , cheapskate
                 , containers >= 0.5


### PR DESCRIPTION
Looked at the changes to blaze-markup between latest 0.5.x.x and latest 0.6.x.x versions, and they were benign.  Should we crank up the minimum version to the latest?
