### PR TITLE
More partial evaluation improvements

### DIFF
--- a/src/Idris/Elab/Instance.hs
+++ b/src/Idris/Elab/Instance.hs
@@ -223,7 +223,7 @@ elabInstance info syn what fc cs n ps t expn ds = do
 
     mkTyDecl (n, op, t, _) = PTy emptyDocstring [] syn fc op n t
 
-    conbind (ty : ns) x = PPi (constraint { pstatic = Dynamic }) 
+    conbind (ty : ns) x = PPi (constraint) -- { pstatic = Dynamic }) 
                               (sMN 0 "class") ty (conbind ns x)
     conbind [] x = x
 

--- a/src/Idris/Elab/Utils.hs
+++ b/src/Idris/Elab/Utils.hs
@@ -251,5 +251,22 @@ getStaticNames ist tm
     getStatics _ _ = []
 getStaticNames _ _ = []
 
+getStatics :: [Name] -> Term -> [Bool]
+getStatics ns (Bind n (Pi _ _) t)
+    | n `elem` ns = True : getStatics ns t
+    | otherwise = False : getStatics ns t
+getStatics _ _ = []
+
+mkStatic :: [Name] -> PDecl -> PDecl
+mkStatic ns (PTy doc argdocs syn fc o n ty) 
+    = PTy doc argdocs syn fc o n (mkStaticTy ns ty)
+mkStatic ns t = t
+
+mkStaticTy :: [Name] -> PTerm -> PTerm
+mkStaticTy ns (PPi p n ty sc) 
+    | n `elem` ns = PPi (p { pstatic = Static }) n ty (mkStaticTy ns sc)
+    | otherwise = PPi p n ty (mkStaticTy ns sc)
+mkStaticTy ns t = t
+
 
 

--- a/src/Idris/Transforms.hs
+++ b/src/Idris/Transforms.hs
@@ -47,7 +47,10 @@ applyAll extra ts ap@(App f a)
                ap' = App (applyAll extra ts f) (applyAll extra ts a) in
                case rules of
                     [] -> ap'
-                    rs -> case applyFnRules rs ap' of
+                    rs -> case applyFnRules rs ap of
+                                   Just tm'@(App f' a') ->
+                                     App (applyAll extra ts f')
+                                         (applyAll extra ts a')
                                    Just tm' -> tm'
                                    _ -> App (applyAll extra ts f) 
                                             (applyAll extra ts a)


### PR DESCRIPTION
Propagate staticness into where blocks, make constraints on instances
static, and generalise over functions in types to make the partially
evaluated version as general as possible.
