### PR TITLE
Agda-style record syntax

### DIFF
--- a/src/Idris/ParseData.hs
+++ b/src/Idris/ParseData.hs
@@ -83,9 +83,7 @@ record syn = do (doc, argDocs, acc, opts) <- try (do
         ist <- get
         fc  <- getFC
 
-        -- we discard the second component because
-        -- fields will be described in the following block
-        (ctorDoc, _) <- option noDocs docComment
+        let ctorDoc = parseDocstring . T.pack $ "Constructor of " ++ show recName
         ctorName <- reserved "constructor" *> fnName
 
         fields <- many $ do
@@ -103,7 +101,7 @@ record syn = do (doc, argDocs, acc, opts) <- try (do
                     symbol "}"
                     return (n, t, impl)
 
-            (n, t, plicity) <- impField <$> expField
+            (n, t, plicity) <- impField <|> expField
 
             return (n, t, plicity, doc, argDocs)
 

--- a/src/Idris/ParseData.hs
+++ b/src/Idris/ParseData.hs
@@ -84,9 +84,9 @@ record syn = do (doc, argDocs, acc, opts) <- try (do
         fc  <- getFC
 
         let ctorDoc = parseDocstring . T.pack $ "Constructor of " ++ show recName
-        ctorName <- reserved "constructor" *> fnName
+        ctorName <- indented (reserved "constructor" *> fnName)
 
-        fields <- many $ do
+        fields <- many . indented $ do
             (doc, argDocs) <- option noDocs docComment
 
             let expField = do

--- a/test/records004/expected
+++ b/test/records004/expected
@@ -1,0 +1,13 @@
+records004.idr:6:8:Warning - can't generate setter for n (tydecl Main.A.set_n : {a : _} -> ({n_out0} : Prelude.Nat.Nat) -> ({rec0} : Main.A a) -> Main.A a)
+records004.idr:6:8:Warning - can't generate setter for xs (tydecl Main.A.set_xs : {a : _} -> ({xs_out0} : Prelude.Vect.Vect n Prelude.Nat.Nat) -> ({rec0} : Main.A a) -> Main.A a)
+records004.idr:16:8:Warning - can't generate setter for a (tydecl Main.B.set_a : ({a_out0} : Type) -> ({rec0} : Main.B a_in) -> Main.B a_out)
+records004.idr:16:8:Warning - can't generate setter for n (tydecl Main.B.set_n : ({n_out0} : Prelude.Nat.Nat) -> ({rec0} : Main.B _) -> Main.B _)
+records004.idr:16:8:Warning - can't generate setter for xs (tydecl Main.B.set_xs : ({xs_out0} : Prelude.Vect.Vect n _) -> ({rec0} : Main.B _) -> Main.B _)
+records004.idr:30:8:Warning - can't generate setter for n (tydecl Main.C.set_n : {a : Type} -> {unhelpfulField : a} -> {a1 : Type} -> ({n_out0} : Prelude.Nat.Nat) -> ({rec0} : Main.C {a = a1} n_in) -> Main.C {a = a1} n_out)
+records004.idr:30:8:Warning - can't generate setter for xs (tydecl Main.C.set_xs : {a : Type} -> {unhelpfulField : a} -> {a1 : Type} -> ({xs_out0} : Prelude.Vect.Vect _ a1) -> ({rec0} : Main.C {a = a1} _) -> Main.C {a = a1} _)
+2
+[0, 1]
+3
+[4, 1, 2]
+4
+[True, False, False, True]

--- a/test/records004/records004.idr
+++ b/test/records004/records004.idr
@@ -1,0 +1,55 @@
+module Main
+
+-- Old-style records
+
+||| The type A.
+record A : Type -> Type where
+  ||| Construct A.
+  ||| @ n the number
+  ||| @ xs the vector
+  MkA : (n : Nat) -> (xs : Vect n Nat) -> A a
+
+-- New-style records, simple.
+
+||| The type B.
+||| @ a The contained type.
+record B : (a : Type) -> Type where
+  constructor MkB
+
+  ||| The number.
+  n : Nat
+
+  ||| The vector.
+  xs : Vect n a
+
+-- New-style records, full-featured.
+
+||| The type C.
+||| @ a An implicit param.
+||| @ n An explicit param.
+record C : {a : Type} -> (n : Nat) -> Type where
+  constructor MkC
+
+  ||| A rather unhelpful implicit because it can't be inferred.
+  {unhelpfulField : a}
+
+  ||| The wrapped vector.
+  xs : Vect n a
+
+rA : A Bool
+rA = MkA 2 [0,1]
+
+rB : B Int
+rB = MkB _ 3 [4,1,2]
+
+rC : C {a = Bool} 4
+rC = MkC _ {unhelpfulField = True} [True, False, False, True]
+
+main : IO ()
+main = do
+  print $ record { n } rA
+  print $ record { xs } rA
+  print $ record { n } rB
+  print $ record { xs } rB
+  print $ record { n } rC
+  print $ record { xs } rC

--- a/test/records004/run
+++ b/test/records004/run
@@ -1,0 +1,4 @@
+#!/usr/bin/env bash
+idris $@ records004.idr -o records004
+./records004
+rm -f records004 *.ibc


### PR DESCRIPTION
This patch adds a nice Agda-style way of defining records. A (contrived) example:
```Idris
||| A vector wrapper.
||| @ a An implicit param.
||| @ n An explicit param.
record C : {a : Type} -> (n : Nat) -> Type where
  constructor MkC

  ||| A rather unhelpful implicit because it can't be inferred.
  {unhelpfulField : a}

  ||| The wrapped vector.
  xs : Vect n a
```
This is just syntactic sugar. Behind the scenes, the above generates the following constructor:
```Idris
MkC : {a : Type} -> (n : Nat) -> {unhelpfulField : a} -> (xs : Vect n a) -> C {a = a} n
```
Shortcomings:
* no docstrings for fields and parameters
  * currently, the record pipeline seems to just ignore this info (old-style records suffer from this as well)
  * should be relatively straightforward to fix
* no tactic implicit fields, just plain implicits
  * will probably require decoupling the syntax of implicits from `PPi`
* the `constructor` clause is mandatory because it syntactically disambiguates old-style records from Agda-style records. Maybe we should find a better way to do this and allow automatic `MkT` constructor naming.
  * old-style records with the constructor named `constructor` will be misparsed as agda-style records
* free variables in fields won't get turned into unbound implicits