### PR TITLE
Indicate the end of each escape sequence in the prompt string

### DIFF
--- a/src/Idris/Colours.hs
+++ b/src/Idris/Colours.hs
@@ -52,6 +52,17 @@ colourise (IdrisColour c v u b i) str = setSGRCode sgr ++ str ++ setSGRCode [Res
           fg Nothing = []
           fg (Just c) = [SetColor Foreground (if v then Vivid else Dull) c]
 
+-- | Set the colour of a string using POSIX escape codes, with trailing '\STX' denoting the end
+-- (required by Haskeline in the prompt string)
+colouriseWithSTX :: IdrisColour -> String -> String
+colouriseWithSTX (IdrisColour c v u b i) str = setSGRCode sgr ++ "\STX" ++ str ++ setSGRCode [Reset] ++ "\STX"
+    where sgr = fg c ++
+                (if u then [SetUnderlining SingleUnderline] else []) ++
+                (if b then [SetConsoleIntensity BoldIntensity] else []) ++
+                (if i then [SetItalicized True] else [])
+          fg Nothing = []
+          fg (Just c) = [SetColor Foreground (if v then Vivid else Dull) c]
+
 colouriseKwd :: ColourTheme -> String -> String
 colouriseKwd t = colourise (keywordColour t)
 
@@ -71,7 +82,7 @@ colouriseData :: ColourTheme -> String -> String
 colouriseData t = colourise (dataColour t)
 
 colourisePrompt :: ColourTheme -> String -> String
-colourisePrompt t = colourise (promptColour t)
+colourisePrompt t = colouriseWithSTX (promptColour t)
 
 colouriseKeyword :: ColourTheme -> String -> String
 colouriseKeyword t = colourise (keywordColour t)


### PR DESCRIPTION
Fixes #1744.
In Idris' REPL, when input is about to reach the end of screen (or exceeds to the next line), <kbd>Home</kbd> was not working properly.

![0](https://cloud.githubusercontent.com/assets/342945/5149101/a3bbb424-71c5-11e4-96e1-656d5be5d5f4.gif)

This is because Haskeline expects all ANSI escape sequences in the prompt string end with an explicit `'\STX'`, since there's no way for Haskeline to detect this automatically. (as explained [here](http://trac.haskell.org/haskeline/wiki/ControlSequencesInPrompt))

Therefore, instead of something like

``` idris
x <- H.catch (getInputLine "\ESC[1mIdris>\ESC[0m ")
             (ctrlC (return Nothing))
```

We need some extra `\STX` (in the prompt string only) to get Haskeline working right:

``` idris
x <- H.catch (getInputLine "\ESC[1m\STXIdris>\ESC[0m\STX ")
             (ctrlC (return Nothing))
```
