### PR TITLE
Updates to idrislang.sty

### DIFF
--- a/contribs/idrislang.sty
+++ b/contribs/idrislang.sty
@@ -6,25 +6,31 @@
 %%      + idris         :: default ascii
 %%      + literateidris :: convert ascii maths to math symbols.
 %%   + Defines a `numbers', `default', and `stdout' listings style.
-%%      + default :: default for Idris which is to use a tt font.
+%%      + default :: Uses TT font for code and SF font for comments,
+%%                   and indented by parident.
 %%      + numbers :: default but with numbers.
+%%      + beamer  :: default minus parindent
 %%      + stdout  :: for formatting stdout.
 %%   + Defines a `code' environment for typesetting idris.
 %%      + \begin{code}[...] ... \end{code}
 %%   + Defines an input command for externally defined idris files.
 %%      + \inputIdrisListing[...]{file.idr}
+%%   + Provides definitions (from Idris Compiler) for pretty-printing Idris
+%%     code using Fancy Verbatim and colour commands.
+%%      + Sets commandchars for latex commands.
 %%   + Defines commands typesetting the name Idris.
 %%      + \Idris{}
 %%      + \idris{}
 %%
 %% Options:
 %%    - literate :: turn on literate idris for code environments.
-%%    - numbers  :: turn on numbers for code environments.
 %%
 %% ----------------------------------------------------------- [ Begin Package ]
 \ProvidesPackage{idrislang}
 
 \RequirePackage{ifthen}
+\RequirePackage{xcolor}
+\RequirePackage{fancyvrb}
 \RequirePackage{listings}
 \RequirePackage{xspace}
 \RequirePackage{textcomp}
@@ -32,15 +38,9 @@
 %% ----------------------------------------------------------------- [ Options ]
 \newboolean{literate}
 \setboolean{literate}{false}
-\newboolean{numbers}
-\setboolean{numbers}{false}
 
 \DeclareOption{literate}{%
   \setboolean{literate}{true}
-}
-
-\DeclareOption{numbers}{%
-  \setboolean{numbers}{true}
 }
 
 \ProcessOptions\relax
@@ -48,6 +48,16 @@
 %% ---------------------------------------------------------------- [ Commands ]
 \newcommand{\Idris}{\textsc{Idris}\xspace}
 \newcommand{\idris}{\textsc{Idris}\xspace}
+\newcommand{\IdrisLineSpacing}{\singlespacing}
+%% ---------------------------------------------------------- [ Color Commands ]
+\newcommand{\IdrisData}[1]{\textcolor{red}{#1}}
+\newcommand{\IdrisType}[1]{\textcolor{blue}{#1}}
+\newcommand{\IdrisBound}[1]{\textcolor{magenta}{#1}}
+\newcommand{\IdrisFunction}[1]{\textcolor{green}{#1}}
+\newcommand{\IdrisKeyword}[1]{{\underline{#1}}}
+\newcommand{\IdrisImplicit}[1]{{\itshape \IdrisBound{#1}}}
+
+\fvset{commandchars=\\\{\}}
 
 %% --------------------------------------------------- [ Define Idris Listings ]
 \lstdefinelanguage{idris}{%
@@ -121,6 +131,11 @@
   escapechar=^
 }
 
+\lstdefinestyle{beamer}{%
+  basicstyle=\ttfamily\normalsize,
+  escapechar=^
+}
+
 %% ------------------------------------------------------ [ A Code Environment ]
 %% Replicate the existence of literate haskell code environments,
 %% option to make pretty with numbers.
@@ -128,10 +143,7 @@
     {\ifthenelse{\boolean{literate}}{%
         \lstset{language=literateidris}}{%
         \lstset{language=idris}}
-        \ifthenelse{\boolean{numbers}}{%
-          \lstset{style=numbers, #1}}{%
-          \lstset{style=default, #1}}
-    \singlespacing
+    \IdrisLineSpacing{}
     }{}
 %% ---------------------------------------------------------- [ Input Listings ]
 %% Command to add externally defined Idris code to the document.
@@ -140,9 +152,6 @@
     \ifthenelse{\boolean{literate}}{%
       \lstset{language=literateidris}}{%
       \lstset{language=idris}}
-    \ifthenelse{\boolean{numbers}}{%
-      \lstset{style=numbers}}{%
-      \lstset{style=default}}
     \lstinputlisting[#1]{#2}
 \endgroup
 }


### PR DESCRIPTION
- Removal of numbers package option. Listing styles must be set either globally using `\lstset{}` or per code or listings environment options.
- Addition of a beamer style.
- Inclusion of the `:pprint` LaTeX formatting commands. No more need to copy everything from the result of `:pprint`, just the code snippet.
  - command chars for fancy verbatim has been set globally.
- Option to change spacing command, useful for cases where line spacing is changed via different commands. For example: memoir has `\SingleSpacing`, setspace has `\singlespacing`.
