### PR TITLE
Exit after running --client

### DIFF
--- a/main/Main.hs
+++ b/main/Main.hs
@@ -51,6 +51,7 @@ runIdris opts = do
            (c:_) -> do setVerbose False
                        setQuiet True
                        runIO $ runClient (getPort opts) c
+                       runIO $ exitWith ExitSuccess
        case opt getPkgCheck opts of
            [] -> return ()
            fs -> do runIO $ mapM_ (checkPkg (WarnOnly `elem` opts) True) fs


### PR DESCRIPTION
Otherwise tools which use --client such as the vim mode don't work since they can't capture the output fully.
