### PR TITLE
Relax lower bound on mtl

### DIFF
--- a/idris.cabal
+++ b/idris.cabal
@@ -751,7 +751,7 @@ Library
                 , fingertree >= 0.1 && < 0.2
                 , haskeline >= 0.7 && < 0.8
                 , lens >= 4.1.1 && < 4.8
-                , mtl >= 2.2.1 && < 2.3
+                , mtl >= 2.1 && < 2.3
                 , network < 2.7
                 , optparse-applicative >= 0.11 && < 0.12
                 , parsers >= 0.9 && < 0.13
@@ -761,6 +761,7 @@ Library
                 , text < 1.3
                 , time >= 1.4 && < 1.6
                 , transformers < 0.5
+                , transformers-compat >= 0.3
                 , trifecta >= 1.1 && < 1.6
                 , uniplate >=1.6 && < 1.7
                 , unordered-containers < 0.3

--- a/src/Idris/AbsSyntax.hs
+++ b/src/Idris/AbsSyntax.hs
@@ -19,7 +19,6 @@ import System.IO
 
 import Control.Applicative
 import Control.Monad.State
-import Control.Monad.Except (throwError, catchError)
 
 import Data.List hiding (insert,union)
 import Data.Char

--- a/src/Idris/AbsSyntaxTree.hs
+++ b/src/Idris/AbsSyntaxTree.hs
@@ -20,6 +20,7 @@ import System.IO
 
 import Control.Monad.Trans.State.Strict
 import Control.Monad.Trans.Except
+import qualified Control.Monad.Trans.Class as Trans (lift)
 
 import Data.Data (Data)
 import Data.Function (on)
@@ -309,6 +310,12 @@ idrisInit = IState initContext [] []
 -- global state (hence the IO inner monad).
 --type Idris = WriterT [Either String (IO ())] (State IState a))
 type Idris = StateT IState (ExceptT Err IO)
+
+catchError :: Idris a -> (Err -> Idris a) -> Idris a
+catchError = liftCatch catchE
+
+throwError :: Err -> Idris a
+throwError = Trans.lift . throwE
 
 -- Commands in the REPL
 

--- a/src/Idris/Core/Execute.hs
+++ b/src/Idris/Core/Execute.hs
@@ -22,7 +22,7 @@ import Control.Applicative hiding (Const)
 import Control.Exception
 import Control.Monad.Trans
 import Control.Monad.Trans.State.Strict
-import Control.Monad.Except (ExceptT, runExceptT, throwError)
+import Control.Monad.Trans.Except (ExceptT, runExceptT, throwE)
 import Control.Monad hiding (forM)
 import Data.Maybe
 import Data.Bits
@@ -138,7 +138,7 @@ putExecState :: ExecState -> Exec ()
 putExecState = lift . put
 
 execFail :: Err -> Exec a
-execFail = throwError
+execFail = throwE
 
 execIO :: IO a -> Exec a
 execIO = lift . lift

--- a/src/Idris/Error.hs
+++ b/src/Idris/Error.hs
@@ -17,7 +17,6 @@ import System.Console.Haskeline
 import System.Console.Haskeline.MonadException
 import Control.Monad (when)
 import Control.Monad.State.Strict
-import Control.Monad.Except (throwError, catchError)
 import System.IO.Error(isUserError, ioeGetErrorString)
 import Data.Char
 import Data.List (intercalate, isPrefixOf)

--- a/src/Idris/Output.hs
+++ b/src/Idris/Output.hs
@@ -13,7 +13,7 @@ import Idris.IdeSlave
 import Util.Pretty
 import Util.ScreenSize (getScreenWidth)
 
-import Control.Monad.Except (ExceptT (ExceptT), runExceptT, throwError)
+import Control.Monad.Trans.Except (ExceptT (ExceptT), runExceptT)
 
 import System.Console.Haskeline.MonadException 
   (MonadException (controlIO), RunIO (RunIO))

--- a/src/Idris/Parser.hs
+++ b/src/Idris/Parser.hs
@@ -50,7 +50,6 @@ import Idris.Core.Evaluate
 
 import Control.Applicative hiding (Const)
 import Control.Monad
-import Control.Monad.Except (throwError, catchError)
 import Control.Monad.State.Strict
 
 import Data.Function

--- a/src/Pkg/Package.hs
+++ b/src/Pkg/Package.hs
@@ -12,7 +12,7 @@ import Util.System
 
 import Control.Monad
 import Control.Monad.Trans.State.Strict (execStateT)
-import Control.Monad.Except (runExceptT)
+import Control.Monad.Trans.Except (runExceptT)
 
 import Data.List
 import Data.List.Split(splitOn)


### PR DESCRIPTION
This lets Idris work with a wider variety of mtl and transformers
versions. In particular, it causes it not to try to replace GHC's own
transformer's lib.

The fix is actually by @glguy, but I couldn't figure out how to
credit him properly in the commit log with the patch file.