### PR TITLE
Fix function wrapping bug in JavaScript RTS

### DIFF
--- a/jsrts/Runtime-common.js
+++ b/jsrts/Runtime-common.js
@@ -68,20 +68,18 @@ var i$ffiWrap = function(fid,oldbase,myoldbase) {
     var res = fid;
 
     for(var i = 0; i < (arguments.length ? arguments.length : 1); ++i) {
-      while (res instanceof i$CON) {
-        i$valstack_top += 1;
-        i$valstack[i$valstack_top] = res;
-        i$valstack[i$valstack_top + 1] = arguments[i];
-        i$SLIDE(2);
-        i$valstack_top = i$valstack_base + 2;
-        i$CALL(_idris__123_APPLY0_125_,[oldbase])
-        while (i$callstack.length) {
-          var func = i$callstack.pop();
-          var args = i$callstack.pop();
-          func.apply(this,args);
-        }
-        res = i$ret;
+      i$valstack_top += 1;
+      i$valstack[i$valstack_top] = res;
+      i$valstack[i$valstack_top + 1] = arguments[i];
+      i$SLIDE(2);
+      i$valstack_top = i$valstack_base + 2;
+      i$CALL(_idris__123_APPLY0_125_,[oldbase])
+      while (i$callstack.length) {
+        var func = i$callstack.pop();
+        var args = i$callstack.pop();
+        func.apply(this,args);
       }
+      res = i$ret;
     }
 
     i$callstack = i$vm.callstack;


### PR DESCRIPTION
`i$ffiWrap` was basically apply the first argument over
and over instead of for looping through each argument.
ie.

```JavaScript
foreach(arg in arguments) {
  while(function is not fully applied) {
    func.apply(arg);
  }
}
```

This has made it impossible to use native JavaScript
higher-order functions through the FFI.

`make test_js` passes, but I'm not familiar with the
js codegen/rts, so someone should check and make sure this
is correct.

This fixes #1531