### PR TITLE
Update optparse-applicative bound to match used features

### DIFF
--- a/idris.cabal
+++ b/idris.cabal
@@ -639,7 +639,7 @@ Library
                 , xml
                 , deepseq
                 , zlib
-                , optparse-applicative
+                , optparse-applicative >= 0.8
   Extensions:     MultiParamTypeClasses
                 , FunctionalDependencies
                 , FlexibleContexts


### PR DESCRIPTION
Having an earlier version than 0.8 was met with failure to compile.
