### PR TITLE
Add 'doc' and 'doc_clean' make targets for Effects lib

### DIFF
--- a/libs/effects/Makefile
+++ b/libs/effects/Makefile
@@ -1,14 +1,21 @@
 IDRIS     := idris
+PKG       := effects
 
 build:
-	$(IDRIS) --build effects.ipkg
+	$(IDRIS) --build ${PKG}.ipkg
 
 clean:
-	$(IDRIS) --clean effects.ipkg
+	$(IDRIS) --clean ${PKG}.ipkg
 
 install:
-	$(IDRIS) --install effects.ipkg
+	$(IDRIS) --install ${PKG}.ipkg
 
 rebuild: clean build
 
-.PHONY: build clean install rebuild
+doc:
+	$(IDRIS) --mkdoc ${PKG}.ipkg
+
+doc_clean:
+	rm -rf ${PKG}_doc
+
+.PHONY: build clean install rebuild doc doc_clean


### PR DESCRIPTION
Running `make lib_doc` from the root was failing with this error.

> ...
> /Applications/Xcode.app/Contents/Developer/usr/bin/make   -C effects doc
> make[2]: **\* No rule to make target `doc'.  Stop.
> make[1]: **\* [doc] Error 2
> make: **\* [lib_doc] Error 2

The problem was `libs/effects/Makefile` lacked the necessary 'doc' target.
