### PR TITLE
Annotate several top-level functions

### DIFF
--- a/main/Main.hs
+++ b/main/Main.hs
@@ -37,6 +37,7 @@ import Paths_idris
 -- Main program reads command line options, parses the main program, and gets
 -- on with the REPL.
 
+main :: IO ()
 main = do opts <- runArgParser
           runMain (runIdris opts)
 
@@ -71,17 +72,21 @@ runIdris opts = do
                       _ -> ifail "Too many packages"
            fs -> runIO $ mapM_ (buildPkg (WarnOnly `elem` opts)) fs
 
+showver :: IO b
 showver = do putStrLn $ "Idris version " ++ ver
              exitWith ExitSuccess
 
+showLibs :: IO b
 showLibs = do libFlags <- getLibFlags
               putStrLn libFlags
               exitWith ExitSuccess
 
+showLibdir :: IO b
 showLibdir = do dir <- getIdrisLibDir
                 putStrLn dir
                 exitWith ExitSuccess
 
+showIncs :: IO b
 showIncs = do incFlags <- getIncFlags
               putStrLn incFlags
               exitWith ExitSuccess

--- a/src/Idris/CaseSplit.hs
+++ b/src/Idris/CaseSplit.hs
@@ -5,10 +5,10 @@ module Idris.CaseSplit(splitOnLine, replaceSplits,
                        mkWith,
                        nameMissing,
                        getUniq, nameRoot) where
-
 -- splitting a variable in a pattern clause
 
 import Idris.AbsSyntax
+import Idris.AbsSyntaxTree (Idris, IState, PTerm)
 import Idris.ElabDecls
 import Idris.ElabTerm
 import Idris.Delaborate
@@ -91,9 +91,11 @@ data MergeState = MS { namemap :: [(Name, Name)],
                        explicit :: [Name],
                        updates :: [(Name, PTerm)] }
 
+addUpdate :: Name -> Idris.AbsSyntaxTree.PTerm -> State MergeState ()
 addUpdate n tm = do ms <- get
                     put (ms { updates = ((n, stripNS tm) : updates ms) } )
 
+inventName :: Idris.AbsSyntaxTree.IState -> Maybe Name -> Name -> State MergeState Name
 inventName ist ty n = 
     do ms <- get
        let supp = case ty of
