### PR TITLE
Fix for language-java 0.2.7

### DIFF
--- a/idris.cabal
+++ b/idris.cabal
@@ -680,7 +680,7 @@ Library
                 , filepath
                 , fingertree >= 0.1
                 , haskeline >= 0.7
-                , language-java >= 0.2.6
+                , language-java >= 0.2.7
                 , lens >= 4.1.1
                 , mtl
                 , parsers >= 0.9 && < 0.13

--- a/src/IRTS/Java/ASTBuilding.hs
+++ b/src/IRTS/Java/ASTBuilding.hs
@@ -60,7 +60,7 @@ localVar i = Ident $ "loc" ++ show i
 
 (@!) :: Exp -> Int -> ArrayIndex
 (@!) target pos =
-  ArrayIndex target (Lit $ Int (toInteger pos))
+  ArrayIndex target [Lit $ Int (toInteger pos)]
 
 (@:=) :: Either ArrayIndex Ident -> Exp -> BlockStmt
 (@:=) (Right lhs) rhs =


### PR DESCRIPTION
`language-java-0.2.7` introduced a breaking change in which the second argument of [`ArrayIndex`](https://github.com/vincenthz/language-java/blob/4c1880264f35f5ebd91313d259e2910824404db5/Language/Java/Syntax.hs#L380) is now an `[Exp]` instead of an `Exp`. This commit simply updates `IRTS.Java.ASTBuilding` to use the new `ArrayIndex`.
