### PR TITLE
Add upper bound to optparse-applicative

### DIFF
--- a/idris.cabal
+++ b/idris.cabal
@@ -699,7 +699,7 @@ Library
                 , xml
                 , deepseq
                 , zlib
-                , optparse-applicative >= 0.8
+                , optparse-applicative >= 0.8 && < 0.10
   Extensions:     MultiParamTypeClasses
                 , DeriveFoldable
                 , DeriveTraversable


### PR DESCRIPTION
The signature of `option` changed in 0.10 - it looks like an easy fix
but I'd rather change the upper bound than the lower bound right now.
