### PR TITLE
Prover output color

### DIFF
--- a/src/Idris/AbsSyntaxTree.hs
+++ b/src/Idris/AbsSyntaxTree.hs
@@ -761,6 +761,7 @@ data PTactic' t = Intro [Name] | Intros | Focus Name
                 | GoalType String (PTactic' t)
                 | TCheck t
                 | TEval t
+                | TDocStr (Either Name Const)
                 | Qed | Abandon
     deriving (Show, Eq, Functor)
 {-!

--- a/src/Idris/ParseExpr.hs
+++ b/src/Idris/ParseExpr.hs
@@ -1285,6 +1285,16 @@ tactic syn = do reserved "intro"; ns <- sepBy (indentPropHolds gtProp *> name) (
                           t <- (indentPropHolds gtProp *> expr syn);
                           i <- get
                           return $ TCheck (desugar syn i t))
+                  <|> try (do reserved "doc"
+                              whiteSpace
+                              c <- constant
+                              eof
+                              return (TDocStr (Right c)))
+                  <|> try (do reserved "doc"
+                              whiteSpace
+                              n <- (fnName <|> (string "_|_" >> return falseTy))
+                              eof
+                              return (TDocStr (Left n)))
                   <?> "prover command")
           <?> "tactic"
   where


### PR DESCRIPTION
This makes the prover follow the IDESlave protocol better. It also adds support for :doc, which is perhaps most useful in the IDE. :search is on the way.
