### PR TITLE
Add a Travis target for make lib_doc

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -25,6 +25,7 @@ script:
   - make -j2 $TESTS
 env:
   - TESTS="doc"
+  - TESTS="lib_doc"
   - TESTS="test_c"
   - TESTS="test_llvm"
   - TESTS="test_js"


### PR DESCRIPTION
This makes sure that we haven't broken idrisdoc generation for the library.

Fixes #1442
