### PR TITLE
Add missing pattern in TT.hs

### DIFF
--- a/src/Idris/Core/TT.hs
+++ b/src/Idris/Core/TT.hs
@@ -1154,6 +1154,7 @@ nextName (UN x) = let (num', nm') = T.span isDigit (T.reverse x)
 nextName (SN x) = SN (nextName' x)
   where
     nextName' (WhereN i f x) = WhereN i f (nextName x)
+    nextName' (WithN i n) = WithN i (nextName n)
     nextName' (CaseN n) = CaseN (nextName n)
     nextName' (MethodN n) = MethodN (nextName n)
 


### PR DESCRIPTION
Idris tripped over an incomplete pattern match in nextName' while typechecking
https://github.com/defanor/parcomb/blob/1cd15bf9c7e4a06c30ee5a804ea5d4d4993bbbab/VISD.idr

I traced and added the missing pattern match. The file typechecks and tests pass
but I have not tried to understand what is actually going on in TT.hs.
