### PR TITLE
Default to no REPL completion if not yet implemented

### DIFF
--- a/idris.cabal
+++ b/idris.cabal
@@ -794,6 +794,7 @@ Executable idris
   Build-depends:  idris
                 , base
                 , filepath
+                , directory
                 , haskeline >= 0.7
                 , transformers
 

--- a/main/Main.hs
+++ b/main/Main.hs
@@ -5,6 +5,7 @@ import System.IO
 import System.Environment
 import System.Exit
 import System.FilePath ((</>), addTrailingPathSeparator)
+import System.Directory
 
 import Data.Maybe
 import Data.Version
@@ -45,6 +46,7 @@ runIdris opts = do
        when (ShowIncs `elem` opts) $ runIO showIncs
        when (ShowLibs `elem` opts) $ runIO showLibs
        when (ShowLibdir `elem` opts) $ runIO showLibdir
+       when (ShowPkgs `elem` opts) $ runIO showPkgs
        case opt getClient opts of
            []    -> return ()
            (c:_) -> do setVerbose False
@@ -91,4 +93,11 @@ showLibdir = do dir <- getIdrisLibDir
 showIncs :: IO b
 showIncs = do incFlags <- getIncFlags
               putStrLn $ unwords incFlags
+              exitWith ExitSuccess
+
+-- | List idris packages installed
+showPkgs :: IO b
+showPkgs = do dir <- getIdrisLibDir
+              pkgs <- getDirectoryContents dir
+              mapM putStrLn (filter (/= ".") . filter (/= "..") $ pkgs)
               exitWith ExitSuccess

--- a/main/Main.hs
+++ b/main/Main.hs
@@ -97,7 +97,5 @@ showIncs = do incFlags <- getIncFlags
 
 -- | List idris packages installed
 showPkgs :: IO b
-showPkgs = do dir <- getIdrisLibDir
-              pkgs <- getDirectoryContents dir
-              mapM putStrLn (filter (/= ".") . filter (/= "..") $ pkgs)
+showPkgs = do mapM putStrLn =<< installedPackages
               exitWith ExitSuccess

--- a/src/Idris/AbsSyntaxTree.hs
+++ b/src/Idris/AbsSyntaxTree.hs
@@ -388,6 +388,7 @@ data Opt = Filename String
          | ShowLibs
          | ShowLibdir
          | ShowIncs
+         | ShowPkgs
          | NoBasePkgs
          | NoPrelude
          | NoBuiltins -- only for the really primitive stuff!

--- a/src/Idris/CmdOptions.hs
+++ b/src/Idris/CmdOptions.hs
@@ -89,6 +89,7 @@ parseFlags = many $
   <|> flag' NoCoverage (long "nocoverage")
   <|> flag' ErrContext (long "errorcontext")
   <|> flag' ShowLibs (long "link" <> help "Display link flags")
+  <|> flag' ShowPkgs (long "listlibs" <> help "Display installed libraries")
   <|> flag' ShowLibdir (long "libdir" <> help "Display library directory")
   <|> flag' ShowIncs (long "include" <> help "Display the includes flags")
   <|> flag' Verbose (short 'V' <> long "verbose" <> help "Loud verbosity")

--- a/src/Idris/Completion.hs
+++ b/src/Idris/Completion.hs
@@ -4,8 +4,10 @@ module Idris.Completion (replCompletion, proverCompletion) where
 import Idris.Core.Evaluate (ctxtAlist)
 import Idris.Core.TT
 
+import Idris.AbsSyntax (runIO)
 import Idris.AbsSyntaxTree
 import Idris.Help
+import Idris.Imports (installedPackages)
 import Idris.Colours
 import Idris.ParseHelpers(opChars)
 import qualified Idris.ParseExpr (constants, tactics)
@@ -142,6 +144,7 @@ completeCmd cmd (prev, next) = fromMaybe completeCmdName $ fmap completeArg $ lo
           completeArg NoArg = noCompletion (prev, next)
           completeArg ConsoleWidthArg = completeConsoleWidth (prev, next)
           completeArg DeclArg = completeExpr [] (prev, next)
+          completeArg PkgArgs = completePkg (prev, next)
           completeArg (ManyArgs a) = completeArg a
           completeArg (OptionalArg a) = completeArg a
           completeArg (SeqArgs a b) = completeArg a
@@ -155,6 +158,11 @@ replCompletion (prev, next) = case firstWord of
                                 _           -> completeExpr [] (prev, next)
     where firstWord = fst $ break isWhitespace $ dropWhile isWhitespace $ reverse prev
 
+
+completePkg :: CompletionFunc Idris
+completePkg = completeWord Nothing " \t()" completeP
+    where completeP p = do pkgs <- runIO installedPackages
+                           return $ completeWith pkgs p
 
 -- The TODOs are Issue #1769 on the issue tracker.
 --     https://github.com/idris-lang/Idris-dev/issues/1769

--- a/src/Idris/Completion.hs
+++ b/src/Idris/Completion.hs
@@ -145,6 +145,7 @@ completeCmd cmd (prev, next) = fromMaybe completeCmdName $ fmap completeArg $ lo
           completeArg (ManyArgs a) = completeArg a
           completeArg (OptionalArg a) = completeArg a
           completeArg (SeqArgs a b) = completeArg a
+          completeArg _ = noCompletion (prev, next)
           completeCmdName = return $ ("", completeWith commands cmd)
 
 -- | Complete REPL commands and defined identifiers


### PR DESCRIPTION
Before this, an incomplete pattern match would break the REPL. The missing completion that caused this error was for `PkgArgs` (which is specified for the :search and :apropos commands)