### PR TITLE
Define `Show` instance for `Vect` via `toList`

### DIFF
--- a/libs/prelude/Prelude.idr
+++ b/libs/prelude/Prelude.idr
@@ -217,11 +217,7 @@ instance Show a => Show (List a) where
         show' acc (x :: xs) = show' (acc ++ show x ++ ", ") xs
 
 instance Show a => Show (Vect n a) where
-    show xs = "[" ++ show' xs ++ "]" where
-        show' : Vect n a -> String
-        show' []        = ""
-        show' [x]       = show x
-        show' (x :: xs) = show x ++ ", " ++ show' xs
+    show = show . toList
 
 instance Show a => Show (Maybe a) where
     show Nothing = "Nothing"


### PR DESCRIPTION
Nicola Botta has got a program whose runtime went from 11 to 42 seconds when we merged erasure. This is mostly caused by a single one wrong case tree generated from the `Show` instance for vectors, which inspects the length index, which in turn cannot be erased in the whole program.

Since it seems that the proper fix is non-trivial, let us use a workaround for now.
