### PR TITLE
Feature/package list

### DIFF
--- a/idris.cabal
+++ b/idris.cabal
@@ -794,6 +794,7 @@ Executable idris
   Build-depends:  idris
                 , base
                 , filepath
+                , directory
                 , haskeline >= 0.7
                 , transformers
 

--- a/main/Main.hs
+++ b/main/Main.hs
@@ -5,6 +5,7 @@ import System.IO
 import System.Environment
 import System.Exit
 import System.FilePath ((</>), addTrailingPathSeparator)
+import System.Directory
 
 import Data.Maybe
 import Data.Version

--- a/main/Main.hs
+++ b/main/Main.hs
@@ -45,6 +45,7 @@ runIdris opts = do
        when (ShowIncs `elem` opts) $ runIO showIncs
        when (ShowLibs `elem` opts) $ runIO showLibs
        when (ShowLibdir `elem` opts) $ runIO showLibdir
+       when (ShowPkgs `elem` opts) $ runIO showPkgs
        case opt getClient opts of
            []    -> return ()
            (c:_) -> do setVerbose False
@@ -91,4 +92,11 @@ showLibdir = do dir <- getIdrisLibDir
 showIncs :: IO b
 showIncs = do incFlags <- getIncFlags
               putStrLn $ unwords incFlags
+              exitWith ExitSuccess
+
+-- | List idris packages installed
+showPkgs :: IO b
+showPkgs = do dir <- getIdrisLibDir
+              pkgs <- getDirectoryContents dir
+              mapM putStrLn (filter (/= ".") . filter (/= "..") $ pkgs)
               exitWith ExitSuccess

--- a/src/Idris/AbsSyntaxTree.hs
+++ b/src/Idris/AbsSyntaxTree.hs
@@ -388,6 +388,7 @@ data Opt = Filename String
          | ShowLibs
          | ShowLibdir
          | ShowIncs
+         | ShowPkgs
          | NoBasePkgs
          | NoPrelude
          | NoBuiltins -- only for the really primitive stuff!

--- a/src/Idris/CmdOptions.hs
+++ b/src/Idris/CmdOptions.hs
@@ -89,6 +89,7 @@ parseFlags = many $
   <|> flag' NoCoverage (long "nocoverage")
   <|> flag' ErrContext (long "errorcontext")
   <|> flag' ShowLibs (long "link" <> help "Display link flags")
+  <|> flag' ShowPkgs (long "listlibs" <> help "Display installed libraries")
   <|> flag' ShowLibdir (long "libdir" <> help "Display library directory")
   <|> flag' ShowIncs (long "include" <> help "Display the includes flags")
   <|> flag' Verbose (short 'V' <> long "verbose" <> help "Loud verbosity")


### PR DESCRIPTION
This is a quick and dirty solution for #1071.

I wish I were able to implement output of metadata, but since there is
no metadata saved (currently) alongside of a package, there is nothing
to display.

Displaying metadata in the output of this subcommand would mean that
there have to happen further improvements in the package-system of
idris.

Please see my proposal in #1126.