@@ -115,11 +117,14 @@ inventName ist ty n =
                 put (ms { invented = (n, n') : invented ms })
                 return n'
                 
+mkSupply :: [Name] -> [Name]
 mkSupply ns = mkSupply' ns (map nextName ns)
   where mkSupply' xs ns' = xs ++ mkSupply ns'
    
+varlist :: [Name]
 varlist = map (sUN . (:[])) "xyzwstuv" -- EB's personal preference :)
 
+stripNS :: Idris.AbsSyntaxTree.PTerm -> Idris.AbsSyntaxTree.PTerm
 stripNS tm = mapPT dens tm where
     dens (PRef fc n) = PRef fc (nsroot n)
     dens t = t
@@ -310,6 +315,8 @@ replaceSplits l ups = updateRHSs 1 (map (rep (expandBraces l)) ups)
                    , not (isSuffixOf ")" tm) = "(" ++ tm ++ ")"
                    | otherwise = tm
 
+
+getUniq :: (Show t, Num t) => [Char] -> t -> Idris ([Char], t) 
 getUniq nm i
        = do ist <- getIState
             let n = nameRoot [] nm ++ "_" ++ show i

--- a/src/Idris/Core/Elaborate.hs
+++ b/src/Idris/Core/Elaborate.hs
@@ -755,6 +755,14 @@ tryAll xs = tryAll' [] 999999 (cantResolve, 0) xs
                             if (s >= i) then (lift (tfail err), s)
                                         else (f, i)
 
+prunStateT
+  :: Int
+     -> Bool
+     -> [a]
+     -> Control.Monad.State.Strict.StateT
+          (ElabState t) (TC' Err) t1
+     -> ElabState t
+     -> TC' Err ((t1, Int, Idris.Core.Unify.Fails), ElabState t)
 prunStateT pmax zok ps x s
       = case runStateT x s of
              OK (v, s'@(ES (p, _) _ _)) ->

--- a/src/Idris/Core/ProofState.hs
+++ b/src/Idris/Core/ProofState.hs
@@ -815,6 +815,7 @@ updateProblems ctxt ns ps inj holes usupp = up ns ps where
                      (ns', (x',y',env',err', while, um) : ps')
 
 -- attempt to solve remaining problems with match_unify
+-- matchProblems :: Bool -> Elab' aux ()
 matchProblems all ns ctxt ps inj holes = up ns ps where
   up ns [] = (ns, [])
   up ns ((x, y, env, err, while, um) : ps)

--- a/src/Idris/Core/ProofTerm.hs
+++ b/src/Idris/Core/ProofTerm.hs
@@ -114,9 +114,11 @@ mkProofTerm tm = PT Top [] tm []
 getProofTerm :: ProofTerm -> Term
 getProofTerm (PT path _ sub ups) = rebuildTerm sub (updateSolvedPath ups path) 
 
+same :: Eq a => Maybe a -> a -> Bool
 same Nothing n  = True
 same (Just x) n = x == n
 
+hole :: Binder b -> Bool
 hole (Hole _)    = True
 hole (Guess _ _) = True
 hole _           = False

--- a/src/Idris/Core/TT.hs
+++ b/src/Idris/Core/TT.hs
@@ -1088,6 +1088,7 @@ unList tm = case unApply tm of
 forget :: TT Name -> Raw
 forget tm = forgetEnv [] tm
     
+forgetEnv :: [Name] -> TT Name -> Raw
 forgetEnv env (P _ n _) = Var n
 forgetEnv env (V i)     = Var (env !! i)
 forgetEnv env (Bind n b sc) = let n' = uniqueName n env in

--- a/src/Idris/Core/Unify.hs
+++ b/src/Idris/Core/Unify.hs
@@ -84,6 +84,10 @@ match_unify ctxt env topx topy inj holes from =
     -- but it scares me. However, matching is never guaranteed to give a unique
     -- answer, merely a valid one, so perhaps we're okay.
     -- In other words: it may vanish without warning some day :)
+    un :: [((Name, Name), TT Name)] -> TT Name -> TT Name ->
+          StateT UInfo
+          TC [(Name, TT Name)]
+
     un names x tm@(App (P _ f (Bind fn (Pi t _) sc)) a)
         | (P (DCon _ _ _) _ _, _) <- unApply x,
           holeIn env f || f `elem` holes
@@ -237,6 +241,7 @@ expandLets env (x, tm) = (x, doSubst (reverse env) tm)
     doSubst (_ : env) tm
         = doSubst env tm
 
+hasv :: TT Name -> Bool
 hasv (V x) = True
 hasv (App f a) = hasv f || hasv a
 hasv (Bind x b sc) = hasv (binderTy b) || hasv sc
@@ -660,6 +665,7 @@ recoverable (Bind _ (Lam _) sc) f = recoverable sc f
 recoverable f (Bind _ (Lam _) sc) = recoverable f sc
 recoverable x y = True
 
+errEnv :: [(a, Binder b)] -> [(a, b)]
 errEnv = map (\(x, b) -> (x, binderTy b))
 
 holeIn :: Env -> Name -> Bool

--- a/src/Idris/Elab/Class.hs
+++ b/src/Idris/Elab/Class.hs
@@ -103,11 +103,13 @@ elabClass info syn_in doc fc constraints tn ps pDocs ds
     pibind [] x = x
     pibind ((n, ty): ns) x = PPi expl n ty (pibind ns x)
 
+    mdec :: Name -> Name
     mdec (UN n) = SN (MethodN (UN n))
     mdec (NS x n) = NS (mdec x) n
     mdec x = x
 
     -- TODO: probably should normalise
+    checkDefaultSuperclassInstance :: PDecl -> Idris () 
     checkDefaultSuperclassInstance (PInstance _ fc cs n ps _ _ _)
         = do when (not $ null cs) . tclift
                 $ tfail (At fc (Msg $ "Default superclass instances can't have constraints."))
@@ -118,8 +120,11 @@ elabClass info syn_in doc fc constraints tn ps pDocs ds
                 $ tfail (At fc (Msg $ "Default instances must be for a superclass constraint on the containing class."))
              return ()
 
+    impbind :: [(Name, PTerm)] -> PTerm -> PTerm 
     impbind [] x = x
     impbind ((n, ty): ns) x = PPi impl n ty (impbind ns x)
+
+    conbind :: [PTerm] -> PTerm -> PTerm 
     conbind (ty : ns) x = PPi constraint (sMN 0 "class") ty (conbind ns x)
     conbind [] x = x
 
@@ -155,6 +160,7 @@ elabClass info syn_in doc fc constraints tn ps pDocs ds
     clause _ = False
 
     -- Generate a function for chasing a dictionary constraint
+    cfun :: Name -> PTerm -> SyntaxInfo -> [a] -> PTerm -> Idris [PDecl' PTerm]
     cfun cn c syn all con
         = do let cfn = sUN ('@':'@':show cn ++ "#" ++ show con)
                        -- SN (ParentN cn (show con))

--- a/src/Idris/PartialEval.hs
+++ b/src/Idris/PartialEval.hs
@@ -86,6 +86,7 @@ mkPE_TyDecl ist args ty = mkty args ty
     mkty [] t = delab ist t
 
 -- | Checks if a given argument is a type class constraint argument
+classConstraint :: Idris.AbsSyntax.IState -> TT Name -> Bool
 classConstraint ist v
     | (P _ c _, args) <- unApply v = case lookupCtxt c (idris_classes ist) of
                                           [_] -> True
@@ -94,6 +95,7 @@ classConstraint ist v
 
 -- | Checks if the given arguments of a type class constraint are all either constants
 -- or references (i.e. that it doesn't contain any complex terms).
+concreteClass :: IState -> TT Name -> Bool
 concreteClass ist v
     | not (classConstraint ist v) = False
     | (P _ c _, args) <- unApply v = all concrete args

--- a/src/Idris/Providers.hs
+++ b/src/Idris/Providers.hs
@@ -7,15 +7,18 @@ import Idris.AbsSyntax
 import Idris.AbsSyntaxTree
 import Idris.Error
 
-import Debug.Trace
-
 -- | Wrap a type provider in the type of type providers
 providerTy :: FC -> PTerm -> PTerm
 providerTy fc tm
   = PApp fc (PRef fc $ sUN "Provider") [PExp 0 [] (sMN 0 "pvarg") tm]
 
+ioret :: Name
 ioret = sUN "prim_io_return"
+
+ermod :: Name
 ermod = sNS (sUN "Error") ["Providers"]
+
+prmod :: Name
 prmod = sNS (sUN "Provide") ["Providers"]
 
 data Provided a = Provide a


### PR DESCRIPTION
I went through the `src/Idris` subdirectory and added type annotations to almost all (~50) top-level functions which were missing them.
