### PR TITLE
compiler (currently) should also use sse2 due rts changes

### DIFF
--- a/src/IRTS/CodegenC.hs
+++ b/src/IRTS/CodegenC.hs
@@ -66,7 +66,7 @@ codegenC' defs out exec incs objs libs flags dbg
              let args = [gccDbg dbg] ++
                         gccFlags ++
                         -- # Any flags defined here which alter the RTS API must also be added to config.mk
-                        ["-DHAS_PTHREAD", "-DIDRIS_ENABLE_STATS",
+                        ["-DHAS_PTHREAD", "-DIDRIS_ENABLE_STATS", "-msse2",
                          "-I."] ++ objs ++ ["-x", "c"] ++
                         (if (exec == Executable) then [] else ["-c"]) ++
                         [tmpn] ++


### PR DESCRIPTION
compiler also should use sse2 with the same reason as here (addition rts types) :
 - https://github.com/idris-lang/Idris-dev/pull/1820
 - https://github.com/idris-lang/Idris-dev/issues/1819

I'm agreed that ideally all that should be optional but it's more complicated to implement, now I just want working compiler.