### PR TITLE
Don't show irrelevant MNs in prover

### DIFF
--- a/CHANGELOG
+++ b/CHANGELOG
@@ -2,6 +2,7 @@ New in 0.9.15:
 --------------
 * Two new tactics: skip and fail. Skip does nothing, and fail takes a string as an argument and produces it as an error.
 * Corresponding reflected tactics Skip and Fail. Reflected Fail takes a list of ErrorReportParts as an argument, like error handlers produce, allowing access to the pretty-printer.
+* Stop showing irrelevant and inaccessible internal names in the interactive prover
 
 New in 0.9.14:
 --------------

--- a/src/Idris/Prover.hs
+++ b/src/Idris/Prover.hs
@@ -140,6 +140,8 @@ dumpState ist ps@(PS nm (h:hs) _ _ tm _ _ _ _ _ _ problems i _ _ ctxy _ _ _ _) =
     prettyPs bnd [] = empty
     prettyPs bnd ((n@(MN _ r), _) : bs)
         | r == txt "rewrite_rule" = prettyPs ((n, False):bnd) bs
+    prettyPs bnd ((n@(MN _ _), _) : bs)
+        | not (n `elem` freeEnvNames bs) = prettyPs bnd bs
     prettyPs bnd ((n, Let t v) : bs) =
       line <> bindingOf n False <+> text "=" <+> tPretty bnd v <+> colon <+>
         align (tPretty bnd t) <> prettyPs ((n, False):bnd) bs
@@ -167,6 +169,9 @@ dumpState ist ps@(PS nm (h:hs) _ _ tm _ _ _ _ _ _ problems i _ _ ctxy _ _ _ _) =
       else
         text "----------              Other goals:              ----------" <$$>
         nest nestingSize (align . cat . punctuate (text ",") . map (flip bindingOf False) $ hs)
+
+    freeEnvNames :: Env -> [Name]
+    freeEnvNames = foldl (++) [] . map (\(n, b) -> freeNames (Bind n b Erased))
 
 lifte :: ElabState [PDecl] -> ElabD a -> Idris a
 lifte st e = do (v, _) <- elabStep st e


### PR DESCRIPTION
Previously, proof steps like applyTactic would introduce MNs to the
proof state, with names like {scriptVar231}. This change hides those, as
the user cannot type them anyway.

If they are used in a later assumption, then they will be shown anyway.
