### PR TITLE
fix for bugs in the bits primitive operations

### DIFF
--- a/rts/idris_bitstring.c
+++ b/rts/idris_bitstring.c
@@ -1,58 +1,66 @@
 #include "idris_rts.h"
 
 VAL idris_b8CopyForGC(VM *vm, VAL a) {
+    uint8_t A = a->info.bits8;
     VAL cl = allocate(vm, sizeof(Closure), 1);
     SETTY(cl, BITS8);
-    cl->info.bits8 = GETBITS8(a);
+    cl->info.bits8 = A;
     return cl;
 }
 
 VAL idris_b16CopyForGC(VM *vm, VAL a) {
+    uint16_t A = a->info.bits16;
     VAL cl = allocate(vm, sizeof(Closure), 1);
     SETTY(cl, BITS16);
-    cl->info.bits16 = GETBITS16(a);
+    cl->info.bits16 = A;
     return cl;
 }
 
 VAL idris_b32CopyForGC(VM *vm, VAL a) {
+    uint32_t A = a->info.bits32;
     VAL cl = allocate(vm, sizeof(Closure), 1);
     SETTY(cl, BITS32);
-    cl->info.bits32 = GETBITS32(a);
+    cl->info.bits32 = A;
     return cl;
 }
 
 VAL idris_b64CopyForGC(VM *vm, VAL a) {
+    uint64_t A = a->info.bits64;
     VAL cl = allocate(vm, sizeof(Closure), 1);
     SETTY(cl, BITS64);
-    cl->info.bits64 = GETBITS64(a);
+    cl->info.bits64 = A;
     return cl;
 }
 
 VAL idris_b8(VM *vm, VAL a) {
+    uint8_t A = GETINT(a);
     VAL cl = allocate(vm, sizeof(Closure), 0);
     SETTY(cl, BITS8);
-    cl->info.bits8 = (uint8_t) GETINT(a);
+    cl->info.bits8 = (uint8_t) A;
     return cl;
 }
 
 VAL idris_b16(VM *vm, VAL a) {
+    uint16_t A = GETINT(a);
     VAL cl = allocate(vm, sizeof(Closure), 0);
     SETTY(cl, BITS16);
-    cl->info.bits16 = (uint16_t) GETINT(a);
+    cl->info.bits16 = (uint16_t) A;
     return cl;
 }
 
 VAL idris_b32(VM *vm, VAL a) {
+    uint32_t A = GETINT(a);
     VAL cl = allocate(vm, sizeof(Closure), 0);
     SETTY(cl, BITS32);
-    cl->info.bits32 = (uint32_t) GETINT(a);
+    cl->info.bits32 = (uint32_t) A;
     return cl;
 }
 
 VAL idris_b64(VM *vm, VAL a) {
+    uint64_t A = GETINT(a);
     VAL cl = allocate(vm, sizeof(Closure), 0);
     SETTY(cl, BITS64);
-    cl->info.bits64 = (uint64_t) GETINT(a);
+    cl->info.bits64 = (uint64_t) A;
     return cl;
 }
 
