### PR TITLE
Allows parsing operators that start with “<==”

### DIFF
--- a/src/Idris/ParseExpr.hs
+++ b/src/Idris/ParseExpr.hs
@@ -522,7 +522,7 @@ app syn = do f <- reserved "mkForeign"
              return (dslify i ap)
 
        <|> do f <- simpleExpr syn
-              (do try $ symbol "<=="
+              (do try $ reservedOp "<=="
                   fc <- getFC
                   ff <- fnName
                   return (PLet (sMN 0 "match")


### PR DESCRIPTION
Fixes #1321
