### PR TITLE
Fix for optparse-applicative breaking change

### DIFF
--- a/idris.cabal
+++ b/idris.cabal
@@ -701,7 +701,7 @@ Library
                 , lens >= 4.1.1 && < 4.5
                 , mtl < 2.3
                 , network < 2.7
-                , optparse-applicative >= 0.10 && < 0.11
+                , optparse-applicative >= 0.11 && < 0.12
                 , parsers >= 0.9 && < 0.13
                 , pretty < 1.2
                 , process < 1.3

--- a/src/Idris/CmdOptions.hs
+++ b/src/Idris/CmdOptions.hs
@@ -64,7 +64,7 @@ pureArgParser args = case getParseResult $ execParserPure (prefs idm) (info pars
 parser :: Parser [Opt]
 parser = runA $ proc () -> do
   flags <- asA parseFlags -< ()
-  files <- asA (many $ argument ((fmap . fmap) Filename str) (metavar "FILES")) -< ()
+  files <- asA (many $ argument (fmap Filename str) (metavar "FILES")) -< ()
   A parseVersion >>> A helper -< (flags ++ files)
 
 parseFlags :: Parser [Opt]


### PR DESCRIPTION
`optparse-applicative-0.11.0` changes the type signature of `argument` from `(String -> Maybe a) -> Mod ArgumentFields a -> Parser` to `ReadM a -> Mod ArgumentFields a -> Parser a`, so change `Idris.CmdOptions` accordingly.