@@ -89,51 +97,65 @@ VAL idris_b64const(VM *vm, uint64_t a) {
 }
 
 VAL idris_b8Plus(VM *vm, VAL a, VAL b) {
+    uint8_t A = a->info.bits8;
+    uint8_t B = b->info.bits8;
     VAL cl = allocate(vm, sizeof(Closure), 0);
     SETTY(cl, BITS8);
-    cl->info.bits8 = GETBITS8(a) + GETBITS8(b);
+    cl->info.bits8 = A + B;
     return cl;
 }
 
 VAL idris_b8Minus(VM *vm, VAL a, VAL b) {
+    uint8_t A = a->info.bits8;
+    uint8_t B = b->info.bits8;
     VAL cl = allocate(vm, sizeof(Closure), 0);
     SETTY(cl, BITS8);
-    cl->info.bits8 = GETBITS8(a) - GETBITS8(b);
+    cl->info.bits8 = A - B;
     return cl;
 }
 
 VAL idris_b8Times(VM *vm, VAL a, VAL b) {
+    uint8_t A = a->info.bits8;
+    uint8_t B = b->info.bits8;
     VAL cl = allocate(vm, sizeof(Closure), 0);
     SETTY(cl, BITS8);
-    cl->info.bits8 = GETBITS8(a) * GETBITS8(b);
+    cl->info.bits8 = A * B;
     return cl;
 }
 
 VAL idris_b8UDiv(VM *vm, VAL a, VAL b) {
+    uint8_t A = a->info.bits8;
+    uint8_t B = b->info.bits8;
     VAL cl = allocate(vm, sizeof(Closure), 0);
     SETTY(cl, BITS8);
-    cl->info.bits8 = GETBITS8(a) / GETBITS8(b);
+    cl->info.bits8 = A / B;
     return cl;
 }
 
 VAL idris_b8SDiv(VM *vm, VAL a, VAL b) {
+    uint8_t A = a->info.bits8;
+    uint8_t B = b->info.bits8;
     VAL cl = allocate(vm, sizeof(Closure), 0);
     SETTY(cl, BITS8);
-    cl->info.bits8 = (uint8_t) (((int8_t) GETBITS8(a)) / ((int8_t) GETBITS8(b)));
+    cl->info.bits8 = (uint8_t) (((int8_t) A) / ((int8_t) B));
     return cl;
 }
 
 VAL idris_b8URem(VM *vm, VAL a, VAL b) {
+    uint8_t A = a->info.bits8;
+    uint8_t B = b->info.bits8;
     VAL cl = allocate(vm, sizeof(Closure), 0);
     SETTY(cl, BITS8);
-    cl->info.bits8 = GETBITS8(a) % GETBITS8(b);
+    cl->info.bits8 = A % B;
     return cl;
 }
 
 VAL idris_b8SRem(VM *vm, VAL a, VAL b) {
+    uint8_t A = a->info.bits8;
+    uint8_t B = b->info.bits8;
     VAL cl = allocate(vm, sizeof(Closure), 0);
     SETTY(cl, BITS8);
-    cl->info.bits8 = (uint8_t) (((int8_t) GETBITS8(a)) % ((int8_t) GETBITS8(b)));
+    cl->info.bits8 = (uint8_t) (((int8_t) A) % ((int8_t) B));
     return cl;
 }
 
