### PR TITLE
Add `until` function to prelude.

### DIFF
--- a/libs/prelude/Prelude.idr
+++ b/libs/prelude/Prelude.idr
@@ -441,6 +441,13 @@ syntax "[" [start] "," [next] ".." "]"
 
 ---- More utilities
 
+||| repeatedly apply f to v until p is True
+partial
+until : (a -> Bool) -> (a -> a) -> a -> a
+until p f v with (p v)
+  | False = until p f (f v)
+  | True = v
+
 curry : ((a, b) -> c) -> a -> b -> c
 curry f a b = f (a, b)
 


### PR DESCRIPTION
Performs the same function as `until` from the Haskell prelude (http://hackage.haskell.org/package/base-4.7.0.1/docs/Prelude.html#v:until).