### PR TITLE
Default case for name generation + proper name supply for identity type

### DIFF
--- a/src/Idris/CaseSplit.hs
+++ b/src/Idris/CaseSplit.hs
@@ -361,7 +361,7 @@ getClause l fn fp
          getNameFrom i used (PPi _ _ _ _) 
               = uniqueNameFrom (mkSupply [sUN "f", sUN "g"]) used
          getNameFrom i used (PApp fc f as) = getNameFrom i used f
-         getNameFrom i used (PEq _ _ _ _ _) = uniqueNameFrom [sUN "prf"] used 
+         getNameFrom i used (PEq _ _ _ _ _) = uniqueNameFrom (mkSupply [sUN "prf"]) used 
          getNameFrom i used (PRef fc f) 
             = case getNameHints i f of
                    [] -> uniqueName (sUN "x") used

--- a/src/Idris/Core/TT.hs
+++ b/src/Idris/Core/TT.hs
@@ -1181,6 +1181,7 @@ getRetTy (Bind n (Pi _ _ _) sc)   = getRetTy sc
 getRetTy sc = sc
 
 uniqueNameFrom :: [Name] -> [Name] -> Name
+uniqueNameFrom []           hs = uniqueName (nextName (sUN "x")) hs
 uniqueNameFrom (s : supply) hs
        | s `elem` hs = uniqueNameFrom supply hs
        | otherwise   = s


### PR DESCRIPTION
This fixes interactive editing when there's multiple patterns of the equality type laying about, such as when proving transitivity.