### PR TITLE
Add IDRIS_LIBRARY_PATH environment variable

### DIFF
--- a/src/IRTS/System.hs
+++ b/src/IRTS/System.hs
@@ -53,7 +53,8 @@ getLibFlags = do dir <- getDataDir
                  return $ ["-L" ++ (dir </> "rts"),
                            "-lidris_rts"] ++ extraLib ++ gmpLib ++ ["-lpthread"]
 
-getIdrisLibDir = do dir <- getDataDir
+getIdrisLibDir = do libPath <- environment "IDRIS_LIBRARY_PATH"
+                    dir <- maybe getDataDir return libPath
                     return $ addTrailingPathSeparator dir
 
 #if defined(FREEBSD) || defined(DRAGONFLY)

--- a/src/Idris/IBC.hs
+++ b/src/Idris/IBC.hs
@@ -14,6 +14,7 @@ import Idris.Delaborate
 import qualified Idris.Docstrings as D
 import Idris.Docstrings (Docstring)
 import Idris.Output
+import IRTS.System (getIdrisLibDir)
 import Paths_idris
 
 import qualified Cheapskate.Types as CT
@@ -102,7 +103,7 @@ loadIBC reexport fp
 
 -- | Load an entire package from its index file
 loadPkgIndex :: String -> Idris ()
-loadPkgIndex pkg = do ddir <- runIO $ getDataDir
+loadPkgIndex pkg = do ddir <- runIO $ getIdrisLibDir
                       addImportDir (ddir </> pkg)
                       fp <- findPkgIndex pkg
                       loadIBC True fp

--- a/src/Idris/REPL.hs
+++ b/src/Idris/REPL.hs
@@ -1619,7 +1619,7 @@ idrisMain opts =
     makeOption _ = return ()
 
     addPkgDir :: String -> Idris ()
-    addPkgDir p = do ddir <- runIO $ getDataDir
+    addPkgDir p = do ddir <- runIO $ getIdrisLibDir
                      addImportDir (ddir </> p)
                      addIBC (IBCImportDir (ddir </> p))
 


### PR DESCRIPTION
Allows specifying where to find Idris libraries.

After doing a build, you can even point Idris to the repo's lib path:

    IDRIS_LIBRARY_PATH=libs dist/build/idris/idris