### PR TITLE
Make isTConName and friends exact

### DIFF
--- a/src/Idris/AbsSyntax.hs
+++ b/src/Idris/AbsSyntax.hs
@@ -1734,7 +1734,11 @@ stripUnmatchable i (PApp fc fn args) = PApp fc fn (fmap (fmap su) args) where
        | (Bind n (Pi _ t _) sc :_) <- lookupTy f (tt_ctxt i)
           = Placeholder
     su (PApp fc f@(PRef _ fn) args)
-       | isDConName fn ctxt 
+       -- here we use canBeDConName because the impossible pattern
+       -- check will not necessarily fully resolve constructor names,
+       -- and these bare names will otherwise get in the way of
+       -- impossbility checking.
+       | canBeDConName fn ctxt
           = PApp fc f (fmap (fmap su) args)
     su (PApp fc f args)
           = PHidden (PApp fc f args)

--- a/src/Idris/Core/Elaborate.hs
+++ b/src/Idris/Core/Elaborate.hs
@@ -173,30 +173,30 @@ elaborating_app = do ES (ps, _) _ _ <- get
 
 -- Some handy gadgets for pulling out bits of state
 
--- get the global context
+-- | Get the global context
 get_context :: Elab' aux Context
 get_context = do ES p _ _ <- get
                  return $! (context (fst p))
 
--- update the context
+-- | Update the context.
 -- (should only be used for adding temporary definitions or all sorts of
 --  stuff could go wrong)
 set_context :: Context -> Elab' aux ()
 set_context ctxt = do ES (p, a) logs prev <- get
                       put (ES (p { context = ctxt }, a) logs prev)
 
--- get the proof term
+-- | get the proof term
 get_term :: Elab' aux Term
 get_term = do ES p _ _ <- get
               return $! (getProofTerm (pterm (fst p)))
 
