### PR TITLE
Make do blocks require an expression

### DIFF
--- a/src/Idris/ParseExpr.hs
+++ b/src/Idris/ParseExpr.hs
@@ -1021,7 +1021,7 @@ DoBlock ::=
 doBlock :: SyntaxInfo -> IdrisParser PTerm
 doBlock syn
     = do reserved "do"
-         ds <- indentedBlock (do_ syn)
+         ds <- indentedBlock1 (do_ syn)
          return (PDoBlock ds)
       <?> "do block"
 


### PR DESCRIPTION
This makes for better error messages and fixes #1656.

Old message:

```
> :t do
When elaborating an application of constructor __infer:
        INTERNAL ERROR: Invalid statement in do block
        This is probably a bug, or a missing error message.
        Please consider reporting at
        https://github.com/idris-lang/Idris-dev/issues
```

New message:

```
> :t do
(input):1:6: error: unexpected
    EOF, expected: ")",
    do block expression,
    end of "do", start of block
:t do<EOF>
```
