### PR TITLE
Add tactics "skip" and "fail"

### DIFF
--- a/CHANGELOG
+++ b/CHANGELOG
@@ -1,3 +1,8 @@
+New in 0.9.15:
+--------------
+* Two new tactics: skip and fail. Skip does nothing, and fail takes a string as an argument and produces it as an error.
+* Corresponding reflected tactics Skip and Fail. Reflected Fail takes a list of ErrorReportParts as an argument, like error handlers produce, allowing access to the pretty-printer.
+
 New in 0.9.14:
 --------------
 * Tactic for case analysis in proofs

--- a/idris.cabal
+++ b/idris.cabal
@@ -425,6 +425,9 @@ Extra-source-files:
                        test/quasiquote003/run
                        test/quasiquote003/*.idr
                        test/quasiquote003/expected
+                       test/quasiquote004/run
+                       test/quasiquote004/*.idr
+                       test/quasiquote004/expected
 
 
                        test/records001/run

--- a/libs/base/Language/Reflection.idr
+++ b/libs/base/Language/Reflection.idr
@@ -156,6 +156,13 @@ data Raw = Var TTName
 
 %name Raw tm, tm'
 
+||| Error reports are a list of report parts
+data ErrorReportPart = TextPart String
+                     | NamePart TTName
+                     | TermPart TT
+                     | SubReport (List ErrorReportPart)
+%name ErrorReportPart part, p
+
 data Tactic = Try Tactic Tactic
             -- ^ try the first tactic and resort to the second one on failure
             | GoalType String Tactic
@@ -202,4 +209,7 @@ data Tactic = Try Tactic Tactic
             -- ^ name a reflected term and type it
             | Compute
             -- ^ normalise the context
+            | Skip
+            -- ^ do nothing
+            | Fail (List ErrorReportPart)
 %name Tactic tac, tac'

--- a/libs/base/Language/Reflection/Errors.idr
+++ b/libs/base/Language/Reflection/Errors.idr
@@ -40,13 +40,6 @@ data Err = Msg String
 
 %name Err err, e
 
-||| Error reports are a list of report parts
-data ErrorReportPart = TextPart String
-                     | NamePart TTName
-                     | TermPart TT
-                     | SubReport (List ErrorReportPart)
-%name ErrorReportPart part, p
-
 -- Error reports become functions in List (String, TT) -> Err -> ErrorReport
 ErrorHandler : Type
 ErrorHandler = Err -> Maybe (List ErrorReportPart)

--- a/src/Idris/AbsSyntaxTree.hs
+++ b/src/Idris/AbsSyntaxTree.hs
@@ -767,6 +767,8 @@ data PTactic' t = Intro [Name] | Intros | Focus Name
                 | TEval t
                 | TDocStr (Either Name Const)
                 | TSearch t
+                | Skip
+                | TFail [ErrorReportPart]
                 | Qed | Abandon
     deriving (Show, Eq, Functor)
 {-!
@@ -796,6 +798,8 @@ instance Sized a => Sized (PTactic' a) where
   size (Fill t) = 1 + size t
   size Qed = 1
   size Abandon = 1
+  size Skip = 1
+  size (TFail ts) = 1 + size ts
 
 type PTactic = PTactic' PTerm
 

--- a/src/Idris/Core/TT.hs
+++ b/src/Idris/Core/TT.hs
@@ -158,6 +158,12 @@ type Err = Err' Term
 deriving instance NFData Err
 !-}
 
+instance Sized ErrorReportPart where
+  size (TextPart msg) = 1 + length msg
+  size (TermPart t) = 1 + size t
+  size (NamePart n) = 1 + size n
+  size (SubReport rs) = 1 + size rs
+
 instance Sized Err where
   size (Msg msg) = length msg
   size (InternalMsg msg) = length msg

--- a/src/Idris/DeepSeq.hs
+++ b/src/Idris/DeepSeq.hs
@@ -260,6 +260,14 @@ instance (NFData t) => NFData (PTactic' t) where
         rnf (GoalType x1 x2) = rnf x1 `seq` rnf x2 `seq` ()
         rnf Qed = ()
         rnf Abandon = ()
+        rnf Skip = ()
+        rnf (TFail x1) = rnf x1 `seq` ()
+
+instance NFData ErrorReportPart where
+        rnf (TermPart x1) = rnf x1 `seq` ()
+        rnf (TextPart x1) = rnf x1 `seq` ()
+        rnf (NamePart x1) = rnf x1 `seq` ()
+        rnf (SubReport x1) = rnf x1 `seq` ()
 
 instance (NFData t) => NFData (PDo' t) where
         rnf (DoExp x1 x2) = rnf x1 `seq` rnf x2 `seq` ()

--- a/src/Idris/ElabDecls.hs
+++ b/src/Idris/ElabDecls.hs
@@ -209,7 +209,7 @@ elabType' norm info syn doc argDocs fc opts n ty' = {- let ty' = piBind (params 
         , ns1 == map txt ["Errors","Reflection","Language"]
         , ns2 == map txt ["Maybe", "Prelude"]
         , ns3 == map txt ["List", "Prelude"]
-        , ns4 == map txt ["Errors","Reflection","Language"] = True
+        , ns4 == map txt ["Reflection","Language"] = True
     tyIsHandler _                                           = False
 
 -- Get the list of (index, name) of inaccessible arguments from an elaborated

--- a/src/Idris/ParseExpr.hs
+++ b/src/Idris/ParseExpr.hs
@@ -1278,6 +1278,10 @@ tactic syn = do reserved "intro"; ns <- sepBy (indentPropHolds gtProp *> name) (
           <|> do reserved "undo"; return Undo
           <|> do reserved "qed"; return Qed
           <|> do reserved "abandon"; return Abandon
+          <|> do reserved "skip"; return Skip
+          <|> do reserved "fail"
+                 msg <- stringLiteral
+                 return $ TFail [Idris.Core.TT.TextPart msg]
           <|> do lchar ':';
                  (    (do reserved "q"; return Abandon)
                   <|> (do (reserved "e" <|> reserved "eval");

--- a/test/quasiquote004/Quasiquote004.idr
+++ b/test/quasiquote004/Quasiquote004.idr
@@ -1,0 +1,51 @@
+module Quasiquote004
+
+import Language.Reflection
+
+%default total
+
+normPlus : List (TTName, Binder TT) -> TT -> Tactic
+normPlus ctxt `((=) {Nat} {Nat} ~x ~y) = normPlus ctxt x `Seq` normPlus ctxt y
+normPlus ctxt `(S ~n) = normPlus ctxt n
+normPlus ctxt `(plus ~n (S ~m)) = Seq (Rewrite `(plusSuccRightSucc ~n ~m))
+                                      (normPlus ctxt m)
+normPlus _ _ = Skip
+
+
+zero : List (TTName, Binder TT) -> TT -> Tactic
+zero ctxt `(Nat) = Exact `(Z)
+zero _ _ = Fail [TextPart "Not a Nat goal"]
+
+-- A number is fizzy if it is evenly divisible by 3
+data Fizzy : Nat -> Type where
+  ZeroFizzy : Fizzy Z
+  Fizz : Fizzy n -> Fizzy (3 + n)
+
+-- Fizzy is a correct specification of divisibility by 3 - that is, if n is
+-- fizzy then there exists some k such that n = 3*k.
+fizzyCorrect : (n : Nat) -> Fizzy n -> (k : Nat ** n = 3 * k)
+fizzyCorrect Z ZeroFizzy = (Z ** refl)
+fizzyCorrect (S (S (S k))) (Fizz x) =
+  let (k' ** ih) = fizzyCorrect k x
+  in (S k' ** ?fizzyIsAOK)
+
+someNat : Nat
+someNat = ?getMeNat
+
+notNat : String
+notNat = ?getMeNat'
+
+---------- Proofs ----------
+Quasiquote004.getMeNat = proof
+  applyTactic zero
+
+Quasiquote004.fizzyIsAOK = proof
+  compute
+  intros
+  applyTactic normPlus
+  applyTactic normPlus
+  rewrite ih
+  trivial
+
+Quasiquote004.getMeNat' = proof
+  applyTactic zero

--- a/test/quasiquote004/expected
+++ b/test/quasiquote004/expected
@@ -1,0 +1,2 @@
+Quasiquote004.idr:50:25:When elaborating right hand side of Quasiquote004.getMeNat':
+Not a Nat goal

--- a/test/quasiquote004/run
+++ b/test/quasiquote004/run
@@ -1,0 +1,3 @@
+#!/usr/bin/env bash
+idris $@ --check --nocolour Quasiquote004.idr
+rm -f *.ibc


### PR DESCRIPTION
"skip" does nothing, while "fail" produces an error. They have
corresponding reflected versions Skip and Fail. Fail has access to the
pretty printer by taking a List ErrorReportPart as its argument.
