### PR TITLE
Add annotations for :search result classification

### DIFF
--- a/src/Idris/AbsSyntaxTree.hs
+++ b/src/Idris/AbsSyntaxTree.hs
@@ -1207,6 +1207,7 @@ consoleDecorate ist (AnnTextFmt fmt) = Idris.Colours.colourise (colour fmt)
         colour UnderlineText = IdrisColour Nothing True True False False
         colour ItalicText    = IdrisColour Nothing True False False True
 consoleDecorate ist (AnnTerm _ _) = id
+consoleDecorate ist (AnnSearchResult _) = id
 
 isPostulateName :: Name -> IState -> Bool
 isPostulateName n ist = S.member n (idris_postulates ist)

--- a/src/Idris/Core/TT.hs
+++ b/src/Idris/Core/TT.hs
@@ -102,6 +102,7 @@ data OutputAnnotation = AnnName Name (Maybe NameOutput) (Maybe String) (Maybe St
                       | AnnFC FC
                       | AnnTextFmt TextFormatting
                       | AnnTerm [(Name, Bool)] (TT Name) -- ^ pprint bound vars, original term
+                      | AnnSearchResult Ordering -- ^ more general, isomorphic, or more specific
 
 -- | Used for error reflection
 data ErrorReportPart = TextPart String

--- a/src/Idris/IdeSlave.hs
+++ b/src/Idris/IdeSlave.hs
@@ -145,6 +145,12 @@ instance SExpable OutputAnnotation where
                        ItalicText    -> "italic"
                        UnderlineText -> "underline"
   toSExp (AnnTerm bnd tm) = toSExp [(SymbolAtom "tt-term", StringAtom (encodeTerm bnd tm))]
+  toSExp (AnnSearchResult ordr) = toSExp [(SymbolAtom "doc-overview", 
+      StringAtom ("Result type is " ++ descr))]
+      where descr = case ordr of
+	      EQ -> "isomorphic"
+	      LT -> "more general than searched type"
+	      GT -> "more specific than searched type"
 
 encodeTerm :: [(Name, Bool)] -> Term -> String
 encodeTerm bnd tm = UTF8.toString . Base64.encode . Lazy.toStrict . Binary.encode $

--- a/src/Idris/TypeSearch.hs
+++ b/src/Idris/TypeSearch.hs
@@ -34,7 +34,7 @@ import Idris.Output (iRenderOutput, iPrintResult, iRenderResult)
 
 import Prelude hiding (pred)
 
-import Util.Pretty (text, char, vsep, (<>), Doc)
+import Util.Pretty (text, char, vsep, (<>), Doc, annotate)
 
 searchByType :: PTerm -> Idris ()
 searchByType pterm = do
@@ -173,13 +173,14 @@ data Score = Score
   , asymMods      :: !(Sided AsymMods)
   } deriving (Eq, Show)
 
-displayScore :: Score -> Doc a
-displayScore score = text $ case both noMods (asymMods score) of
-  Sided True  True  -> "=" -- types are isomorphic
-  Sided True  False -> "<" -- found type is more general than searched type
-  Sided False True  -> ">" -- searched type is more general than found type
-  Sided False False -> "_"
+displayScore :: Score -> Doc OutputAnnotation
+displayScore score = case both noMods (asymMods score) of
+  Sided True  True  -> annotated EQ "=" -- types are isomorphic
+  Sided True  False -> annotated LT "<" -- found type is more general than searched type
+  Sided False True  -> annotated GT ">" -- searched type is more general than found type
+  Sided False False -> text "_"
   where 
+  annotated ordr = annotate (AnnSearchResult ordr) . text
   noMods (Mods app tcApp tcIntro) = app + tcApp + tcIntro == 0
 
 scoreCriterion :: Score -> Bool


### PR DESCRIPTION
This adds "doc-overview" annotation strings for the `>`, `<`, and `=` symbols that are returned for each search result in the :search feature. I also just added a [page to the Wiki which describes :search results in more detail](https://github.com/idris-lang/Idris-dev/wiki/Type-directed-search-%28:search%29).

These annotations currently do not display by default in _Idris-mode_, because there is no corresponding "name" annotation. I suggest that a change is made to _Idris-mode_ to support mouse hover text even when there is just "doc-overview" but no "name".
