### PR TITLE
Better tracking of FC in implicit coercions / DSL

### DIFF
--- a/src/Idris/AbsSyntaxTree.hs
+++ b/src/Idris/AbsSyntaxTree.hs
@@ -18,6 +18,8 @@ import Idris.Colours
 import System.Console.Haskeline
 import System.IO
 
+import Control.Applicative ((<|>))
+
 import Control.Monad.Trans.State.Strict
 import Control.Monad.Trans.Except
 import qualified Control.Monad.Trans.Class as Trans (lift)
@@ -944,6 +946,63 @@ pconst t = PConstraint 1 [] (sMN 0 "carg") t
 ptacimp n s t = PTacImplicit 2 [] n s t
 
 type PArg = PArg' PTerm
+
+-- | Get the highest FC in a term, if one exists
+highestFC :: PTerm -> Maybe FC
+highestFC (PQuote _) = Nothing
+highestFC (PRef fc _) = Just fc
+highestFC (PInferRef fc _) = Just fc
+highestFC (PPatvar fc _) = Just fc
+highestFC (PLam fc _ _ _) = Just fc
+highestFC (PPi  _ _ _ _) = Nothing
+highestFC (PLet fc _ _ _ _) = Just fc
+highestFC (PTyped tm ty) = highestFC tm <|> highestFC ty
+highestFC (PApp fc _ _) = Just fc
+highestFC (PAppBind fc _ _) = Just fc
+highestFC (PMatchApp fc _) = Just fc
+highestFC (PCase fc _ _) = Just fc
+highestFC (PTrue fc _) = Just fc
+highestFC (PRefl fc _) = Just fc
+highestFC (PResolveTC fc) = Just fc
+highestFC (PEq fc _ _ _ _) = Just fc
+highestFC (PRewrite fc _ _ _) = Just fc
+highestFC (PPair fc _ _ _) = Just fc
+highestFC (PDPair fc _ _ _ _) = Just fc
+highestFC (PAs fc _ _) = Just fc
+highestFC (PAlternative _ args) =
+  case mapMaybe highestFC args of
+    [] -> Nothing
+    (fc:_) -> Just fc
+highestFC (PHidden _) = Nothing
+highestFC PType = Nothing
+highestFC (PUniverse _) = Nothing
+highestFC (PGoal fc _ _ _) = Just fc
+highestFC (PConstant _) = Nothing
+highestFC Placeholder = Nothing
+highestFC (PDoBlock lines) =
+  case map getDoFC lines of
+    [] -> Nothing
+    (fc:_) -> Just fc
+  where
+    getDoFC (DoExp fc t)          = fc
+    getDoFC (DoBind fc nm t)      = fc
+    getDoFC (DoBindP fc l r alts) = fc
+    getDoFC (DoLet fc nm l r)     = fc
+    getDoFC (DoLetP fc l r)       = fc
+
+highestFC (PIdiom fc _) = Just fc
+highestFC (PReturn fc) = Just fc
+highestFC (PMetavar _) = Nothing
+highestFC (PProof _) = Nothing
+highestFC (PTactics _) = Nothing
+highestFC (PElabError _) = Nothing
+highestFC PImpossible = Nothing
+highestFC (PCoerced tm) = highestFC tm
+highestFC (PDisamb _ opts) = highestFC opts
+highestFC (PUnifyLog tm) = highestFC tm
+highestFC (PNoImplicits tm) = highestFC tm
+highestFC (PQuasiquote _ _) = Nothing
+highestFC (PUnquote tm) = highestFC tm
 
 -- Type class data
 

--- a/src/Idris/ElabTerm.hs
+++ b/src/Idris/ElabTerm.hs
@@ -1096,7 +1096,7 @@ elab ist info emode opts fn tm
                                        PAlternative True (map (mkCoerce env t) cs)]
            return t'
        where
-         mkCoerce env t n = let fc = fileFC "Coercion" in -- line never appears!
+         mkCoerce env t n = let fc = maybe (fileFC "Coercion") id (highestFC t) in
                                 addImplBound ist (map fst env)
                                   (PApp fc (PRef fc n) [pexp (PCoerced t)])
 


### PR DESCRIPTION
Now, implicit coercion-related type errors give their source location
when its available from a subterm.

Also, index_first variables in DSL blocks give the source location of
their use site rather than the DSL's definition site.