@@ -158,102 +180,127 @@ VAL idris_b8Gte(VM *vm, VAL a, VAL b) {
 }
 
 VAL idris_b8Compl(VM *vm, VAL a) {
+    uint8_t A = a->info.bits8;
     VAL cl = allocate(vm, sizeof(Closure), 0);
     SETTY(cl, BITS8);
-    cl->info.bits8 = ~ GETBITS8(a);
+    cl->info.bits8 = ~ A;
     return cl;
 }
 
 VAL idris_b8And(VM *vm, VAL a, VAL b) {
+    uint8_t A = a->info.bits8;
+    uint8_t B = b->info.bits8;
     VAL cl = allocate(vm, sizeof(Closure), 0);
     SETTY(cl, BITS8);
-    cl->info.bits8 = GETBITS8(a) & GETBITS8(b);
+    cl->info.bits8 = A & B;
     return cl;
 }
 
 VAL idris_b8Or(VM *vm, VAL a, VAL b) {
+    uint8_t A = a->info.bits8;
+    uint8_t B = b->info.bits8;
     VAL cl = allocate(vm, sizeof(Closure), 0);
     SETTY(cl, BITS8);
-    cl->info.bits8 = GETBITS8(a) | GETBITS8(b);
+    cl->info.bits8 = A | B;
     return cl;
 }
 
 VAL idris_b8Xor(VM *vm, VAL a, VAL b) {
+    uint8_t A = a->info.bits8;
+    uint8_t B = b->info.bits8;
     VAL cl = allocate(vm, sizeof(Closure), 0);
     SETTY(cl, BITS8);
-    cl->info.bits8 = GETBITS8(a) ^ GETBITS8(b);
+    cl->info.bits8 = A ^ B;
     return cl;
 }
 
 VAL idris_b8Shl(VM *vm, VAL a, VAL b) {
+    uint8_t A = a->info.bits8;
+    uint8_t B = b->info.bits8;
     VAL cl = allocate(vm, sizeof(Closure), 0);
     SETTY(cl, BITS8);
-    cl->info.bits8 = GETBITS8(a) << GETBITS8(b);
+    cl->info.bits8 = A << B;
     return cl;
 }
 
 VAL idris_b8LShr(VM *vm, VAL a, VAL b) {
+    uint8_t A = a->info.bits8;
+    uint8_t B = b->info.bits8;
     VAL cl = allocate(vm, sizeof(Closure), 0);
     SETTY(cl, BITS8);
-    cl->info.bits8 = GETBITS8(a) >> GETBITS8(b);
+    cl->info.bits8 = A >> B;
     return cl;
 }
 
 VAL idris_b8AShr(VM *vm, VAL a, VAL b) {
+    uint8_t A = a->info.bits8;
+    uint8_t B = b->info.bits8;
     VAL cl = allocate(vm, sizeof(Closure), 0);
     SETTY(cl, BITS8);
-    cl->info.bits8 = (uint8_t) (((int8_t)GETBITS8(a)) >> ((int8_t)GETBITS8(b)));
+    cl->info.bits8 = (uint8_t) (((int8_t) A) >> ((int8_t) B));
     return cl;
 }
 
 VAL idris_b16Plus(VM *vm, VAL a, VAL b) {
+    uint16_t A = a->info.bits16;
+    uint16_t B = b->info.bits16;
     VAL cl = allocate(vm, sizeof(Closure), 0);
     SETTY(cl, BITS16);
-    cl->info.bits16 = GETBITS16(a) + GETBITS16(b);
+    cl->info.bits16 = A + B;
     return cl;
 }
 
 VAL idris_b16Minus(VM *vm, VAL a, VAL b) {
+    uint16_t A = a->info.bits16;
+    uint16_t B = b->info.bits16;
     VAL cl = allocate(vm, sizeof(Closure), 0);
     SETTY(cl, BITS16);
-    cl->info.bits16 = GETBITS16(a) - GETBITS16(b);
+    cl->info.bits16 = A - B;
     return cl;
 }
 
 VAL idris_b16Times(VM *vm, VAL a, VAL b) {
+    uint16_t A = a->info.bits16;
+    uint16_t B = b->info.bits16;
     VAL cl = allocate(vm, sizeof(Closure), 0);
     SETTY(cl, BITS16);
-    cl->info.bits16 = GETBITS16(a) * GETBITS16(b);
+    cl->info.bits16 = A * B;
     return cl;
 }
 
 VAL idris_b16UDiv(VM *vm, VAL a, VAL b) {
+    uint16_t A = a->info.bits16;
+    uint16_t B = b->info.bits16;
     VAL cl = allocate(vm, sizeof(Closure), 0);
     SETTY(cl, BITS16);
-    cl->info.bits16 = GETBITS16(a) / GETBITS16(b);
+    cl->info.bits16 = A / B;
     return cl;
 }
 
 VAL idris_b16SDiv(VM *vm, VAL a, VAL b) {
+    uint16_t A = a->info.bits16;
+    uint16_t B = b->info.bits16;
     VAL cl = allocate(vm, sizeof(Closure), 0);
     SETTY(cl, BITS16);
-    cl->info.bits16 =
-    (uint16_t) (((int16_t) GETBITS16(a)) / ((int16_t) GETBITS16(b)));
+    cl->info.bits16 = (uint16_t) (((int16_t) A) / ((int16_t) B));
     return cl;
 }
 
 VAL idris_b16URem(VM *vm, VAL a, VAL b) {
+    uint16_t A = a->info.bits16;
+    uint16_t B = b->info.bits16;
     VAL cl = allocate(vm, sizeof(Closure), 0);
     SETTY(cl, BITS16);
-    cl->info.bits16 = GETBITS16(a) % GETBITS16(b);
+    cl->info.bits16 = A % B;
     return cl;
 }
 
 VAL idris_b16SRem(VM *vm, VAL a, VAL b) {
+    uint16_t A = a->info.bits16;
+    uint16_t B = b->info.bits16;
     VAL cl = allocate(vm, sizeof(Closure), 0);
     SETTY(cl, BITS16);
-    cl->info.bits16 =
-    (uint16_t) (((int16_t) GETBITS16(a)) % ((int16_t) GETBITS16(b)));
+    cl->info.bits16 = (uint16_t) (((int16_t) A) % ((int16_t) B));
     return cl;
 }
 
