### PR TITLE
Simplify some of the REPL parsing/completion code

### DIFF
--- a/libs/prelude/Builtins.idr
+++ b/libs/prelude/Builtins.idr
@@ -116,14 +116,14 @@ par : Lazy a -> a -- Doesn't actually do anything yet. Maybe a 'Par a' type
                   -- is better in any case?
 par (Delay x) = x
 
-||| Assert to the totality checker than y is always structurally smaller than
+||| Assert to the totality checker that y is always structurally smaller than
 ||| x (which is typically a pattern argument)
 ||| @ x the larger value (typically a pattern argument)
 ||| @ y the smaller value (typically an argument to a recursive call)
 assert_smaller : (x : a) -> (y : b) -> b
 assert_smaller x y = y
 
-||| Assert to the totality checker than the given expression will always
+||| Assert to the totality checker that the given expression will always
 ||| terminate.
 assert_total : a -> a
 assert_total x = x

--- a/src/Idris/Completion.hs
+++ b/src/Idris/Completion.hs
@@ -10,6 +10,7 @@ import Idris.Colours
 import Idris.ParseHelpers(opChars)
 import qualified Idris.ParseExpr (constants, tactics)
 import Idris.ParseExpr (TacticArg (..))
+import Idris.REPLParser (allHelp)
 import Control.Monad.State.Strict
 
 import Data.List
@@ -20,10 +21,7 @@ import System.Console.Haskeline
 import System.Console.ANSI (Color)
 
 
