### PR TITLE
Allow building with base-4.8.0.0, deepseq 1.5, lens 4.8

### DIFF
--- a/idris.cabal
+++ b/idris.cabal
@@ -725,12 +725,12 @@ Library
                 , bytestring < 0.11
                 , cheapskate < 0.2
                 , containers >= 0.5 && < 0.6
-                , deepseq < 1.4
+                , deepseq < 1.5
                 , directory >= 1.2 && < 1.3
                 , filepath < 1.4
                 , fingertree >= 0.1 && < 0.2
                 , haskeline >= 0.7 && < 0.8
-                , lens >= 4.1.1 && < 4.7
+                , lens >= 4.1.1 && < 4.8
                 , mtl >= 2.2.1 && < 2.3
                 , network < 2.7
                 , optparse-applicative >= 0.11 && < 0.12

--- a/src/Idris/Core/Unify.hs
+++ b/src/Idris/Core/Unify.hs
@@ -73,14 +73,14 @@ match_unify ctxt env topx topy inj holes from =
                let topxn = renameBindersTm env (normalise ctxt env topx)
                    topyn = renameBindersTm env (normalise ctxt env topy) in
                      case runStateT (un [] topxn topyn)
-        	  	        (UI 0 []) of
+                                (UI 0 []) of
                        OK (v, UI _ fails) ->
                             do v' <- trimSolutions topx topy from env v
                                return (map (renameBinders env) v')
                        Error e ->
                         -- just normalise the term we're matching against
                          case runStateT (un [] topxn topy)
-        	  	          (UI 0 []) of
+                                  (UI 0 []) of
                            OK (v, UI _ fails) ->
                               do v' <- trimSolutions topx topy from env v
                                  return (map (renameBinders env) v')
@@ -286,12 +286,12 @@ unify ctxt env topx topy inj holes usersupp from =
                    topyn = renameBindersTm env (normalise ctxt env topy) in
 --                     trace ("Unifying " ++ show (topx, topy) ++ "\n\n==>\n" ++ show (topxn, topyn) ++ "\n\n" ++ show res ++ "\n\n") $
                      case runStateT (un False [] topxn topyn)
-        	  	        (UI 0 []) of
+                                (UI 0 []) of
                        OK (v, UI _ fails) ->
                             do v' <- trimSolutions topx topy from env v
                                return (map (renameBinders env) v', reverse fails)
 --         Error e@(CantUnify False _ _ _ _ _)  -> tfail e
-        	       Error e -> tfail e
+                       Error e -> tfail e
   where
     headDiff (P (DCon _ _ _) x _) (P (DCon _ _ _) y _) = x /= y
     headDiff (P (TCon _ _) x _) (P (TCon _ _) y _) = x /= y

--- a/src/Idris/IdeSlave.hs
+++ b/src/Idris/IdeSlave.hs
@@ -150,9 +150,9 @@ instance SExpable OutputAnnotation where
   toSExp (AnnSearchResult ordr) = toSExp [(SymbolAtom "doc-overview",
       StringAtom ("Result type is " ++ descr))]
       where descr = case ordr of
-	      EQ -> "isomorphic"
-	      LT -> "more general than searched type"
-	      GT -> "more specific than searched type"
+              EQ -> "isomorphic"
+              LT -> "more general than searched type"
+              GT -> "more specific than searched type"
   toSExp (AnnErr e) = toSExp [(SymbolAtom "error", StringAtom (encodeErr e))]
 
 encodeTerm :: [(Name, Bool)] -> Term -> String

--- a/src/Idris/ParseHelpers.hs
+++ b/src/Idris/ParseHelpers.hs
@@ -1,4 +1,7 @@
-{-# LANGUAGE GeneralizedNewtypeDeriving, ConstraintKinds, PatternGuards, OverlappingInstances, StandaloneDeriving #-}
+{-# LANGUAGE CPP, GeneralizedNewtypeDeriving, ConstraintKinds, PatternGuards, StandaloneDeriving #-}
+#if !(MIN_VERSION_base(4,8,0))
+{-# LANGUAGE OverlappingInstances #-}
+#endif
 module Idris.ParseHelpers where
 
 import Prelude hiding (pi)
@@ -47,7 +50,11 @@ newtype IdrisInnerParser a = IdrisInnerParser { runInnerParser :: Parser a }
 
 deriving instance Parsing IdrisInnerParser
 
+#if MIN_VERSION_base(4,8,0)
+instance {-# OVERLAPPING #-} TokenParsing IdrisParser where
+#else
 instance TokenParsing IdrisParser where
+#endif
   someSpace = many (simpleWhiteSpace <|> singleLineComment <|> multiLineComment) *> pure ()
   token p = do s <- get
                (FC fn (sl, sc) _) <- getFC --TODO: Update after fixing getFC

--- a/src/Idris/Primitives.hs
+++ b/src/Idris/Primitives.hs
@@ -20,7 +20,7 @@ data Prim = Prim { p_name  :: Name,
                    p_type  :: Type,
                    p_arity :: Int,
                    p_def   :: [Const] -> Maybe Const,
-		   p_lexp  :: (Int, PrimFn),
+                   p_lexp  :: (Int, PrimFn),
                    p_total :: Totality
                  }
 

--- a/src/Pkg/PParser.hs
+++ b/src/Pkg/PParser.hs
@@ -1,4 +1,7 @@
+{-# LANGUAGE CPP #-}
+#if !(MIN_VERSION_base(4,8,0))
 {-# LANGUAGE OverlappingInstances #-}
+#endif
 
 module Pkg.PParser where
 
@@ -31,7 +34,11 @@ data PkgDesc = PkgDesc { pkgname :: String,
                        }
     deriving Show
 
+#if MIN_VERSION_base(4,8,0)
+instance {-# OVERLAPPING #-} TokenParsing PParser where
+#else
 instance TokenParsing PParser where
+#endif
   someSpace = many (simpleWhiteSpace <|> singleLineComment <|> multiLineComment) *> pure ()
 
 


### PR DESCRIPTION
Most of these changes are to fix warnings that arise in GHC 7.10, since the `OverlappingInstances` extension was deprecated and `-fwarn-tabs` is now enabled with `-Wall`. This also bumps the upper version bounds of `deepseq` and `lens`, since none of the changes introduced in `deepseq-1.4` and `lens-4.7` affect `idris`.