### PR TITLE
Faster universe checking

### DIFF
--- a/src/Idris/Core/Constraints.hs
+++ b/src/Idris/Core/Constraints.hs
@@ -11,7 +11,7 @@ import Control.Monad.RWS
 import Control.Monad.State
 import Data.List
 import Data.Maybe
-import qualified Data.Map as M
+import qualified Data.Map.Strict as M
 
 import Debug.Trace
 
@@ -20,7 +20,8 @@ ucheck :: [(UConstraint, FC)] -> TC ()
 ucheck cs = acyclic rels (map fst (M.toList rels))
   where lhs (ULT l _) = l
         lhs (ULE l _) = l
-        rels = mkRels cs M.empty
+        cs' = nub cs
+        rels = mkRels cs' M.empty
 
 type Relations = M.Map UExp [(UConstraint, FC)]
 
@@ -44,13 +45,13 @@ acyclic r cvs = checkCycle (fileFC "root") r [] 0 cvs
     checkCycle :: FC -> Relations -> [(UExp, FC)] -> Int -> [UExp] -> TC ()
     checkCycle fc r path inc [] = return ()
     checkCycle fc r path inc (c : cs)
-        = do check fc path inc c
+        = do check fc r path inc c
              -- Remove c from r since we know there's no cycles now
              let r' = M.insert c [] r
              checkCycle fc r' path inc cs
 
-    check fc path inc (UVar x) | x < 0 = return ()
-    check fc path inc cv
+    check fc r path inc (UVar x) | x < 0 = return ()
+    check fc r path inc cv
         | inc > 0 && cv `elem` map fst path
             = Error $ At fc UniverseError
                 -- FIXME: Make informative
@@ -59,10 +60,11 @@ acyclic r cvs = checkCycle (fileFC "root") r [] 0 cvs
         -- fine, because they must all be equal, so stop.
         | inc == 0 && cv `elem` map fst path
             = return ()
-        | otherwise = case M.lookup cv r of
-                            Nothing       -> return ()
-                            Just cs -> mapM_ (next ((cv, fc):path) inc) cs
+        | otherwise 
+             = case M.lookup cv r of
+                    Nothing -> return ()
+                    Just cs -> mapM_ (next r ((cv, fc):path) inc) cs
 
-    next path inc (ULT l r, fc) = check fc path (inc + 1) r
-    next path inc (ULE l r, fc) = check fc path inc r
+    next r path inc (ULT l x, fc) = check fc r path (inc + 1) x
+    next r path inc (ULE l x, fc) = check fc r path inc x
 


### PR DESCRIPTION
This mainly fixes a scoping issue which made the cycle checker search
too many times.

Fixes #1649