-fst3 :: (a, b, c) -> a
-fst3 (a, b, c) = a
-
-commands = concatMap fst3 (help ++ extraHelp)
+commands = [ n | (names, _, _) <- allHelp ++ extraHelp, n <- names ]
 
 tacticArgs :: [(String, Maybe TacticArg)]
 tacticArgs = [ (name, args) | (names, args, _) <- Idris.ParseExpr.tactics
@@ -97,7 +95,7 @@ isWhitespace :: Char -> Bool
 isWhitespace = (flip elem) " \t\n"
 
 lookupInHelp :: String -> Maybe CmdArg
-lookupInHelp cmd = lookupInHelp' cmd help
+lookupInHelp cmd = lookupInHelp' cmd allHelp
     where lookupInHelp' cmd ((cmds, arg, _):xs) | elem cmd cmds = Just arg
                                                 | otherwise   = lookupInHelp' cmd xs
           lookupInHelp' cmd [] = Nothing

--- a/src/Idris/Completion.hs
+++ b/src/Idris/Completion.hs
@@ -8,7 +8,8 @@ import Idris.AbsSyntaxTree
 import Idris.Help
 import Idris.Colours
 import Idris.ParseHelpers(opChars)
-
+import qualified Idris.ParseExpr (constants, tactics)
+import Idris.ParseExpr (TacticArg (..))
 import Control.Monad.State.Strict
 
 import Data.List
@@ -24,39 +25,9 @@ fst3 (a, b, c) = a
 
 commands = concatMap fst3 (help ++ extraHelp)
 
--- | A specification of the arguments that tactics can take
-data TacticArg = NameTArg -- ^ Names: n1, n2, n3, ... n
-               | ExprTArg
-               | AltsTArg
-
--- The FIXMEs are Issue #1766 in the issue tracker.
---     https://github.com/idris-lang/Idris-dev/issues/1766
--- | A list of available tactics and their argument requirements
 tacticArgs :: [(String, Maybe TacticArg)]
-tacticArgs = [ ("intro", Nothing) -- FIXME syntax for intro (fresh name)
-             , ("refine", Just ExprTArg)
-             , ("mrefine", Just ExprTArg)
-             , ("rewrite", Just ExprTArg)
-             , ("let", Nothing) -- FIXME syntax for let
-             , ("focus", Just ExprTArg)
-             , ("exact", Just ExprTArg)
-             , ("equiv", Just ExprTArg)
-             , ("applyTactic", Just ExprTArg)
-             , ("byReflection", Just ExprTArg)
-             , ("reflect", Just ExprTArg)
-             , ("fill", Just ExprTArg)
-             , ("try", Just AltsTArg)
-             , ("induction", Just ExprTArg)
-             , ("case", Just ExprTArg)
-             , (":t", Just ExprTArg)
-             , (":type", Just ExprTArg)
-             , (":e", Just ExprTArg)
-             , (":eval", Just ExprTArg)
-             ] ++ map (\x -> (x, Nothing)) [
-              "intros", "compute", "trivial", "search", "solve", "attack",
-              "unify", "state", "term", "undo", "qed", "abandon", ":q",
-              "sourceLocation"
-             ]
+tacticArgs = [ (name, args) | (names, args, _) <- Idris.ParseExpr.tactics
+                            , name <- names ]
 tactics = map fst tacticArgs
 
 -- | Convert a name into a string usable for completion. Filters out names
@@ -77,10 +48,7 @@ names = do i <- get
            let ctxt = tt_ctxt i
            return . nub $
              mapMaybe (nameString . fst) (ctxtAlist ctxt) ++
-             -- Explicitly add primitive types, as these are special-cased in the parser
-             ["Int", "Integer", "Float", "Char", "String", "Type",
-              "Ptr", "Bits8", "Bits16", "Bits32", "Bits64",
-              "Bits8x16", "Bits16x8", "Bits32x4", "Bits64x2"]
+             "Type" : map fst Idris.ParseExpr.constants
 
 metavars :: Idris [String]
 metavars = do i <- get
@@ -195,10 +163,11 @@ completeTactic :: [String] -> String -> CompletionFunc Idris
 completeTactic as tac (prev, next) = fromMaybe completeTacName . fmap completeArg $
                                      lookup tac tacticArgs
     where completeTacName = return $ ("", completeWith tactics tac)
-          completeArg Nothing           = noCompletion (prev, next)
-          completeArg (Just NameTArg)   = noCompletion (prev, next) -- this is for binding new names!
-          completeArg (Just ExprTArg)   = completeExpr as (prev, next)
-          completeArg (Just AltsTArg)   = noCompletion (prev, next) -- TODO
+          completeArg Nothing              = noCompletion (prev, next)
+          completeArg (Just NameTArg)      = noCompletion (prev, next) -- this is for binding new names!
+          completeArg (Just ExprTArg)      = completeExpr as (prev, next)
+          completeArg (Just StringLitTArg) = noCompletion (prev, next)
+          completeArg (Just AltsTArg)      = noCompletion (prev, next) -- TODO
 
 -- | Complete tactics and their arguments
 proverCompletion :: [String] -- ^ The names of current local assumptions

--- a/src/Idris/Help.hs
+++ b/src/Idris/Help.hs
@@ -95,4 +95,19 @@ extraHelp =
     , ([":addproofclause!", ":apc!"], NoArg, ":apc! <line> <name> destructively adds a pattern-matching proof clause to name on line")
     , ([":refine", ":ref"], NoArg, ":ref <line> <name> <name'> attempts to partially solve name on line, with name' as hint, introducing metavariables for arguments that aren't inferrable")
     , ([":refine!", ":ref!"], NoArg, ":ref! <line> <name> <name'> destructively attempts to partially solve name on line, with name' as hint, introducing metavariables for arguments that aren't inferrable")
+
+    , ([":u", ":universes"], NoArg, "Display universe constraints")
+    , ([":errorhandlers"], NoArg, "List registered error handlers")
+    , ([":d", ":def"], NameArg, "Display a name's internal definitions")
+    , ([":transinfo"], NameArg, "Show relevant transformation rules for a name")
+    , ([":di", ":dbginfo"], NameArg, "Show debugging information for a name")
+    , ([":spec"], ExprArg, "?")
+    , ([":hnf"], ExprArg, "?")
+    , ([":inline"], ExprArg, "?")
+
+    , ([":ml", ":makelemma"], NoArg, "?")
+
+    , ([":log"], NumberArg, "Set logging verbosity level")
+    , ([":lto", ":loadto"], SeqArgs NumberArg FileArg, "Load file up to line number")
+    , ([":debugunify"], SeqArgs ExprArg ExprArg, "(Debugging) Try to unify two expressions")
     ]

