### PR TITLE
Partial evaluator fixes

### DIFF
--- a/src/Idris/Core/Evaluate.hs
+++ b/src/Idris/Core/Evaluate.hs
@@ -89,12 +89,17 @@ normaliseTrace tr ctxt env t
    = evalState (do val <- eval tr ctxt [] (map finalEntry env) (finalise t) []
                    quote 0 val) initEval
 
-specialise :: Context -> Env -> [(Name, Int)] -> TT Name -> TT Name
+-- Return a specialised name, and an updated list of reductions available,
+-- so that the caller can tell how much specialisation was achieved.
+specialise :: Context -> Env -> [(Name, Int)] -> TT Name -> 
+              (TT Name, [(Name, Int)])
 specialise ctxt env limits t
-   = evalState (do val <- eval False ctxt []
+   = let (tm, st) =
+          runState (do val <- eval False ctxt []
                                  (map finalEntry env) (finalise t)
                                  [Spec]
-                   quote 0 val) (initEval { limited = limits })
+                       quote 0 val) (initEval { limited = limits }) in
+         (tm, limited st)
 
 -- | Like normalise, but we only reduce functions that are marked as okay to
 -- inline (and probably shouldn't reduce lets?)

--- a/src/Idris/Core/ProofState.hs
+++ b/src/Idris/Core/ProofState.hs
@@ -651,7 +651,7 @@ casetac tm induction ctxt env (Bind x (Hole t) (P _ x' _)) | x == x' = do
              mapM_ addConsHole (reverse consargs')
              let res' = forget $ res
              (scv, sct) <- lift $ check ctxt env res'
-             let scv' = specialise ctxt env [] scv
+             let (scv', _) = specialise ctxt env [] scv
              return scv'
           [] -> fail $ tactt ++ " needs " ++ tacstr ++ " for " ++ show tnm
           xs -> fail $ "Multiple definitions found when searching for " ++ tacstr ++ "of " ++ show tnm
@@ -705,7 +705,7 @@ hnf_compute ctxt env t = return t
 -- reduce let bindings only
 simplify :: RunTactic
 simplify ctxt env (Bind x (Hole ty) sc) =
-    do return $ Bind x (Hole (specialise ctxt env [] ty)) sc
+    do return $ Bind x (Hole (fst (specialise ctxt env [] ty))) sc
 simplify ctxt env t = return t
 
 check_in :: Raw -> RunTactic

--- a/src/Idris/Elab/Transform.hs
+++ b/src/Idris/Elab/Transform.hs
@@ -48,7 +48,7 @@ import Data.List.Split (splitOn)
 
 import Util.Pretty(pretty, text)
 
-elabTransform :: ElabInfo -> FC -> Bool -> PTerm -> PTerm -> Idris ()
+elabTransform :: ElabInfo -> FC -> Bool -> PTerm -> PTerm -> Idris (Term, Term)
 elabTransform info fc safe lhs_in@(PApp _ (PRef _ tf) _) rhs_in
     = do ctxt <- getContext
          i <- getIState
@@ -88,6 +88,7 @@ elabTransform info fc safe lhs_in@(PApp _ (PRef _ tf) _) rhs_in
               (P _ tfname _, _) -> do addTrans tfname (clhs_tm, crhs_tm)
                                       addIBC (IBCTrans tf (clhs_tm, crhs_tm))
               _ -> ierror (At fc (Msg "Invalid transformation rule (must be function application)"))
+         return (clhs_tm, crhs_tm)
 
   where
     depat (Bind n (PVar t) sc) = depat (instantiate (P Bound n t) sc)

--- a/src/Idris/ElabDecls.hs
+++ b/src/Idris/ElabDecls.hs
@@ -254,6 +254,7 @@ elabDecl' what info (PProvider syn fc provWhat n)
     = do iLOG $ "Elaborating type provider " ++ show n
          elabProvider info syn fc provWhat n
 elabDecl' what info (PTransform fc safety old new)
-    = elabTransform info fc safety old new
+    = do elabTransform info fc safety old new
+         return ()
 elabDecl' _ _ _ = return () -- skipped this time
 

--- a/src/Idris/Interactive.hs
+++ b/src/Idris/Interactive.hs
@@ -188,7 +188,7 @@ doProofSearch fn updatefile rec l n hints (Just depth)
                    pprintPTerm defaultPPOption [] [] (idris_infixes i)
                      (stripNS
                         (dropCtxt envlen
-                           (delab i (specialise ctxt [] [(mn, 1)] tm)))))
+                           (delab i (fst (specialise ctxt [] [(mn, 1)] tm))))))
              (\e -> return ("?" ++ show n))
          if updatefile then
             do let fb = fn ++ "~"


### PR DESCRIPTION
Need to identify when a specialisation has made no progress, so we don't
treat it as a specialisable application. Also fixes tranform rules.

With this it turns out to be safe (if not yet useful) to mark type class
dictionaries as 'static', but without further work on the partial
evaluator this isn't going to help much yet, so it's not enabled yet.
