### PR TITLE
Add pi to overridable syntax in DSL blocks

### DIFF
--- a/CHANGELOG
+++ b/CHANGELOG
@@ -3,6 +3,8 @@ New in 0.9.14:
 * Support for running tests for a package with the tests section of .ipkg files and the
   --testpkg command-line option
 * Clearly distinguish between type providers and postulate providers at the use site
+* Allow dependent function syntax to be overridden in dsl blocks, similarly to
+  functions and let. The keyword for this is "pi".
 
 New in 0.9.13:
 --------------

--- a/idris.cabal
+++ b/idris.cabal
@@ -289,6 +289,9 @@ Extra-source-files:
                        test/dsl002/test
                        test/dsl002/*.idr
                        test/dsl002/expected
+                       test/dsl003/run
+                       test/dsl003/*.idr
+                       test/dsl003/expected
 
                        test/effects001/run
                        test/effects001/*.idr

--- a/src/Idris/AbsSyntaxTree.hs
+++ b/src/Idris/AbsSyntaxTree.hs
@@ -904,7 +904,8 @@ data DSL' t = DSL { dsl_bind    :: t,
                     index_first :: Maybe t,
                     index_next  :: Maybe t,
                     dsl_lambda  :: Maybe t,
-                    dsl_let     :: Maybe t
+                    dsl_let     :: Maybe t,
+                    dsl_pi      :: Maybe t
                   }
     deriving (Show, Functor)
 {-!
@@ -943,6 +944,7 @@ initDSL = DSL (PRef f (sUN ">>="))
               (PRef f (sUN "return"))
               (PRef f (sUN "<$>"))
               (PRef f (sUN "pure"))
+              Nothing
               Nothing
               Nothing
               Nothing

--- a/src/Idris/DeepSeq.hs
+++ b/src/Idris/DeepSeq.hs
@@ -291,12 +291,13 @@ instance NFData TypeInfo where
         rnf (TI x1 x2 x3 x4 x5) = rnf x1 `seq` rnf x2 `seq` rnf x3 `seq` rnf x4 `seq` rnf x5 `seq` ()
 
 instance (NFData t) => NFData (DSL' t) where
-        rnf (DSL x1 x2 x3 x4 x5 x6 x7 x8 x9)
+        rnf (DSL x1 x2 x3 x4 x5 x6 x7 x8 x9 x10)
           = rnf x1 `seq`
               rnf x2 `seq`
                 rnf x3 `seq`
                   rnf x4 `seq`
-                    rnf x5 `seq` rnf x6 `seq` rnf x7 `seq` rnf x8 `seq` rnf x9 `seq` ()
+                    rnf x5 `seq`
+                      rnf x6 `seq` rnf x7 `seq` rnf x8 `seq` rnf x9 `seq` rnf x10 `seq` ()
 
 instance NFData SynContext where
         rnf PatternSyntax = ()

--- a/src/Idris/IBC.hs
+++ b/src/Idris/IBC.hs
@@ -2191,7 +2191,7 @@ instance Binary Syntax where
                return (Rule x1 x2 x3)
 
 instance (Binary t) => Binary (DSL' t) where
-        put (DSL x1 x2 x3 x4 x5 x6 x7 x8 x9)
+        put (DSL x1 x2 x3 x4 x5 x6 x7 x8 x9 x10)
           = do put x1
                put x2
                put x3
@@ -2201,6 +2201,7 @@ instance (Binary t) => Binary (DSL' t) where
                put x7
                put x8
                put x9
+               put x10
         get
           = do x1 <- get
                x2 <- get
@@ -2211,7 +2212,8 @@ instance (Binary t) => Binary (DSL' t) where
                x7 <- get
                x8 <- get
                x9 <- get
-               return (DSL x1 x2 x3 x4 x5 x6 x7 x8 x9)
+               x10 <- get
+               return (DSL x1 x2 x3 x4 x5 x6 x7 x8 x9 x10)
 
 instance Binary SSymbol where
         put x

--- a/src/Idris/ParseData.hs
+++ b/src/Idris/ParseData.hs
@@ -209,12 +209,14 @@ dsl syn = do reserved "dsl"
                              first  = lookup "index_first" bs
                              next   = lookup "index_next" bs
                              leto   = lookup "let" bs
-                             lambda = lookup "lambda" bs in
+                             lambda = lookup "lambda" bs
+                             pi     = lookup "pi" bs in
                              initDSL { dsl_var = var,
                                        index_first = first,
                                        index_next = next,
                                        dsl_lambda = lambda,
-                                       dsl_let = leto }
+                                       dsl_let = leto,
+                                       dsl_pi = pi }
 
 {- | Checks DSL for errors -}
 -- FIXME: currently does nothing, check if DSL is really sane
@@ -235,6 +237,6 @@ overload syn = do o <- identifier <|> do reserved "let"
                        t <- expr syn
                        return (o, t)
                <?> "dsl overload declaratioN"
-    where overloadable = ["let","lambda","index_first","index_next","variable"]
+    where overloadable = ["let","lambda","pi","index_first","index_next","variable"]
 
 

--- a/test/dsl003/DSLPi.idr
+++ b/test/dsl003/DSLPi.idr
@@ -1,0 +1,38 @@
+module DSLPi
+
+data Ty = BOOL | INT | UNIT | ARR Ty Ty
+
+dsl simple_type
+  pi = ARR
+
+test1 : simple_type (BOOL -> INT -> UNIT) = BOOL `ARR` (INT `ARR` UNIT)
+test1 = refl
+
+using (vars : Vect n Ty)
+  infix 2 ===
+
+  data Expr : Vect n Ty -> Ty -> Type where
+    Var : (i : Fin n) -> Expr vars (index i vars)
+    (===) : Expr vars t -> Expr vars t -> Expr vars BOOL
+
+  data Spec : Vect n Ty -> Type where
+    ForAll : (t : Ty) -> Spec (t :: vars) -> Spec vars
+    ItHolds : Expr vars BOOL -> Spec vars
+
+  implicit exprSpec : Expr vars BOOL -> Spec vars
+  exprSpec = ItHolds
+
+dsl specs
+  pi = ForAll
+  variable = Var
+  index_first = fZ
+  index_next = fS
+
+test2 : Spec []
+test2 = specs ((x, y : INT) -> x === y)
+
+test3 : Spec []
+test3 = ForAll INT . ForAll INT . ItHolds $ Var (fS fZ) === Var fZ
+
+test4 : test2 = test3
+test4 = refl

--- a/test/dsl003/expected
+++ b/test/dsl003/expected
@@ -1,0 +1,2 @@
+ForAll INT (ForAll INT (ItHolds (Var (fS fZ) === Var fZ))) : Spec []
+refl : ARR BOOL (ARR INT UNIT) = ARR BOOL (ARR INT UNIT)

--- a/test/dsl003/run
+++ b/test/dsl003/run
@@ -1,0 +1,3 @@
+#!/usr/bin/env bash
+idris $@ --nocolour --check DSLPi.idr -e test1 -e test2
+rm -f *.ibc


### PR DESCRIPTION
Example, from the tests:

```
module DSLPi

data Ty = BOOL | INT | UNIT | ARR Ty Ty

dsl simple_type
  pi = ARR

test1 : simple_type (BOOL -> INT -> UNIT) = BOOL `ARR` (INT `ARR` UNIT)
test1 = refl

using (vars : Vect n Ty)
  infix 2 ===

  data Expr : Vect n Ty -> Ty -> Type where
    Var : (i : Fin n) -> Expr vars (index i vars)
    (===) : Expr vars t -> Expr vars t -> Expr vars BOOL

  data Spec : Vect n Ty -> Type where
    ForAll : (t : Ty) -> Spec (t :: vars) -> Spec vars
    ItHolds : Expr vars BOOL -> Spec vars

  implicit exprSpec : Expr vars BOOL -> Spec vars
  exprSpec = ItHolds

dsl specs
  pi = ForAll
  variable = Var
  index_first = fZ
  index_next = fS

test2 : Spec []
test2 = specs ((x, y : INT) -> x === y)

test3 : Spec []
test3 = ForAll INT . ForAll INT . ItHolds $ Var (fS fZ) === Var fZ

test4 : test2 = test3
test4 = refl
```
