### PR TITLE
Fixed case-splitting

### DIFF
--- a/src/Idris/CaseSplit.hs
+++ b/src/Idris/CaseSplit.hs
@@ -280,6 +280,8 @@ replaceSplits l ups = updateRHSs 1 (map (rep (expandBraces l)) ups)
     nshow t = show t
 
     -- if there's any {n} replace with {n=n}
+    -- but don't replace it in comments
+    expandBraces ('{' : '-' : xs) = '{' : '-' : xs
     expandBraces ('{' : xs)
         = let (brace, (_:rest)) = span (/= '}') xs in
               if (not ('=' `elem` brace))


### PR DESCRIPTION
On case-splitting `x` in `test_x x = ...` or `test1x x = ...` it was replacing both occurences
of `x` (including that one in `test_x`, e.g. making it `test_Z` and `test_(S k)`).

Most likely this fix does not cover all the possible cases and it should be
fixed further.
