### PR TITLE
Fix for pattern vars in transforms

### DIFF
--- a/src/Idris/AbsSyntax.hs
+++ b/src/Idris/AbsSyntax.hs
@@ -1068,10 +1068,9 @@ addStatics n tm ptm =
        let stpos = staticList statics' tm
        i <- getIState
        when (not (null statics)) $
-          logLvl 2 $ "Statics for " ++ show n ++ " " ++ show tm ++ " "
-                        ++ showTmImpls ptm 
+          logLvl 3 $ "Statics for " ++ show n ++ " " ++ show tm ++ " "
                         ++ show statics' ++ "\n" ++ show dynamics
-                        ++ "\n" ++ show stnames ++ "\n" ++ show dnames
+                        ++ "\n" ++ show stpos
        putIState $ i { idris_statics = addDef n stpos (idris_statics i) }
        addIBC (IBCStatic n)
   where

--- a/src/Idris/Core/Elaborate.hs
+++ b/src/Idris/Core/Elaborate.hs
@@ -373,6 +373,7 @@ equiv tm = processTactic' (Equiv tm)
 
 -- | Turn the current hole into a pattern variable with the provided name, made unique if MN
 patvar :: Name -> Elab' aux ()
+patvar n@(SN _) = do apply (Var n) []; solve 
 patvar n = do env <- get_env
               hs <- get_holes
               if (n `elem` map fst env) then do apply (Var n) []; solve
@@ -380,6 +381,7 @@ patvar n = do env <- get_env
                                     UN _ -> return $! n
                                     MN _ _ -> unique_hole n
                                     NS _ _ -> return $! n
+                                    x -> return $! n
                         processTactic' (PatVar n')
 
 patbind :: Name -> Elab' aux ()

--- a/src/Idris/Elab/Class.hs
+++ b/src/Idris/Elab/Class.hs
@@ -220,7 +220,8 @@ elabClass info syn_in doc fc constraints tn ps pDocs ds
 
     insertConstraint c (PPi p@(Imp _ _ _) n ty sc)
                           = PPi p n ty (insertConstraint c sc)
-    insertConstraint c sc = PPi constraint (sMN 0 "class") c sc
+    insertConstraint c sc = PPi (constraint) -- { pstatic = Static }) 
+                                  (sMN 0 "class") c sc
 
     -- make arguments explicit and don't bind class parameters
     toExp ns e (PPi (Imp l s p) n ty sc)

--- a/src/Idris/Elab/Clause.hs
+++ b/src/Idris/Elab/Clause.hs
@@ -318,7 +318,7 @@ elabPE info fc caller r =
             let opts = [Specialise (map (\x -> (x, Nothing)) cgns ++
                                      mapMaybe specName (snd specapp))]
             logLvl 3 $ "Specialising application: " ++ show specapp
-                          ++ " with " ++ show cgns
+                          ++ " with " ++ show opts
             logLvl 3 $ "New name: " ++ show newnm
             logLvl 3 $ "PE definition type : " ++ (show specTy)
                         ++ "\n" ++ show opts
@@ -370,8 +370,8 @@ elabPE info fc caller r =
 
     -- get the clause of a specialised application
     getSpecClause ist (n, args)
-       = let newnm = sUN ("PE_"++show (nsroot n) ++ "_" ++
-                               qhash 0 (showSep "_" (map showArg args))) in
+       = let newnm = sUN ("PE_"++ show (nsroot n) ++ "_" ++
+                               qhash 0 (showSep "_" (map showArg args))) in 
                                -- UN (show n ++ show (map snd args)) in
              (n, newnm, mkPE_TermDecl ist newnm n args)
       where showArg (ExplicitS, n) = show n

--- a/src/Idris/Elab/Instance.hs
+++ b/src/Idris/Elab/Instance.hs
@@ -223,7 +223,8 @@ elabInstance info syn what fc cs n ps t expn ds = do
 
     mkTyDecl (n, op, t, _) = PTy emptyDocstring [] syn fc op n t
 
-    conbind (ty : ns) x = PPi constraint (sMN 0 "class") ty (conbind ns x)
+    conbind (ty : ns) x = PPi (constraint { pstatic = Dynamic }) 
+                              (sMN 0 "class") ty (conbind ns x)
     conbind [] x = x
 
     coninsert cs (PPi p@(Imp _ _ _) n t sc) = PPi p n t (coninsert cs sc)

--- a/src/Idris/Elab/Type.hs
+++ b/src/Idris/Elab/Type.hs
@@ -130,6 +130,7 @@ elabType' norm info syn doc argDocs fc opts n ty' = {- let ty' = piBind (params 
          let nty = cty -- normalise ctxt [] cty
          -- if the return type is something coinductive, freeze the definition
          ctxt <- getContext
+         logLvl 2 $ "Rechecked to " ++ show nty
          let nty' = normalise ctxt [] nty
          logLvl 2 $ "Rechecked to " ++ show nty'
 

--- a/src/Idris/ParseExpr.hs
+++ b/src/Idris/ParseExpr.hs
@@ -721,7 +721,8 @@ TypeExpr ::= ConstraintList? Expr;
 typeExpr :: SyntaxInfo -> IdrisParser PTerm
 typeExpr syn = do cs <- if implicitAllowed syn then constraintList syn else return []
                   sc <- expr syn
-                  return (bindList (PPi constraint) (map (\x -> (sMN 0 "constrarg", x)) cs) sc)
+                  return (bindList (PPi constraint)
+                                   (map (\x -> (sMN 0 "constrarg", x)) cs) sc)
                <?> "type signature"
 
 {- | Parses a lambda expression

--- a/src/Idris/Parser.hs
+++ b/src/Idris/Parser.hs
@@ -639,7 +639,8 @@ instance_ syn = do reserved "instance"; fc <- getFC
                    cn <- fnName
                    args <- many (simpleExpr syn)
                    let sc = PApp fc (PRef fc cn) (map pexp args)
-                   let t = bindList (PPi constraint) (map (\x -> (sMN 0 "constraint", x)) cs) sc
+                   let t = bindList (PPi constraint)
+                                    (map (\x -> (sMN 0 "constraint", x)) cs) sc
                    ds <- option [] (instanceBlock syn)
                    return [PInstance syn fc cs cn args t en ds]
                  <?> "instance declaration"

--- a/src/Idris/PartialEval.hs
+++ b/src/Idris/PartialEval.hs
@@ -163,6 +163,7 @@ getSpecApps ist env tm = ga env (explicitNames tm) where
                 lookupCtxt n (idris_implicits ist)) of
              ([statics], [imps]) -> 
                  if (length statics == length args && or statics) then
+--                     trace (show (n, statics, imps, args)) $
                     case buildApp env statics imps args [0..] of
                          args -> [(n, args)]
 --                          _ -> []


### PR DESCRIPTION
We'll need this when making rewrite rules for partially evaluating type
class dictionaries.
