### PR TITLE
Reinsert check for constructor/family mismatch.

### DIFF
--- a/idris.cabal
+++ b/idris.cabal
@@ -241,6 +241,12 @@ Extra-source-files:
                        test/reg047/run
                        test/reg047/*.idr
                        test/reg047/expected
+                       test/reg048/run
+                       test/reg048/*.idr
+                       test/reg048/expected
+                       test/reg049/run
+                       test/reg049/*.idr
+                       test/reg049/expected
 
                        test/basic001/run
                        test/basic001/*.idr

--- a/src/Idris/ElabDecls.hs
+++ b/src/Idris/ElabDecls.hs
@@ -395,6 +395,9 @@ elabCon info syn tn codata (doc, argDocs, n, t_in, fc, forcenames)
          ctxt <- getContext
          let cty' = normalise ctxt [] cty
 
+         -- Check that the constructor type is, in fact, a part of the family being defined
+         tyIs n cty'
+
          logLvl 2 $ show fc ++ ":Constructor " ++ show n ++ " : " ++ show t
          logLvl 5 $ "Inaccessible args: " ++ show inacc
          logLvl 2 $ "---> " ++ show n ++ " : " ++ show cty'
@@ -407,11 +410,11 @@ elabCon info syn tn codata (doc, argDocs, n, t_in, fc, forcenames)
          addIBC (IBCOpt n)
          return (n, cty')
   where
-    tyIs (Bind n b sc) = tyIs sc
-    tyIs t | (P _ n' _, _) <- unApply t
-        = if n' /= tn then tclift $ tfail (At fc (Msg (show n' ++ " is not " ++ show tn)))
+    tyIs con (Bind n b sc) = tyIs con sc
+    tyIs con t | (P _ n' _, _) <- unApply t
+        = if n' /= tn then tclift $ tfail (At fc (Elaborating "constructor " con (Msg (show n' ++ " is not " ++ show tn))))
              else return ()
-    tyIs t = tclift $ tfail (At fc (Msg (show t ++ " is not " ++ show tn)))
+    tyIs con t = tclift $ tfail (At fc (Elaborating "constructor " con (Msg (show t ++ " is not " ++ show tn))))
 
     mkLazy (PPi pl n ty sc) 
         = let ty' = if getTyName ty

--- a/test/reg049/expected
+++ b/test/reg049/expected
@@ -1,0 +1,2 @@
+reg049.idr:2:9:When elaborating constructor Main.Bogus:
+{__False0} is not Main.Foo

--- a/test/reg049/reg049.idr
+++ b/test/reg049/reg049.idr
@@ -1,0 +1,5 @@
+data Foo : Type where
+  Bogus : _|_
+
+uhOh : _|_
+uhOh = Bogus

--- a/test/reg049/run
+++ b/test/reg049/run
@@ -1,0 +1,3 @@
+#!/usr/bin/env bash
+idris --nocolour --check $@ reg049.idr
+rm -f *.ibc


### PR DESCRIPTION
It appears that the code to do this was accidentally deleted at some
point. It is now called again.

Fixes #1434.
