### PR TITLE
clean includes from c file

### DIFF
--- a/rts/idris_rts.c
+++ b/rts/idris_rts.c
@@ -1,11 +1,4 @@
-#include <stdlib.h>
-#include <stdio.h>
-#include <string.h>
-#include <stdarg.h>
 #include <assert.h>
-#ifdef HAS_PTHREAD
-#include <pthread.h>
-#endif
 
 #include "idris_rts.h"
 #include "idris_gc.h"


### PR DESCRIPTION
I'm not sure why same files included in header `idris_rts.h` and c file
Sorry if that is done for obvious reason