### PR TITLE
Make type search work in the prover

### DIFF
--- a/src/Idris/AbsSyntaxTree.hs
+++ b/src/Idris/AbsSyntaxTree.hs
@@ -762,6 +762,7 @@ data PTactic' t = Intro [Name] | Intros | Focus Name
                 | TCheck t
                 | TEval t
                 | TDocStr (Either Name Const)
+                | TSearch t
                 | Qed | Abandon
     deriving (Show, Eq, Functor)
 {-!

--- a/src/Idris/ParseExpr.hs
+++ b/src/Idris/ParseExpr.hs
@@ -1298,6 +1298,11 @@ tactic syn = do reserved "intro"; ns <- sepBy (indentPropHolds gtProp *> name) (
                               n <- (fnName <|> (string "_|_" >> return falseTy))
                               eof
                               return (TDocStr (Left n)))
+                  <|> try (do reserved "search"
+                              whiteSpace
+                              t <- (indentPropHolds gtProp *> expr syn);
+                              i <- get
+                              return $ TSearch (desugar syn i t))
                   <?> "prover command")
           <?> "tactic"
   where

--- a/src/Idris/Prover.hs
+++ b/src/Idris/Prover.hs
@@ -18,6 +18,7 @@ import Idris.DataOpts
 import Idris.Completion
 import Idris.IdeSlave
 import Idris.Output
+import Idris.TypeSearch (searchByType)
 
 import Text.Trifecta.Result(Result(..))
 
@@ -227,6 +228,7 @@ ploop fn d prompt prf e h
               Success (TCheck t) -> checkType t
               Success (TEval t)  -> evalTerm t e
               Success (TDocStr x) -> docStr x
+              Success (TSearch t) -> search t
               Success tac -> do (_, e) <- elabStep e saveState
                                 (_, st) <- elabStep e (runTac autoSolve i fn tac)
                                 return (True, st, False, prf ++ [step], Right $ iPrintResult ""))
@@ -318,3 +320,6 @@ ploop fn d prompt prf e h
         docStr (Right c) = do ist <- getIState
                               let h = idris_outh ist
                               return (False, e, False, prf, Right . ihRenderResult h $ pprintConstDocs ist c (constDocs c))
+        search t = do ist <- getIState
+                      let h = idris_outh ist
+                      return (False, e, False, prf, Right $ searchByType h t)


### PR DESCRIPTION
This patch does two things:
1. It adds support for a new prover command, :search, with the same
   syntax and semantics as the REPL command
2. It makes :search work properly with IDESlave, enabling type search
   from the Emacs prover as well as enabling length-limits in the IRC bot
   again.
