### PR TITLE
Add syntax for example code to docs

### DIFF
--- a/CHANGELOG
+++ b/CHANGELOG
@@ -22,6 +22,7 @@ New in 0.9.15:
 * New REPL command :pprint pretty-prints a definition or term with LaTeX or HTML highlighting
 * Naming of data and type constructors is made consistent across the standard library (see #1516)
 * Terms in `code blocks` inside of documentation strings are now parsed and type checked. If this succeeds, they are rendered in full color in documentation lookups, and with semantic highlighting for IDEs.
+* Fenced code blocks in docs defined with the "example" attribute are rendered as code examples.
 
 New in 0.9.14:
 --------------

--- a/src/Idris/Delaborate.hs
+++ b/src/Idris/Delaborate.hs
@@ -441,7 +441,7 @@ fancifyAnnots ist annot@(AnnName n _ _ _) =
                                    -- Issue #1588 on the Issue Tracker
                                    -- https://github.com/idris-lang/Idris-dev/issues/1588
                                    out = displayS . renderPretty 1.0 50 $
-                                         renderDocstring (pprintDelab ist) o
+                                         renderDocstring (pprintDelab ist) (normaliseAll (tt_ctxt ist) []) o
                                return (out "")
         getTy :: IState -> Name -> String -- fails if name not already extant!
         getTy ist n = let theTy = pprintPTerm (ppOptionIst ist) [] [] (idris_infixes ist) $

--- a/src/Idris/Docs.hs
+++ b/src/Idris/Docs.hs
@@ -35,14 +35,14 @@ data Docs = FunDoc FunDoc
   deriving Show
 
 showDoc ist d | nullDocstring d = empty
-              | otherwise       = text "  -- " <> renderDocstring (pprintDelab ist) d
+              | otherwise       = text "  -- " <> renderDocstring (pprintDelab ist) (normaliseAll (tt_ctxt ist) []) d
 
 pprintFD :: IState -> FunDoc -> Doc OutputAnnotation
 pprintFD ist (FD n doc args ty f)
     = nest 4 (prettyName True (ppopt_impl ppo) [] n <+> colon <+>
               pprintPTerm ppo [] [ n | (n@(UN n'),_,_,_) <- args
                                      , not (T.isPrefixOf (T.pack "__") n') ] infixes ty <$>
-              renderDocstring (pprintDelab ist) doc <$>
+              renderDocstring (pprintDelab ist) (normaliseAll (tt_ctxt ist) []) doc <$>
               maybe empty (\f -> text (show f) <> line) f <>
               let argshow = showArgs args [] in
               if not (null argshow)
@@ -84,7 +84,7 @@ pprintDocs ist (ClassDoc n doc meths params instances superclasses)
            = nest 4 (text "Type class" <+> prettyName True (ppopt_impl ppo) [] n <>
                      if nullDocstring doc
                        then empty
-                       else line <> renderDocstring (pprintDelab ist) doc)
+                       else line <> renderDocstring (pprintDelab ist) (normaliseAll (tt_ctxt ist) []) doc)
              <> line <$>
              nest 4 (text "Parameters:" <$> prettyParameters)
              <> line <$>

--- a/src/Idris/Output.hs
+++ b/src/Idris/Output.hs
@@ -3,7 +3,7 @@
 module Idris.Output where
 
 import Idris.Core.TT
-import Idris.Core.Evaluate (isDConName, isTConName, isFnName)
+import Idris.Core.Evaluate (isDConName, isTConName, isFnName, normaliseAll)
 
 import Idris.AbsSyntax
 import Idris.Delaborate
@@ -181,7 +181,7 @@ prettyDocumentedIst :: IState
                     -> Doc OutputAnnotation
 prettyDocumentedIst ist (name, ty, docs) =
           prettyName True True [] name <+> colon <+> align (prettyIst ist ty) <$>
-          fromMaybe empty (fmap (\d -> renderDocstring ppTm d <> line) docs)
+          fromMaybe empty (fmap (\d -> renderDocstring ppTm (normaliseAll (tt_ctxt ist) []) d <> line) docs)
   where ppTm = pprintDelab ist
 
 


### PR DESCRIPTION
Now, code defined with the "example" Markdown attribute will be rendered
as an inline REPL-style example. For instance:

``````
```` idris example
with List (reverse ["a", "b", "c"])
``````

```

renders to

        > reverse ["a", "b", "c"]
        ["c", "b", "a"]
```
