### PR TITLE
Haskell Platform compatibility with transformers and mtl

### DIFF
--- a/idris.cabal
+++ b/idris.cabal
@@ -751,7 +751,7 @@ Library
                 , fingertree >= 0.1 && < 0.2
                 , haskeline >= 0.7 && < 0.8
                 , lens >= 4.1.1 && < 4.8
-                , mtl >= 2.2.1 && < 2.3
+                , mtl >= 2.0.1 && < 2.3
                 , network < 2.7
                 , optparse-applicative >= 0.11 && < 0.12
                 , parsers >= 0.9 && < 0.13

--- a/src/Idris/AbsSyntax.hs
+++ b/src/Idris/AbsSyntax.hs
@@ -1,5 +1,5 @@
-{-# LANGUAGE MultiParamTypeClasses, FlexibleInstances, DeriveFunctor,
-             TypeSynonymInstances, PatternGuards #-}
+{-# LANGUAGE CPP, MultiParamTypeClasses, FlexibleInstances,
+             DeriveFunctor, TypeSynonymInstances, PatternGuards #-}
 
 module Idris.AbsSyntax(module Idris.AbsSyntax, module Idris.AbsSyntaxTree) where
 
@@ -19,7 +19,11 @@ import System.IO
 
 import Control.Applicative
 import Control.Monad.State
+#if MIN_VERSION_mtl(2,2,1)
 import Control.Monad.Except (throwError, catchError)
+#else
+import Control.Monad.Error  (throwError, catchError)
+#endif
 
 import Data.List hiding (insert,union)
 import Data.Char

--- a/src/Idris/AbsSyntaxTree.hs
+++ b/src/Idris/AbsSyntaxTree.hs
@@ -1,4 +1,4 @@
-{-# LANGUAGE MultiParamTypeClasses, FlexibleInstances, DeriveFunctor,
+{-# LANGUAGE CPP, MultiParamTypeClasses, FlexibleInstances, DeriveFunctor,
              DeriveDataTypeable, TypeSynonymInstances, PatternGuards #-}
 
 module Idris.AbsSyntaxTree where
@@ -19,7 +19,11 @@ import System.Console.Haskeline
 import System.IO
 
 import Control.Monad.Trans.State.Strict
+#if MIN_VERSION_transformers(0,4,0)
 import Control.Monad.Trans.Except
+#else
+import Control.Monad.Trans.Error
+#endif
 
 import Data.Data (Data)
 import Data.Function (on)
@@ -308,7 +312,11 @@ idrisInit = IState initContext [] []
 -- | The monad for the main REPL - reading and processing files and updating
 -- global state (hence the IO inner monad).
 --type Idris = WriterT [Either String (IO ())] (State IState a))
+#if MIN_VERSION_transformers(0,4,0)
 type Idris = StateT IState (ExceptT Err IO)
+#else
+type Idris = StateT IState (ErrorT  Err IO)
+#endif
 
 -- Commands in the REPL
 

--- a/src/Idris/Core/TT.hs
+++ b/src/Idris/Core/TT.hs
@@ -1,4 +1,5 @@
-{-# LANGUAGE MultiParamTypeClasses, FunctionalDependencies, DeriveFunctor, DeriveDataTypeable #-}
+{-# LANGUAGE CPP, MultiParamTypeClasses, FunctionalDependencies,
+             DeriveFunctor, DeriveDataTypeable #-}
 
 {-| TT is the core language of Idris. The language has:
 
@@ -23,7 +24,11 @@ module Idris.Core.TT where
 import Control.Applicative (Applicative (..), Alternative)
 import qualified Control.Applicative as A (Alternative (..))
 import Control.Monad.State.Strict
+#if MIN_VERSION_transformers(0,4,0)
 import Control.Monad.Trans.Except (Except (..))
+#else
+import Control.Monad.Trans.Error  (Error  (..))
+#endif
 import Debug.Trace
 import qualified Data.Map.Strict as Map
 import Data.Char
@@ -163,6 +168,11 @@ data Err' t
           | ReflectionError [[ErrorReportPart]] (Err' t)
           | ReflectionFailed String (Err' t)
   deriving (Eq, Functor, Data, Typeable)
+
+#if !(MIN_VERSION_transformers(0,4,0))
+instance Error Err where
+    strMsg = InternalMsg
+#endif
 
 type Err = Err' Term
 

--- a/src/Idris/Error.hs
+++ b/src/Idris/Error.hs
@@ -1,4 +1,4 @@
-{-# LANGUAGE DeriveDataTypeable #-}
+{-# LANGUAGE CPP, DeriveDataTypeable #-}
 
 module Idris.Error where
 
@@ -17,7 +17,11 @@ import System.Console.Haskeline
 import System.Console.Haskeline.MonadException
 import Control.Monad (when)
 import Control.Monad.State.Strict
+#if MIN_VERSION_mtl(2,2,1)
 import Control.Monad.Except (throwError, catchError)
+#else
+import Control.Monad.Error  (throwError, catchError)
+#endif
 import System.IO.Error(isUserError, ioeGetErrorString)
 import Data.Char
 import Data.List (intercalate, isPrefixOf)

--- a/src/Idris/Parser.hs
+++ b/src/Idris/Parser.hs
@@ -1,4 +1,4 @@
-{-# LANGUAGE GeneralizedNewtypeDeriving, ConstraintKinds, PatternGuards #-}
+{-# LANGUAGE CPP, GeneralizedNewtypeDeriving, ConstraintKinds, PatternGuards #-}
 {-# OPTIONS_GHC -O0 #-}
 module Idris.Parser(module Idris.Parser,
                     module Idris.ParseExpr,
@@ -50,7 +50,11 @@ import Idris.Core.Evaluate
 
 import Control.Applicative hiding (Const)
 import Control.Monad
+#if MIN_VERSION_mtl(2,2,1)
 import Control.Monad.Except (throwError, catchError)
+#else
+import Control.Monad.Error  (throwError, catchError)
+#endif
 import Control.Monad.State.Strict
 
 import Data.Function

--- a/src/Pkg/Package.hs
+++ b/src/Pkg/Package.hs
@@ -12,7 +12,11 @@ import Util.System
 
 import Control.Monad
 import Control.Monad.Trans.State.Strict (execStateT)
+#if MIN_VERSION_mtl(2,2,1)
 import Control.Monad.Except (runExceptT)
+#else
+import Control.Monad.Error  (runErrorT)
+#endif
 
 import Data.List
 import Data.List.Split(splitOn)
@@ -142,7 +146,13 @@ documentPkg fp =
      setCurrentDirectory $ pkgDir </> sourcedir pkgdesc
      make (makefile pkgdesc)
      setCurrentDirectory $ pkgDir
-     let run l       = runExceptT . execStateT l
+     let run l       =
+#if MIN_VERSION_mtl(2,2,1)
+                       runExceptT
+#else
+                       runErrorT
+#endif
+                                  . execStateT l
          load []     = return ()
          load (f:fs) = do loadModule f; load fs
          loader      = do idrisMain opts; load fs


### PR DESCRIPTION
Currently, it is tricky to install `idris` with the latest version of the Haskell Platform, since it is shipped with `mtl-2.1.3.1` but `idris` requires >= 2.2.1. This commit allows older `mtl` and `transformers` versions to be used to build `idris`, using CPP pragmas to import `ExceptT` instead of `ErrorT` if using the latest versions so as to avoid deprecation warnings.