### PR TITLE
fix to some "obvious" bugs in BitsN primops

### DIFF
--- a/rts/idris_bitstring.c
+++ b/rts/idris_bitstring.c
@@ -3,28 +3,28 @@
 VAL idris_b8CopyForGC(VM *vm, VAL a) {
     VAL cl = allocate(vm, sizeof(Closure), 1);
     SETTY(cl, BITS8);
-    cl->info.bits8 = a->info.bits8;
+    cl->info.bits8 = GETBITS8(a);
     return cl;
 }
 
 VAL idris_b16CopyForGC(VM *vm, VAL a) {
     VAL cl = allocate(vm, sizeof(Closure), 1);
     SETTY(cl, BITS16);
-    cl->info.bits16 = a->info.bits16;
+    cl->info.bits16 = GETBITS16(a);
     return cl;
 }
 
 VAL idris_b32CopyForGC(VM *vm, VAL a) {
     VAL cl = allocate(vm, sizeof(Closure), 1);
     SETTY(cl, BITS32);
-    cl->info.bits32 = a->info.bits32;
+    cl->info.bits32 = GETBITS32(a);
     return cl;
 }
 
 VAL idris_b64CopyForGC(VM *vm, VAL a) {
     VAL cl = allocate(vm, sizeof(Closure), 1);
     SETTY(cl, BITS64);
-    cl->info.bits64 = a->info.bits64;
+    cl->info.bits64 = GETBITS64(a);
     return cl;
 }
 
