### PR TITLE
Parse lambdas with impossible

### DIFF
--- a/idris.cabal
+++ b/idris.cabal
@@ -609,6 +609,9 @@ Extra-source-files:
                        test/totality008/run
                        test/totality008/*.idr
                        test/totality008/expected
+                       test/totality009/run
+                       test/totality009/*.idr
+                       test/totality009/expected
 
                        test/tutorial001/run
                        test/tutorial001/*.idr

--- a/src/Idris/ParseExpr.hs
+++ b/src/Idris/ParseExpr.hs
@@ -256,7 +256,7 @@ CaseOption ::=
 -}
 caseOption :: SyntaxInfo -> IdrisParser (PTerm, PTerm)
 caseOption syn = do lhs <- expr (syn { inPattern = True })
-                    symbol "=>"; r <- expr syn
+                    r <- PImpossible <$ reserved "impossible" <|> do symbol "=>"; expr syn
                     return (lhs, r)
                  <?> "case option"
 

--- a/src/Idris/ParseExpr.hs
+++ b/src/Idris/ParseExpr.hs
@@ -747,14 +747,16 @@ lambda :: SyntaxInfo -> IdrisParser PTerm
 lambda syn = do lchar '\\' <?> "lambda expression"
                 (do xt <- try $ tyOptDeclList syn
                     fc <- getFC
-                    symbol "=>"
-                    sc <- expr syn
+                    sc <- PImpossible <$ reserved "impossible" <|> do
+                      symbol "=>"
+                      expr syn
                     return (bindList (PLam fc) xt sc)) <|> do
                       ps <- sepBy (do fc <- getFC
                                       e <- simpleExpr (syn { inPattern = True })
                                       return (fc, e)) (lchar ',')
-                      symbol "=>"
-                      sc <- expr syn
+                      sc <- PImpossible <$ reserved "impossible" <|> do
+                        symbol "=>"
+                        expr syn
                       return (pmList (zip [0..] ps) sc)
                  <?> "lambda expression"
     where pmList :: [(Int, (FC, PTerm))] -> PTerm -> PTerm

--- a/src/Idris/Parser.hs
+++ b/src/Idris/Parser.hs
@@ -811,7 +811,7 @@ argExpr syn = let syn' = syn { inPattern = True } in
 @
 RHS ::= '='            Expr
      |  '?='  RHSName? Expr
-     |  'impossible'
+     |  Impossible
      ;
 @
 
@@ -827,7 +827,7 @@ rhs syn n = do lchar '='; expr syn
                                      return n)
                r <- expr syn
                return (addLet fc name r)
-        <|> do reserved "impossible"; return PImpossible
+        <|> impossible
         <?> "function right hand side"
   where mkN :: Name -> Name
         mkN (UN x)   = if (tnull x || not (isAlpha (thead x)))

--- a/test/totality009/TestLambdaImpossible.idr
+++ b/test/totality009/TestLambdaImpossible.idr
@@ -1,0 +1,29 @@
+module TestLambdaImpossible
+
+%default total
+
+eqBool : (x, y : Bool) -> Dec (x = y)
+eqBool False False = Yes Refl
+eqBool False True = No (\(Refl) impossible)
+eqBool True False = No (\(Refl) impossible)
+eqBool True True = Yes Refl
+
+data Elem : {a : Type} -> a -> Prelude.List.List a -> Type where
+  Here : {a : Type} -> {x : a} -> {xs : List a} -> Elem x (x :: xs)
+  There : {a : Type} -> {x, y : a} -> {xs : List a} -> Elem x xs -> Elem x (y :: xs)
+
+notHereNotThere : Not (x = y) -> Not (Elem x xs) -> Not (Elem x (y :: xs))
+notHereNotThere notEq notElem Here = notEq Refl
+notHereNotThere notEq notElem (There elem) = notElem elem
+
+decElem : DecEq a => (x : a) -> (xs : List a) -> Dec (Elem x xs)
+decElem x [] = No (\Here impossible)
+decElem x (y :: xs) with (decEq x y)
+  decElem x (x :: xs) | (Yes Refl) = Yes Here
+  decElem x (y :: xs) | (No notHere) with (decElem x xs)
+    decElem x (y :: xs) | (No notHere) | (Yes prf) = Yes (There prf)
+    decElem x (y :: xs) | (No notHere) | (No notThere) = No $ notHereNotThere notHere notThere
+
+notEta : ((a : Type) -> (b : Type) -> (f : a -> b) -> f = (\x => f x)) -> Void
+notEta eta = case eta Nat Nat id of
+                  Refl impossible

--- a/test/totality009/TestLambdaPossible.idr
+++ b/test/totality009/TestLambdaPossible.idr
@@ -1,0 +1,13 @@
+||| Some functions that should be non-total, as detected with --warnpartial
+module TestLambdaPossible
+
+data Nool : Bool -> Type where
+  Flase : Nool False
+  Ture : Nool True
+
+wrongPossible : Nool True -> Bool
+wrongPossible = (\Flase impossible)
+
+wrongPossible' : Nool True -> Bool
+wrongPossible' x = case x of
+                        Flase impossible

--- a/test/totality009/expected
+++ b/test/totality009/expected
@@ -1,0 +1,8 @@
+TestLambdaPossible.idr:9:25:Warning - TestLambdaPossible.case block in wrongPossible is not total as there are missing cases
+TestLambdaPossible.idr:9:1:Warning - TestLambdaPossible.wrongPossible is possibly not total due to: TestLambdaPossible.case block in wrongPossible
+TestLambdaPossible.idr:12:25:Warning - TestLambdaPossible.case block in wrongPossible' is not total as there are missing cases
+TestLambdaPossible.idr:12:1:Warning - TestLambdaPossible.wrongPossible' is possibly not total due to: TestLambdaPossible.case block in wrongPossible'
+TestLambdaPossible.idr:9:15:Warning - TestLambdaPossible.case block in wrongPossible is not total as there are missing cases
+TestLambdaPossible.idr:9:1:Warning - TestLambdaPossible.wrongPossible is possibly not total due to: TestLambdaPossible.case block in wrongPossible
+TestLambdaPossible.idr:12:16:Warning - TestLambdaPossible.case block in wrongPossible' is not total as there are missing cases
+TestLambdaPossible.idr:12:1:Warning - TestLambdaPossible.wrongPossible' is possibly not total due to: TestLambdaPossible.case block in wrongPossible'

--- a/test/totality009/run
+++ b/test/totality009/run
@@ -1,0 +1,5 @@
+#!/usr/bin/env bash
+OPTS="--consolewidth infinite --nocolour"
+idris "$@" $OPTS --check TestLambdaImpossible
+idris "$@" $OPTS --check --warnpartial TestLambdaPossible
+rm -f *.ibc


### PR DESCRIPTION
An attempt at making things like `the (True = False -> Void) (\(Refl) impossible)` work. This would reduce the need for small lemmas that only consist of a single clause with `impossible`.