### PR TITLE
Be free of malloc

### DIFF
--- a/libs/prelude/Builtins.idr
+++ b/libs/prelude/Builtins.idr
@@ -109,12 +109,6 @@ par : Lazy a -> a -- Doesn't actually do anything yet. Maybe a 'Par a' type
                   -- is better in any case?
 par (Delay x) = x
 
-malloc : Int -> a -> a
-malloc size x = x -- compiled specially
-
-trace_malloc : a -> a
-trace_malloc x = x -- compiled specially
-
 ||| Assert to the totality checker than y is always structurally smaller than
 ||| x (which is typically a pattern argument)
 ||| @ x the larger value (typically a pattern argument)


### PR DESCRIPTION
It was intended to do something, but does nothing but confuse people who
wonder why it's there...
