### PR TITLE
Fix possible bug in alpha conversion

### DIFF
--- a/src/Idris/Core/TT.hs
+++ b/src/Idris/Core/TT.hs
@@ -1056,8 +1056,9 @@ uniqueName n hs | n `elem` hs = uniqueName (nextName n) hs
 
 uniqueBinders :: [Name] -> TT Name -> TT Name
 uniqueBinders ns (Bind n b sc)
-    = let n' = uniqueName n ns in
-          Bind n' (fmap (uniqueBinders (n':ns)) b) (uniqueBinders ns sc)
+    = let n' = uniqueName n ns
+          ns' = n' : ns in
+          Bind n' (fmap (uniqueBinders ns') b) (uniqueBinders ns' sc)
 uniqueBinders ns (App f a) = App (uniqueBinders ns f) (uniqueBinders ns a)
 uniqueBinders ns t = t
 


### PR DESCRIPTION
The function `uniqueBinders` in `Idris.Core.TT` is behaving differently than I expected. I expected that if `term :: TT Name`  has uniquely named binders, then for any list of names to avoid, `names :: [Name]`, we should have that `uniqueBinders names term :: TT Name` should still have uniquely named binders.

However, if we have a term `(a1 : Type) -> (a2 : Type) -> Type`, and we avoid the names `[a1,a2]`, then uniqueBinders ends up giving `(a3 : Type) -> (a3 : Type) -> Type`. With my pull request, the result will instead be `(a3 : Type) -> (a4 : Type) -> Type`.

I can't say with certainty that my change is correct (partially because there is no documentation saying what `uniqueBinders` _should_ do), but I thought I'd bring this up.

Also, I don't think the newly bound name has to be avoided in the binder type, either, since the newly bound name _isn't_ bound in the binder type. However, just to be safe, I left that as it is.
