### PR TITLE
Add missing cases in checkUniqueKind (fixed #1606)

### DIFF
--- a/src/Idris/Elab/Data.hs
+++ b/src/Idris/Elab/Data.hs
@@ -265,10 +265,10 @@ elabCon info syn tn codata expkind (doc, argDocs, n, t_in, fc, forcenames)
         = tclift $ tfail (At fc (UniqueKindError NullType n))
     checkUniqueKind (UType UniqueType) (UType UniqueType) = return ()
     checkUniqueKind (UType UniqueType) (UType AllTypes) = return ()
-    checkUniqueKind (UType UniqueType) (TType _)
+    checkUniqueKind (UType UniqueType) _
         = tclift $ tfail (At fc (UniqueKindError UniqueType n))
     checkUniqueKind (UType AllTypes) _ = return ()
-    checkUniqueKind (TType _) _ = return ()
+    checkUniqueKind _ _ = return ()
 
 type EliminatorState = StateT (Map.Map String Int) Idris
 


### PR DESCRIPTION
This PR fixes #1606. Currently `checkUniqueKind` breaks on type definitions such like:

``` idr
Monoid_Unit : Type -> Type
Monoid_Unit carrier = carrier

data TypeUnit : (Monoid_Unit Type) where
  MkTypeUnit : TypeUnit
```

(missing pattern for `App !(TT n) (TT n)`)

``` idr
data Foo : Type where
  bar : let x = Nat in x -> Foo
```

(missing pattern for `Bind n !(Binder (TT n)) (TT n)`)

`checkUniqueKind (UType UniqueType) _` should be a catch-all of `UniqueKindError`, and `checkUniqueKind _ _`  lets pass the unique checking in all other cases (as this fixes #1606).
