### PR TITLE
VerifiedSemigroup, VerifiedMonoid for List

### DIFF
--- a/libs/prelude/Prelude/List.idr
+++ b/libs/prelude/Prelude/List.idr
@@ -232,10 +232,6 @@ instance Semigroup (List a) where
 instance Monoid (List a) where
   neutral = []
 
--- XXX: unification failure
--- instance VerifiedSemigroup (List a) where
---  semigroupOpIsAssociative = appendAssociative
-
 instance Functor List where
   map f []      = []
   map f (x::xs) = f x :: map f xs
@@ -810,6 +806,13 @@ hasAnyByNilFalse p (x::xs) =
 ||| No list contains an element of the empty list.
 hasAnyNilFalse : Eq a => (l : List a) -> hasAny [] l = False
 hasAnyNilFalse l = ?hasAnyNilFalseBody
+
+instance VerifiedSemigroup (List a) where
+  semigroupOpIsAssociative = appendAssociative
+
+instance VerifiedMonoid (List a) where
+  monoidNeutralIsNeutralL = appendNilRightNeutral
+  monoidNeutralIsNeutralR xs = Refl
 
 --------------------------------------------------------------------------------
 -- Proofs


### PR DESCRIPTION
After implementing `VerifiedSemigroup (List a)` myself (reynir/Verified@7c42d6e6105335c72c732d13b9004cb4474c9f0a) I noticed there was an outcommented implementation in Prelude.List saying "unification failure". 

Anyway, it works now, and I also added a VerifiedMonoid instance. Both are very simple.

There's some disagreement about what is left and right neutral in the names which looks odd in the VerifiedMonoid instance, namely `monoidNeutralIsNeutralL = appendNilRightNeutral`
