### PR TITLE
Remove dep sets from bound variables

### DIFF
--- a/src/Idris/Erasure.hs
+++ b/src/Idris/Erasure.hs
@@ -358,8 +358,8 @@ buildDepMap ci ctx mainName = addPostulates $ dfs S.empty M.empty [mainName]
 
         -- let-bound variables can get partially evaluated
         -- it is sufficient just to plug the Cond in when the bound names are used
-        |  Let ty t <- bdr = var t cd `union` getDepsTerm vs ((n, var t) : bs) cd body
-        | NLet ty t <- bdr = var t cd `union` getDepsTerm vs ((n, var t) : bs) cd body
+        |  Let ty t <- bdr = var t cd `union` getDepsTerm vs ((n, const M.empty) : bs) cd body
+        | NLet ty t <- bdr = var t cd `union` getDepsTerm vs ((n, const M.empty) : bs) cd body
       where
         var t cd = getDepsTerm vs bs cd t
 


### PR DESCRIPTION
While writing the paper, I noticed that there's no point in adding dep sets to bound variables when the same dep set is already added unguarded.

Fixed, tests pass.
