### PR TITLE
Force UTF8 for all text reading / writing.

### DIFF
--- a/src/IRTS/CodegenC.hs
+++ b/src/IRTS/CodegenC.hs
@@ -17,6 +17,7 @@ import System.Exit
 import System.IO
 import System.Directory
 import System.FilePath ((</>), (<.>))
+import qualified System.IO.UTF8 as UTF8
 import Control.Monad
 
 codegenC :: CodeGenerator
@@ -50,12 +51,12 @@ codegenC' defs out exec incs objs libs flags dbg
          let h = concatMap toDecl (map fst bc)
          let cc = concatMap (uncurry toC) bc
          d <- getDataDir
-         mprog <- readFile (d </> "rts" </> "idris_main" <.> "c")
+         mprog <- UTF8.readFile (d </> "rts" </> "idris_main" <.> "c")
          let cout = headers incs ++ debug dbg ++ h ++ cc ++
                      (if (exec == Executable) then mprog else "")
          case exec of
            MavenProject -> putStrLn ("FAILURE: output type not supported")
-           Raw -> writeFile out cout
+           Raw -> UTF8.writeFile out cout
            _ -> do
              (tmpn, tmph) <- tempfile
              hPutStr tmph cout

--- a/src/IRTS/CodegenJava.hs
+++ b/src/IRTS/CodegenJava.hs
@@ -30,6 +30,7 @@ import           System.Directory
 import           System.Exit
 import           System.FilePath
 import           System.IO
+import qualified System.IO.UTF8 as UTF8
 import           System.Process
 
 -----------------------------------------------------------------------
@@ -97,7 +98,7 @@ generateJavaFile globalInit defs hdrs srcDir out = do
     let code = either error
                       (prettyPrint)-- flatIndent . prettyPrint)
                       (evalStateT (mkCompilationUnit globalInit defs hdrs out) mkCodeGenEnv)
-    writeFile (javaFileName srcDir out) code
+    UTF8.writeFile (javaFileName srcDir out) code
 
 pomFileName :: FilePath -> FilePath
 pomFileName tgtDir = tgtDir </> "pom.xml"
@@ -106,7 +107,7 @@ generatePom :: FilePath -> -- tgt dir
                FilePath -> -- output target
                [String] -> -- libs
                IO ()
-generatePom tgtDir out libs = writeFile (pomFileName tgtDir) execPom
+generatePom tgtDir out libs = UTF8.writeFile (pomFileName tgtDir) execPom
   where
     (Ident clsName) = either error id (mkClassName out)
     execPom = pomString clsName (takeBaseName out) libs

--- a/src/IRTS/CodegenJavaScript.hs
+++ b/src/IRTS/CodegenJavaScript.hs
@@ -23,6 +23,7 @@ import Data.Word
 import Data.Traversable hiding (mapM)
 import System.IO
 import System.Directory
+import qualified System.IO.UTF8 as UTF8
 
 import qualified Data.Map.Strict as M
 
@@ -394,10 +395,10 @@ codegenJS_all target definitions includes libs filename outputType = do
 
   included   <- concat <$> getIncludes includes
   path       <- (++) <$> getDataDir <*> (pure "/jsrts/")
-  idrRuntime <- readFile $ path ++ "Runtime-common.js"
-  tgtRuntime <- readFile $ concat [path, "Runtime", rt, ".js"]
+  idrRuntime <- UTF8.readFile $ path ++ "Runtime-common.js"
+  tgtRuntime <- UTF8.readFile $ concat [path, "Runtime", rt, ".js"]
   jsbn       <- if compileInfoNeedsBigInt info
-                   then readFile $ path ++ "jsbn/jsbn.js"
+                   then UTF8.readFile $ path ++ "jsbn/jsbn.js"
                    else return ""
   let runtime = (  header
                 ++ includeLibs libs
@@ -406,7 +407,7 @@ codegenJS_all target definitions includes libs filename outputType = do
                 ++ idrRuntime
                 ++ tgtRuntime
                 )
