### PR TITLE
Documentation for modules

### DIFF
--- a/CHANGELOG
+++ b/CHANGELOG
@@ -15,9 +15,9 @@ New in 0.9.16:
   to search.
 * Vect, Fin and So moved out of prelude into base, in modules Data.Vect,
   Data.Fin and Data.So respectively.
-
 * Several long-standing issues resolved, particularly with pattern matching
   and coverage checking.
+* Modules can now have API documentation strings.
 
 New in 0.9.15:
 --------------

--- a/idris.cabal
+++ b/idris.cabal
@@ -422,6 +422,10 @@ Extra-source-files:
                        test/idrisdoc008/expected
                        test/idrisdoc008/*.idr
                        test/idrisdoc008/*.ipkg
+                       test/idrisdoc009/run
+                       test/idrisdoc009/expected
+                       test/idrisdoc009/*.idr
+
 
                        test/interactive001/run
                        test/interactive001/input

--- a/idris.cabal
+++ b/idris.cabal
@@ -424,6 +424,7 @@ Extra-source-files:
                        test/idrisdoc008/*.ipkg
                        test/idrisdoc009/run
                        test/idrisdoc009/expected
+                       test/idrisdoc009/input
                        test/idrisdoc009/*.idr
 
 

--- a/libs/prelude/Prelude/Uninhabited.idr
+++ b/libs/prelude/Prelude/Uninhabited.idr
@@ -1,3 +1,6 @@
+||| Utilities for working with uninhabited types, to record explicit
+||| locations for canonical proofs of emptiness. Typically, one should
+||| use the `absurd` function.
 module Prelude.Uninhabited
 
 import Builtins

--- a/src/Idris/AbsSyntaxTree.hs
+++ b/src/Idris/AbsSyntaxTree.hs
@@ -166,6 +166,9 @@ data IState = IState {
     idris_callgraph :: Ctxt CGInfo, -- name, args used in each pos
     idris_calledgraph :: Ctxt [Name],
     idris_docstrings :: Ctxt (Docstring DocTerm, [(Name, Docstring DocTerm)]),
+    idris_moduledocs :: Ctxt (Docstring DocTerm),
+    -- ^ module documentation is saved in a special MN so the context
+    -- mechanism can be used for disambiguation
     idris_tyinfodata :: Ctxt TIData,
     idris_fninfo :: Ctxt FnInfo,
     idris_transforms :: Ctxt [(Term, Term)],
@@ -285,11 +288,13 @@ data IBCWrite = IBCFix FixDecl
               | IBCPostulate Name
               | IBCTotCheckErr FC String
               | IBCParsedRegion FC
+              | IBCModDocs Name -- ^ The name is the special name used to track module docs
   deriving Show
 
 -- | The initial state for the compiler
 idrisInit :: IState
-idrisInit = IState initContext [] [] emptyContext emptyContext emptyContext
+idrisInit = IState initContext [] []
+                   emptyContext emptyContext emptyContext emptyContext
                    emptyContext emptyContext emptyContext emptyContext
                    emptyContext emptyContext emptyContext emptyContext
                    emptyContext emptyContext emptyContext emptyContext
@@ -1196,6 +1201,12 @@ eqParamDoc = [(n "A", annotCode (const (Left $ Msg "")) . parseDocstring . T.pac
     where n a = sUN a
 
 eqOpts = []
+
+-- | The special name to be used in the module documentation context -
+-- not for use in the main definition context. The namespace around it
+-- will determine the module to which the docs adhere.
+modDocName :: Name
+modDocName = sMN 0 "ModuleDocs"
 
 -- Defined in builtins.idr
 sigmaTy   = sNS (sUN "Sigma") ["Builtins"]

--- a/src/Idris/Chaser.hs
+++ b/src/Idris/Chaser.hs
@@ -135,7 +135,7 @@ buildTree built fp = btree [] fp
         if exist then do
             file_in <- runIO $ readFile f
             file <- if lit then tclift $ unlit f file_in else return file_in
-            (_, modules, _) <- parseImports f file
+            (_, _, modules, _) <- parseImports f file
             -- The chaser should never report warnings from sub-modules
             clearParserWarnings
             ms <- mapM (btree done) [realName | (_, realName, alias, fc) <- modules]

--- a/src/Idris/Core/Binary.hs
+++ b/src/Idris/Core/Binary.hs
@@ -1,4 +1,4 @@
-{-# OPTIONS_GHC -fwarn-incomplete-patterns -Werror #-}
+{-# OPTIONS_GHC -fwarn-incomplete-patterns #-}
 
 {-| Binary instances for the core datatypes -}
 module Idris.Core.Binary where

--- a/src/Idris/IBC.hs
+++ b/src/Idris/IBC.hs
@@ -35,7 +35,7 @@ import Codec.Compression.Zlib (compress)
 import Util.Zlib (decompressEither)
 
 ibcVersion :: Word8
-ibcVersion = 90
+ibcVersion = 92
 
 data IBCFile = IBCFile { ver :: Word8,
                          sourcefile :: FilePath,
@@ -65,6 +65,7 @@ data IBCFile = IBCFile { ver :: Word8,
                          ibc_cg :: ![(Name, CGInfo)],
                          ibc_defs :: ![(Name, Def)],
                          ibc_docstrings :: ![(Name, (Docstring D.DocTerm, [(Name, Docstring D.DocTerm)]))],
+                         ibc_moduledocs :: ![(Name, Docstring D.DocTerm)],
                          ibc_transforms :: ![(Name, (Term, Term))],
                          ibc_errRev :: ![(Term, Term)],
                          ibc_coercions :: ![Name],
@@ -84,7 +85,7 @@ deriving instance Binary IBCFile
 !-}
 
 initIBC :: IBCFile
-initIBC = IBCFile ibcVersion "" [] [] [] [] [] [] [] [] [] [] [] [] [] [] [] [] [] [] [] [] [] [] [] [] [] [] [] [] [] [] [] [] [] [] [] [] [] Nothing
+initIBC = IBCFile ibcVersion "" [] [] [] [] [] [] [] [] [] [] [] [] [] [] [] [] [] [] [] [] [] [] [] [] [] [] [] [] [] [] [] [] [] [] [] [] [] [] Nothing
 
 loadIBC :: Bool -- ^ True = reexport, False = make everything private 
         -> FilePath -> Idris ()
@@ -280,6 +281,9 @@ ibc i (IBCMetavar n) f =
 ibc i (IBCPostulate n) f = return f { ibc_postulates = n : ibc_postulates f }
 ibc i (IBCTotCheckErr fc err) f = return f { ibc_totcheckfail = (fc, err) : ibc_totcheckfail f }
 ibc i (IBCParsedRegion fc) f = return f { ibc_parsedSpan = Just fc }
+ibc i (IBCModDocs n) f = case lookupCtxtExact n (idris_moduledocs i) of
+                           Just v -> return f { ibc_moduledocs = (n,v) : ibc_moduledocs f }
+                           _ -> ifail "IBC write failed"
 
 process :: Bool -- ^ Reexporting
            -> IBCFile -> FilePath -> Idris ()
@@ -324,6 +328,7 @@ process reexp i fn
                pTotCheckErr $ force (ibc_totcheckfail i)
                pCG $ force (ibc_cg i)
                pDocs $ force (ibc_docstrings i)
+               pMDocs $ force (ibc_moduledocs i)
                pCoercions $ force (ibc_coercions i)
                pTrans $ force (ibc_transforms i)
                pErrRev $ force (ibc_errRev i)
@@ -502,7 +507,12 @@ pDefs reexp syms ds
     update t = t
 
 pDocs :: [(Name, (Docstring D.DocTerm, [(Name, Docstring D.DocTerm)]))] -> Idris ()
-pDocs ds = mapM_ (\ (n, a) -> addDocStr n (fst a) (snd a)) ds
+pDocs ds = mapM_ (\(n, a) -> addDocStr n (fst a) (snd a)) ds
+
+pMDocs :: [(Name, Docstring D.DocTerm)] -> Idris ()
+pMDocs ds = mapM_ addMDocStr ds
+  where addMDocStr (n, d) = do ist <- getIState
+                               putIState ist { idris_moduledocs = addDef n d (idris_moduledocs ist) }
 
 pAccess :: Bool -- ^ Reexporting?
            -> [(Name, Accessibility)] -> Idris ()
@@ -918,7 +928,7 @@ instance Binary MetaInformation where
                      return (DataMI x1)
 
 instance Binary IBCFile where
-        put x@(IBCFile x1 x2 x3 x4 x5 x6 x7 x8 x9 x10 x11 x12 x13 x14 x15 x16 x17 x18 x19 x20 x21 x22 x23 x24 x25 x26 x27 x28 x29 x30 x31 x32 x33 x34 x35 x36 x37 x38 x39 x40)
+        put x@(IBCFile x1 x2 x3 x4 x5 x6 x7 x8 x9 x10 x11 x12 x13 x14 x15 x16 x17 x18 x19 x20 x21 x22 x23 x24 x25 x26 x27 x28 x29 x30 x31 x32 x33 x34 x35 x36 x37 x38 x39 x40 x41)
          = {-# SCC "putIBCFile" #-}
             do put x1
                put x2
@@ -960,6 +970,7 @@ instance Binary IBCFile where
                put x38
                put x39
                put x40
+               put x41
 
         get
           = do x1 <- get
@@ -1003,7 +1014,8 @@ instance Binary IBCFile where
                     x38 <- get
                     x39 <- get
                     x40 <- get
-                    return (IBCFile x1 x2 x3 x4 x5 x6 x7 x8 x9 x10 x11 x12 x13 x14 x15 x16 x17 x18 x19 x20 x21 x22 x23 x24 x25 x26 x27 x28 x29 x30 x31 x32 x33 x34 x35 x36 x37 x38 x39 x40)
+                    x41 <- get
+                    return (IBCFile x1 x2 x3 x4 x5 x6 x7 x8 x9 x10 x11 x12 x13 x14 x15 x16 x17 x18 x19 x20 x21 x22 x23 x24 x25 x26 x27 x28 x29 x30 x31 x32 x33 x34 x35 x36 x37 x38 x39 x40 x41)
                   else return (initIBC { ver = x1 })
 
 instance Binary DataOpt where

--- a/src/Idris/REPL.hs
+++ b/src/Idris/REPL.hs
@@ -887,12 +887,17 @@ process fn (Check t)
 
 process fn (DocStr (Left n))
    = do ist <- getIState
-        case lookupCtxtName n (idris_docstrings ist) of
+        let docs = lookupCtxtName n (idris_docstrings ist) ++
+                   map (\(n,d)-> (n, (d,[]))) (lookupCtxtName (modDocN n) (idris_moduledocs ist))
+        case docs of
           [] -> iPrintError $ "No documentation for " ++ show n
           ns -> do toShow <- mapM (showDoc ist) ns
                    iRenderResult (vsep toShow)
     where showDoc ist (n, d) = do doc <- getDocs n
                                   return $ pprintDocs ist doc
+          modDocN (NS (UN n) ns) = NS modDocName (n:ns)
+          modDocN (UN n)         = NS modDocName [n]
+          modDocN _              = sMN 1 "NotFoundForSure"
 
 process fn (DocStr (Right c))
    = do ist <- getIState

--- a/test/idrisdoc009/Test.idr
+++ b/test/idrisdoc009/Test.idr
@@ -1,0 +1,45 @@
+||| Docs for module Test.
+|||
+||| It is a great module.
+||| Prelude thingy:
+||| ```idris example
+||| "foo" ++ "bar"
+||| ```
+|||
+||| Imported thingy:
+||| ```idris example
+||| 0.0 :+ 0.2
+||| ```
+|||
+||| Type error:
+||| ```idris
+||| "foo" + 2
+||| ```
+|||
+||| From this module:
+||| ```idris example
+||| MkTest
+||| ```
+module Test
+import Data.Complex
+
+myplus : Nat -> Nat -> Nat
+myplus Z j = j
+myplus (S k) j = S (myplus k j)
+
+||| Docs for datatype Test.
+data Test = MkTest
+
+data Thing : Type -> Type where
+  MkThing : Thing Nat
+
+-- fnord ++ xyz do done let module argh
+
+namespace Main
+  ||| Main is handy to do things in. ++. 
+  main : IO ()
+  main = do putStrLn "Hi!"
+            l <- getLine
+            case l of
+              "" => putStrLn "No!"
+              str => putStrLn str

--- a/test/idrisdoc009/expected
+++ b/test/idrisdoc009/expected
@@ -1,0 +1,29 @@
+Type checking ./Test.idr
+Data type Test : Type
+    Docs for datatype Test.
+    
+Constructors:
+    MkTest : Test
+        
+        
+Module Test:
+    Docs for module Test.
+    
+    It is a great module. Prelude thingy:
+    
+        > "foo" ++ "bar"
+        "foobar"
+    
+    Imported thingy:
+    
+        > 0.0 :+ 0.2
+        0.0 :+ 0.2
+    
+    Type error:
+    
+        "foo" + 2
+    
+    From this module:
+    
+        > MkTest
+        MkTest

--- a/test/idrisdoc009/input
+++ b/test/idrisdoc009/input
@@ -1,0 +1,1 @@
+:doc Test

--- a/test/idrisdoc009/input
+++ b/test/idrisdoc009/input
@@ -1,1 +1,2 @@
+:consolewidth infinite
 :doc Test

--- a/test/idrisdoc009/run
+++ b/test/idrisdoc009/run
@@ -1,0 +1,3 @@
+#!/usr/bin/env bash
+idris $@ --nocolour --quiet Test.idr < input
+rm -f *.ibc


### PR DESCRIPTION
This allows docstrings for modules.

The syntax is the same as for other documentation, right before the "module" declaration. For an example, see the "idrisdoc009" test. Terms in module documentation are elaborated in a context including all of its imports and definitions, so the documentation can provide examples and descriptions.

The :doc command now also shows documentation for modules.