@@ -278,102 +325,127 @@ VAL idris_b16Gte(VM *vm, VAL a, VAL b) {
 }
 
 VAL idris_b16Compl(VM *vm, VAL a) {
+    uint16_t A = a->info.bits16;
     VAL cl = allocate(vm, sizeof(Closure), 0);
     SETTY(cl, BITS16);
-    cl->info.bits16 = ~ GETBITS16(a);
+    cl->info.bits16 = ~ A;
     return cl;
 }
 
 VAL idris_b16And(VM *vm, VAL a, VAL b) {
+    uint16_t A = a->info.bits16;
+    uint16_t B = b->info.bits16;
     VAL cl = allocate(vm, sizeof(Closure), 0);
     SETTY(cl, BITS16);
-    cl->info.bits16 = GETBITS16(a) & GETBITS16(b);
+    cl->info.bits16 = A & B;
     return cl;
 }
 
 VAL idris_b16Or(VM *vm, VAL a, VAL b) {
+    uint16_t A = a->info.bits16;
+    uint16_t B = b->info.bits16;
     VAL cl = allocate(vm, sizeof(Closure), 0);
     SETTY(cl, BITS16);
-    cl->info.bits16 = GETBITS16(a) | GETBITS16(b);
+    cl->info.bits16 = A | B;
     return cl;
 }
 
 VAL idris_b16Xor(VM *vm, VAL a, VAL b) {
+    uint16_t A = a->info.bits16;
+    uint16_t B = b->info.bits16;
     VAL cl = allocate(vm, sizeof(Closure), 0);
     SETTY(cl, BITS16);
-    cl->info.bits16 = GETBITS16(a) ^ GETBITS16(b);
+    cl->info.bits16 = A ^ B;
     return cl;
 }
 
 VAL idris_b16Shl(VM *vm, VAL a, VAL b) {
+    uint16_t A = a->info.bits16;
+    uint16_t B = b->info.bits16;
     VAL cl = allocate(vm, sizeof(Closure), 0);
     SETTY(cl, BITS16);
-    cl->info.bits16 = GETBITS16(a) << GETBITS16(b);
+    cl->info.bits16 = A << B;
     return cl;
 }
 
 VAL idris_b16LShr(VM *vm, VAL a, VAL b) {
+    uint16_t A = a->info.bits16;
+    uint16_t B = b->info.bits16;
     VAL cl = allocate(vm, sizeof(Closure), 0);
     SETTY(cl, BITS16);
-    cl->info.bits16 = GETBITS16(a) >> GETBITS16(b);
+    cl->info.bits16 = A >> B;
     return cl;
 }
 
 VAL idris_b16AShr(VM *vm, VAL a, VAL b) {
+    uint16_t A = a->info.bits16;
+    uint16_t B = b->info.bits16;
     VAL cl = allocate(vm, sizeof(Closure), 0);
     SETTY(cl, BITS16);
-    cl->info.bits16 = (uint16_t) (((int16_t)GETBITS16(a)) >> ((int16_t)GETBITS16(b)));
+    cl->info.bits16 = (uint16_t) (((int16_t) A) >> ((int16_t) B));
     return cl;
 }
 
 VAL idris_b32Plus(VM *vm, VAL a, VAL b) {
+    uint32_t A = a->info.bits32;
+    uint32_t B = b->info.bits32;
     VAL cl = allocate(vm, sizeof(Closure), 0);
     SETTY(cl, BITS32);
-    cl->info.bits32 = GETBITS32(a) + GETBITS32(b);
+    cl->info.bits32 = A + B;
     return cl;
 }
 
 VAL idris_b32Minus(VM *vm, VAL a, VAL b) {
+    uint32_t A = a->info.bits32;
+    uint32_t B = b->info.bits32;
     VAL cl = allocate(vm, sizeof(Closure), 0);
     SETTY(cl, BITS32);
-    cl->info.bits32 = GETBITS32(a) - GETBITS32(b);
+    cl->info.bits32 = A - B;
     return cl;
 }
 
 VAL idris_b32Times(VM *vm, VAL a, VAL b) {
+    uint32_t A = a->info.bits32;
+    uint32_t B = b->info.bits32;
     VAL cl = allocate(vm, sizeof(Closure), 0);
     SETTY(cl, BITS32);
-    cl->info.bits32 = GETBITS32(a) * GETBITS32(b);
+    cl->info.bits32 = A * B;
     return cl;
 }
 
 VAL idris_b32UDiv(VM *vm, VAL a, VAL b) {
+    uint32_t A = a->info.bits32;
+    uint32_t B = b->info.bits32;
     VAL cl = allocate(vm, sizeof(Closure), 0);
     SETTY(cl, BITS32);
-    cl->info.bits32 = GETBITS32(a) / GETBITS32(b);
+    cl->info.bits32 = A / B;
     return cl;
 }
 
 VAL idris_b32SDiv(VM *vm, VAL a, VAL b) {
+    uint32_t A = a->info.bits32;
+    uint32_t B = b->info.bits32;
     VAL cl = allocate(vm, sizeof(Closure), 0);
     SETTY(cl, BITS32);
-    cl->info.bits32 =
-    (uint32_t) (((int32_t) GETBITS32(a)) / ((int32_t) GETBITS32(b)));
+    cl->info.bits32 = (uint32_t) (((int32_t) A) / ((int32_t) B));
     return cl;
 }
 
 VAL idris_b32URem(VM *vm, VAL a, VAL b) {
+    uint32_t A = a->info.bits32;
+    uint32_t B = b->info.bits32;
     VAL cl = allocate(vm, sizeof(Closure), 0);
     SETTY(cl, BITS32);
-    cl->info.bits32 = GETBITS32(a) % GETBITS32(b);
+    cl->info.bits32 = A % B;
     return cl;
 }
 
 VAL idris_b32SRem(VM *vm, VAL a, VAL b) {
+    uint32_t A = a->info.bits32;
+    uint32_t B = b->info.bits32;
     VAL cl = allocate(vm, sizeof(Closure), 0);
     SETTY(cl, BITS32);
-    cl->info.bits32 =
-    (uint32_t) (((int32_t) GETBITS32(a)) % ((int32_t) GETBITS32(b)));
+    cl->info.bits32 = (uint32_t) (((int32_t) A) % ((int32_t) B));
     return cl;
 }
 