--- a/src/Idris/Help.hs
+++ b/src/Idris/Help.hs
@@ -1,4 +1,4 @@
-module Idris.Help (CmdArg(..), help, extraHelp) where
+module Idris.Help (CmdArg(..), extraHelp) where
 
 data CmdArg = ExprArg -- ^ The command takes an expression
             | NameArg -- ^ The command takes a name
@@ -37,77 +37,14 @@ instance Show CmdArg where
     show (OptionalArg a) = "[" ++ show a ++ "]"
     show (SeqArgs a b) = show a ++ " " ++ show b
 
-help :: [([String], CmdArg, String)]
-help =
-  [ (["<expr>"], NoArg, "Evaluate an expression"),
-    ([":t"], ExprArg, "Check the type of an expression"),
-    ([":miss", ":missing"], NameArg, "Show missing clauses"),
-    ([":doc"], NameArg, "Show internal documentation"),
-    ([":mkdoc"], NamespaceArg, "Generate IdrisDoc for namespace(s) and dependencies"),
-    ([":apropos"], SeqArgs (OptionalArg PkgArgs) NameArg, " Search names, types, and documentation"),
-    ([":search", ":s"], SeqArgs (OptionalArg PkgArgs) ExprArg, " Search for values by type"),
-    ([":whocalls", ":wc"], NameArg, "List the callers of some name"),
-    ([":callswho", ":cw"], NameArg, "List the callees of some name"),
-    ([":total"], NameArg, "Check the totality of a name"),
-    ([":r",":reload"], NoArg, "Reload current file"),
-    ([":l",":load"], FileArg, "Load a new file"),
-    ([":cd"], FileArg, "Change working directory"),
-    ([":module"], ModuleArg, "Import an extra module"), -- NOTE: dragons
-    ([":e",":edit"], NoArg, "Edit current file using $EDITOR or $VISUAL"),
-    ([":m",":metavars"], NoArg, "Show remaining proof obligations (metavariables)"),
-    ([":p",":prove"], MetaVarArg, "Prove a metavariable"),
-    ([":a",":addproof"], NameArg, "Add proof to source file"),
-    ([":rmproof"], NameArg, "Remove proof from proof stack"),
-    ([":showproof"], NameArg, "Show proof"),
-    ([":proofs"], NoArg, "Show available proofs"),
-    ([":x"], ExprArg, "Execute IO actions resulting from an expression using the interpreter"),
-    ([":c",":compile"], FileArg, "Compile to an executable [codegen] <filename>"),
-    ([":exec",":execute"], NoArg, "Compile to an executable and run"),
-    ([":dynamic"], FileArg, "Dynamically load a C library (similar to %dynamic)"),
-    ([":dynamic"], NoArg, "List dynamically loaded C libraries"),
-    ([":?",":h",":help"], NoArg, "Display this help text"),
-    ([":set"], OptionArg, "Set an option (errorcontext, showimplicits)"),
-    ([":unset"], OptionArg, "Unset an option"),
-    ([":colour", ":color"], ColourArg, "Turn REPL colours on or off; set a specific colour"),
-    ([":consolewidth"], ConsoleWidthArg, "Set the width of the console"),
-    ([":q",":quit"], NoArg, "Exit the Idris system"),
-    ([":w", ":warranty"], NoArg, "Displays warranty information"),
-    ([":let"], ManyArgs DeclArg, "Evaluate a declaration, such as a function definition, instance implementation, or fixity declaration"),
-    ([":undefine",":unlet"], ManyArgs NameArg, "Remove the listed repl definitions, or all repl definitions if no names given"),
-    ([":printdef"], NameArg, "Show the definition of a function"),
-    ([":pp", ":pprint"], (SeqArgs OptionArg (SeqArgs NumberArg NameArg)), "Pretty prints an Idris function in either LaTeX or HTML and for a specified width.")
-  ]
-
 -- | Use these for completion, but don't show them in :help
 extraHelp ::[([String], CmdArg, String)]
 extraHelp =
