### PR TITLE
Fix typo in Idris network C code

### DIFF
--- a/rts/idris_net.c
+++ b/rts/idris_net.c
@@ -110,7 +110,7 @@ char* idrnet_sockaddr_ipv4(void* sockaddr) {
 }
 
 int idrnet_sockaddr_ipv4_port(void* sockaddr) {
-    struct sockaddr_in* addr = (struct sockaddr_in*) addr;
+    struct sockaddr_in* addr = (struct sockaddr_in*) sockaddr;
     return ((int) ntohs(addr->sin_port));  
 }
 


### PR DESCRIPTION
I've been getting a warning when I compile with GCC 4.8.2, and with good reason! I think I found what looks to be an obvious typo in the Idris network C code.