-  writeFile filename (  runtime
+  UTF8.writeFile filename (  runtime
                      ++ concatMap compileJS opt
                      ++ concatMap compileJS cons
                      ++ main
@@ -476,7 +477,7 @@ codegenJS_all target definitions includes libs filename outputType = do
         concatMap (\lib -> "var " ++ lib ++ " = require(\"" ++ lib ++"\");\n")
 
       getIncludes :: [FilePath] -> IO [String]
-      getIncludes = mapM readFile
+      getIncludes = mapM UTF8.readFile
 
       main :: String
       main =

--- a/src/IRTS/Compiler.hs
+++ b/src/IRTS/Compiler.hs
@@ -46,6 +46,7 @@ import System.IO
 import System.Directory
 import System.Environment
 import System.FilePath ((</>), addTrailingPathSeparator)
+import qualified System.IO.UTF8 as UTF8
 
 compile :: Codegen -> FilePath -> Term -> Idris ()
 compile codegen f tm
@@ -78,10 +79,10 @@ compile codegen f tm
         dumpDefun <- getDumpDefun
         case dumpCases of
             Nothing -> return ()
-            Just f -> runIO $ writeFile f (showCaseTrees defs)
+            Just f -> runIO $ UTF8.writeFile f (showCaseTrees defs)
         case dumpDefun of
             Nothing -> return ()
-            Just f -> runIO $ writeFile f (dumpDefuns defuns)
+            Just f -> runIO $ UTF8.writeFile f (dumpDefuns defuns)
         triple <- Idris.AbsSyntax.targetTriple
         cpu <- Idris.AbsSyntax.targetCPU
         optimise <- optLevel

--- a/src/IRTS/DumpBC.hs
+++ b/src/IRTS/DumpBC.hs
@@ -6,6 +6,7 @@ import Idris.Core.TT
 
 import IRTS.Bytecode
 import Data.List
+import qualified System.IO.UTF8 as UTF8
 
 interMap :: [a] -> [b] -> (a -> [b]) -> [b]
 interMap xs y f = concat (intersperse y (map f xs))
@@ -73,4 +74,4 @@ serialize decls =
       show name ++ ":\n" ++ interMap bcs "\n" (serializeBC 1)
 
 dumpBC :: [(Name, SDecl)] -> String -> IO ()
-dumpBC c output = writeFile output $ serialize $ map toBC c
+dumpBC c output = UTF8.writeFile output $ serialize $ map toBC c

--- a/src/Idris/Chaser.hs
+++ b/src/Idris/Chaser.hs
@@ -13,6 +13,7 @@ import Data.Time.Clock
 import Control.Monad.Trans
 import Control.Monad.State
 import Data.List
+import qualified System.IO.UTF8 as UTF8
 
 import Debug.Trace
 
@@ -129,7 +130,7 @@ buildTree built fp = btree [] fp
   children lit f done = -- idrisCatch
      do exist <- runIO $ doesFileExist f
         if exist then do
-            file_in <- runIO $ readFile f
+            file_in <- runIO $ UTF8.readFile f
             file <- if lit then tclift $ unlit f file_in else return file_in
             (_, modules, _) <- parseImports f file
             -- The chaser should never report warnings from sub-modules

--- a/src/Idris/Core/Execute.hs
+++ b/src/Idris/Core/Execute.hs
@@ -36,6 +36,7 @@ import Foreign.Ptr
 #endif
 
 import System.IO
+import qualified System.IO.UTF8 as UTF8
 
 #ifndef IDRIS_FFI
 execute :: Term -> Idris Term
@@ -244,7 +245,7 @@ execApp env ctxt (EP _ fp _) (_:fn:_:handle:_:rest)
     | fp == mkfprim,
       Just (FFun "idris_readStr" _ _) <- foreignFromTT fn
            = case handle of
-               EHandle h -> do contents <- execIO $ hGetLine h
+               EHandle h -> do contents <- execIO $ UTF8.hGetLine h
                                execApp env ctxt (EConstant (Str (contents ++ "\n"))) rest
                _ -> execFail . Msg $
                       "The argument to idris_readStr should be a handle, but it was " ++
@@ -395,7 +396,7 @@ getOp fn [EP _ fn' _]
                         return (EConstant (Str line))
 getOp fn [EHandle h]
     | fn == prs =
-              Just $ do contents <- execIO $ hGetLine h
+              Just $ do contents <- execIO $ UTF8.hGetLine h
                         return (EConstant (Str (contents ++ "\n")))
 getOp n args = getPrim n primitives >>= flip applyPrim args
     where getPrim :: Name -> [Prim] -> Maybe ([ExecVal] -> Maybe ExecVal)

--- a/src/Idris/IdrisDoc.hs
+++ b/src/Idris/IdrisDoc.hs
@@ -31,6 +31,7 @@ import qualified Data.Map as M hiding ((!))
 import qualified Data.Ord (compare)
 import qualified Data.Set as S
 import qualified Data.Text as T
+import qualified System.IO.UTF8 as UTF8
 
 import System.IO
 import System.IO.Error
@@ -381,7 +382,7 @@ createDocs ist nsd out =
          createIndex nss out
          -- Create an empty IdrisDoc file to signal 'out' is used for IdrisDoc
          if new -- But only if it not already existed...
-            then withFile (out </> "IdrisDoc") WriteMode ((flip hPutStr) "")
+            then withFile (out </> "IdrisDoc") WriteMode ((flip UTF8.hPutStr) "")
             else return ()
          copyDependencies out
          return $ Right ()

--- a/src/Idris/Parser.hs
+++ b/src/Idris/Parser.hs
@@ -68,7 +68,9 @@ import qualified Data.Set as S
 import Debug.Trace
 
 import System.FilePath
-import System.IO
+import System.IO (Handle(..))
+import qualified System.IO.UTF8 as UTF8
+
 
 {-
 @
@@ -1233,7 +1235,7 @@ loadSource h lidr f toline
              = do iLOG ("Reading " ++ f)
                   i <- getIState
                   let def_total = default_total i
-                  file_in <- runIO $ readFile f
+                  file_in <- runIO $ UTF8.readFile f
                   file <- if lidr then tclift $ unlit f file_in else return file_in
                   (mname, imports, pos) <- parseImports f file
                   ids <- allImportDirs

--- a/src/Pkg/PParser.hs
+++ b/src/Pkg/PParser.hs
@@ -12,7 +12,7 @@ import Idris.CmdOptions
 
 import Control.Monad.State.Strict
 import Control.Applicative
-
+import qualified System.IO.UTF8 as UTF8
 
 type PParser = StateT PkgDesc IdrisInnerParser
 
@@ -36,7 +36,7 @@ instance TokenParsing PParser where
 defaultPkg = PkgDesc "" [] [] Nothing [] "" [] (sUN "") Nothing []
 
 parseDesc :: FilePath -> IO PkgDesc
-parseDesc fp = do p <- readFile fp
+parseDesc fp = do p <- UTF8.readFile fp
                   case runparser pPkg defaultPkg fp p of
                        Failure err -> fail (show err)
                        Success x -> return x

--- a/src/Pkg/Package.hs
+++ b/src/Pkg/Package.hs
@@ -7,6 +7,7 @@ import System.Exit
 import System.IO
 import System.FilePath ((</>), addTrailingPathSeparator, takeFileName, takeDirectory, normalise)
 import System.Directory (createDirectoryIfMissing, copyFile)
+import qualified System.IO.UTF8 as UTF8
 
 import Util.System
 
@@ -168,7 +169,7 @@ testPkg fp
                make (makefile pkgdesc)
                -- Get a temporary file to save the tests' source in
                (tmpn, tmph) <- tempIdr
-               hPutStrLn tmph $
+               UTF8.hPutStrLn tmph $
                  "module Test_______\n" ++
                  concat ["import " ++ show m ++ "\n"
                          | m <- modules pkgdesc] ++


### PR DESCRIPTION
Replaced all usages of readFile, writeFile, hGetLine, and hPutStrLn from
Prelude with versions from
[System.IO.UTF8](http://hackage.haskell.org/package/utf8-string-0.3.8/docs/System-IO-UTF8.html)

Fixes #94

Tested with `export LANG=C`. Was able to load a unicode-containing .idr
file, compile and run it, use interactive vim stuff like
case-splitting and proof search, and could also :addproof from the repl.

Technically, only the change to readFile in Idris/Chaser.hs is necessary
to fix #94.  The rest are mainly for consistency.  I am a little leary
of changing the output encoding to unicode when the system encoding
might not be that on the things that don't deal with idris code, e.g.
the .c, .java, .pom, etc output files, that are then run through gcc,
javac, whatever.

Also, this might address the issue fixed by #1334, and make #1334
redunant?