-    [ ([":casesplit", ":cs"], NoArg, ":cs <line> <name> splits the pattern variable on the line")
-    , ([":casesplit!", ":cs!"], NoArg, ":cs! <line> <name> destructively splits the pattern variable on the line")
-    , ([":addclause", ":ac"], NoArg, ":ac <line> <name> adds a clause for the definition of the name on the line")
+    [ ([":casesplit!", ":cs!"], NoArg, ":cs! <line> <name> destructively splits the pattern variable on the line")
     , ([":addclause!", ":ac!"], NoArg, ":ac! <line> <name> destructively adds a clause for the definition of the name on the line")
-    , ([":addmissing", ":am"], NoArg, ":am <line> <name> adds all missing pattern matches for the name on the line")
     , ([":addmissing!", ":am!"], NoArg, ":am! <line> <name> destructively adds all missing pattern matches for the name on the line")
-    , ([":makewith", ":mw"], NoArg, ":mw <line> <name> adds a with clause for the definition of the name on the line")
     , ([":makewith!", ":mw!"], NoArg, ":mw! <line> <name> destructively adds a with clause for the definition of the name on the line")
-    , ([":proofsearch", ":ps"], NoArg, ":ps <line> <name> <names> does proof search for name on line, with names as hints")
     , ([":proofsearch!", ":ps!"], NoArg, ":ps! <line> <name> <names> destructively does proof search for name on line, with names as hints")
-    , ([":addproofclause", ":apc"], NoArg, ":apc <line> <name> adds a pattern-matching proof clause to name on line")
     , ([":addproofclause!", ":apc!"], NoArg, ":apc! <line> <name> destructively adds a pattern-matching proof clause to name on line")
-    , ([":refine", ":ref"], NoArg, ":ref <line> <name> <name'> attempts to partially solve name on line, with name' as hint, introducing metavariables for arguments that aren't inferrable")
     , ([":refine!", ":ref!"], NoArg, ":ref! <line> <name> <name'> destructively attempts to partially solve name on line, with name' as hint, introducing metavariables for arguments that aren't inferrable")
-
-    , ([":u", ":universes"], NoArg, "Display universe constraints")
-    , ([":errorhandlers"], NoArg, "List registered error handlers")
-    , ([":d", ":def"], NameArg, "Display a name's internal definitions")
-    , ([":transinfo"], NameArg, "Show relevant transformation rules for a name")
-    , ([":di", ":dbginfo"], NameArg, "Show debugging information for a name")
-    , ([":spec"], ExprArg, "?")
-    , ([":hnf"], ExprArg, "?")
-    , ([":inline"], ExprArg, "?")
-
-    , ([":ml", ":makelemma"], NoArg, "?")
-
-    , ([":log"], NumberArg, "Set logging verbosity level")
-    , ([":lto", ":loadto"], SeqArgs NumberArg FileArg, "Load file up to line number")
-    , ([":debugunify"], SeqArgs ExprArg ExprArg, "(Debugging) Try to unify two expressions")
     ]

--- a/src/Idris/ParseExpr.hs
+++ b/src/Idris/ParseExpr.hs
@@ -1135,23 +1135,29 @@ Constant ::=
   ;
 @
 -}
