### PR TITLE
Remove the windows header files from cabal

### DIFF
--- a/idris.cabal
+++ b/idris.cabal
@@ -67,7 +67,6 @@ Extra-source-files:
                        rts/*.c
                        rts/*.h
                        rts/windows/*.c
-                       rts/windows/*.h
                        rts/Makefile
 
                        libs/Makefile


### PR DESCRIPTION
They were removed in #1237 and cabal balks if a glob isn't matched by any file.
