### PR TITLE
Modified Makefile 'install' target.

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -3,7 +3,7 @@
 include config.mk
 -include custom.mk
 
-install:
+install: lib_clean
 	$(CABAL) install $(CABALFLAGS)
 
 pinstall: CABALFLAGS += --enable-executable-profiling


### PR DESCRIPTION
Default action for `$ make install` is to:
1. purge directory of `ibc` files.
2. build and install `idris`.
