### PR TITLE
Propagate static flags into with blocks

### DIFF
--- a/src/Idris/PartialEval.hs
+++ b/src/Idris/PartialEval.hs
@@ -267,9 +267,8 @@ getSpecApps ist env tm = ga env (explicitNames tm) where
         ga env f ++ ga env a ++
           case (lookupCtxt n (idris_statics ist),
                   lookupCtxt n (idris_implicits ist)) of
-               ([statics], [imps]) -> 
+               ([statics], [imps]) ->
                    if (length statics == length args && or statics) then
---                       trace (show (n, statics, imps, args)) $
                       case buildApp env statics imps args [0..] of
                            args -> [(n, args)]
 --                            _ -> []


### PR DESCRIPTION
Need this to properly specialise functions generated using 'with',
otherwise the with blocks get left alone.