+
+constants :: [(String, Idris.Core.TT.Const)]
+constants = 
+  [ ("Integer",            AType (ATInt ITBig))
+  , ("Int",                AType (ATInt ITNative))
+  , ("Char",               AType (ATInt ITChar))
+  , ("Float",              AType ATFloat)
+  , ("String",             StrType)
+  , ("Ptr",                PtrType)
+  , ("ManagedPtr",         ManagedPtrType)
+  , ("prim__UnsafeBuffer", BufferType)
+  , ("Bits8",              AType (ATInt (ITFixed IT8)))
+  , ("Bits16",             AType (ATInt (ITFixed IT16)))
+  , ("Bits32",             AType (ATInt (ITFixed IT32)))
+  , ("Bits64",             AType (ATInt (ITFixed IT64)))
+  , ("Bits8x16",           AType (ATInt (ITVec IT8 16)))
+  , ("Bits16x8",           AType (ATInt (ITVec IT16 8)))
+  , ("Bits32x4",           AType (ATInt (ITVec IT32 4)))
+  , ("Bits64x2",           AType (ATInt (ITVec IT64 2)))
+  ]
+ 
 constant :: IdrisParser Idris.Core.TT.Const
-constant =  do reserved "Integer";      return (AType (ATInt ITBig))
-        <|> do reserved "Int";          return (AType (ATInt ITNative))
-        <|> do reserved "Char";         return (AType (ATInt ITChar))
-        <|> do reserved "Float";        return (AType ATFloat)
-        <|> do reserved "String";       return StrType
-        <|> do reserved "Ptr";          return PtrType
-        <|> do reserved "ManagedPtr";   return ManagedPtrType
-        <|> do reserved "prim__UnsafeBuffer"; return BufferType
-        <|> do reserved "Bits8";  return (AType (ATInt (ITFixed IT8)))
-        <|> do reserved "Bits16"; return (AType (ATInt (ITFixed IT16)))
-        <|> do reserved "Bits32"; return (AType (ATInt (ITFixed IT32)))
-        <|> do reserved "Bits64"; return (AType (ATInt (ITFixed IT64)))
-        <|> do reserved "Bits8x16"; return (AType (ATInt (ITVec IT8 16)))
-        <|> do reserved "Bits16x8"; return (AType (ATInt (ITVec IT16 8)))
-        <|> do reserved "Bits32x4"; return (AType (ATInt (ITVec IT32 4)))
-        <|> do reserved "Bits64x2"; return (AType (ATInt (ITVec IT64 2)))
+constant = choice [ do reserved name; return ty | (name, ty) <- constants ]
         <|> do f <- try float;   return $ Fl f
         <|> do i <- natural; return $ BI i
         <|> do s <- verbatimStringLiteral; return $ Str s
@@ -1224,116 +1230,109 @@ TacticSeq ::=
 @
 -}
 
