### PR TITLE
Bump utf8-string upper version bounds

### DIFF
--- a/idris.cabal
+++ b/idris.cabal
@@ -765,7 +765,7 @@ Library
                 , trifecta >= 1.1 && < 1.6
                 , uniplate >=1.6 && < 1.7
                 , unordered-containers < 0.3
-                , utf8-string < 0.4
+                , utf8-string < 1.1
                 , vector < 0.11
                 , vector-binary-instances < 0.3
                 , xml < 1.4


### PR DESCRIPTION
Allow `idris` to build with `utf8-string-1`.