### PR TITLE
Bump lens upper version bounds

### DIFF
--- a/idris.cabal
+++ b/idris.cabal
@@ -701,7 +701,7 @@ Library
                 , filepath < 1.4
                 , fingertree >= 0.1 && < 0.2
                 , haskeline >= 0.7 && < 0.8
-                , lens >= 4.1.1 && < 4.6
+                , lens >= 4.1.1 && < 4.7
                 , mtl < 2.3
                 , network < 2.7
                 , optparse-applicative >= 0.11 && < 0.12


### PR DESCRIPTION
Allow `idris` to be built with the latest version of `lens` (4.6).