--- get the proof term
+-- | get the proof term
 update_term :: (Term -> Term) -> Elab' aux ()
 update_term f = do ES (p,a) logs prev <- get
                    let p' = p { pterm = mkProofTerm (f (getProofTerm (pterm p))) }
                    put (ES (p', a) logs prev)
 
--- get the local context at the currently in focus hole
+-- | get the local context at the currently in focus hole
 get_env :: Elab' aux Env
 get_env = do ES p _ _ <- get
              lift $ envAtFocus (fst p)
@@ -213,14 +213,14 @@ get_probs :: Elab' aux Fails
 get_probs = do ES p _ _ <- get
                return $! (problems (fst p))
 
--- Return recently solved names (that is, the names solved since the
+-- | Return recently solved names (that is, the names solved since the
 -- last call to get_recents)
 get_recents :: Elab' aux [Name]
 get_recents = do ES (p, a) l prev <- get
                  put (ES (p { recents = [] }, a) l prev)
                  return (recents p)
 
--- get the current goal type
+-- | get the current goal type
 goal :: Elab' aux Type
 goal = do ES p _ _ <- get
           b <- lift $ goalAtFocus (fst p)
@@ -233,7 +233,7 @@ is_guess = do ES p _ _ <- get
                    Guess _ _ -> return True
                    _ -> return False
 
--- Get the guess at the current hole, if there is one
+-- | Get the guess at the current hole, if there is one
 get_guess :: Elab' aux Type
 get_guess = do ES p _ _ <- get
                b <- lift $ goalAtFocus (fst p)
@@ -241,7 +241,7 @@ get_guess = do ES p _ _ <- get
                     Guess t v -> return $! v
                     _ -> fail "Not a guess"
 
--- typecheck locally
+-- | Typecheck locally
 get_type :: Raw -> Elab' aux Type
 get_type tm = do ctxt <- get_context
                  env <- get_env
@@ -254,7 +254,7 @@ get_type_val tm = do ctxt <- get_context
                      (val, ty) <- lift $ check ctxt env tm
                      return $! (finalise val, finalise ty)
 
--- get holes we've deferred for later definition
+-- | get holes we've deferred for later definition
 get_deferred :: Elab' aux [Name]
 get_deferred = do ES p _ _ <- get
                   return $! (deferred (fst p))
@@ -271,17 +271,18 @@ checkInjective (tm, l, r) = do ctxt <- get_context
         isInj ctxt (Bind _ (Pi _ _ _) sc) = True
         isInj ctxt _ = False
 
--- get instance argument names
+-- | get instance argument names
 get_instances :: Elab' aux [Name]
 get_instances = do ES p _ _ <- get
                    return $! (instances (fst p))
 
--- get auto argument names
+-- | get auto argument names
 get_autos :: Elab' aux [(Name, [Name])]
 get_autos = do ES p _ _ <- get
                return $! (autos (fst p))
 
--- given a desired hole name, return a unique hole name
+-- | given a desired hole name, return a unique hole name
+unique_hole :: Name -> Elab' aux Name
 unique_hole = unique_hole' False
 
 unique_hole' :: Bool -> Name -> Elab' aux Name

--- a/src/Idris/Core/Evaluate.hs
+++ b/src/Idris/Core/Evaluate.hs
@@ -11,7 +11,7 @@ module Idris.Core.Evaluate(normalise, normaliseTrace, normaliseC, normaliseAll,
                 lookupNames, lookupTyName, lookupTyNameExact, lookupTy, lookupTyExact,
                 lookupP, lookupDef, lookupNameDef, lookupDefExact, lookupDefAcc, lookupDefAccExact, lookupVal,
                 mapDefCtxt,
-                lookupTotal, lookupNameTotal, lookupMetaInformation, lookupTyEnv, isTCDict, isDConName, isTConName, isConName, isFnName,
+                lookupTotal, lookupNameTotal, lookupMetaInformation, lookupTyEnv, isTCDict, isDConName, canBeDConName, isTConName, isConName, isFnName,
                 Value(..), Quote(..), initEval, uniqueNameCtxt, uniqueBindersCtxt, definitions,
                 isUniverse) where
 
@@ -975,11 +975,20 @@ isTConName n ctxt
          Just (TyDecl (TCon _ _) _) -> True
          _                          -> False
 
+-- | Check whether a resolved name is certainly a data constructor
 isDConName :: Name -> Context -> Bool
 isDConName n ctxt
      = case lookupDefExact n ctxt of
          Just (TyDecl (DCon _ _ _) _) -> True
          _                            -> False
+
+-- | Check whether any overloading of a name is a data constructor
+canBeDConName :: Name -> Context -> Bool
+canBeDConName n ctxt
+     = or $ do def <- lookupCtxt n (definitions ctxt)
+               case tfst def of
+                 (TyDecl (DCon _ _ _) _) -> return True
+                 _ -> return False
 
 isFnName :: Name -> Context -> Bool
 isFnName n ctxt

--- a/src/Idris/Core/Evaluate.hs
+++ b/src/Idris/Core/Evaluate.hs
@@ -971,47 +971,43 @@ isConName n ctxt = isTConName n ctxt || isDConName n ctxt
 
 isTConName :: Name -> Context -> Bool
 isTConName n ctxt
-     = or $ do def <- lookupCtxt n (definitions ctxt)
-               case tfst def of
-                    (TyDecl (TCon _ _) _) -> return True
-                    _ -> return False
+     = case lookupDefExact n ctxt of
+         Just (TyDecl (TCon _ _) _) -> True
+         _                          -> False
 
 isDConName :: Name -> Context -> Bool
 isDConName n ctxt
-     = or $ do def <- lookupCtxt n (definitions ctxt)
-               case tfst def of
-                    (TyDecl (DCon _ _ _) _) -> return True
-                    _ -> return False
+     = case lookupDefExact n ctxt of
+         Just (TyDecl (DCon _ _ _) _) -> True
+         _                            -> False
 
 isFnName :: Name -> Context -> Bool
 isFnName n ctxt
-     = let def = lookupCtxtExact n (definitions ctxt) in
-          case def of
-               Just (Function _ _, _, _, _) -> True
-               Just (Operator _ _ _, _, _, _) -> True
-               Just (CaseOp _ _ _ _ _ _, _, _, _) -> True
-               _ -> False
+     = case lookupDefExact n ctxt of
+         Just (Function _ _)       -> True
+         Just (Operator _ _ _)     -> True
+         Just (CaseOp _ _ _ _ _ _) -> True
+         _                         -> False
 
 isTCDict :: Name -> Context -> Bool
 isTCDict n ctxt
-     = let def = lookupCtxtExact n (definitions ctxt) in
-          case def of
-               Just (Function _ _, _, _, _) -> False
-               Just (Operator _ _ _, _, _, _) -> False
-               Just (CaseOp ci _ _ _ _ _, _, _, _) -> tc_dictionary ci
-               _ -> False
+     = case lookupDefExact n ctxt of
+         Just (Function _ _)        -> False
+         Just (Operator _ _ _)      -> False
+         Just (CaseOp ci _ _ _ _ _) -> tc_dictionary ci
+         _                          -> False
 
 lookupP :: Name -> Context -> [Term]
 lookupP n ctxt
    = do def <- lookupCtxt n (definitions ctxt)
         p <- case def of
-          (Function ty tm, a, _, _) -> return (P Ref n ty, a)
-          (TyDecl nt ty, a, _, _) -> return (P nt n ty, a)
+          (Function ty tm, a, _, _)      -> return (P Ref n ty, a)
+          (TyDecl nt ty, a, _, _)        -> return (P nt n ty, a)
           (CaseOp _ ty _ _ _ _, a, _, _) -> return (P Ref n ty, a)
-          (Operator ty _ _, a, _, _) -> return (P Ref n ty, a)
+          (Operator ty _ _, a, _, _)     -> return (P Ref n ty, a)
         case snd p of
-            Hidden -> []
-            _ -> return (fst p)
+          Hidden -> []
+          _      -> return (fst p)
 
 lookupDefExact :: Name -> Context -> Maybe Def
 lookupDefExact n ctxt = tfst <$> lookupCtxtExact n (definitions ctxt)

--- a/src/Idris/Coverage.hs
+++ b/src/Idris/Coverage.hs
@@ -18,10 +18,10 @@ import Debug.Trace
 
 import Control.Monad.State.Strict
 
--- Generate a pattern from an 'impossible' LHS. (Need this to eliminate the
--- pattern clauses which have been provided explicitly from new clause
--- generation.)
-
+-- | Generate a pattern from an 'impossible' LHS.
+--
+-- We need this to eliminate the pattern clauses which have been
+-- provided explicitly from new clause generation.
 mkPatTm :: PTerm -> Idris Term
 mkPatTm t = do i <- getIState
                let timp = addImpl' True [] [] i t
@@ -44,13 +44,12 @@ mkPatTm t = do i <- getIState
     deNS (PRef f (NS n _)) = PRef f n
     deNS t = t
 
--- Given a list of LHSs, generate a extra clauses which cover the remaining
--- cases. The ones which haven't been provided are marked 'absurd' so that the
--- checker will make sure they can't happen.
-
+-- | Given a list of LHSs, generate a extra clauses which cover the remaining
+-- cases. The ones which haven't been provided are marked 'absurd' so
+-- that the checker will make sure they can't happen.
+--
 -- This will only work after the given clauses have been typechecked and the
 -- names are fully explicit!
-
 genClauses :: FC -> Name -> [Term] -> [PTerm] -> Idris [PTerm]
 genClauses fc n xs given
    = do i <- getIState

--- a/src/Idris/Coverage.hs
+++ b/src/Idris/Coverage.hs
@@ -28,8 +28,8 @@ mkPatTm t = do i <- getIState
                evalStateT (toTT (mapPT deNS timp)) 0
   where
     toTT (PRef _ n) = do i <- lift getIState
-                         case lookupDef n (tt_ctxt i) of
-                              [TyDecl nt _] -> return $ P nt n Erased
+                         case lookupNameDef n (tt_ctxt i) of
+                              [(n', TyDecl nt _)] -> return $ P nt n' Erased
                               _ -> return $ P Ref n Erased
     toTT (PApp _ t args) = do t' <- toTT t
                               args' <- mapM (toTT . getTm) args

--- a/src/Idris/Delaborate.hs
+++ b/src/Idris/Delaborate.hs
@@ -308,7 +308,7 @@ pprintErr' i (ElaboratingArg f x _ e)
   where whatIsName = let ctxt = tt_ctxt i
                      in if isTConName f ctxt
                            then text "type constructor" <> space
-                           else if isConName f ctxt
+                           else if isDConName f ctxt
                                    then text "constructor" <> space
                                    else if isFnName f ctxt
                                            then text "function" <> space

--- a/src/Idris/Delaborate.hs
+++ b/src/Idris/Delaborate.hs
@@ -488,7 +488,7 @@ fancifyAnnots ist annot@(AnnName n _ _ _) =
        _ | isTConName      n ctxt -> AnnName n (Just TypeOutput) docs ty
        _ | isMetavarName   n ist  -> AnnName n (Just MetavarOutput) docs ty
        _ | isPostulateName n ist  -> AnnName n (Just PostulateOutput) docs ty
-       _ | otherwise            -> annot
+       _ | otherwise              -> annot
   where docOverview :: IState -> Name -> Maybe String -- pretty-print first paragraph of docs
         docOverview ist n = do docs <- lookupCtxtExact n (idris_docstrings ist)
                                let o    = overview (fst docs)

--- a/test/totality006/expected
+++ b/test/totality006/expected
@@ -1,2 +1,3 @@
 totality006.idr:8:1:Main.prf is not total as there are missing cases
 totality006a.idr:11:6:prf' (S _) (S _) Oh is a valid case
+totality006b.idr:10:1:totality006b.blargh is not total as there are missing cases

--- a/test/totality006/run
+++ b/test/totality006/run
@@ -1,4 +1,5 @@
 #!/usr/bin/env bash
 idris $@ totality006.idr --check
 idris $@ totality006a.idr --check
+idris $@ totality006b.idr --check
 rm -f *.ibc

--- a/test/totality006/totality006b.idr
+++ b/test/totality006/totality006b.idr
@@ -1,0 +1,14 @@
+module totality006b
+
+import Data.So
+
+
+-- There are approaches to impossibility checking that break on this
+-- case but not on test006.idr, due to the extra computation.
+total
+blargh : (xs, ys : List a) -> So (length xs > length ys) -> GT (length xs) (length ys)
+blargh [] [] Oh impossible
+blargh [] (y :: xs) so = absurd so
+blargh (y :: xs) [] Oh = LTESucc LTEZero
+
+-- Missing: blargh (y :: xs) (z :: ys) x = ?blargh_rhs_3


### PR DESCRIPTION
They should only be used in a disambiguated context anyway to avoid it
picking the wrong one. Before this change, the coloring was wrong on

    :let data A = A.A
    :t A

Now it is fixed.