### PR TITLE
isInfixOf for List

### DIFF
--- a/libs/prelude/Prelude/List.idr
+++ b/libs/prelude/Prelude/List.idr
@@ -579,6 +579,9 @@ isSuffixOfBy p left right = isPrefixOfBy p (reverse left) (reverse right)
 isSuffixOf : Eq a => List a -> List a -> Bool
 isSuffixOf = isSuffixOfBy (==)
 
+isInfixOf : Eq a => List a -> List a -> Bool
+isInfixOf n h = any (isPrefixOf n) (tails h)
+
 --------------------------------------------------------------------------------
 -- Sorting
 --------------------------------------------------------------------------------


### PR DESCRIPTION
`isInfixOf` for List
- tested
- can't implement for `Vect` since there is no `tails`, how implement tails there?
- no auto tests written, since there are no tests for other (e.g. `isSuffixOf` etc)