@@ -91,49 +91,49 @@ VAL idris_b64const(VM *vm, uint64_t a) {
 VAL idris_b8Plus(VM *vm, VAL a, VAL b) {
     VAL cl = allocate(vm, sizeof(Closure), 0);
     SETTY(cl, BITS8);
-    cl->info.bits8 = a->info.bits8 + b->info.bits8;
+    cl->info.bits8 = GETBITS8(a) + GETBITS8(b);
     return cl;
 }
 
 VAL idris_b8Minus(VM *vm, VAL a, VAL b) {
     VAL cl = allocate(vm, sizeof(Closure), 0);
     SETTY(cl, BITS8);
-    cl->info.bits8 = a->info.bits8 - b->info.bits8;
+    cl->info.bits8 = GETBITS8(a) - GETBITS8(b);
     return cl;
 }
 
 VAL idris_b8Times(VM *vm, VAL a, VAL b) {
     VAL cl = allocate(vm, sizeof(Closure), 0);
     SETTY(cl, BITS8);
-    cl->info.bits8 = a->info.bits8 * b->info.bits8;
+    cl->info.bits8 = GETBITS8(a) * GETBITS8(b);
     return cl;
 }
 
 VAL idris_b8UDiv(VM *vm, VAL a, VAL b) {
     VAL cl = allocate(vm, sizeof(Closure), 0);
     SETTY(cl, BITS8);
-    cl->info.bits8 = a->info.bits8 / b->info.bits8;
+    cl->info.bits8 = GETBITS8(a) / GETBITS8(b);
     return cl;
 }
 
 VAL idris_b8SDiv(VM *vm, VAL a, VAL b) {
     VAL cl = allocate(vm, sizeof(Closure), 0);
     SETTY(cl, BITS8);
-    cl->info.bits8 = (uint8_t) (((int8_t) a->info.bits8) / ((int8_t) b->info.bits8));
+    cl->info.bits8 = (uint8_t) (((int8_t) GETBITS8(a)) / ((int8_t) GETBITS8(b)));
     return cl;
 }
 
 VAL idris_b8URem(VM *vm, VAL a, VAL b) {
     VAL cl = allocate(vm, sizeof(Closure), 0);
     SETTY(cl, BITS8);
-    cl->info.bits8 = a->info.bits8 % b->info.bits8;
+    cl->info.bits8 = GETBITS8(a) % GETBITS8(b);
     return cl;
 }
 
 VAL idris_b8SRem(VM *vm, VAL a, VAL b) {
     VAL cl = allocate(vm, sizeof(Closure), 0);
     SETTY(cl, BITS8);
-    cl->info.bits8 = (uint8_t) (((int8_t) a->info.bits8) % ((int8_t) b->info.bits8));
+    cl->info.bits8 = (uint8_t) (((int8_t) GETBITS8(a)) % ((int8_t) GETBITS8(b)));
     return cl;
 }
 
@@ -160,77 +160,77 @@ VAL idris_b8Gte(VM *vm, VAL a, VAL b) {
 VAL idris_b8Compl(VM *vm, VAL a) {
     VAL cl = allocate(vm, sizeof(Closure), 0);
     SETTY(cl, BITS8);
-    cl->info.bits8 = ~ a->info.bits8;
+    cl->info.bits8 = ~ GETBITS8(a);
     return cl;
 }
 
 VAL idris_b8And(VM *vm, VAL a, VAL b) {
     VAL cl = allocate(vm, sizeof(Closure), 0);
     SETTY(cl, BITS8);
-    cl->info.bits8 = a->info.bits8 & b->info.bits8;
+    cl->info.bits8 = GETBITS8(a) & GETBITS8(b);
     return cl;
 }
 
 VAL idris_b8Or(VM *vm, VAL a, VAL b) {
     VAL cl = allocate(vm, sizeof(Closure), 0);
     SETTY(cl, BITS8);
-    cl->info.bits8 = a->info.bits8 | b->info.bits8;
+    cl->info.bits8 = GETBITS8(a) | GETBITS8(b);
     return cl;
 }
 
 VAL idris_b8Xor(VM *vm, VAL a, VAL b) {
     VAL cl = allocate(vm, sizeof(Closure), 0);
     SETTY(cl, BITS8);
-    cl->info.bits8 = a->info.bits8 ^ b->info.bits8;
+    cl->info.bits8 = GETBITS8(a) ^ GETBITS8(b);
     return cl;
 }
 
 VAL idris_b8Shl(VM *vm, VAL a, VAL b) {
     VAL cl = allocate(vm, sizeof(Closure), 0);
     SETTY(cl, BITS8);
-    cl->info.bits8 = a->info.bits8 << b->info.bits8;
+    cl->info.bits8 = GETBITS8(a) << GETBITS8(b);
     return cl;
 }
 
 VAL idris_b8LShr(VM *vm, VAL a, VAL b) {
     VAL cl = allocate(vm, sizeof(Closure), 0);
     SETTY(cl, BITS8);
-    cl->info.bits8 = a->info.bits8 >> b->info.bits8;
+    cl->info.bits8 = GETBITS8(a) >> GETBITS8(b);
     return cl;
 }
 
 VAL idris_b8AShr(VM *vm, VAL a, VAL b) {
     VAL cl = allocate(vm, sizeof(Closure), 0);
     SETTY(cl, BITS8);
-    cl->info.bits8 = (uint8_t) (((int8_t)a->info.bits8) >> ((int8_t)b->info.bits8));
+    cl->info.bits8 = (uint8_t) (((int8_t)GETBITS8(a)) >> ((int8_t)GETBITS8(b)));
     return cl;
 }
 
 VAL idris_b16Plus(VM *vm, VAL a, VAL b) {
     VAL cl = allocate(vm, sizeof(Closure), 0);
     SETTY(cl, BITS16);
-    cl->info.bits16 = a->info.bits16 + b->info.bits16;
+    cl->info.bits16 = GETBITS16(a) + GETBITS16(b);
     return cl;
 }
 
 VAL idris_b16Minus(VM *vm, VAL a, VAL b) {
     VAL cl = allocate(vm, sizeof(Closure), 0);
     SETTY(cl, BITS16);
-    cl->info.bits16 = a->info.bits16 - b->info.bits16;
+    cl->info.bits16 = GETBITS16(a) - GETBITS16(b);
     return cl;
 }
 
 VAL idris_b16Times(VM *vm, VAL a, VAL b) {
     VAL cl = allocate(vm, sizeof(Closure), 0);
     SETTY(cl, BITS16);
-    cl->info.bits16 = a->info.bits16 * b->info.bits16;
+    cl->info.bits16 = GETBITS16(a) * GETBITS16(b);
     return cl;
 }
 
 VAL idris_b16UDiv(VM *vm, VAL a, VAL b) {
     VAL cl = allocate(vm, sizeof(Closure), 0);
     SETTY(cl, BITS16);
-    cl->info.bits16 = a->info.bits16 / b->info.bits16;
+    cl->info.bits16 = GETBITS16(a) / GETBITS16(b);
     return cl;
 }
 
@@ -238,14 +238,14 @@ VAL idris_b16SDiv(VM *vm, VAL a, VAL b) {
     VAL cl = allocate(vm, sizeof(Closure), 0);
     SETTY(cl, BITS16);
     cl->info.bits16 =
-    (uint16_t) (((int16_t) a->info.bits16) / ((int16_t) b->info.bits16));
+    (uint16_t) (((int16_t) GETBITS16(a)) / ((int16_t) GETBITS16(b)));
     return cl;
 }
 
 VAL idris_b16URem(VM *vm, VAL a, VAL b) {
     VAL cl = allocate(vm, sizeof(Closure), 0);
     SETTY(cl, BITS16);
-    cl->info.bits16 = a->info.bits16 % b->info.bits16;
+    cl->info.bits16 = GETBITS16(a) % GETBITS16(b);
     return cl;
 }
 
@@ -253,7 +253,7 @@ VAL idris_b16SRem(VM *vm, VAL a, VAL b) {
     VAL cl = allocate(vm, sizeof(Closure), 0);
     SETTY(cl, BITS16);
     cl->info.bits16 =
-    (uint16_t) (((int16_t) a->info.bits16) % ((int16_t) b->info.bits16));
+    (uint16_t) (((int16_t) GETBITS16(a)) % ((int16_t) GETBITS16(b)));
     return cl;
 }
 
@@ -280,77 +280,77 @@ VAL idris_b16Gte(VM *vm, VAL a, VAL b) {
 VAL idris_b16Compl(VM *vm, VAL a) {
     VAL cl = allocate(vm, sizeof(Closure), 0);
     SETTY(cl, BITS16);
-    cl->info.bits16 = ~ a->info.bits16;
+    cl->info.bits16 = ~ GETBITS16(a);
     return cl;
 }
 
 VAL idris_b16And(VM *vm, VAL a, VAL b) {
     VAL cl = allocate(vm, sizeof(Closure), 0);
     SETTY(cl, BITS16);
-    cl->info.bits16 = a->info.bits16 & b->info.bits16;
+    cl->info.bits16 = GETBITS16(a) & GETBITS16(b);
     return cl;
 }
 
 VAL idris_b16Or(VM *vm, VAL a, VAL b) {
     VAL cl = allocate(vm, sizeof(Closure), 0);
     SETTY(cl, BITS16);
-    cl->info.bits16 = a->info.bits16 | b->info.bits16;
+    cl->info.bits16 = GETBITS16(a) | GETBITS16(b);
     return cl;
 }
 
 VAL idris_b16Xor(VM *vm, VAL a, VAL b) {
     VAL cl = allocate(vm, sizeof(Closure), 0);
     SETTY(cl, BITS16);
-    cl->info.bits16 = a->info.bits16 ^ b->info.bits16;
+    cl->info.bits16 = GETBITS16(a) ^ GETBITS16(b);
     return cl;
 }
 
 VAL idris_b16Shl(VM *vm, VAL a, VAL b) {
     VAL cl = allocate(vm, sizeof(Closure), 0);
     SETTY(cl, BITS16);
-    cl->info.bits16 = a->info.bits16 << b->info.bits16;
+    cl->info.bits16 = GETBITS16(a) << GETBITS16(b);
     return cl;
 }
 
 VAL idris_b16LShr(VM *vm, VAL a, VAL b) {
     VAL cl = allocate(vm, sizeof(Closure), 0);
     SETTY(cl, BITS16);
-    cl->info.bits16 = a->info.bits16 >> b->info.bits16;
+    cl->info.bits16 = GETBITS16(a) >> GETBITS16(b);
     return cl;
 }
 
 VAL idris_b16AShr(VM *vm, VAL a, VAL b) {
     VAL cl = allocate(vm, sizeof(Closure), 0);
     SETTY(cl, BITS16);
-    cl->info.bits16 = (uint16_t) (((int16_t)a->info.bits16) >> ((int16_t)b->info.bits16));
+    cl->info.bits16 = (uint16_t) (((int16_t)GETBITS16(a)) >> ((int16_t)GETBITS16(b)));
     return cl;
 }
 
 VAL idris_b32Plus(VM *vm, VAL a, VAL b) {
     VAL cl = allocate(vm, sizeof(Closure), 0);
     SETTY(cl, BITS32);
-    cl->info.bits32 = a->info.bits32 + b->info.bits32;
+    cl->info.bits32 = GETBITS32(a) + GETBITS32(b);
     return cl;
 }
 
 VAL idris_b32Minus(VM *vm, VAL a, VAL b) {
     VAL cl = allocate(vm, sizeof(Closure), 0);
     SETTY(cl, BITS32);
-    cl->info.bits32 = a->info.bits32 - b->info.bits32;
+    cl->info.bits32 = GETBITS32(a) - GETBITS32(b);
     return cl;
 }
 
 VAL idris_b32Times(VM *vm, VAL a, VAL b) {
     VAL cl = allocate(vm, sizeof(Closure), 0);
     SETTY(cl, BITS32);
-    cl->info.bits32 = a->info.bits32 * b->info.bits32;
+    cl->info.bits32 = GETBITS32(a) * GETBITS32(b);
     return cl;
 }
 
 VAL idris_b32UDiv(VM *vm, VAL a, VAL b) {
     VAL cl = allocate(vm, sizeof(Closure), 0);
     SETTY(cl, BITS32);
-    cl->info.bits32 = a->info.bits32 / b->info.bits32;
+    cl->info.bits32 = GETBITS32(a) / GETBITS32(b);
     return cl;
 }
 
@@ -358,14 +358,14 @@ VAL idris_b32SDiv(VM *vm, VAL a, VAL b) {
     VAL cl = allocate(vm, sizeof(Closure), 0);
     SETTY(cl, BITS32);
     cl->info.bits32 =
-    (uint32_t) (((int32_t) a->info.bits32) / ((int32_t) b->info.bits32));
+    (uint32_t) (((int32_t) GETBITS32(a)) / ((int32_t) GETBITS32(b)));
     return cl;
 }
 
 VAL idris_b32URem(VM *vm, VAL a, VAL b) {
     VAL cl = allocate(vm, sizeof(Closure), 0);
     SETTY(cl, BITS32);
-    cl->info.bits32 = a->info.bits32 % b->info.bits32;
+    cl->info.bits32 = GETBITS32(a) % GETBITS32(b);
     return cl;
 }
 
@@ -373,7 +373,7 @@ VAL idris_b32SRem(VM *vm, VAL a, VAL b) {
     VAL cl = allocate(vm, sizeof(Closure), 0);
     SETTY(cl, BITS32);
     cl->info.bits32 =
-    (uint32_t) (((int32_t) a->info.bits32) % ((int32_t) b->info.bits32));
+    (uint32_t) (((int32_t) GETBITS32(a)) % ((int32_t) GETBITS32(b)));
     return cl;
 }
 
@@ -400,77 +400,77 @@ VAL idris_b32Gte(VM *vm, VAL a, VAL b) {
 VAL idris_b32Compl(VM *vm, VAL a) {
     VAL cl = allocate(vm, sizeof(Closure), 0);
     SETTY(cl, BITS32);
-    cl->info.bits32 = ~ a->info.bits32;
+    cl->info.bits32 = ~ GETBITS32(a);
     return cl;
 }
 
 VAL idris_b32And(VM *vm, VAL a, VAL b) {
     VAL cl = allocate(vm, sizeof(Closure), 0);
     SETTY(cl, BITS32);
-    cl->info.bits32 = a->info.bits32 & b->info.bits32;
+    cl->info.bits32 = GETBITS32(a) & GETBITS32(b);
     return cl;
 }
 
 VAL idris_b32Or(VM *vm, VAL a, VAL b) {
     VAL cl = allocate(vm, sizeof(Closure), 0);
     SETTY(cl, BITS32);
-    cl->info.bits32 = a->info.bits32 | b->info.bits32;
+    cl->info.bits32 = GETBITS32(a) | GETBITS32(b);
     return cl;
 }
 
 VAL idris_b32Xor(VM *vm, VAL a, VAL b) {
     VAL cl = allocate(vm, sizeof(Closure), 0);
     SETTY(cl, BITS32);
-    cl->info.bits32 = a->info.bits32 ^ b->info.bits32;
+    cl->info.bits32 = GETBITS32(a) ^ GETBITS32(b);
     return cl;
 }
 
 VAL idris_b32Shl(VM *vm, VAL a, VAL b) {
     VAL cl = allocate(vm, sizeof(Closure), 0);
     SETTY(cl, BITS32);
-    cl->info.bits32 = a->info.bits32 << b->info.bits32;
+    cl->info.bits32 = GETBITS32(a) << GETBITS32(b);
     return cl;
 }
 
 VAL idris_b32LShr(VM *vm, VAL a, VAL b) {
     VAL cl = allocate(vm, sizeof(Closure), 0);
     SETTY(cl, BITS32);
-    cl->info.bits32 = a->info.bits32 >> b->info.bits32;
+    cl->info.bits32 = GETBITS32(a) >> GETBITS32(b);
     return cl;
 }
 
 VAL idris_b32AShr(VM *vm, VAL a, VAL b) {
     VAL cl = allocate(vm, sizeof(Closure), 0);
     SETTY(cl, BITS32);
-    cl->info.bits32 = (uint32_t) (((int32_t)a->info.bits32) >> ((int32_t)b->info.bits32));
+    cl->info.bits32 = (uint32_t) (((int32_t)GETBITS32(a)) >> ((int32_t)GETBITS32(b)));
     return cl;
 }
 
 VAL idris_b64Plus(VM *vm, VAL a, VAL b) {
     VAL cl = allocate(vm, sizeof(Closure), 0);
     SETTY(cl, BITS64);
-    cl->info.bits64 = a->info.bits64 + b->info.bits64;
+    cl->info.bits64 = GETBITS64(a) + GETBITS64(b);
     return cl;
 }
 
 VAL idris_b64Minus(VM *vm, VAL a, VAL b) {
     VAL cl = allocate(vm, sizeof(Closure), 0);
     SETTY(cl, BITS64);
-    cl->info.bits64 = a->info.bits64 - b->info.bits64;
+    cl->info.bits64 = GETBITS64(a) - GETBITS64(b);
     return cl;
 }
 
 VAL idris_b64Times(VM *vm, VAL a, VAL b) {
     VAL cl = allocate(vm, sizeof(Closure), 0);
     SETTY(cl, BITS64);
-    cl->info.bits64 = a->info.bits64 * b->info.bits64;
+    cl->info.bits64 = GETBITS64(a) * GETBITS64(b);
     return cl;
 }
 
 VAL idris_b64UDiv(VM *vm, VAL a, VAL b) {
     VAL cl = allocate(vm, sizeof(Closure), 0);
     SETTY(cl, BITS64);
-    cl->info.bits64 = a->info.bits64 / b->info.bits64;
+    cl->info.bits64 = GETBITS64(a) / GETBITS64(b);
     return cl;
 }
 
@@ -478,14 +478,14 @@ VAL idris_b64SDiv(VM *vm, VAL a, VAL b) {
     VAL cl = allocate(vm, sizeof(Closure), 0);
     SETTY(cl, BITS64);
     cl->info.bits64 =
-    (uint64_t) (((int64_t) a->info.bits64) / ((int64_t) b->info.bits64));
+    (uint64_t) (((int64_t) GETBITS64(a)) / ((int64_t) GETBITS64(b)));
     return cl;
 }
 
 VAL idris_b64URem(VM *vm, VAL a, VAL b) {
     VAL cl = allocate(vm, sizeof(Closure), 0);
     SETTY(cl, BITS64);
-    cl->info.bits64 = a->info.bits64 % b->info.bits64;
+    cl->info.bits64 = GETBITS64(a) % GETBITS64(b);
     return cl;
 }
 
@@ -493,7 +493,7 @@ VAL idris_b64SRem(VM *vm, VAL a, VAL b) {
     VAL cl = allocate(vm, sizeof(Closure), 0);
     SETTY(cl, BITS64);
     cl->info.bits64 =
-    (uint64_t) (((int64_t) a->info.bits64) % ((int64_t) b->info.bits64));
+    (uint64_t) (((int64_t) GETBITS64(a)) % ((int64_t) GETBITS64(b)));
     return cl;
 }
 
@@ -520,175 +520,175 @@ VAL idris_b64Gte(VM *vm, VAL a, VAL b) {
 VAL idris_b64Compl(VM *vm, VAL a) {
     VAL cl = allocate(vm, sizeof(Closure), 0);
     SETTY(cl, BITS64);
-    cl->info.bits64 = ~ a->info.bits64;
+    cl->info.bits64 = ~ GETBITS64(a);
     return cl;
 }
 
 VAL idris_b64And(VM *vm, VAL a, VAL b) {
     VAL cl = allocate(vm, sizeof(Closure), 0);
     SETTY(cl, BITS64);
-    cl->info.bits64 = a->info.bits64 & b->info.bits64;
+    cl->info.bits64 = GETBITS64(a) & GETBITS64(b);
     return cl;
 }
 
 VAL idris_b64Or(VM *vm, VAL a, VAL b) {
     VAL cl = allocate(vm, sizeof(Closure), 0);
     SETTY(cl, BITS64);
-    cl->info.bits64 = a->info.bits64 | b->info.bits64;
+    cl->info.bits64 = GETBITS64(a) | GETBITS64(b);
     return cl;
 }
 
 VAL idris_b64Xor(VM *vm, VAL a, VAL b) {
     VAL cl = allocate(vm, sizeof(Closure), 0);
     SETTY(cl, BITS64);
-    cl->info.bits64 = a->info.bits64 ^ b->info.bits64;
+    cl->info.bits64 = GETBITS64(a) ^ GETBITS64(b);
     return cl;
 }
 
 VAL idris_b64Shl(VM *vm, VAL a, VAL b) {
     VAL cl = allocate(vm, sizeof(Closure), 0);
     SETTY(cl, BITS64);
-    cl->info.bits64 = a->info.bits64 << b->info.bits64;
+    cl->info.bits64 = GETBITS64(a) << GETBITS64(b);
     return cl;
 }
 
 VAL idris_b64LShr(VM *vm, VAL a, VAL b) {
     VAL cl = allocate(vm, sizeof(Closure), 0);
     SETTY(cl, BITS64);
-    cl->info.bits64 = a->info.bits64 >> b->info.bits64;
+    cl->info.bits64 = GETBITS64(a) >> GETBITS64(b);
     return cl;
 }
 
 VAL idris_b64AShr(VM *vm, VAL a, VAL b) {
     VAL cl = allocate(vm, sizeof(Closure), 0);
     SETTY(cl, BITS64);
-    cl->info.bits64 = (uint64_t) (((int64_t)a->info.bits64) >> ((int64_t)b->info.bits64));
+    cl->info.bits64 = (uint64_t) (((int64_t)GETBITS64(a)) >> ((int64_t)GETBITS64(b)));
     return cl;
 }
 
 VAL idris_b8Z16(VM *vm, VAL a) {
     VAL cl = allocate(vm, sizeof(Closure), 0);
     SETTY(cl, BITS16);
-    cl->info.bits16 = (uint16_t) a->info.bits8;
+    cl->info.bits16 = (uint16_t) GETBITS8(a);
     return cl;
 }
 
 VAL idris_b8Z32(VM *vm, VAL a) {
     VAL cl = allocate(vm, sizeof(Closure), 0);
     SETTY(cl, BITS32);
-    cl->info.bits32 = (uint32_t) a->info.bits8;
+    cl->info.bits32 = (uint32_t) GETBITS8(a);
     return cl;
 }
 
 VAL idris_b8Z64(VM *vm, VAL a) {
     VAL cl = allocate(vm, sizeof(Closure), 0);
-    SETTY(cl, BITS16);
-    cl->info.bits64 = (uint64_t) a->info.bits8;
+    SETTY(cl, BITS64);
+    cl->info.bits64 = (uint64_t) GETBITS8(a);
     return cl;
 }
 
 VAL idris_b8S16(VM *vm, VAL a) {
     VAL cl = allocate(vm, sizeof(Closure), 0);
     SETTY(cl, BITS16);
-    cl->info.bits16 = (uint16_t) (int16_t) (int8_t) a->info.bits8;
+    cl->info.bits16 = (uint16_t) (int16_t) (int8_t) GETBITS8(a);
     return cl;
 }
 
 VAL idris_b8S32(VM *vm, VAL a) {
     VAL cl = allocate(vm, sizeof(Closure), 0);
     SETTY(cl, BITS32);
-    cl->info.bits32 = (uint32_t) (int32_t) (int8_t) a->info.bits8;
+    cl->info.bits32 = (uint32_t) (int32_t) (int8_t) GETBITS8(a);
     return cl;
 }
 
 VAL idris_b8S64(VM *vm, VAL a) {
     VAL cl = allocate(vm, sizeof(Closure), 0);
     SETTY(cl, BITS64);
-    cl->info.bits64 = (uint64_t) (int64_t) (int8_t) a->info.bits8;
+    cl->info.bits64 = (uint64_t) (int64_t) (int8_t) GETBITS8(a);
     return cl;
 }
 
 VAL idris_b16Z32(VM *vm, VAL a) {
     VAL cl = allocate(vm, sizeof(Closure), 0);
     SETTY(cl, BITS32);
-    cl->info.bits32 = (uint32_t) a->info.bits16;
+    cl->info.bits32 = (uint32_t) GETBITS16(a);
     return cl;
 }
 
 VAL idris_b16Z64(VM *vm, VAL a) {
     VAL cl = allocate(vm, sizeof(Closure), 0);
     SETTY(cl, BITS64);
-    cl->info.bits64 = (uint64_t) a->info.bits16;
+    cl->info.bits64 = (uint64_t) GETBITS16(a);
     return cl;
 }
 
 VAL idris_b16S32(VM *vm, VAL a) {
     VAL cl = allocate(vm, sizeof(Closure), 0);
     SETTY(cl, BITS32);
-    cl->info.bits32 = (uint32_t) (int32_t) (int16_t) a->info.bits16;
+    cl->info.bits32 = (uint32_t) (int32_t) (int16_t) GETBITS16(a);
     return cl;
 }
 
 VAL idris_b16S64(VM *vm, VAL a) {
     VAL cl = allocate(vm, sizeof(Closure), 0);
     SETTY(cl, BITS64);
-    cl->info.bits64 = (uint64_t) (int64_t) (int16_t) a->info.bits16;
+    cl->info.bits64 = (uint64_t) (int64_t) (int16_t) GETBITS16(a);
     return cl;
 }
 
 VAL idris_b16T8(VM *vm, VAL a) {
     VAL cl = allocate(vm, sizeof(Closure), 0);
     SETTY(cl, BITS8);
-    cl->info.bits8 = (uint8_t) a->info.bits16;
+    cl->info.bits8 = (uint8_t) GETBITS16(a);
     return cl;
 }
 
 VAL idris_b32Z64(VM *vm, VAL a) {
     VAL cl = allocate(vm, sizeof(Closure), 0);
     SETTY(cl, BITS64);
-    cl->info.bits64 = (uint64_t) a->info.bits32;
+    cl->info.bits64 = (uint64_t) GETBITS32(a);
     return cl;
 }
 
 VAL idris_b32S64(VM *vm, VAL a) {
     VAL cl = allocate(vm, sizeof(Closure), 0);
     SETTY(cl, BITS64);
-    cl->info.bits64 = (uint64_t) (int64_t) (int32_t) a->info.bits32;
+    cl->info.bits64 = (uint64_t) (int64_t) (int32_t) GETBITS32(a);
     return cl;
 }
 
 VAL idris_b32T8(VM *vm, VAL a) {
     VAL cl = allocate(vm, sizeof(Closure), 0);
     SETTY(cl, BITS8);
-    cl->info.bits8 = (uint8_t) a->info.bits32;
+    cl->info.bits8 = (uint8_t) GETBITS32(a);
     return cl;
 }
 
 VAL idris_b32T16(VM *vm, VAL a) {
     VAL cl = allocate(vm, sizeof(Closure), 0);
     SETTY(cl, BITS16);
-    cl->info.bits16 = (uint16_t) a->info.bits32;
+    cl->info.bits16 = (uint16_t) GETBITS32(a);
     return cl;
 }
 
 VAL idris_b64T8(VM *vm, VAL a) {
     VAL cl = allocate(vm, sizeof(Closure), 0);
     SETTY(cl, BITS8);
-    cl->info.bits8 = (uint8_t) a->info.bits64;
+    cl->info.bits8 = (uint8_t) GETBITS64(a);
     return cl;
 }
 
 VAL idris_b64T16(VM *vm, VAL a) {
     VAL cl = allocate(vm, sizeof(Closure), 0);
     SETTY(cl, BITS16);
-    cl->info.bits16 = (uint16_t) a->info.bits64;
+    cl->info.bits16 = (uint16_t) GETBITS64(a);
     return cl;
 }
 
 VAL idris_b64T32(VM *vm, VAL a) {
     VAL cl = allocate(vm, sizeof(Closure), 0);
     SETTY(cl, BITS32);
-    cl->info.bits32 = (uint32_t) a->info.bits64;
+    cl->info.bits32 = (uint32_t) GETBITS64(a);
     return cl;
 }
 

--- a/rts/idris_rts.h
+++ b/rts/idris_rts.h
@@ -129,6 +129,11 @@ typedef void(*func)(VM*, VAL*);
 #define GETMPTR(x) (((VAL)(x))->info.mptr->data) 
 #define GETFLOAT(x) (((VAL)(x))->info.f)
 
+#define GETBITS64(x) ((x)->ty == FWD ? ((VAL)((x)->info.ptr))->info.bits64 : (x)->info.bits64)
+#define GETBITS32(x) ((x)->ty == FWD ? ((VAL)((x)->info.ptr))->info.bits32 : (x)->info.bits32)
+#define GETBITS16(x) ((x)->ty == FWD ? ((VAL)((x)->info.ptr))->info.bits16 : (x)->info.bits16)
+#define GETBITS8(x) ((x)->ty == FWD ? ((VAL)((x)->info.ptr))->info.bits8 : (x)->info.bits8)
+
 #define TAG(x) (ISINT(x) || x == NULL ? (-1) : ( GETTY(x) == CON ? (x)->info.c.tag_arity >> 8 : (-1)) )
 #define ARITY(x) (ISINT(x) || x == NULL ? (-1) : ( GETTY(x) == CON ? (x)->info.c.tag_arity & 0x000000ff : (-1)) )
 


### PR DESCRIPTION
Ok, so many primops on 8, 16, 32, 64 bit machine words in the C runtime operate
by passing arg pointers to functions that begin by allocating a new VAL cell to
hold the result. If this allocation results in a GC collection then the
argument pointers may be pointing into the old heap, to a cell whose contents
has been overwritten with a forwarding pointer. While the collection algorithm
should update any references to these forwarding cells to the new cell, it
can't fixup the pointer you are holding onto right now "between instructions".

This bug happens when your operation is interrupted by the GC and you use the
forwarding pointer(s) as the arguments, resulting in incorrect results. This
would be hard to reproduce because it depends on the timing of the GC.

But the package idris-tf-random nonetheless can reproduce this if it runs long
enough, because it makes extensive use of BitsN operations. My canary program
at http://lpaste.net/112132 dumps the output of a Bits32 generator with a
static seed, but after a certain number of iterations (depending on GC timing)
the sequence will act differently from previous runs (depending on the value of
the forwarding pointers it is erroneously using). This commit makes the program
apparently deterministic again.

If you look at the GMP operations in rts/idris_gmp.c you will see in the
corresponding gmp ops, after the allocation of the result, the arguments are
retrieved using GETBIG which may follow this forwarding pointer.

Similarly I added four GETBITSN macros which either get these bits value
directly or get it from the forwarded VAL cell by testing if ty = FWD.
Operations in rts/idris_bitstring.c that do not do an allocation did not get
wrapped in this macro.

I'm planning to review GETBIG too, since it is recursive and the shortcut case
for INT (which does allocation) may suffer from this bug too.
