### PR TITLE
Fix a bug in qsort

### DIFF
--- a/test/totality003/totality003.idr
+++ b/test/totality003/totality003.idr
@@ -3,5 +3,5 @@ module smaller
 total
 qsort : Ord a => List a -> List a
 qsort [] = []
-qsort (x :: xs) = qsort (assert_smaller (x :: xs) (filter (<= x) xs)) ++ 
+qsort (x :: xs) = qsort (assert_smaller (x :: xs) (filter (< x) xs)) ++ 
                   (x :: qsort (assert_smaller (x :: xs) (filter (>= x) xs)))

--- a/test/totality003/totality003a.idr
+++ b/test/totality003/totality003a.idr
@@ -3,5 +3,5 @@ module smaller
 total
 qsort : Ord a => List a -> List a
 qsort [] = []
-qsort (x :: xs) = qsort (assert_smaller (x :: xs) (filter (<= x) xs)) ++ 
+qsort (x :: xs) = qsort (assert_smaller (x :: xs) (filter (< x) xs)) ++ 
                   (x :: qsort (filter (>= x) xs))


### PR DESCRIPTION
Try `qsort [3,3]`. Under the old code, you'd get `[3,3,3]` out.
