### PR TITLE
Support builds that doesn't use cabal for libs and rts

### DIFF
--- a/idris.cabal
+++ b/idris.cabal
@@ -511,6 +511,11 @@ Flag release
   Default:      False
   manual:       True
 
+Flag freestanding
+  Description:  Build an Idris that doesn't use cabal
+  Default:      False
+  manual:       True
+
 Library
   hs-source-dirs: src
   Exposed-modules:
@@ -683,6 +688,9 @@ Library
   if flag(curses)
      build-depends: hscurses
      cpp-options:   -DCURSES
+  if flag(freestanding)
+     other-modules: Target_idris
+     cpp-options:   -DFREESTANDING
 
 Executable idris
   Main-is:        Main.hs

--- a/src/IRTS/CodegenC.hs
+++ b/src/IRTS/CodegenC.hs
@@ -7,7 +7,6 @@ import IRTS.Simplified
 import IRTS.System
 import IRTS.CodegenCommon
 import Idris.Core.TT
-import Paths_idris
 import Util.System
 
 import Numeric

--- a/src/IRTS/CodegenJavaScript.hs
+++ b/src/IRTS/CodegenJavaScript.hs
@@ -8,7 +8,7 @@ import IRTS.Lang
 import IRTS.Simplified
 import IRTS.CodegenCommon
 import Idris.Core.TT
-import Paths_idris
+import IRTS.System
 import Util.System
 
 import Control.Arrow

--- a/src/IRTS/CodegenLLVM.hs
+++ b/src/IRTS/CodegenLLVM.hs
@@ -9,7 +9,6 @@ import qualified Idris.Core.TT as TT
 import Idris.Core.TT (ArithTy(..), IntTy(..), NativeTy(..), nativeTyWidth)
 
 import Util.System
-import Paths_idris
 
 import LLVM.General.Context
 import LLVM.General.Diagnostic

--- a/src/IRTS/Compiler.hs
+++ b/src/IRTS/Compiler.hs
@@ -47,8 +47,6 @@ import System.Directory
 import System.Environment
 import System.FilePath ((</>), addTrailingPathSeparator)
 
-import Paths_idris
-
 compile :: Codegen -> FilePath -> Term -> Idris ()
 compile codegen f tm
    = do checkMVs  -- check for undefined metavariables

--- a/src/IRTS/System.hs
+++ b/src/IRTS/System.hs
@@ -1,6 +1,6 @@
 {-# LANGUAGE CPP #-}
-module IRTS.System(getTargetDir,getCC,getLibFlags,getIdrisLibDir,
-                   getIncFlags,getMvn,getExecutablePom) where
+module IRTS.System(getDataFileName, getDataDir, getTargetDir,getCC,getLibFlags,getIdrisLibDir,
+                   getIncFlags,getMvn,getExecutablePom, version) where
 
 import Util.System
 
@@ -9,7 +9,12 @@ import Data.Maybe (fromMaybe)
 import System.FilePath ((</>), addTrailingPathSeparator)
 import System.Environment
 
+#ifdef FREESTANDING
+import Target_idris
+import Paths_idris (version)
+#else
 import Paths_idris
+#endif
 
 getCC :: IO String
 getCC = fromMaybe "gcc" <$> environment "IDRIS_CC"

--- a/src/Idris/AbsSyntax.hs
+++ b/src/Idris/AbsSyntax.hs
@@ -14,8 +14,6 @@ import Idris.IdeSlave hiding (Opt(..))
 import IRTS.CodegenCommon
 import Util.DynamicLinker
 
-import Paths_idris
-
 import System.Console.Haskeline
 import System.IO
 

--- a/src/Idris/AbsSyntaxTree.hs
+++ b/src/Idris/AbsSyntaxTree.hs
@@ -15,8 +15,6 @@ import Util.DynamicLinker
 
 import Idris.Colours
 
-import Paths_idris
-
 import System.Console.Haskeline
 import System.IO
 

--- a/src/Idris/DSL.hs
+++ b/src/Idris/DSL.hs
@@ -3,7 +3,6 @@
 module Idris.DSL where
 
 import Idris.AbsSyntax
-import Paths_idris
 
 import Idris.Core.TT
 import Idris.Core.Evaluate

--- a/src/Idris/ElabDecls.hs
+++ b/src/Idris/ElabDecls.hs
@@ -19,7 +19,6 @@ import Idris.PartialEval
 import Idris.DeepSeq
 import Idris.Output (iputStrLn, pshow, iWarn)
 import IRTS.Lang
-import Paths_idris
 
 import Idris.Core.TT
 import Idris.Core.Elaborate hiding (Tactic(..))

--- a/src/Idris/IdrisDoc.hs
+++ b/src/Idris/IdrisDoc.hs
@@ -14,7 +14,7 @@ import Idris.AbsSyntax
 import Idris.Docs
 import Idris.Docstrings (nullDocstring)
 
-import Paths_idris (getDataFileName)
+import IRTS.System (getDataFileName)
 
 import Control.Monad (forM_)
 import Control.Monad.Trans.Error

--- a/src/Idris/Imports.hs
+++ b/src/Idris/Imports.hs
@@ -4,7 +4,6 @@ import Idris.AbsSyntax
 import Idris.Error
 
 import Idris.Core.TT
-import Paths_idris
 
 import System.FilePath
 import System.Directory

--- a/src/Idris/REPL.hs
+++ b/src/Idris/REPL.hs
@@ -34,7 +34,6 @@ import Idris.Interactive
 import Idris.WhoCalls
 import Idris.TypeSearch (searchByType)
 
-import Paths_idris
 import Version_idris (gitHash)
 import Util.System
 import Util.DynamicLinker
@@ -48,6 +47,7 @@ import Idris.Core.Constraints
 
 import IRTS.Compiler
 import IRTS.CodegenCommon
+import IRTS.System
 
 import Data.List.Split (splitOn)
 import qualified Data.Text as T

--- a/src/Pkg/PParser.hs
+++ b/src/Pkg/PParser.hs
@@ -10,8 +10,6 @@ import Idris.AbsSyntaxTree
 import Idris.ParseHelpers
 import Idris.CmdOptions
 
-import Paths_idris
-
 import Control.Monad.State.Strict
 import Control.Applicative
 

--- a/src/Pkg/Package.hs
+++ b/src/Pkg/Package.hs
@@ -29,8 +29,6 @@ import IRTS.System
 
 import Pkg.PParser
 
-import Paths_idris (getDataDir)
-
 -- To build a package:
 -- * read the package description
 -- * check all the library dependencies exist


### PR DESCRIPTION
This makes it possible to build idrises that don't depend on cabal to store the lib files. It is enabled by -f freestanding and takes the dir where the files will be in IDRIS_INSTALL_DIR (it can be either relative to the executable or an absolute path). It does nothing to actually place the files there (because this is presumably a prelude to building an installer or linux/bsd package)
