### PR TITLE
Add Functor Monad and Applicative id instances

### DIFF
--- a/CONTRIBUTORS
+++ b/CONTRIBUTORS
@@ -8,6 +8,7 @@ Michael R. Bernstein
 Nicola Botta
 Edwin Brady
 David Raymond Christiansen
+Carter Charbonneau
 Jason Dagit
 Simon Fowler
 Google

--- a/libs/prelude/Prelude/Applicative.idr
+++ b/libs/prelude/Prelude/Applicative.idr
@@ -13,6 +13,10 @@ class Functor f => Applicative (f : Type -> Type) where
     pure  : a -> f a
     (<$>) : f (a -> b) -> f a -> f b
 
+instance Applicative id where
+    pure a = a
+    f <$> a = f a
+
 infixl 2 <$
 (<$) : Applicative f => f a -> f b -> f a
 a <$ b = map const a <$> b

--- a/libs/prelude/Prelude/Functor.idr
+++ b/libs/prelude/Prelude/Functor.idr
@@ -1,5 +1,7 @@
 module Prelude.Functor
 
+import Prelude.Basics
+
 ||| Functors
 ||| @ f the action of the functor on objects
 class Functor (f : Type -> Type) where
@@ -7,3 +9,6 @@ class Functor (f : Type -> Type) where
     ||| @ f the functor
     ||| @ m the morphism
     map : (m : a -> b) -> f a -> f b
+
+instance Functor id where
+    map f a = f a

--- a/libs/prelude/Prelude/Monad.idr
+++ b/libs/prelude/Prelude/Monad.idr
@@ -5,6 +5,7 @@ module Prelude.Monad
 import Builtins
 import Prelude.List
 import Prelude.Applicative
+import Prelude.Basics
 
 %access public
 
@@ -12,6 +13,9 @@ infixl 5 >>=
 
 class Applicative m => Monad (m : Type -> Type) where
     (>>=)  : m a -> (a -> m b) -> m b
+
+instance Monad id where
+    a >>= f = f a
 
 ||| Also called `join` or mu
 flatten : Monad m => m (m a) -> m a


### PR DESCRIPTION
Useful for working with structures that are parametrized on a `Functor` (or `Monad`) and let you use `id` in place of an actual `Monad`. One example is monad transformers, where these eliminate the need for two variants of the `run` family of functions.