@@ -398,102 +470,127 @@ VAL idris_b32Gte(VM *vm, VAL a, VAL b) {
 }
 
 VAL idris_b32Compl(VM *vm, VAL a) {
+    uint32_t A = a->info.bits32;
     VAL cl = allocate(vm, sizeof(Closure), 0);
     SETTY(cl, BITS32);
-    cl->info.bits32 = ~ GETBITS32(a);
+    cl->info.bits32 = ~ A;
     return cl;
 }
 
 VAL idris_b32And(VM *vm, VAL a, VAL b) {
+    uint32_t A = a->info.bits32;
+    uint32_t B = b->info.bits32;
     VAL cl = allocate(vm, sizeof(Closure), 0);
     SETTY(cl, BITS32);
-    cl->info.bits32 = GETBITS32(a) & GETBITS32(b);
+    cl->info.bits32 = A & B;
     return cl;
 }
 
 VAL idris_b32Or(VM *vm, VAL a, VAL b) {
+    uint32_t A = a->info.bits32;
+    uint32_t B = b->info.bits32;
     VAL cl = allocate(vm, sizeof(Closure), 0);
     SETTY(cl, BITS32);
-    cl->info.bits32 = GETBITS32(a) | GETBITS32(b);
+    cl->info.bits32 = A | B;
     return cl;
 }
 
 VAL idris_b32Xor(VM *vm, VAL a, VAL b) {
+    uint32_t A = a->info.bits32;
+    uint32_t B = b->info.bits32;
     VAL cl = allocate(vm, sizeof(Closure), 0);
     SETTY(cl, BITS32);
-    cl->info.bits32 = GETBITS32(a) ^ GETBITS32(b);
+    cl->info.bits32 = A ^ B;
     return cl;
 }
 
 VAL idris_b32Shl(VM *vm, VAL a, VAL b) {
+    uint32_t A = a->info.bits32;
+    uint32_t B = b->info.bits32;
     VAL cl = allocate(vm, sizeof(Closure), 0);
     SETTY(cl, BITS32);
-    cl->info.bits32 = GETBITS32(a) << GETBITS32(b);
+    cl->info.bits32 = A << B;
     return cl;
 }
 
 VAL idris_b32LShr(VM *vm, VAL a, VAL b) {
+    uint32_t A = a->info.bits32;
+    uint32_t B = b->info.bits32;
     VAL cl = allocate(vm, sizeof(Closure), 0);
     SETTY(cl, BITS32);
-    cl->info.bits32 = GETBITS32(a) >> GETBITS32(b);
+    cl->info.bits32 = A >> B;
     return cl;
 }
 
 VAL idris_b32AShr(VM *vm, VAL a, VAL b) {
+    uint32_t A = a->info.bits32;
+    uint32_t B = b->info.bits32;
     VAL cl = allocate(vm, sizeof(Closure), 0);
     SETTY(cl, BITS32);
-    cl->info.bits32 = (uint32_t) (((int32_t)GETBITS32(a)) >> ((int32_t)GETBITS32(b)));
+    cl->info.bits32 = (uint32_t) (((int32_t)A) >> ((int32_t)B));
     return cl;
 }
 
 VAL idris_b64Plus(VM *vm, VAL a, VAL b) {
+    uint64_t A = a->info.bits64;
+    uint64_t B = b->info.bits64;
     VAL cl = allocate(vm, sizeof(Closure), 0);
     SETTY(cl, BITS64);
-    cl->info.bits64 = GETBITS64(a) + GETBITS64(b);
+    cl->info.bits64 = A + B;
     return cl;
 }
 
 VAL idris_b64Minus(VM *vm, VAL a, VAL b) {
+    uint64_t A = a->info.bits64;
+    uint64_t B = b->info.bits64;
     VAL cl = allocate(vm, sizeof(Closure), 0);
     SETTY(cl, BITS64);
-    cl->info.bits64 = GETBITS64(a) - GETBITS64(b);
+    cl->info.bits64 = A - B;
     return cl;
 }
 
 VAL idris_b64Times(VM *vm, VAL a, VAL b) {
+    uint64_t A = a->info.bits64;
+    uint64_t B = b->info.bits64;
     VAL cl = allocate(vm, sizeof(Closure), 0);
     SETTY(cl, BITS64);
-    cl->info.bits64 = GETBITS64(a) * GETBITS64(b);
+    cl->info.bits64 = A * B;
     return cl;
 }
 
 VAL idris_b64UDiv(VM *vm, VAL a, VAL b) {
+    uint64_t A = a->info.bits64;
+    uint64_t B = b->info.bits64;
     VAL cl = allocate(vm, sizeof(Closure), 0);
     SETTY(cl, BITS64);
-    cl->info.bits64 = GETBITS64(a) / GETBITS64(b);
+    cl->info.bits64 = A / B;
     return cl;
 }
 
 VAL idris_b64SDiv(VM *vm, VAL a, VAL b) {
+    uint64_t A = a->info.bits64;
+    uint64_t B = b->info.bits64;
     VAL cl = allocate(vm, sizeof(Closure), 0);
     SETTY(cl, BITS64);
-    cl->info.bits64 =
-    (uint64_t) (((int64_t) GETBITS64(a)) / ((int64_t) GETBITS64(b)));
+    cl->info.bits64 = (uint64_t) (((int64_t) A) / ((int64_t) B));
     return cl;
 }
 
 VAL idris_b64URem(VM *vm, VAL a, VAL b) {
+    uint64_t A = a->info.bits64;
+    uint64_t B = b->info.bits64;
     VAL cl = allocate(vm, sizeof(Closure), 0);
     SETTY(cl, BITS64);
-    cl->info.bits64 = GETBITS64(a) % GETBITS64(b);
+    cl->info.bits64 = A % B;
     return cl;
 }
 
 VAL idris_b64SRem(VM *vm, VAL a, VAL b) {
+    uint64_t A = a->info.bits64;
+    uint64_t B = b->info.bits64;
     VAL cl = allocate(vm, sizeof(Closure), 0);
     SETTY(cl, BITS64);
-    cl->info.bits64 =
-    (uint64_t) (((int64_t) GETBITS64(a)) % ((int64_t) GETBITS64(b)));
+    cl->info.bits64 = (uint64_t) (((int64_t) A) % ((int64_t) B));
     return cl;
 }
 