+-- | A specification of the arguments that tactics can take
+data TacticArg = NameTArg -- ^ Names: n1, n2, n3, ... n
+               | ExprTArg
+               | AltsTArg
+               | StringLitTArg
+
+-- The FIXMEs are Issue #1766 in the issue tracker.
+--     https://github.com/idris-lang/Idris-dev/issues/1766
+-- | A list of available tactics and their argument requirements
+tactics :: [([String], Maybe TacticArg, SyntaxInfo -> IdrisParser PTactic)]
+tactics = 
+  [ (["intro"], Nothing, const $ -- FIXME syntax for intro (fresh name)
+      do ns <- sepBy (spaced name) (lchar ','); return $ Intro ns)
+  , noArgs ["intros"] Intros
+  , (["refine"], Just ExprTArg, const $
+       do n <- spaced fnName
+          imps <- many imp
+          return $ Refine n imps)
+  , (["mrefine"], Just ExprTArg, const $
+       do n <- spaced fnName
+          return $ MatchRefine n)
+  , expressionTactic ["rewrite"] Rewrite
+  , expressionTactic ["case"] CaseTac
+  , expressionTactic ["induction"] Induction
+  , expressionTactic ["equiv"] Equiv
+  , (["let"], Nothing, \syn -> -- FIXME syntax for let
+       do n <- (indentPropHolds gtProp *> name)
+          (do indentPropHolds gtProp *> lchar ':'
+              ty <- indentPropHolds gtProp *> expr' syn
+              indentPropHolds gtProp *> lchar '='
+              t <- indentPropHolds gtProp *> expr syn
+              i <- get
+              return $ LetTacTy n (desugar syn i ty) (desugar syn i t))
+            <|> (do indentPropHolds gtProp *> lchar '='
+                    t <- indentPropHolds gtProp *> expr syn
+                    i <- get
+                    return $ LetTac n (desugar syn i t)))
+
+  , (["focus"], Just ExprTArg, const $
+       do n <- spaced name
+          return $ Focus n)
+  , expressionTactic ["exact"] Exact
+  , expressionTactic ["applyTactic"] ApplyTactic
+  , expressionTactic ["byReflection"] ByReflection
+  , expressionTactic ["reflect"] Reflect
+  , expressionTactic ["fill"] Fill
+  , (["try"], Just AltsTArg, \syn ->
+        do t <- spaced (tactic syn)
+           lchar '|'
+           t1 <- spaced (tactic syn)
+           return $ Try t t1)
+  , noArgs ["compute"] Compute
+  , noArgs ["trivial"] Trivial
+  , noArgs ["unify"] DoUnify
+  , (["search"], Nothing, const $
+      do depth <- option 10 natural
+         return (ProofSearch True True (fromInteger depth) Nothing []))
+  , noArgs ["instance"] TCInstance
+  , noArgs ["solve"] Solve
+  , noArgs ["attack"] Attack
+  , noArgs ["state"] ProofState
+  , noArgs ["term"] ProofTerm
+  , noArgs ["undo"] Undo
+  , noArgs ["qed"] Qed
+  , noArgs ["abandon", ":q"] Abandon
+  , noArgs ["skip"] Skip
+  , noArgs ["sourceLocation"] SourceFC
+  , expressionTactic [":e", ":eval"] TEval
+  , expressionTactic [":t", ":type"] TCheck
+  , expressionTactic [":search"] TSearch
+  , (["fail"], Just StringLitTArg, const $
+       do msg <- stringLiteral
+          return $ TFail [Idris.Core.TT.TextPart msg])
+  , ([":doc"], Just ExprTArg, const $
+       do whiteSpace
+          doc <- (Right <$> constant) <|> (Left <$> fnName)
+          eof
+          return (TDocStr doc))
+  ]
+  where
+  expressionTactic names tactic = (names, Just ExprTArg, \syn ->
+     do t <- spaced (expr syn)
+        i <- get
+        return $ tactic (desugar syn i t))
+  noArgs names tactic = (names, Nothing, const (return tactic))
+  spaced parser = indentPropHolds gtProp *> parser
+  imp :: IdrisParser Bool
+  imp = do lchar '?'; return False
+    <|> do lchar '_'; return True
+  
+
 tactic :: SyntaxInfo -> IdrisParser PTactic
