### PR TITLE
Fix parameter identification

### DIFF
--- a/src/Idris/Elab/Data.hs
+++ b/src/Idris/Elab/Data.hs
@@ -132,8 +132,15 @@ elabData info syn doc argDocs fc opts (PDatadecl n t_in dcons)
         -- them for repeated arguments
 
         findParams :: [Type] -> [Int]
-        findParams ts = let allapps = concatMap getDataApp ts in
-                            paramPos allapps
+        findParams ts = let allapps = map getDataApp ts
+           -- do each constructor separately, then merge the results (names
+           -- may change between constructors)
+                            conParams = map paramPos allapps in
+                            inAll conParams
+
+        inAll :: [[Int]] -> [Int]
+        inAll [] = []
+        inAll (x : xs) = filter (\p -> all (\ps -> p `elem` ps) xs) x
 
         paramPos [] = []
         paramPos (args : rest)


### PR DESCRIPTION
Names may vary between constructors, but what's important is that the
parameters are in the same position for each constructor. This fix no
longer makes the assumption that the names are the same throughout.

Fixes #1467
