### PR TITLE
Improve parser errors in dependent type signatures

### DIFF
--- a/src/Idris/ParseExpr.hs
+++ b/src/Idris/ParseExpr.hs
@@ -874,12 +874,12 @@ pi syn =
                        symbol "->"
                        sc <- expr syn
                        return (bindList (PPi (TacImp [] Dynamic script)) xt sc))
-                 <|> (if implicitAllowed syn then do
-                            xt <- try (lchar '{' *> typeDeclList syn <* lchar '}')
-                            symbol "->"
-                            sc <- expr syn
-                            return (bindList (PPi (Imp opts st False)) xt sc)
-                       else do fail "no implicit arguments allowed here"))
+                 <|> (do xt <- try (lchar '{' *> typeDeclList syn <* lchar '}')
+                         symbol "->"
+                         sc <- expr syn
+                         if implicitAllowed syn
+                           then return (bindList (PPi (Imp opts st False)) xt sc)
+                           else fail "no implicit arguments allowed here"))
                  <|> (do x <- opExpr syn
                          (do symbol "->"
                              sc <- expr syn


### PR DESCRIPTION
Partially addresses https://github.com/idris-lang/Idris-dev/issues/405. There is one change:
- Even if implicit arguments are not allowed, still try to parse them, and then fail saying that implicits are not allowed _only_ after a successful parse of the implicit arguments.

The new error message for

``` Idris
data Labelled : Type -> Type -> Type where
    (:::) : {Mark Payload : Type} -> Mark -> Payload -> Labelled Mark Payload
```

is

```
./Test.idr:2:13: error: expected: "%",
    type signature
    (:::) : {Mark Payload : Type} -> Mark -> Payload -> Labelled Mark Payload 
            ^
```

The spurious message about implicit arguments not being allowed is now gone. Unfortunately, it's difficult to produce a much better error message than this, due to custom syntax such as that in the Effects library.
