### PR TITLE
New command :pprint for outputting paper/slide bits

### DIFF
--- a/CHANGELOG
+++ b/CHANGELOG
@@ -18,6 +18,8 @@ New in 0.9.15:
   to DSL authors.
 * The Java and LLVM backends have been factored out for separate maintenance. Now, the
   compiler distribution only ships with the C and JavaScript backends.
+* New REPL command :printdef displays the internal definition of a name
+* New REPL command :pprint pretty-prints a definition or term with LaTeX or HTML highlighting
 
 New in 0.9.14:
 --------------

--- a/src/Idris/AbsSyntaxTree.hs
+++ b/src/Idris/AbsSyntaxTree.hs
@@ -364,6 +364,9 @@ data Command = Quit
              | MakeDoc String                      -- IdrisDoc
              | Warranty
              | PrintDef Name
+             | PPrint OutputFmt Int PTerm
+
+data OutputFmt = HTMLOutput | LaTeXOutput
 
 data Opt = Filename String
          | Quiet

--- a/src/Idris/Output.hs
+++ b/src/Idris/Output.hs
@@ -1,3 +1,5 @@
+{-# OPTIONS_GHC -fwarn-incomplete-patterns #-}
+
 module Idris.Output where
 
 import Idris.Core.TT
@@ -13,10 +15,12 @@ import Util.ScreenSize (getScreenWidth)
 
 import Debug.Trace
 
+import Control.Monad.Error (throwError)
+
 import System.IO (stdout, Handle, hPutStrLn)
 
 import Data.Char (isAlpha)
-import Data.List (nub)
+import Data.List (nub, intersperse)
 import Data.Maybe (fromMaybe)
 
 pshow :: IState -> Err -> String
@@ -170,3 +174,94 @@ printUndefinedNames :: [Name] -> Doc OutputAnnotation
 printUndefinedNames ns = text "Undefined " <> names <> text "."
   where names = encloseSep empty empty (char ',') $ map ppName ns
         ppName = prettyName True True []
+
+renderExternal :: OutputFmt -> Int -> Doc OutputAnnotation -> Idris String
+renderExternal fmt width doc
+  | width < 1 = throwError . Msg $ "There must be at least one column for the pretty-printer."
+  | otherwise =
+    do ist <- getIState
+       return . wrap fmt .
+         displayDecorated (decorate fmt) .
+         renderPretty 1.0 width .
+         fmap (fancifyAnnots ist) $
+           doc
+  where
+    decorate _ (AnnFC _) = id
+
+    decorate HTMLOutput (AnnName _ (Just TypeOutput) d _) =
+      tag "idris-type" d
+    decorate HTMLOutput (AnnName _ (Just FunOutput) d _) =
+      tag "idris-function" d
+    decorate HTMLOutput (AnnName _ (Just DataOutput) d _) =
+      tag "idris-data" d
+    decorate HTMLOutput (AnnName _ (Just MetavarOutput) d _) =
+      tag "idris-metavar" d
+    decorate HTMLOutput (AnnName _ (Just PostulateOutput) d _) =
+      tag "idris-postulate" d
+    decorate HTMLOutput (AnnName _ _ _ _) = id
+    decorate HTMLOutput (AnnBoundName _ True) = tag "idris-bound idris-implicit" Nothing
+    decorate HTMLOutput (AnnBoundName _ False) = tag "idris-bound" Nothing
+    decorate HTMLOutput (AnnConst _) = id -- TODO
+    decorate HTMLOutput (AnnData _ _) = tag "idris-data" Nothing
+    decorate HTMLOutput (AnnType _ _) = tag "idris-type" Nothing
+    decorate HTMLOutput AnnKeyword = tag "idris-keyword" Nothing
+    decorate HTMLOutput (AnnTextFmt _) = id -- TODO
+    decorate HTMLOutput (AnnTerm _ _) = id
+    decorate HTMLOutput (AnnSearchResult _) = id
+
+    decorate LaTeXOutput (AnnName _ (Just TypeOutput) _ _) =
+      latex "IdrisType"
+    decorate LaTeXOutput (AnnName _ (Just FunOutput) _ _) =
+      latex "IdrisFunction"
+    decorate LaTeXOutput (AnnName _ (Just DataOutput) _ _) =
+      latex "IdrisData"
+    decorate LaTeXOutput (AnnName _ (Just MetavarOutput) _ _) =
+      latex "IdrisMetavar"
+    decorate LaTeXOutput (AnnName _ (Just PostulateOutput) _ _) =
+      latex "IdrisPostulate"
+    decorate LaTeXOutput (AnnName _ _ _ _) = id
+    decorate LaTeXOutput (AnnBoundName _ True) = latex "IdrisImplicit"
+    decorate LaTeXOutput (AnnBoundName _ False) = latex "IdrisBound"
+    decorate LaTeXOutput (AnnConst _) = id -- TODO
+    decorate LaTeXOutput (AnnData _ _) = latex "IdrisData"
+    decorate LaTeXOutput (AnnType _ _) = latex "IdrisType"
+    decorate LaTeXOutput AnnKeyword = latex "IdrisKeyword"
+    decorate LaTeXOutput (AnnTextFmt _) = id -- TODO
+    decorate LaTeXOutput (AnnTerm _ _) = id
+    decorate LaTeXOutput (AnnSearchResult _) = id
+
+    tag cls docs str = "<span class=\""++cls++"\""++title++">" ++ str ++ "</span>"
+      where title = maybe "" (\d->" title=\"" ++ d ++ "\"") docs
+
+    latex cmd str = "\\"++cmd++"{"++str++"}"
+
+    wrap HTMLOutput str =
+      "<!doctype html><html><head><style>" ++ css ++ "</style></head>" ++
+      "<body><!-- START CODE --><pre>" ++ str ++ "</pre><!-- END CODE --></body></html>"
+      where css = concat . intersperse "\n" $
+                    [".idris-data { color: red; } ",
+                     ".idris-type { color: blue; }",
+                     ".idris-function {color: green; }",
+                     ".idris-keyword { font-weight: bold; }",
+                     ".idris-bound { color: purple; }",
+                     ".idris-implicit { font-style: italic; }"]
+    wrap LaTeXOutput str =
+      concat . intersperse "\n" $
+        ["\\documentclass{article}",
+         "\\usepackage{fancyvrb}",
+         "\\usepackage[usenames]{xcolor}"] ++
+        map (\(cmd, color) ->
+               "\\newcommand{\\"++ cmd ++
+               "}[1]{\\textcolor{"++ color ++"}{#1}}")
+             [("IdrisData", "red"), ("IdrisType", "blue"),
+              ("IdrisBound", "magenta"), ("IdrisFunction", "green")] ++
+        ["\\newcommand{\\IdrisKeyword}[1]{{\\underline{#1}}}",
+         "\\newcommand{\\IdrisImplicit}[1]{{\\itshape \\IdrisBound{#1}}}",
+         "\n",
+         "\\begin{document}",
+         "% START CODE",
+         "\\begin{Verbatim}[commandchars=\\\\\\{\\}]",
+         str,
+         "\\end{Verbatim}",
+         "% END CODE",
+         "\\end{document}"]

--- a/src/Idris/REPLParser.hs
+++ b/src/Idris/REPLParser.hs
@@ -134,6 +134,14 @@ pCmd = do P.whiteSpace; do cmd ["q", "quit"]; eof; return Quit
               <|> do cmd ["cw", "callswho"]; P.whiteSpace; n <- P.fnName ; return (CallsWho n)
               <|> do cmd ["mkdoc"]; str <- many anyChar; return (MakeDoc str)
               <|> do cmd ["printdef"]; P.whiteSpace; n <- P.fnName; return (PrintDef n)
+              <|> do cmd ["pp", "pprint"]
+                     P.whiteSpace
+                     fmt <- ppFormat
+                     P.whiteSpace
+                     n <- fmap fromInteger P.natural
+                     P.whiteSpace
+                     t <- P.fullExpr defaultSyntax
+                     return (PPrint fmt n t)
               <|> do P.whiteSpace; do eof; return NOP
                              <|> do t <- P.fullExpr defaultSyntax; return (Eval t)
 
@@ -156,6 +164,10 @@ pConsoleWidth :: P.IdrisParser ConsoleWidth
 pConsoleWidth = do discard (P.symbol "auto"); return AutomaticWidth
             <|> do discard (P.symbol "infinite"); return InfinitelyWide
             <|> do n <- fmap fromInteger P.natural; return (ColsWide n)
+
+ppFormat :: P.IdrisParser OutputFmt
+ppFormat = (discard (P.symbol "html") >> return HTMLOutput)
+       <|> (discard (P.symbol "latex") >> return LaTeXOutput)
 
 colours :: [(String, Maybe Color)]
 colours = [ ("black", Just Black)


### PR DESCRIPTION
The command:

:pprint fmt width n

outputs the definition of name n for format FMT, with a screen width of
WIDTH columns.

:pprint fmt width tm

outputs the term TM.

The allowed formats are "html" and "latex".

Sample output:

```
Idris> :pprint latex 80 Vect
\documentclass{article}
\usepackage{fancyvrb}
\usepackage[usenames]{xcolor}
\newcommand{\IdrisData}[1]{\textcolor{red}{#1}}
\newcommand{\IdrisType}[1]{\textcolor{blue}{#1}}
\newcommand{\IdrisBound}[1]{\textcolor{magenta}{#1}}
\newcommand{\IdrisFunction}[1]{\textcolor{green}{#1}}
\newcommand{\IdrisKeyword}[1]{{\underline{#1}}}
\newcommand{\IdrisImplicit}[1]{{\itshape \IdrisBound{#1}}}


\begin{document}
% START CODE
\begin{Verbatim}[commandchars=\\\{\}]
\IdrisKeyword{data} \IdrisType{Vect} : \IdrisType{Nat} -> \IdrisType{Type} -> \IdrisType{Type} \IdrisKeyword{where}
  \IdrisData{Nil} : \IdrisType{Vect} \IdrisData{0} \IdrisImplicit{a}
  \IdrisData{(::)} : \IdrisImplicit{a} -> \IdrisType{Vect} \IdrisImplicit{n} \IdrisImplicit{a} -> \IdrisType{Vect} (\IdrisData{S} \IdrisImplicit{n}) \IdrisImplicit{a}
\end{Verbatim}
% END CODE
\end{document}
Idris> :pprint html 80 Vect
<!doctype html><html><head><style>.idris-data { color: red; } 
.idris-type { color: blue; }
.idris-function {color: green; }
.idris-keyword { font-weight: bold; }
.idris-bound { color: purple; }
.idris-implicit { font-style: italic; }</style></head><body><!-- START CODE --><pre><span class="idris-keyword">data</span> <span class="idris-type" title="">Vect</span> : <span class="idris-type" title="Unary natural numbers">Nat</span> -> <span class="idris-type">Type</span> -> <span class="idris-type">Type</span> <span class="idris-keyword">where</span>
  <span class="idris-data" title="">Nil</span> : <span class="idris-type" title="">Vect</span> <span class="idris-data">0</span> <span class="idris-bound idris-implicit">a</span>
  <span class="idris-data" title="">(::)</span> : <span class="idris-bound idris-implicit">a</span> -> <span class="idris-type" title="">Vect</span> <span class="idris-bound idris-implicit">n</span> <span class="idris-bound idris-implicit">a</span> -> <span class="idris-type" title="">Vect</span> (<span class="idris-data" title="Successor">S</span> <span class="idris-bound idris-implicit">n</span>) <span class="idris-bound idris-implicit">a</span></pre><!-- END CODE --></body></html>
```
