### PR TITLE
enable -Werror on travis and encorage to use it locally, but not on hackage!

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -20,7 +20,7 @@ before_script:
   - tar -xf Idris-dev/dist/idris*.tar.gz
   - cd idris*
 script:
-  - cabal configure -f FFI
+  - cabal configure -f FFI -f CI
   - if [[ "$TESTS" != "doc" ]]; then cabal build; fi
   - if [[ "$TESTS" != "doc" ]]; then cabal copy; fi
   - if [[ "$TESTS" != "doc" ]]; then cabal register; fi

--- a/Makefile
+++ b/Makefile
@@ -3,6 +3,10 @@
 include config.mk
 -include custom.mk
 
+ifdef CI
+CABALFLAGS += -f CI
+endif
+
 install:
 	$(CABAL) install $(CABALFLAGS)
 

--- a/README.md
+++ b/README.md
@@ -37,6 +37,12 @@ To build with `libffi` by default, create a `custom.mk` file and add the followi
 
 The file custom.mk-alldeps is a suitable example.
 
+The continues integration builds on travis-ci.org are build using the ghc-flag -Werror. To enable this behaviour locally also, please compile using `make CI=true` or adding the following line into `custom.mk`:
+
+`CI = true`
+
+If you are only compiling for installing the most current version, you can ommit the CI flag, but please make sure you use it if you want to contribute.
+
 ## Code Generation
 
 Idris has support for external code generators. Supplied with the distribution

--- a/idris.cabal
+++ b/idris.cabal
@@ -613,6 +613,11 @@ Flag freestanding
   Default:      False
   manual:       True
 
+Flag CI
+  Description:  Built everything using "-Werror", meant for CI-builds only
+  Default:      False
+  manual:       True
+
 Library
   hs-source-dirs: src
   Exposed-modules:
@@ -791,6 +796,8 @@ Library
   if flag(freestanding)
      other-modules: Target_idris
      cpp-options:   -DFREESTANDING
+  if flag(CI)
+     ghc-options:   -Werror
 
 Executable idris
   Main-is:        Main.hs


### PR DESCRIPTION
Due to an update in the `mtl`-library, a deprecation warning was emitted in many modules, in some of them `-Werror` was set locally for this specific module. This local usage of `-Werror` caused idris to not build anymore, even if it had worked.

There was some discussion going on in IRC, also the PR #1829 was created because of this.

This PR is thought as an addition to already mentioned #1829. If really al `-Werror` are removed from codebase, there might be some cases where we need it! If there are warnings introduced because of dependency updates, or other stuff, they might be overseen easily when compiling locally, but by using this flag on travis there will be some reminder when warnings occur.

**WARNING**: This might fail on travis, because of changes on hackage, I can't foresee, but I did a complete clean and update of all dependencies right before preparing this PR.