### PR TITLE
Fix erasure from data constructors

### DIFF
--- a/src/IRTS/Compiler.hs
+++ b/src/IRTS/Compiler.hs
@@ -297,7 +297,7 @@ irTerm vs env tm@(App f a) = case unApply tm of
         -- hence it takes a lambda: \unerased_argname_list -> resulting_LExp.
         let padLams = padLambdas used (length args) arity
 
-        case compare arity (length args) of
+        case compare (length args) arity of
 
             -- overapplied
             GT  -> ifail ("overapplied data constructor: " ++ show tm)


### PR DESCRIPTION
The comparison `compare arity (length args)` is backwards. Strangely enough, I can't construct a failing testcase because other features of the language seem to always exactly saturate data constructors — and that's probably also the reason that the bug has not manifested so far.

This also means that all that elaborate code that handles underapplied data constructors is 1) unused 2) untested. Maybe we should delete it.

[On the other hand, I'm now experimenting with erasure from functions (arguments are actually _removed_, not `NULL`ed) so if that turns out to be a worthwhile optimisation, that code will actually be put to use.]