@@ -518,177 +615,208 @@ VAL idris_b64Gte(VM *vm, VAL a, VAL b) {
 }
 
 VAL idris_b64Compl(VM *vm, VAL a) {
+    uint64_t A = a->info.bits64;
     VAL cl = allocate(vm, sizeof(Closure), 0);
     SETTY(cl, BITS64);
-    cl->info.bits64 = ~ GETBITS64(a);
+    cl->info.bits64 = ~ A;
     return cl;
 }
 
 VAL idris_b64And(VM *vm, VAL a, VAL b) {
+    uint64_t A = a->info.bits64;
+    uint64_t B = b->info.bits64;
     VAL cl = allocate(vm, sizeof(Closure), 0);
     SETTY(cl, BITS64);
-    cl->info.bits64 = GETBITS64(a) & GETBITS64(b);
+    cl->info.bits64 = A & B;
     return cl;
 }
 
 VAL idris_b64Or(VM *vm, VAL a, VAL b) {
+    uint64_t A = a->info.bits64;
+    uint64_t B = b->info.bits64;
     VAL cl = allocate(vm, sizeof(Closure), 0);
     SETTY(cl, BITS64);
-    cl->info.bits64 = GETBITS64(a) | GETBITS64(b);
+    cl->info.bits64 = A | B;
     return cl;
 }
 
 VAL idris_b64Xor(VM *vm, VAL a, VAL b) {
+    uint64_t A = a->info.bits64;
+    uint64_t B = b->info.bits64;
     VAL cl = allocate(vm, sizeof(Closure), 0);
     SETTY(cl, BITS64);
-    cl->info.bits64 = GETBITS64(a) ^ GETBITS64(b);
+    cl->info.bits64 = A ^ B;
     return cl;
 }
 
 VAL idris_b64Shl(VM *vm, VAL a, VAL b) {
+    uint64_t A = a->info.bits64;
+    uint64_t B = b->info.bits64;
     VAL cl = allocate(vm, sizeof(Closure), 0);
     SETTY(cl, BITS64);
-    cl->info.bits64 = GETBITS64(a) << GETBITS64(b);
+    cl->info.bits64 = A << B;
     return cl;
 }
 
 VAL idris_b64LShr(VM *vm, VAL a, VAL b) {
+    uint64_t A = a->info.bits64;
+    uint64_t B = b->info.bits64;
     VAL cl = allocate(vm, sizeof(Closure), 0);
     SETTY(cl, BITS64);
-    cl->info.bits64 = GETBITS64(a) >> GETBITS64(b);
+    cl->info.bits64 = A >> B;
     return cl;
 }
 
 VAL idris_b64AShr(VM *vm, VAL a, VAL b) {
+    uint64_t A = a->info.bits64;
+    uint64_t B = b->info.bits64;
     VAL cl = allocate(vm, sizeof(Closure), 0);
     SETTY(cl, BITS64);
-    cl->info.bits64 = (uint64_t) (((int64_t)GETBITS64(a)) >> ((int64_t)GETBITS64(b)));
+    cl->info.bits64 = (uint64_t) (((int64_t) A) >> ((int64_t) B));
     return cl;
 }
 
 VAL idris_b8Z16(VM *vm, VAL a) {
+    uint8_t A = a->info.bits8;
     VAL cl = allocate(vm, sizeof(Closure), 0);
     SETTY(cl, BITS16);
-    cl->info.bits16 = (uint16_t) GETBITS8(a);
+    cl->info.bits16 = (uint16_t) A;
     return cl;
 }
 
 VAL idris_b8Z32(VM *vm, VAL a) {
+    uint8_t A = a->info.bits8;
     VAL cl = allocate(vm, sizeof(Closure), 0);
     SETTY(cl, BITS32);
-    cl->info.bits32 = (uint32_t) GETBITS8(a);
+    cl->info.bits32 = (uint32_t) A;
     return cl;
 }
 
 VAL idris_b8Z64(VM *vm, VAL a) {
+    uint8_t A = a->info.bits8;
     VAL cl = allocate(vm, sizeof(Closure), 0);
     SETTY(cl, BITS64);
-    cl->info.bits64 = (uint64_t) GETBITS8(a);
+    cl->info.bits64 = (uint64_t) A;
     return cl;
 }
 
 VAL idris_b8S16(VM *vm, VAL a) {
+    uint8_t A = a->info.bits8;
     VAL cl = allocate(vm, sizeof(Closure), 0);
     SETTY(cl, BITS16);
-    cl->info.bits16 = (uint16_t) (int16_t) (int8_t) GETBITS8(a);
+    cl->info.bits16 = (uint16_t) (int16_t) (int8_t) A;
     return cl;
 }
 
 VAL idris_b8S32(VM *vm, VAL a) {
+    uint8_t A = a->info.bits8;
     VAL cl = allocate(vm, sizeof(Closure), 0);
     SETTY(cl, BITS32);
-    cl->info.bits32 = (uint32_t) (int32_t) (int8_t) GETBITS8(a);
+    cl->info.bits32 = (uint32_t) (int32_t) (int8_t) A;
     return cl;
 }
 
 VAL idris_b8S64(VM *vm, VAL a) {
+    uint8_t A = a->info.bits8;
     VAL cl = allocate(vm, sizeof(Closure), 0);
     SETTY(cl, BITS64);
-    cl->info.bits64 = (uint64_t) (int64_t) (int8_t) GETBITS8(a);
+    cl->info.bits64 = (uint64_t) (int64_t) (int8_t) A;
     return cl;
 }
 
 VAL idris_b16Z32(VM *vm, VAL a) {
+    uint16_t A = a->info.bits16;
     VAL cl = allocate(vm, sizeof(Closure), 0);
     SETTY(cl, BITS32);
-    cl->info.bits32 = (uint32_t) GETBITS16(a);
+    cl->info.bits32 = (uint32_t) A;
     return cl;
 }
 
 VAL idris_b16Z64(VM *vm, VAL a) {
+    uint16_t A = a->info.bits16;
     VAL cl = allocate(vm, sizeof(Closure), 0);
     SETTY(cl, BITS64);
-    cl->info.bits64 = (uint64_t) GETBITS16(a);
+    cl->info.bits64 = (uint64_t) A;
     return cl;
 }
 
 VAL idris_b16S32(VM *vm, VAL a) {
+    uint16_t A = a->info.bits16;
     VAL cl = allocate(vm, sizeof(Closure), 0);
     SETTY(cl, BITS32);
-    cl->info.bits32 = (uint32_t) (int32_t) (int16_t) GETBITS16(a);
+    cl->info.bits32 = (uint32_t) (int32_t) (int16_t) A;
     return cl;
 }
 
 VAL idris_b16S64(VM *vm, VAL a) {
+    uint16_t A = a->info.bits16;
     VAL cl = allocate(vm, sizeof(Closure), 0);
     SETTY(cl, BITS64);
-    cl->info.bits64 = (uint64_t) (int64_t) (int16_t) GETBITS16(a);
+    cl->info.bits64 = (uint64_t) (int64_t) (int16_t) A;
     return cl;
 }
 
 VAL idris_b16T8(VM *vm, VAL a) {
+    uint16_t A = a->info.bits16;
     VAL cl = allocate(vm, sizeof(Closure), 0);
     SETTY(cl, BITS8);
-    cl->info.bits8 = (uint8_t) GETBITS16(a);
+    cl->info.bits8 = (uint8_t) A;
     return cl;
 }
 
 VAL idris_b32Z64(VM *vm, VAL a) {
+    uint32_t A = a->info.bits32;
     VAL cl = allocate(vm, sizeof(Closure), 0);
     SETTY(cl, BITS64);
-    cl->info.bits64 = (uint64_t) GETBITS32(a);
+    cl->info.bits64 = (uint64_t) A;
     return cl;
 }
 
 VAL idris_b32S64(VM *vm, VAL a) {
+    uint32_t A = a->info.bits32;
     VAL cl = allocate(vm, sizeof(Closure), 0);
     SETTY(cl, BITS64);
-    cl->info.bits64 = (uint64_t) (int64_t) (int32_t) GETBITS32(a);
+    cl->info.bits64 = (uint64_t) (int64_t) (int32_t) A;
     return cl;
 }
 
 VAL idris_b32T8(VM *vm, VAL a) {
+    uint32_t A = a->info.bits32;
     VAL cl = allocate(vm, sizeof(Closure), 0);
     SETTY(cl, BITS8);
-    cl->info.bits8 = (uint8_t) GETBITS32(a);
+    cl->info.bits8 = (uint8_t) A;
     return cl;
 }
 
 VAL idris_b32T16(VM *vm, VAL a) {
+    uint32_t A = a->info.bits32;
     VAL cl = allocate(vm, sizeof(Closure), 0);
     SETTY(cl, BITS16);
-    cl->info.bits16 = (uint16_t) GETBITS32(a);
+    cl->info.bits16 = (uint16_t) A;
     return cl;
 }
 
 VAL idris_b64T8(VM *vm, VAL a) {
+    uint64_t A = a->info.bits64;
     VAL cl = allocate(vm, sizeof(Closure), 0);
     SETTY(cl, BITS8);
-    cl->info.bits8 = (uint8_t) GETBITS64(a);
+    cl->info.bits8 = (uint8_t) A;
     return cl;
 }
 
 VAL idris_b64T16(VM *vm, VAL a) {
+    uint64_t A = a->info.bits64;
     VAL cl = allocate(vm, sizeof(Closure), 0);
     SETTY(cl, BITS16);
-    cl->info.bits16 = (uint16_t) GETBITS64(a);
+    cl->info.bits16 = (uint16_t) A;
     return cl;
 }
 
 VAL idris_b64T32(VM *vm, VAL a) {
+    uint64_t A = a->info.bits64;
     VAL cl = allocate(vm, sizeof(Closure), 0);
     SETTY(cl, BITS32);
-    cl->info.bits32 = (uint32_t) GETBITS64(a);
+    cl->info.bits32 = (uint32_t) A;
     return cl;
 }
 