-tactic syn = do reserved "intro"; ns <- sepBy (indentPropHolds gtProp *> name) (lchar ',')
-                return $ Intro ns
-          <|> do reserved "intros"; return Intros
-          <|> try (do reserved "refine"; n <- (indentPropHolds gtProp *> fnName)
-                      imps <- some imp
-                      return $ Refine n imps)
-          <|> do reserved "refine"; n <- (indentPropHolds gtProp *> fnName)
-                 i <- get
-                 return $ Refine n []
-          <|> do reserved "mrefine"; n <- (indentPropHolds gtProp *> fnName)
-                 i <- get
-                 return $ MatchRefine n
-          <|> do reserved "rewrite"; t <- (indentPropHolds gtProp *> expr syn);
-                 i <- get
-                 return $ Rewrite (desugar syn i t)
-          <|> do reserved "case"; t <- (indentPropHolds gtProp *> expr syn);
-                 i <- get
-                 return $ CaseTac (desugar syn i t)
-          <|> do reserved "induction"; t <- (indentPropHolds gtProp *> expr syn);
-                 i <- get
-                 return $ Induction (desugar syn i t)
-          <|> do reserved "equiv"; t <- (indentPropHolds gtProp *> expr syn);
-                 i <- get
-                 return $ Equiv (desugar syn i t)
-          <|> try (do reserved "let"; n <- (indentPropHolds gtProp *> name); (indentPropHolds gtProp *> lchar ':');
-                      ty <- (indentPropHolds gtProp *> expr' syn); (indentPropHolds gtProp *> lchar '='); t <- (indentPropHolds gtProp *> expr syn);
-                      i <- get
-                      return $ LetTacTy n (desugar syn i ty) (desugar syn i t))
-          <|> try (do reserved "let"; n <- (indentPropHolds gtProp *> name); (indentPropHolds gtProp *> lchar '=');
-                      t <- (indentPropHolds gtProp *> expr syn);
-                      i <- get
-                      return $ LetTac n (desugar syn i t))
-          <|> do reserved "focus"; n <- (indentPropHolds gtProp *> name)
-                 return $ Focus n
-          <|> do reserved "exact"; t <- (indentPropHolds gtProp *> expr syn);
-                 i <- get
-                 return $ Exact (desugar syn i t)
-          <|> do reserved "applyTactic"; t <- (indentPropHolds gtProp *> expr syn);
-                 i <- get
-                 return $ ApplyTactic (desugar syn i t)
-          <|> do reserved "byReflection"; t <- (indentPropHolds gtProp *> expr syn);
-                 i <- get
-                 return $ ByReflection (desugar syn i t)
-          <|> do reserved "reflect"; t <- (indentPropHolds gtProp *> expr syn);
-                 i <- get
-                 return $ Reflect (desugar syn i t)
-          <|> do reserved "fill"; t <- (indentPropHolds gtProp *> expr syn);
-                 i <- get
-                 return $ Fill (desugar syn i t)
-          <|> do reserved "try"; t <- (indentPropHolds gtProp *> tactic syn);
-                 lchar '|';
-                 t1 <- (indentPropHolds gtProp *> tactic syn)
-                 return $ Try t t1
+tactic syn = choice [ do choice (map reserved names); parser syn 
+                    | (names, _, parser) <- tactics ]
           <|> do lchar '{'
                  t <- tactic syn;
                  lchar ';';
                  ts <- sepBy1 (tactic syn) (lchar ';')
                  lchar '}'
                  return $ TSeq t (mergeSeq ts)
-          <|> do reserved "compute"; return Compute
-          <|> do reserved "trivial"; return Trivial
-          <|> do reserved "unify"; return DoUnify
-          <|> do reserved "search"
-                 depth <- option 10 natural
-                 return (ProofSearch True True (fromInteger depth) Nothing [])
-          <|> do reserved "instance"; return TCInstance
-          <|> do reserved "solve"; return Solve
-          <|> do reserved "attack"; return Attack
-          <|> do reserved "state"; return ProofState
-          <|> do reserved "term"; return ProofTerm
-          <|> do reserved "undo"; return Undo
-          <|> do reserved "qed"; return Qed
-          <|> do reserved "abandon"; return Abandon
-          <|> do reserved "skip"; return Skip
-          <|> do reserved "fail"
-                 msg <- stringLiteral
-                 return $ TFail [Idris.Core.TT.TextPart msg]
-          <|> do reserved "sourceLocation"; return SourceFC
-          <|> do lchar ':';
-                 (    (do reserved "q"; return Abandon)
-                  <|> (do (reserved "e" <|> reserved "eval");
-                          t <- (indentPropHolds gtProp *> expr syn);
-                          i <- get
-                          return $ TEval (desugar syn i t))
-                  <|> (do (reserved "t" <|> reserved "type");
-                          t <- (indentPropHolds gtProp *> expr syn);
-                          i <- get
-                          return $ TCheck (desugar syn i t))
-                  <|> try (do reserved "doc"
-                              whiteSpace
-                              c <- constant
-                              eof
-                              return (TDocStr (Right c)))
-                  <|> try (do reserved "doc"
-                              whiteSpace
-                              n <- fnName
-                              eof
-                              return (TDocStr (Left n)))
-                  <|> try (do reserved "search"
-                              whiteSpace
-                              t <- (indentPropHolds gtProp *> expr syn);
-                              i <- get
-                              return $ TSearch (desugar syn i t))
-                  <?> "prover command")
+          <|> ((lchar ':' >> empty) <?> "prover command")
           <?> "tactic"
   where
-    imp :: IdrisParser Bool
-    imp = do lchar '?'; return False
-      <|> do lchar '_'; return True
     mergeSeq :: [PTactic] -> PTactic
     mergeSeq [t]    = t
     mergeSeq (t:ts) = TSeq t (mergeSeq ts)

--- a/src/Idris/ParseHelpers.hs
+++ b/src/Idris/ParseHelpers.hs
@@ -488,7 +488,7 @@ notEndBlock = do ist <- get
 data IndentProperty = IndentProperty (Int -> Int -> Bool) String
 
 -- | Allows comparison of indent, and fails if property doesn't hold
-indentPropHolds :: IndentProperty -> IdrisParser()
+indentPropHolds :: IndentProperty -> IdrisParser ()
 indentPropHolds (IndentProperty op msg) = do
   li <- lastIndent
   i <- indent

--- a/src/Idris/Parser.hs
+++ b/src/Idris/Parser.hs
@@ -1198,13 +1198,13 @@ parseProg syn fname input mrk
                           return (ds, i')
 
 {- | Load idris module and show error if something wrong happens -}
-loadModule :: FilePath -> Idris String
+loadModule :: FilePath -> Idris (Maybe String)
 loadModule f
-   = idrisCatch (loadModule' f)
+   = idrisCatch (fmap Just (loadModule' f))
                 (\e -> do setErrSpan (getErrSpan e)
                           ist <- getIState
                           iWarn (getErrSpan e) $ pprintErr ist e
-                          return "")
+                          return Nothing)
 
 {- | Load idris module -}
 loadModule' :: FilePath -> Idris String

--- a/src/Idris/REPL.hs
+++ b/src/Idris/REPL.hs
@@ -14,13 +14,13 @@ import Idris.Error
 import Idris.ErrReverse
 import Idris.Delaborate
 import Idris.Docstrings (Docstring, overview, renderDocstring)
+import Idris.Help
 import Idris.IdrisDoc
 import Idris.Prover
 import Idris.Parser hiding (indent)
 import Idris.Primitives
 import Idris.Coverage
 import Idris.Docs hiding (Doc)
-import Idris.Help
 import Idris.Completion
 import qualified Idris.IdeSlave as IdeSlave
 import Idris.Chaser
@@ -633,7 +633,7 @@ processInput cmd orig inputs
             Success (Right (ModImport f)) ->
                 do clearErr
                    fmod <- loadModule f
-                   return (Just (inputs ++ [fmod]))
+                   return (Just (inputs ++ maybe [] (:[]) fmod))
             Success (Right Edit) -> do -- takeMVar stvar
                                edit fn orig
                                return (Just inputs)


### PR DESCRIPTION
I've thrown together several commits. The main thing that I've done is try to remove code duplication. In particular, I tried to link the suggestions given in the REPL completion, and given at the REPL help prompt, to the actual code for parsing those things that are completed. This way, as features are added and removed, they will also be added and removed to the REPL completion, so it should be easier to keep things consistent with each other.

From doing this, I noticed that there are now several constants (such as `prim__UnsafeBuffer`) and several REPL commands (such as `:u` - this is what actually got me to look at the REPL parsing and completion) which are now available for REPL completion.

I also modified a bunch of the parsing code, mainly in an attempt to remove code duplication. I've also simplified the parsing code in some places, removing unnecessary whitespace parsing and unnecessary calls to `try`.

Finally, I fixed a couple of typos in the library documentation, and made some very minor changes to the code for :search and its documentation.