### PR TITLE
Add a prim__systemInfo primitive.

### DIFF
--- a/idris.cabal
+++ b/idris.cabal
@@ -90,6 +90,7 @@ Extra-source-files:
                        libs/base/Language/Reflection/*.idr
                        libs/base/Makefile
                        libs/base/Network/*.idr
+                       libs/base/System/*.idr
                        libs/base/System/Concurrency/*.idr
                        libs/base/Syntax/*.idr
 

--- a/jsrts/Runtime-browser.js
+++ b/jsrts/Runtime-browser.js
@@ -1,3 +1,14 @@
 var __IDRRT__print = function(s) {
   console.log(s);
 };
+
+
+var __IDRRT__systemInfo = function(index) {
+    switch(index) {
+        case 0:
+            return "javascript";
+        case 1:
+            return navigator.platform;
+    }
+    return "";
+}

--- a/jsrts/Runtime-node.js
+++ b/jsrts/Runtime-node.js
@@ -4,3 +4,14 @@ var __IDRRT__print = (function() {
     util.print(s);
   };
 })();
+
+var __IDRRT__systemInfo = function(index) {
+    var os = require('os')
+    switch(index) {
+        case 0:
+            return "node";
+        case 1:
+            return os.platform();
+    }
+    return "";
+}

--- a/libs/base/System/Info.idr
+++ b/libs/base/System/Info.idr
@@ -1,0 +1,13 @@
+module System.Info
+
+||| The Idris backend in use
+backend : String
+backend = prim__systemInfo 0
+
+||| The operating system in use.
+os : String
+os = prim__systemInfo 1
+
+||| The triple this program was targeted for
+targetTriple : String
+targetTriple = prim__systemInfo 2

--- a/libs/base/base.ipkg
+++ b/libs/base/base.ipkg
@@ -6,6 +6,7 @@ modules = System,
           Network.Cgi, Network.Socket,
           Debug.Trace,
 
+          System.Info,
           System.Concurrency.Raw, System.Concurrency.Process,
 
           Decidable.Decidable, Decidable.Order,

--- a/rts/Makefile
+++ b/rts/Makefile
@@ -5,7 +5,8 @@ OBJS = idris_rts.o idris_heap.o idris_gc.o idris_gmp.o idris_bitstring.o \
 HDRS = idris_rts.h idris_heap.h idris_gc.h idris_gmp.h idris_bitstring.h \
        idris_opts.h idris_stats.h mini-gmp.h idris_stdfgn.h idris_net.h
 CFLAGS:=-fPIC $(CFLAGS)
-CFLAGS += $(GMP_INCLUDE_DIR) $(GMP)
+CFLAGS += $(GMP_INCLUDE_DIR) $(GMP) -DIDRIS_TARGET_OS="\"$(OS)\""
+CFLAGS += -DIDRIS_TARGET_TRIPLE="\"$(MACHINE)\""
 
 ifeq ($(OS), windows)
 	OBJS += windows/idris_stdfgn.o windows/idris_net.o

--- a/rts/idris_rts.c
+++ b/rts/idris_rts.c
@@ -506,6 +506,19 @@ VAL idris_strRev(VM* vm, VAL str) {
     return cl;
 }
 
+VAL idris_systemInfo(VM* vm, VAL index) {
+    int i = GETINT(index);
+    switch(i) {
+        case 0: // backend
+            return MKSTR(vm, "c");
+        case 1:
+            return MKSTR(vm, IDRIS_TARGET_OS);
+        case 2:
+            return MKSTR(vm, IDRIS_TARGET_TRIPLE);
+    }
+    return MKSTR(vm, "");
+}
+
 VAL MKBUFFERc(VM* vm, Buffer* buf) {
     Closure* cl = allocate(vm, sizeof(Closure) + sizeof *buf + buf->cap, 1);
     SETTY(cl, BUFFER);

--- a/rts/idris_rts.h
+++ b/rts/idris_rts.h
@@ -279,6 +279,12 @@ VAL idris_peekB64Native(VM* vm, VAL buf, VAL off);
 VAL idris_peekB64LE(VM* vm, VAL buf, VAL off);
 VAL idris_peekB64BE(VM* vm, VAL buf, VAL off);
 
+// system infox
+// used indices:
+//   0 returns backend
+//   1 returns OS
+VAL idris_systemInfo(VM* vm, VAL index);
+
 // Command line args
 
 extern int __idris_argc;

--- a/src/IRTS/CodegenC.hs
+++ b/src/IRTS/CodegenC.hs
@@ -493,6 +493,8 @@ doOp v (LChInt ITNative) args = v ++ creg (last args)
 doOp v (LChInt ITChar) args = doOp v (LChInt ITNative) args
 doOp v (LIntCh ITNative) args = v ++ creg (last args)
 doOp v (LIntCh ITChar) args = doOp v (LIntCh ITNative) args
+
+doOp v LSystemInfo [x] = v ++ "idris_systemInfo(vm, " ++ creg x ++ ")"
 doOp v LNoOp args = v ++ creg (last args)
 doOp _ op _ = "FAIL /* " ++ show op ++ " */"
 

--- a/src/IRTS/CodegenJavaScript.hs
+++ b/src/IRTS/CodegenJavaScript.hs
@@ -2508,6 +2508,8 @@ translateExpression (SOp op vars)
                                 JSNum (JSInt 1),
                                 JSBinOp "-" (JSProj (JSIdent v) "length") (JSNum (JSInt 1))
                               ]
+  | LSystemInfo <- op
+  , (arg:_) <- vars = jsCall "__IDRRT__systemInfo"  [JSVar arg]
   | LNullPtr    <- op
   , (_)         <- vars = JSNull
 

--- a/src/IRTS/Lang.hs
+++ b/src/IRTS/Lang.hs
@@ -55,6 +55,8 @@ data PrimFn = LPlus ArithTy | LMinus ArithTy | LTimes ArithTy
             -- Buffers
             | LAllocate
             | LAppendBuffer
+            -- system info
+            | LSystemInfo
             -- Note that for Bits8 only Native endianness is actually used
             -- and the user-exposed interface for Bits8 doesn't mention
             -- endianness

--- a/src/Idris/Primitives.hs
+++ b/src/Idris/Primitives.hs
@@ -184,7 +184,9 @@ primitives =
    Prim (sUN "prim__allocate") (ty [AType (ATInt (ITFixed IT64))] BufferType) 1 (p_allocate)
     (1, LAllocate) total,
    Prim (sUN "prim__appendBuffer") (ty [BufferType, AType (ATInt (ITFixed IT64)), AType (ATInt (ITFixed IT64)), AType (ATInt (ITFixed IT64)), AType (ATInt (ITFixed IT64)), BufferType] BufferType) 6 (p_appendBuffer)
-    (6, LAppendBuffer) partial
+    (6, LAppendBuffer) partial,
+    Prim (sUN "prim__systemInfo") (ty [AType (ATInt ITNative)] StrType) 1 (p_cantreduce)
+        (1, LSystemInfo) total
   ] ++ concatMap intOps [ITFixed IT8, ITFixed IT16, ITFixed IT32, ITFixed IT64, ITBig, ITNative, ITChar]
     ++ concatMap vecOps vecTypes
     ++ concatMap fixedOps [ITFixed IT8, ITFixed IT16, ITFixed IT32, ITFixed IT64] -- ITNative, ITChar, ATFloat ] ++ vecTypes


### PR DESCRIPTION
Add System.Info with os and backend functions.

Add system info to JS and C backends.