--- a/rts/idris_rts.h
+++ b/rts/idris_rts.h
@@ -129,11 +129,6 @@ typedef void(*func)(VM*, VAL*);
 #define GETMPTR(x) (((VAL)(x))->info.mptr->data) 
 #define GETFLOAT(x) (((VAL)(x))->info.f)
 
-#define GETBITS64(x) ((x)->ty == FWD ? ((VAL)((x)->info.ptr))->info.bits64 : (x)->info.bits64)
-#define GETBITS32(x) ((x)->ty == FWD ? ((VAL)((x)->info.ptr))->info.bits32 : (x)->info.bits32)
-#define GETBITS16(x) ((x)->ty == FWD ? ((VAL)((x)->info.ptr))->info.bits16 : (x)->info.bits16)
-#define GETBITS8(x) ((x)->ty == FWD ? ((VAL)((x)->info.ptr))->info.bits8 : (x)->info.bits8)
-
 #define TAG(x) (ISINT(x) || x == NULL ? (-1) : ( GETTY(x) == CON ? (x)->info.c.tag_arity >> 8 : (-1)) )
 #define ARITY(x) (ISINT(x) || x == NULL ? (-1) : ( GETTY(x) == CON ? (x)->info.c.tag_arity & 0x000000ff : (-1)) )
 


### PR DESCRIPTION
In summary, any C code that uses the allocator should save any relevant values
that its pointers are pointing to first.

This commit gives the right fix for the bug, which is to take out the values
that you will need from the arguments before using the allocator.  The reason
is that the allocator may trigger a GC collection which will move your
arguments away. While you can use the resulting FWD pointer to get the data,
FWD values should never be used outside of the garbage collector.  The gmp
operations should be looked at to make sure it is not doing this.
