### PR TITLE
Prevent REPL from compiling to source file

### DIFF
--- a/src/Idris/REPL.hs
+++ b/src/Idris/REPL.hs
@@ -1054,12 +1054,14 @@ process fn Execute
                        (\e -> getIState >>= iRenderError . flip pprintErr e)
   where fc = fileFC "main"
 process fn (Compile codegen f)
-      = do (m, _) <- elabVal recinfo ERHS
-                       (PApp fc (PRef fc (sUN "run__IO"))
-                       [pexp $ PRef fc (sNS (sUN "main") ["Main"])])
-           ir <- compile codegen f m
-           i <- getIState
-           runIO $ generate codegen (head (idris_imported i)) ir
+      = if map toLower (takeExtension f) `elem` [".idr", ".idc"]
+           then runIO $ putStrLn ("Will not compile to " ++ f)
+           else do (m, _) <- elabVal recinfo ERHS
+                             (PApp fc (PRef fc (sUN "run__IO"))
+                             [pexp $ PRef fc (sNS (sUN "main") ["Main"])])
+                   ir <- compile codegen f m
+                   i <- getIState
+                   runIO $ generate codegen (head (idris_imported i)) ir
   where fc = fileFC "main"
 process fn (LogLvl i) = setLogLevel i
 -- Elaborate as if LHS of a pattern (debug command)


### PR DESCRIPTION
When compiling from the REPL, autocomplete suggests the source file as a possible output. This patch protects the user from accidentally overwriting his source file.
