### PR TITLE
Fixes backtracking in parser of REPL command

### DIFF
--- a/src/Idris/REPLParser.hs
+++ b/src/Idris/REPLParser.hs
@@ -29,7 +29,7 @@ parseCmd i inputname = P.runparser pCmd i inputname
 cmd :: [String] -> P.IdrisParser ()
 cmd xs = try (do P.lchar ':'; docmd (sortBy (\x y -> compare (length y) (length x)) xs))
     where docmd [] = fail "No such command"
-          docmd (x:xs) = try (discard (P.symbol x)) <|> docmd xs
+          docmd (x:xs) = try (discard (P.reserved x)) <|> docmd xs
 
 pCmd :: P.IdrisParser Command
 pCmd = do P.whiteSpace; do cmd ["q", "quit"]; eof; return Quit
@@ -77,7 +77,7 @@ pCmd = do P.whiteSpace; do cmd ["q", "quit"]; eof; return Quit
               <|> do cmd ["set"]; o <- pOption; return (SetOpt o)
               <|> do cmd ["unset"]; o <- pOption; return (UnsetOpt o)
               <|> do cmd ["s", "search"]; P.whiteSpace;
-                          t <- P.typeExpr (defaultSyntax { implicitAllowed = True }); return (Search t)
+                     t <- P.typeExpr (defaultSyntax { implicitAllowed = True }); return (Search t)
               <|> do cmd ["cs", "casesplit"]; P.whiteSpace;
                      upd <- option False (do P.lchar '!'; return True)
                      l <- P.natural; n <- P.name;


### PR DESCRIPTION
The previous REPL command parser used alot of backtracking and had used some unfortunate combinators, that made it hard to understand what errors there were when a failure occured. 
It also accepted commands like `:cs` which was parsed as `:compile s` and not `:casesplit` due to lack of the correct arguments which made such definition pass.
