### PR TITLE
Fix missing case in PartialEval.hs

### DIFF
--- a/src/Idris/PartialEval.hs
+++ b/src/Idris/PartialEval.hs
@@ -207,7 +207,7 @@ mkNewPats ist d ns newname sname lhs rhs =
                                   (mkRHSargs ns lhsargs) in
                      (lhs, rhs)
 
-    mkLHSargs _ [] [] = []
+    mkLHSargs _ [] _ = []
     -- dynamics don't appear if they're implicit
     mkLHSargs sub ((ExplicitD, t) : ns) (a : as) 
          = pexp (delab ist (substNames sub a)) : mkLHSargs sub ns as


### PR DESCRIPTION
Fixes #1664. We may need to think more carefully about how to build
partially evaluated definitions better later, but this is a safe
solution for the moment.
