### PR TITLE
Proper REPL module reloading

### DIFF
--- a/idris.cabal
+++ b/idris.cabal
@@ -455,6 +455,9 @@ Extra-source-files:
                        test/interactive006/input
                        test/interactive006/*.idr
                        test/interactive006/expected
+                       test/interactive007/run
+                       test/interactive007/input
+                       test/interactive007/expected
 
                        test/io001/run
                        test/io001/*.idr

--- a/src/Idris/Error.hs
+++ b/src/Idris/Error.hs
@@ -5,7 +5,6 @@ module Idris.Error where
 import Prelude hiding (catch)
 import Idris.AbsSyntax
 import Idris.Delaborate
-import Idris.Output
 
 import Idris.Core.Evaluate (ctxtAlist)
 import Idris.Core.TT

--- a/src/Idris/Parser.hs
+++ b/src/Idris/Parser.hs
@@ -221,10 +221,10 @@ decl' syn =    fixity
 -}
 syntaxDecl :: SyntaxInfo -> IdrisParser PDecl
 syntaxDecl syn = do s <- syntaxRule syn
-                    i <- get 
+                    i <- get
                     put (i `addSyntax` s)
                     fc <- getFC
-                    return (PSyntax fc s) 
+                    return (PSyntax fc s)
 
 -- | Extend an 'IState' with a new syntax extension. See also 'addReplSyntax'.
 addSyntax :: IState -> Syntax -> IState
@@ -1203,14 +1203,14 @@ parseProg syn fname input mrk
 {- | Load idris module and show error if something wrong happens -}
 loadModule :: FilePath -> Idris (Maybe String)
 loadModule f
-   = idrisCatch (fmap Just (loadModule' f))
+   = idrisCatch (loadModule' f)
                 (\e -> do setErrSpan (getErrSpan e)
                           ist <- getIState
                           iWarn (getErrSpan e) $ pprintErr ist e
                           return Nothing)
 
 {- | Load idris module -}
-loadModule' :: FilePath -> Idris String
+loadModule' :: FilePath -> Idris (Maybe String)
 loadModule' f
    = do i <- getIState
         let file = takeWhile (/= ' ') f
@@ -1218,7 +1218,8 @@ loadModule' f
         ids <- allImportDirs
         fp <- findImport ids ibcsd file
         if file `elem` imported i
-          then iLOG $ "Already read " ++ file
+          then do iLOG $ "Already read " ++ file
+                  return Nothing
           else do putIState (i { imported = file : imported i })
                   case fp of
                     IDR fn  -> loadSource False fn Nothing
@@ -1229,9 +1230,7 @@ loadModule' f
                                            case src of
                                              IDR sfn -> loadSource False sfn Nothing
                                              LIDR sfn -> loadSource True sfn Nothing)
-        let (dir, fh) = splitFileName file
-        return (dropExtension fh)
-
+                  return $ Just file
 
 {- | Load idris code from file -}
 loadFromIFile :: Bool -> IFileType -> Maybe Int -> Idris ()
@@ -1270,7 +1269,7 @@ loadSource lidr f toline
                   let imports = map (\n -> (True, n, Just n, emptyFC)) ai ++ imports_in
                   ids <- allImportDirs
                   ibcsd <- valIBCSubDir i
-                  mapM_ (\(re, f) -> 
+                  mapM_ (\(re, f) ->
                                do fp <- findImport ids ibcsd f
                                   case fp of
                                       LIDR fn -> ifail $ "No ibc for " ++ f

--- a/src/Idris/REPL.hs
+++ b/src/Idris/REPL.hs
@@ -623,6 +623,7 @@ processInput cmd orig inputs efile
             Success (Right Reload) ->
                 do putIState $ orig { idris_options = idris_options i
                                     , idris_colourTheme = idris_colourTheme i
+                                    , imported = imported i
                                     }
                    clearErr
                    mods <- loadInputs inputs Nothing
@@ -1175,7 +1176,7 @@ process fn (SetConsoleWidth w) = setWidth w
 
 process fn (Apropos pkgs a) =
   do orig <- getIState
-     when (not (null pkgs)) $ 
+     when (not (null pkgs)) $
        iputStrLn $ "Searching packages: " ++ showSep ", " pkgs
      mapM_ loadPkgIndex pkgs
      ist <- getIState

--- a/test/interactive007/expected
+++ b/test/interactive007/expected
@@ -1,0 +1,1 @@
+Idris> *Data/ZZ> *Data/ZZ> *Data/ZZ> *Data/ZZ> Bye bye

--- a/test/interactive007/input
+++ b/test/interactive007/input
@@ -1,0 +1,4 @@
+:module Data.ZZ
+:module Data.ZZ
+:r
+:module Data.ZZ

--- a/test/interactive007/run
+++ b/test/interactive007/run
@@ -1,0 +1,2 @@
+#!/usr/bin/env bash
+idris --nobanner --nocolor < input


### PR DESCRIPTION
Fixes #1587 

* Fixed module reloading and duplication of the prompt.
* Cleanup some trailing whitespaces and duplicated import

Seems the error was in [loadModule](https://github.com/4e6/Idris-dev/compare/repl-module-reload?expand=1#diff-1d48226d1dac346466ee598f04edcf20L1232)

    let (dir, fh) = splitFileName file
    return (dropExtension fh)

Don't know why we need to discard path and extension (where `file` is of `Data/ZZ`), so I removed this logic. Correct me if I'm wrong.

Diff:
``` 
    ____    __     _                                          
    /  _/___/ /____(_)____                                     
    / // __  / ___/ / ___/     Version 0.9.15.1
  _/ // /_/ / /  / (__  )      http://www.idris-lang.org/      
 /___/\__,_/_/  /_/____/       Type :? for help               

Idris is free software with ABSOLUTELY NO WARRANTY.            
For details type :warranty.
Idris> :module Data.ZZ
*ZZ> :module Data.ZZ
*ZZ *ZZ> :r
Can't find import ZZ
*ZZ *ZZ> :module Data.Bits
*ZZ *ZZ *Bits>
```

```
     ____    __     _                                          
    /  _/___/ /____(_)____                                     
    / // __  / ___/ / ___/     Version 0.9.16-git:2fd3ebc
  _/ // /_/ / /  / (__  )      http://www.idris-lang.org/      
 /___/\__,_/_/  /_/____/       Type :? for help               

Idris is free software with ABSOLUTELY NO WARRANTY.            
For details type :warranty.
Idris> :module Data.ZZ
*Data/ZZ> :module Data.ZZ
*Data/ZZ> :r
*Data/ZZ> :module Data.ZZ
*Data/ZZ> :module Data.Bits
*Data/ZZ *Data/Bits>
```