### PR TITLE
Rename ideslave to ide-mode

### DIFF
--- a/CHANGELOG
+++ b/CHANGELOG
@@ -1,3 +1,8 @@
+New in 0.9.17:
+--------------
+* The --ideslave command line option has been replaced with a --ide-mode
+  command line option with the same semantics.
+
 New in 0.9.16:
 --------------
 * Inductive-inductive definitions are now supported (i.e. simultaneously

--- a/idris.cabal
+++ b/idris.cabal
@@ -682,7 +682,7 @@ Library
                 , Idris.ErrReverse
                 , Idris.Help
                 , Idris.IBC
-                , Idris.IdeSlave
+                , Idris.IdeMode
                 , Idris.IdrisDoc
                 , Idris.Imports
                 , Idris.Inliner

--- a/src/Idris/AbsSyntax.hs
+++ b/src/Idris/AbsSyntax.hs
@@ -10,7 +10,7 @@ import Idris.Core.Typecheck
 import Idris.AbsSyntaxTree
 import Idris.Colours
 import Idris.Docstrings
-import Idris.IdeSlave hiding (Opt(..))
+import Idris.IdeMode hiding (Opt(..))
 import IRTS.CodegenCommon
 import Util.DynamicLinker
 
@@ -601,7 +601,7 @@ type1Doc = (annotate (AnnType "Type" "The type of types, one level up") $ text "
 isetPrompt :: String -> Idris ()
 isetPrompt p = do i <- getIState
                   case idris_outputmode i of
-                    IdeSlave n h -> runIO . hPutStrLn h $ convSExp "set-prompt" p n
+                    IdeMode n h -> runIO . hPutStrLn h $ convSExp "set-prompt" p n
 
 -- | Tell clients how much was parsed and loaded
 isetLoadedRegion :: Idris ()
@@ -610,7 +610,7 @@ isetLoadedRegion = do i <- getIState
                       case span of
                         Just fc ->
                           case idris_outputmode i of
-                            IdeSlave n h ->
+                            IdeMode n h ->
                               runIO . hPutStrLn h $
                                 convSExp "set-loaded-region" fc n
                         Nothing -> return ()
@@ -752,10 +752,12 @@ outputTy :: Idris OutputType
 outputTy = do i <- getIState
               return $ opt_outputTy $ idris_options i
 
-setIdeSlave :: Bool -> Handle -> Idris ()
-setIdeSlave True  h = do i <- getIState
-                         putIState $ i { idris_outputmode = (IdeSlave 0 h), idris_colourRepl = False }
-setIdeSlave False _ = return ()
+setIdeMode :: Bool -> Handle -> Idris ()
+setIdeMode True  h = do i <- getIState
+                        putIState $ i { idris_outputmode = IdeMode 0 h
+                                      , idris_colourRepl = False
+                                      }
+setIdeMode False _ = return ()
 
 setTargetTriple :: String -> Idris ()
 setTargetTriple t = do i <- getIState
@@ -870,7 +872,7 @@ logLvl l str = do i <- getIState
                   when (lvl >= l) $
                     case idris_outputmode i of
                       RawOutput h -> do runIO $ hPutStrLn h str
-                      IdeSlave n h ->
+                      IdeMode n h ->
                         do let good = SexpList [IntegerAtom (toInteger l), toSExp str]
                            runIO . hPutStrLn h $ convSExp "log" good n
 

--- a/src/Idris/AbsSyntaxTree.hs
+++ b/src/Idris/AbsSyntaxTree.hs
@@ -144,7 +144,7 @@ data LanguageExt = TypeProviders | ErrorReflection deriving (Show, Eq, Read, Ord
 
 -- | The output mode in use
 data OutputMode = RawOutput Handle -- ^ Print user output directly to the handle
-                | IdeSlave Integer Handle -- ^ Send IDE output for some request ID to the handle
+                | IdeMode Integer Handle -- ^ Send IDE output for some request ID to the handle
                 deriving Show
 
 -- | How wide is the console?
@@ -405,8 +405,8 @@ data Opt = Filename String
          | Quiet
          | NoBanner
          | ColourREPL Bool
-         | Ideslave
-         | IdeslaveSocket
+         | Idemode
+         | IdemodeSocket
          | ShowLibs
          | ShowLibdir
          | ShowIncs

--- a/src/Idris/CmdOptions.hs
+++ b/src/Idris/CmdOptions.hs
@@ -71,8 +71,10 @@ parseFlags :: Parser [Opt]
 parseFlags = many $
   flag' NoBanner (long "nobanner" <> help "Suppress the banner")
   <|> flag' Quiet (short 'q' <> long "quiet" <> help "Quiet verbosity")
-  <|> flag' Ideslave (long "ideslave")
-  <|> flag' IdeslaveSocket (long "ideslave-socket")
+  <|> flag' Idemode (long "ide-mode" <> help "Run the Idris REPL with machine-readable syntax")
+  <|> flag' IdemodeSocket (long "ide-mode-socket" <> help "Choose a socket for IDE mode to listen on")
+  <|> flag' Idemode (long "ideslave" <> help "Deprecated version of --ide-mode") -- TODO: Remove in v0.9.18
+  <|> flag' IdemodeSocket (long "ideslave-socket" <> help "Deprecated version of --ide-mode-socket") -- TODO: Remove in v0.9.18
   <|> (Client <$> strOption (long "client"))
   <|> (OLogging <$> option auto (long "log" <> metavar "LEVEL" <> help "Debugging log level"))
   <|> flag' NoBasePkgs (long "nobasepkgs" <> help "Do not use the given base package")

--- a/src/Idris/IdeMode.hs
+++ b/src/Idris/IdeMode.hs
@@ -2,7 +2,7 @@
 
 {-# LANGUAGE FlexibleInstances, IncoherentInstances, PatternGuards #-}
 
-module Idris.IdeSlave(parseMessage, convSExp, IdeSlaveCommand(..), sexpToCommand, toSExp, SExp(..), SExpable, Opt(..), ideSlaveEpoch, getLen, getNChar) where
+module Idris.IdeMode(parseMessage, convSExp, IdeModeCommand(..), sexpToCommand, toSExp, SExp(..), SExpable, Opt(..), ideModeEpoch, getLen, getNChar) where
 
 import Text.Printf
 import Numeric
@@ -206,32 +206,32 @@ parseSExp = parseString pSExp (Directed (UTF8.fromString "(unknown)") 0 0 0 0)
 
 data Opt = ShowImpl | ErrContext deriving Show
 
-data IdeSlaveCommand = REPLCompletions String
-                     | Interpret String
-                     | TypeOf String
-                     | CaseSplit Int String
-                     | AddClause Int String
-                     | AddProofClause Int String
-                     | AddMissing Int String
-                     | MakeWithBlock Int String
-                     | ProofSearch Bool Int String [String] (Maybe Int) -- ^^ Recursive?, line, name, hints, depth
-                     | MakeLemma Int String
-                     | LoadFile String (Maybe Int)
-                     | DocsFor String
-                     | Apropos String
-                     | GetOpts
-                     | SetOpt Opt Bool
-                     | Metavariables Int -- ^^ the Int is the column count for pretty-printing
-                     | WhoCalls String
-                     | CallsWho String
-                     | TermNormalise [(Name, Bool)] Term
-                     | TermShowImplicits [(Name, Bool)] Term
-                     | TermNoImplicits [(Name, Bool)] Term
-                     | PrintDef String
-                     | ErrString Err
-                     | ErrPPrint Err
+data IdeModeCommand = REPLCompletions String
+                    | Interpret String
+                    | TypeOf String
+                    | CaseSplit Int String
+                    | AddClause Int String
+                    | AddProofClause Int String
+                    | AddMissing Int String
+                    | MakeWithBlock Int String
+                    | ProofSearch Bool Int String [String] (Maybe Int) -- ^^ Recursive?, line, name, hints, depth
+                    | MakeLemma Int String
+                    | LoadFile String (Maybe Int)
+                    | DocsFor String
+                    | Apropos String
+                    | GetOpts
+                    | SetOpt Opt Bool
+                    | Metavariables Int -- ^^ the Int is the column count for pretty-printing
+                    | WhoCalls String
+                    | CallsWho String
+                    | TermNormalise [(Name, Bool)] Term
+                    | TermShowImplicits [(Name, Bool)] Term
+                    | TermNoImplicits [(Name, Bool)] Term
+                    | PrintDef String
+                    | ErrString Err
+                    | ErrPPrint Err
 
-sexpToCommand :: SExp -> Maybe IdeSlaveCommand
+sexpToCommand :: SExp -> Maybe IdeModeCommand
 sexpToCommand (SexpList (x:[]))                                                         = sexpToCommand x
 sexpToCommand (SexpList [SymbolAtom "interpret", StringAtom cmd])                       = Just (Interpret cmd)
 sexpToCommand (SexpList [SymbolAtom "repl-completions", StringAtom prefix])             = Just (REPLCompletions prefix)
@@ -298,5 +298,5 @@ convSExp pre s id =
 getHexLength :: String -> String
 getHexLength s = printf "%06x" (1 + (length s))
 
-ideSlaveEpoch :: Int
-ideSlaveEpoch = 1
+ideModeEpoch :: Int
+ideModeEpoch = 1

--- a/src/Idris/Interactive.hs
+++ b/src/Idris/Interactive.hs
@@ -16,7 +16,7 @@ import Idris.ElabTerm
 import Idris.Error
 import Idris.Delaborate
 import Idris.Output
-import Idris.IdeSlave hiding (IdeSlaveCommand(..))
+import Idris.IdeMode hiding (IdeModeCommand(..))
 
 import Idris.Elab.Value
 
@@ -271,7 +271,7 @@ makeLemma fn updatefile l n
                   runIO $ copyFile fb fn
                else case idris_outputmode i of
                       RawOutput _  -> iPrintResult $ lem ++ "\n" ++ lem_app
-                      IdeSlave n h ->
+                      IdeMode n h ->
                         let good = SexpList [SymbolAtom "ok",
                                              SexpList [SymbolAtom "metavariable-lemma",
                                                        SexpList [SymbolAtom "replace-metavariable",
@@ -289,7 +289,7 @@ makeLemma fn updatefile l n
                   runIO $ copyFile fb fn
                else case idris_outputmode i of
                       RawOutput _  -> iPrintResult $ lem_app
-                      IdeSlave n h ->
+                      IdeMode n h ->
                         let good = SexpList [SymbolAtom "ok",
                                              SexpList [SymbolAtom "provisional-definition-lemma",
                                                        SexpList [SymbolAtom "definition-clause",

--- a/src/Idris/Output.hs
+++ b/src/Idris/Output.hs
@@ -8,7 +8,7 @@ import Idris.Core.Evaluate (isDConName, isTConName, isFnName, normaliseAll)
 import Idris.AbsSyntax
 import Idris.Delaborate
 import Idris.Docstrings
-import Idris.IdeSlave
+import Idris.IdeMode
 
 import Util.Pretty
 import Util.ScreenSize (getScreenWidth)
@@ -43,7 +43,7 @@ iWarn fc err =
                         then text (show fc) <> colon <//> err
                         else err
             runIO . hPutStrLn h $ displayDecorated (consoleDecorate i) err'
-       IdeSlave n h ->
+       IdeMode n h ->
          do err' <- iRender . fmap (fancifyAnnots i) $ err
             let (str, spans) = displaySpans err'
             runIO . hPutStrLn h $
@@ -52,8 +52,8 @@ iWarn fc err =
 iRender :: Doc a -> Idris (SimpleDoc a)
 iRender d = do w <- getWidth
                ist <- getIState
-               let ideSlave = case idris_outputmode ist of
-                                IdeSlave _ _ -> True
+               let ideMode = case idris_outputmode ist of
+                                IdeMode _ _ -> True
                                 _            -> False
                case w of
                  InfinitelyWide -> return $ renderPretty 1.0 1000000000 d
@@ -61,7 +61,7 @@ iRender d = do w <- getWidth
                                if n < 1
                                  then renderPretty 1.0 1000000000 d
                                  else renderPretty 0.8 n d
-                 AutomaticWidth | ideSlave  -> return $ renderPretty 1.0 1000000000 d
+                 AutomaticWidth | ideMode  -> return $ renderPretty 1.0 1000000000 d
                                 | otherwise -> do width <- runIO getScreenWidth
                                                   return $ renderPretty 0.8 width d
 
@@ -76,7 +76,7 @@ consoleDisplayAnnotated h output = do ist <- getIState
 iPrintTermWithType :: Doc OutputAnnotation -> Doc OutputAnnotation -> Idris ()
 iPrintTermWithType tm ty = iRenderResult (tm <+> colon <+> align ty)
 
--- | Pretty-print a collection of overloadings to REPL or IDESlave - corresponds to :t name
+-- | Pretty-print a collection of overloadings to REPL or IDEMode - corresponds to :t name
 iPrintFunTypes :: [(Name, Bool)] -> Name -> [(Name, Doc OutputAnnotation)] -> Idris ()
 iPrintFunTypes bnd n []        = iPrintError $ "No such variable " ++ show n
 iPrintFunTypes bnd n overloads = do ist <- getIState
@@ -94,7 +94,7 @@ iRenderOutput doc =
      case idris_outputmode i of
        RawOutput h -> do out <- iRender doc
                          runIO $ putStrLn (displayDecorated (consoleDecorate i) out)
-       IdeSlave n h ->
+       IdeMode n h ->
         do (str, spans) <- fmap displaySpans . iRender . fmap (fancifyAnnots i) $ doc
            let out = [toSExp str, toSExp spans]
            runIO . hPutStrLn h $ convSExp "write-decorated" out n
@@ -103,10 +103,10 @@ iRenderResult :: Doc OutputAnnotation -> Idris ()
 iRenderResult d = do ist <- getIState
                      case idris_outputmode ist of
                        RawOutput h  -> consoleDisplayAnnotated h d
-                       IdeSlave n h -> ideSlaveReturnAnnotated n h d
+                       IdeMode n h -> ideModeReturnAnnotated n h d
 
-ideSlaveReturnWithStatus :: String -> Integer -> Handle -> Doc OutputAnnotation -> Idris ()
-ideSlaveReturnWithStatus status n h out = do
+ideModeReturnWithStatus :: String -> Integer -> Handle -> Doc OutputAnnotation -> Idris ()
+ideModeReturnWithStatus status n h out = do
   ist <- getIState
   (str, spans) <- fmap displaySpans .
                   iRender .
@@ -116,16 +116,16 @@ ideSlaveReturnWithStatus status n h out = do
   runIO . hPutStrLn h $ convSExp "return" good n
 
 
--- | Write pretty-printed output to IDESlave with semantic annotations
-ideSlaveReturnAnnotated :: Integer -> Handle -> Doc OutputAnnotation -> Idris ()
-ideSlaveReturnAnnotated = ideSlaveReturnWithStatus "ok"
+-- | Write pretty-printed output to IDEMode with semantic annotations
+ideModeReturnAnnotated :: Integer -> Handle -> Doc OutputAnnotation -> Idris ()
+ideModeReturnAnnotated = ideModeReturnWithStatus "ok"
 
 -- | Show an error with semantic highlighting
 iRenderError :: Doc OutputAnnotation -> Idris ()
 iRenderError e = do ist <- getIState
                     case idris_outputmode ist of
                       RawOutput h  -> consoleDisplayAnnotated h e
-                      IdeSlave n h -> ideSlaveReturnWithStatus "error" n h e
+                      IdeMode n h -> ideModeReturnWithStatus "error" n h e
 
 iPrintWithStatus :: String -> String -> Idris ()
 iPrintWithStatus status s = do
@@ -134,7 +134,7 @@ iPrintWithStatus status s = do
     RawOutput h -> case s of
       "" -> return ()
       s  -> runIO $ hPutStrLn h s
-    IdeSlave n h ->
+    IdeMode n h ->
       let good = SexpList [SymbolAtom status, toSExp s] in
       runIO $ hPutStrLn h $ convSExp "return" good n
 
@@ -149,13 +149,13 @@ iputStrLn :: String -> Idris ()
 iputStrLn s = do i <- getIState
                  case idris_outputmode i of
                    RawOutput h  -> runIO $ hPutStrLn h s
-                   IdeSlave n h -> runIO . hPutStrLn h $ convSExp "write-string" s n
+                   IdeMode n h -> runIO . hPutStrLn h $ convSExp "write-string" s n
 
 
 ideslavePutSExp :: SExpable a => String -> a -> Idris ()
 ideslavePutSExp cmd info = do i <- getIState
                               case idris_outputmode i of
-                                   IdeSlave n h -> runIO . hPutStrLn h $ convSExp cmd info n
+                                   IdeMode n h -> runIO . hPutStrLn h $ convSExp cmd info n
                                    _ -> return ()
 
 -- TODO: send structured output similar to the metavariable list
@@ -163,7 +163,7 @@ iputGoal :: SimpleDoc OutputAnnotation -> Idris ()
 iputGoal g = do i <- getIState
                 case idris_outputmode i of
                   RawOutput h -> runIO $ hPutStrLn h (displayDecorated (consoleDecorate i) g)
-                  IdeSlave n h ->
+                  IdeMode n h ->
                     let (str, spans) = displaySpans . fmap (fancifyAnnots i) $ g
                         goal = [toSExp str, toSExp spans]
                     in runIO . hPutStrLn h $ convSExp "write-goal" goal n

--- a/src/Idris/Parser.hs
+++ b/src/Idris/Parser.hs
@@ -1192,7 +1192,7 @@ parseProg syn fname input mrk
                                   i <- getIState
                                   case idris_outputmode i of
                                     RawOutput h  -> iputStrLn (show $ fixColour (idris_colourRepl i) doc)
-                                    IdeSlave n h -> iWarn fc (P.text msg)
+                                    IdeMode n h -> iWarn fc (P.text msg)
                                   putIState (i { errSpan = Just fc })
                                   return []
             Success (x, i)  -> do putIState i

--- a/src/Idris/Prover.hs
+++ b/src/Idris/Prover.hs
@@ -20,7 +20,7 @@ import Idris.Parser hiding (params)
 import Idris.Error
 import Idris.DataOpts
 import Idris.Completion
-import qualified Idris.IdeSlave as IdeSlave
+import qualified Idris.IdeMode as IdeMode
 import Idris.Output
 import Idris.TypeSearch (searchByType)
 
@@ -72,7 +72,7 @@ prove opt ctxt lit n ty
          iLOG $ "Adding " ++ show tm
          i <- getIState
          case idris_outputmode i of
-           IdeSlave _ _ -> ideslavePutSExp "end-proof-mode" (n, showProof lit n prf)
+           IdeMode _ _ -> ideslavePutSExp "end-proof-mode" (n, showProof lit n prf)
            _            -> iputStrLn $ showProof lit n prf
          let proofs = proof_list i
          putIState (i { proof_list = (n, prf) : proofs })
@@ -95,8 +95,8 @@ prove opt ctxt lit n ty
                                  [([], P Ref n ty, ptm')] ty)
          solveDeferred n
          case idris_outputmode i of
-           IdeSlave n h ->
-             runIO . hPutStrLn h $ IdeSlave.convSExp "return" (IdeSlave.SymbolAtom "ok", "") n
+           IdeMode n h ->
+             runIO . hPutStrLn h $ IdeMode.convSExp "return" (IdeMode.SymbolAtom "ok", "") n
            _ -> return ()
 
 elabStep :: ElabState EState -> ElabD a -> Idris (a, ElabState EState)
@@ -185,24 +185,24 @@ receiveInput :: Handle -> ElabState EState -> Idris (Maybe String)
 receiveInput h e =
   do i <- getIState
      let inh = if h == stdout then stdin else h
-     len' <- runIO $ IdeSlave.getLen inh
+     len' <- runIO $ IdeMode.getLen inh
      len <- case len' of
        Left err -> ierror err
        Right n  -> return n
-     l <- runIO $ IdeSlave.getNChar inh len ""
-     (sexp, id) <- case IdeSlave.parseMessage l of
+     l <- runIO $ IdeMode.getNChar inh len ""
+     (sexp, id) <- case IdeMode.parseMessage l of
                      Left err -> ierror err
                      Right (sexp, id) -> return (sexp, id)
-     putIState $ i { idris_outputmode = (IdeSlave id h) }
-     case IdeSlave.sexpToCommand sexp of
-       Just (IdeSlave.REPLCompletions prefix) ->
+     putIState $ i { idris_outputmode = (IdeMode id h) }
+     case IdeMode.sexpToCommand sexp of
+       Just (IdeMode.REPLCompletions prefix) ->
          do (unused, compls) <- proverCompletion (assumptionNames e) (reverse prefix, "")
-            let good = IdeSlave.SexpList [IdeSlave.SymbolAtom "ok", IdeSlave.toSExp (map replacement compls, reverse unused)]
+            let good = IdeMode.SexpList [IdeMode.SymbolAtom "ok", IdeMode.toSExp (map replacement compls, reverse unused)]
             ideslavePutSExp "return" good
             receiveInput h e
-       Just (IdeSlave.Interpret cmd) -> return (Just cmd)
-       Just (IdeSlave.TypeOf str) -> return (Just (":t " ++ str))
-       Just (IdeSlave.DocsFor str) -> return (Just (":doc " ++ str))
+       Just (IdeMode.Interpret cmd) -> return (Just cmd)
+       Just (IdeMode.TypeOf str) -> return (Just (":t " ++ str))
+       Just (IdeMode.DocsFor str) -> return (Just (":doc " ++ str))
        _ -> return Nothing
 
 ploop :: Name -> Bool -> String -> [String] -> ElabState EState -> Maybe History -> Idris (Term, [String])
@@ -221,7 +221,7 @@ ploop fn d prompt prf e h
                     l <- getInputLine (prompt ++ "> ")
                     h' <- getHistory
                     return (l, Just h')
-             IdeSlave _ handle ->
+             IdeMode _ handle ->
                do isetPrompt prompt
                   i <- receiveInput handle e
                   return (i, h)

--- a/src/Idris/REPL.hs
+++ b/src/Idris/REPL.hs
@@ -22,7 +22,7 @@ import Idris.Primitives
 import Idris.Coverage
 import Idris.Docs hiding (Doc)
 import Idris.Completion
-import qualified Idris.IdeSlave as IdeSlave
+import qualified Idris.IdeMode as IdeMode
 import Idris.Chaser
 import Idris.Imports
 import Idris.Colours hiding (colourise)
@@ -165,7 +165,7 @@ startServer port orig fn_in = do tid <- runIO $ forkOS (serverLoop port)
                  cmd <- hGetLine h
                  let isth = case idris_outputmode ist of
                               RawOutput _ -> ist {idris_outputmode = RawOutput h}
-                              IdeSlave n _ -> ist {idris_outputmode = IdeSlave n h}
+                              IdeMode n _ -> ist {idris_outputmode = IdeMode n h}
                  (ist', fn) <- processNetCmd orig isth h fn cmd
                  hClose h
                  loop fn ist' sock
@@ -204,7 +204,7 @@ processNetCmd orig i h fn cmd
       do ist <- getIState
          putIState $ case idris_outputmode ist of
            RawOutput _ -> ist {idris_outputmode = RawOutput h}
-           IdeSlave n _ -> ist {idris_outputmode = IdeSlave n h}
+           IdeMode n _ -> ist {idris_outputmode = IdeMode n h}
 
 -- | Run a command on the server on localhost
 runClient :: PortID -> String -> IO ()
@@ -232,25 +232,25 @@ runClient port str = withSocketsDo $ do
             putStrLn "Unable to connect to a running Idris repl"
 
 
-initIdeslaveSocket :: IO Handle
-initIdeslaveSocket = do
+initIdemodeSocket :: IO Handle
+initIdemodeSocket = do
   (sock, port) <- listenOnLocalhostAnyPort
   putStrLn $ show port
   (h, _, _) <- accept sock
   hSetEncoding h utf8
   return h
 
--- | Run the IdeSlave
+-- | Run the IdeMode
 ideslaveStart :: Bool -> IState -> [FilePath] -> Idris ()
 ideslaveStart s orig mods
-  = do h <- runIO $ if s then initIdeslaveSocket else return stdout
-       setIdeSlave True h
+  = do h <- runIO $ if s then initIdemodeSocket else return stdout
+       setIdeMode True h
        i <- getIState
        case idris_outputmode i of
-         IdeSlave n h ->
-           do runIO $ hPutStrLn h $ IdeSlave.convSExp "protocol-version" IdeSlave.ideSlaveEpoch n
+         IdeMode n h ->
+           do runIO $ hPutStrLn h $ IdeMode.convSExp "protocol-version" IdeMode.ideModeEpoch n
               case mods of
-                a:_ -> runIdeSlaveCommand h n i "" [] (IdeSlave.LoadFile a Nothing)
+                a:_ -> runIdeModeCommand h n i "" [] (IdeMode.LoadFile a Nothing)
                 _   -> return ()
        ideslave h orig mods
 
@@ -258,36 +258,36 @@ ideslave :: Handle -> IState -> [FilePath] -> Idris ()
 ideslave h orig mods
   = do idrisCatch
          (do let inh = if h == stdout then stdin else h
-             len' <- runIO $ IdeSlave.getLen inh
+             len' <- runIO $ IdeMode.getLen inh
              len <- case len' of
                Left err -> ierror err
                Right n  -> return n
-             l <- runIO $ IdeSlave.getNChar inh len ""
-             (sexp, id) <- case IdeSlave.parseMessage l of
+             l <- runIO $ IdeMode.getNChar inh len ""
+             (sexp, id) <- case IdeMode.parseMessage l of
                              Left err -> ierror err
                              Right (sexp, id) -> return (sexp, id)
              i <- getIState
-             putIState $ i { idris_outputmode = (IdeSlave id h) }
+             putIState $ i { idris_outputmode = (IdeMode id h) }
              idrisCatch -- to report correct id back!
                (do let fn = case mods of
                               (f:_) -> f
                               _     -> ""
-                   case IdeSlave.sexpToCommand sexp of
-                     Just cmd -> runIdeSlaveCommand h id orig fn mods cmd
+                   case IdeMode.sexpToCommand sexp of
+                     Just cmd -> runIdeModeCommand h id orig fn mods cmd
                      Nothing  -> iPrintError "did not understand" )
                (\e -> do iPrintError $ show e))
          (\e -> do iPrintError $ show e)
        ideslave h orig mods
 
--- | Run IDESlave commands
-runIdeSlaveCommand :: Handle -- ^^ The handle for communication
+-- | Run IDEMode commands
+runIdeModeCommand :: Handle -- ^^ The handle for communication
                    -> Integer -- ^^ The continuation ID for the client
                    -> IState -- ^^ The original IState
                    -> FilePath -- ^^ The current open file
                    -> [FilePath] -- ^^ The currently loaded modules
-                   -> IdeSlave.IdeSlaveCommand -- ^^ The command to process
+                   -> IdeMode.IdeModeCommand -- ^^ The command to process
                    -> Idris ()
-runIdeSlaveCommand h id orig fn mods (IdeSlave.Interpret cmd) =
+runIdeModeCommand h id orig fn mods (IdeMode.Interpret cmd) =
   do c <- colourise
      i <- getIState
      case parseCmd i "(input)" cmd of
@@ -297,96 +297,96 @@ runIdeSlaveCommand h id orig fn mods (IdeSlave.Interpret cmd) =
            (do process fn (Prove n')
                isetPrompt (mkPrompt mods)
                case idris_outputmode i of
-                 IdeSlave n h -> -- signal completion of proof to ide
+                 IdeMode n h -> -- signal completion of proof to ide
                    runIO . hPutStrLn h $
-                     IdeSlave.convSExp "return"
-                       (IdeSlave.SymbolAtom "ok", "")
+                     IdeMode.convSExp "return"
+                       (IdeMode.SymbolAtom "ok", "")
                        n
                  _ -> return ())
            (\e -> do ist <- getIState
                      isetPrompt (mkPrompt mods)
                      case idris_outputmode i of
-                       IdeSlave n h ->
+                       IdeMode n h ->
                          runIO . hPutStrLn h $
-                           IdeSlave.convSExp "abandon-proof" "Abandoned" n
+                           IdeMode.convSExp "abandon-proof" "Abandoned" n
                        _ -> return ()
                      iRenderError $ pprintErr ist e)
        Success (Right cmd) -> idrisCatch
                         (ideslaveProcess fn cmd)
                         (\e -> getIState >>= iRenderError . flip pprintErr e)
        Success (Left err) -> iPrintError err
-runIdeSlaveCommand h id orig fn mods (IdeSlave.REPLCompletions str) =
+runIdeModeCommand h id orig fn mods (IdeMode.REPLCompletions str) =
   do (unused, compls) <- replCompletion (reverse str, "")
-     let good = IdeSlave.SexpList [IdeSlave.SymbolAtom "ok",
-                                   IdeSlave.toSExp (map replacement compls,
+     let good = IdeMode.SexpList [IdeMode.SymbolAtom "ok",
+                                   IdeMode.toSExp (map replacement compls,
                                    reverse unused)]
-     runIO . hPutStrLn h $ IdeSlave.convSExp "return" good id
-runIdeSlaveCommand h id orig fn mods (IdeSlave.LoadFile filename toline) =
+     runIO . hPutStrLn h $ IdeMode.convSExp "return" good id
+runIdeModeCommand h id orig fn mods (IdeMode.LoadFile filename toline) =
   do i <- getIState
      clearErr
      putIState (orig { idris_options = idris_options i,
-                       idris_outputmode = (IdeSlave id h) })
+                       idris_outputmode = (IdeMode id h) })
      mods <- loadInputs [filename] toline
      isetPrompt (mkPrompt mods)
      -- Report either success or failure
      i <- getIState
      case (errSpan i) of
-       Nothing -> let msg = maybe (IdeSlave.SexpList [IdeSlave.SymbolAtom "ok",
-                                                      IdeSlave.SexpList []])
-                                  (\fc -> IdeSlave.SexpList [IdeSlave.SymbolAtom "ok",
-                                                             IdeSlave.toSExp fc])
+       Nothing -> let msg = maybe (IdeMode.SexpList [IdeMode.SymbolAtom "ok",
+                                                      IdeMode.SexpList []])
+                                  (\fc -> IdeMode.SexpList [IdeMode.SymbolAtom "ok",
+                                                             IdeMode.toSExp fc])
                                   (idris_parsedSpan i)
-                  in runIO . hPutStrLn h $ IdeSlave.convSExp "return" msg id
+                  in runIO . hPutStrLn h $ IdeMode.convSExp "return" msg id
        Just x -> iPrintError $ "didn't load " ++ filename
      ideslave h orig mods
-runIdeSlaveCommand h id orig fn mods (IdeSlave.TypeOf name) =
+runIdeModeCommand h id orig fn mods (IdeMode.TypeOf name) =
   case splitName name of
     Left err -> iPrintError err
     Right n -> process "(ideslave)"
                  (Check (PRef (FC "(ideslave)" (0,0) (0,0)) n))
-runIdeSlaveCommand h id orig fn mods (IdeSlave.DocsFor name) =
+runIdeModeCommand h id orig fn mods (IdeMode.DocsFor name) =
   case parseConst orig name of
     Success c -> process "(ideslave)" (DocStr (Right c))
     Failure _ ->
      case splitName name of
        Left err -> iPrintError err
        Right n -> process "(ideslave)" (DocStr (Left n))
-runIdeSlaveCommand h id orig fn mods (IdeSlave.CaseSplit line name) =
+runIdeModeCommand h id orig fn mods (IdeMode.CaseSplit line name) =
   process fn (CaseSplitAt False line (sUN name))
-runIdeSlaveCommand h id orig fn mods (IdeSlave.AddClause line name) =
+runIdeModeCommand h id orig fn mods (IdeMode.AddClause line name) =
   process fn (AddClauseFrom False line (sUN name))
-runIdeSlaveCommand h id orig fn mods (IdeSlave.AddProofClause line name) =
+runIdeModeCommand h id orig fn mods (IdeMode.AddProofClause line name) =
   process fn (AddProofClauseFrom False line (sUN name))
-runIdeSlaveCommand h id orig fn mods (IdeSlave.AddMissing line name) =
+runIdeModeCommand h id orig fn mods (IdeMode.AddMissing line name) =
   process fn (AddMissing False line (sUN name))
-runIdeSlaveCommand h id orig fn mods (IdeSlave.MakeWithBlock line name) =
+runIdeModeCommand h id orig fn mods (IdeMode.MakeWithBlock line name) =
   process fn (MakeWith False line (sUN name))
-runIdeSlaveCommand h id orig fn mods (IdeSlave.ProofSearch r line name hints depth) =
+runIdeModeCommand h id orig fn mods (IdeMode.ProofSearch r line name hints depth) =
   doProofSearch fn False r line (sUN name) (map sUN hints) depth
-runIdeSlaveCommand h id orig fn mods (IdeSlave.MakeLemma line name) =
+runIdeModeCommand h id orig fn mods (IdeMode.MakeLemma line name) =
   case splitName name of
     Left err -> iPrintError err
     Right n -> process fn (MakeLemma False line n)
-runIdeSlaveCommand h id orig fn mods (IdeSlave.Apropos a) =
+runIdeModeCommand h id orig fn mods (IdeMode.Apropos a) =
   process fn (Apropos [] a)
-runIdeSlaveCommand h id orig fn mods (IdeSlave.GetOpts) =
+runIdeModeCommand h id orig fn mods (IdeMode.GetOpts) =
   do ist <- getIState
      let opts = idris_options ist
      let impshow = opt_showimp opts
      let errCtxt = opt_errContext opts
-     let options = (IdeSlave.SymbolAtom "ok",
-                    [(IdeSlave.SymbolAtom "show-implicits", impshow),
-                     (IdeSlave.SymbolAtom "error-context", errCtxt)])
-     runIO . hPutStrLn h $ IdeSlave.convSExp "return" options id
-runIdeSlaveCommand h id orig fn mods (IdeSlave.SetOpt IdeSlave.ShowImpl b) =
+     let options = (IdeMode.SymbolAtom "ok",
+                    [(IdeMode.SymbolAtom "show-implicits", impshow),
+                     (IdeMode.SymbolAtom "error-context", errCtxt)])
+     runIO . hPutStrLn h $ IdeMode.convSExp "return" options id
+runIdeModeCommand h id orig fn mods (IdeMode.SetOpt IdeMode.ShowImpl b) =
   do setImpShow b
-     let msg = (IdeSlave.SymbolAtom "ok", b)
-     runIO . hPutStrLn h $ IdeSlave.convSExp "return" msg id
-runIdeSlaveCommand h id orig fn mods (IdeSlave.SetOpt IdeSlave.ErrContext b) =
+     let msg = (IdeMode.SymbolAtom "ok", b)
+     runIO . hPutStrLn h $ IdeMode.convSExp "return" msg id
+runIdeModeCommand h id orig fn mods (IdeMode.SetOpt IdeMode.ErrContext b) =
   do setErrContext b
-     let msg = (IdeSlave.SymbolAtom "ok", b)
-     runIO . hPutStrLn h $ IdeSlave.convSExp "return" msg id
-runIdeSlaveCommand h id orig fn mods (IdeSlave.Metavariables cols) =
+     let msg = (IdeMode.SymbolAtom "ok", b)
+     runIO . hPutStrLn h $ IdeMode.convSExp "return" msg id
+runIdeModeCommand h id orig fn mods (IdeMode.Metavariables cols) =
   do ist <- getIState
      let mvs = reverse $ map fst (idris_metavars ist) \\ primDefs
      let ppo = ppOptionIst ist
@@ -403,7 +403,7 @@ runIdeSlaveCommand h id orig fn mods (IdeSlave.Metavariables cols) =
                               render ist bnd c pc))
                             splitMvs
      runIO . hPutStrLn h $
-       IdeSlave.convSExp "return" (IdeSlave.SymbolAtom "ok", mvOutput) id
+       IdeMode.convSExp "return" (IdeMode.SymbolAtom "ok", mvOutput) id
   where mapPair f g xs = zip (map (f . fst) xs) (map (g . snd) xs)
         mapSnd f xs = zip (map fst xs) (map (f . snd) xs)
 
@@ -447,32 +447,32 @@ runIdeSlaveCommand h id orig fn mods (IdeSlave.Metavariables cols) =
           let (out, spans) = render ist bnd t pt in
           (show n , out, spans)
 
-runIdeSlaveCommand h id orig fn mods (IdeSlave.WhoCalls n) =
+runIdeModeCommand h id orig fn mods (IdeMode.WhoCalls n) =
   case splitName n of
        Left err -> iPrintError err
        Right n -> do calls <- whoCalls n
                      ist <- getIState
-                     let msg = (IdeSlave.SymbolAtom "ok",
+                     let msg = (IdeMode.SymbolAtom "ok",
                                 map (\ (n,ns) -> (pn ist n, map (pn ist) ns)) calls)
-                     runIO . hPutStrLn h $ IdeSlave.convSExp "return" msg id
+                     runIO . hPutStrLn h $ IdeMode.convSExp "return" msg id
   where pn ist = displaySpans .
                  renderPretty 0.9 1000 .
                  fmap (fancifyAnnots ist) .
                  prettyName True True []
-runIdeSlaveCommand h id orig fn mods (IdeSlave.CallsWho n) =
+runIdeModeCommand h id orig fn mods (IdeMode.CallsWho n) =
   case splitName n of
        Left err -> iPrintError err
        Right n -> do calls <- callsWho n
                      ist <- getIState
-                     let msg = (IdeSlave.SymbolAtom "ok",
+                     let msg = (IdeMode.SymbolAtom "ok",
                                 map (\ (n,ns) -> (pn ist n, map (pn ist) ns)) calls)
-                     runIO . hPutStrLn h $ IdeSlave.convSExp "return" msg id
+                     runIO . hPutStrLn h $ IdeMode.convSExp "return" msg id
   where pn ist = displaySpans .
                  renderPretty 0.9 1000 .
                  fmap (fancifyAnnots ist) .
                  prettyName True True []
 
-runIdeSlaveCommand h id orig fn modes (IdeSlave.TermNormalise bnd tm) =
+runIdeModeCommand h id orig fn modes (IdeMode.TermNormalise bnd tm) =
   do ctxt <- getContext
      ist <- getIState
      let tm' = force (normaliseAll ctxt [] tm)
@@ -482,46 +482,46 @@ runIdeSlaveCommand h id orig fn modes (IdeSlave.TermNormalise bnd tm) =
                             []
                             (idris_infixes ist)
                             (delab ist tm'))
-         msg = (IdeSlave.SymbolAtom "ok",
+         msg = (IdeMode.SymbolAtom "ok",
                 displaySpans .
                 renderPretty 0.9 80 .
                 fmap (fancifyAnnots ist) $ ptm)
-     runIO . hPutStrLn h $ IdeSlave.convSExp "return" msg id
-runIdeSlaveCommand h id orig fn modes (IdeSlave.TermShowImplicits bnd tm) =
-  ideSlaveForceTermImplicits h id bnd True tm
-runIdeSlaveCommand h id orig fn modes (IdeSlave.TermNoImplicits bnd tm) =
-  ideSlaveForceTermImplicits h id bnd False tm
-runIdeSlaveCommand h id orig fn mods (IdeSlave.PrintDef name) =
+     runIO . hPutStrLn h $ IdeMode.convSExp "return" msg id
+runIdeModeCommand h id orig fn modes (IdeMode.TermShowImplicits bnd tm) =
+  ideModeForceTermImplicits h id bnd True tm
+runIdeModeCommand h id orig fn modes (IdeMode.TermNoImplicits bnd tm) =
+  ideModeForceTermImplicits h id bnd False tm
+runIdeModeCommand h id orig fn mods (IdeMode.PrintDef name) =
   case splitName name of
     Left err -> iPrintError err
     Right n -> process "(ideslave)" (PrintDef n)
-runIdeSlaveCommand h id orig fn modes (IdeSlave.ErrString e) =
+runIdeModeCommand h id orig fn modes (IdeMode.ErrString e) =
   do ist <- getIState
      let out = displayS . renderPretty 1.0 60 $ pprintErr ist e
-         msg = (IdeSlave.SymbolAtom "ok", IdeSlave.StringAtom $ out "")
-     runIO . hPutStrLn h $ IdeSlave.convSExp "return" msg id
-runIdeSlaveCommand h id orig fn modes (IdeSlave.ErrPPrint e) =
+         msg = (IdeMode.SymbolAtom "ok", IdeMode.StringAtom $ out "")
+     runIO . hPutStrLn h $ IdeMode.convSExp "return" msg id
+runIdeModeCommand h id orig fn modes (IdeMode.ErrPPrint e) =
   do ist <- getIState
      let (out, spans) =
            displaySpans .
            renderPretty 0.9 80 .
            fmap (fancifyAnnots ist) $ pprintErr ist e
-         msg = (IdeSlave.SymbolAtom "ok", out, spans)
-     runIO . hPutStrLn h $ IdeSlave.convSExp "return" msg id
+         msg = (IdeMode.SymbolAtom "ok", out, spans)
+     runIO . hPutStrLn h $ IdeMode.convSExp "return" msg id
 
--- | Show a term for IDESlave with the specified implicitness
-ideSlaveForceTermImplicits :: Handle -> Integer -> [(Name, Bool)] -> Bool -> Term -> Idris ()
-ideSlaveForceTermImplicits h id bnd impl tm =
+-- | Show a term for IDEMode with the specified implicitness
+ideModeForceTermImplicits :: Handle -> Integer -> [(Name, Bool)] -> Bool -> Term -> Idris ()
+ideModeForceTermImplicits h id bnd impl tm =
   do ist <- getIState
      let expl = annotate (AnnTerm bnd tm)
                 (pprintPTerm ((ppOptionIst ist) { ppopt_impl = impl })
                              bnd [] (idris_infixes ist)
                              (delab ist tm))
-         msg = (IdeSlave.SymbolAtom "ok",
+         msg = (IdeMode.SymbolAtom "ok",
                 displaySpans .
                 renderPretty 0.9 80 .
                 fmap (fancifyAnnots ist) $ expl)
-     runIO . hPutStrLn h $ IdeSlave.convSExp "return" msg id
+     runIO . hPutStrLn h $ IdeMode.convSExp "return" msg id
 
 splitName :: String -> Either String Name
 splitName s = case reverse $ splitOn "." s of
@@ -1101,8 +1101,8 @@ process fn Execute
                            case idris_outputmode ist of
                              RawOutput h -> do runIO $ rawSystem tmpn []
                                                return ()
-                             IdeSlave n h -> runIO . hPutStrLn h $
-                                             IdeSlave.convSExp "run-program" tmpn n)
+                             IdeMode n h -> runIO . hPutStrLn h $
+                                             IdeMode.convSExp "run-program" tmpn n)
                        (\e -> getIState >>= iRenderError . flip pprintErr e)
   where fc = fileFC "main"
 process fn (Compile codegen f)
@@ -1487,7 +1487,7 @@ idrisMain opts =
     do let inputs = opt getFile opts
        let quiet = Quiet `elem` opts
        let nobanner = NoBanner `elem` opts
-       let idesl = Ideslave `elem` opts || IdeslaveSocket `elem` opts
+       let idesl = Idemode `elem` opts || IdemodeSocket `elem` opts
        let runrepl = not (NoREPL `elem` opts)
        let verbose = runrepl || Verbose `elem` opts
        let output = opt getOutput opts
@@ -1612,7 +1612,7 @@ idrisMain opts =
 --          clearOrigPats
          startServer port orig mods
          runInputT (replSettings (Just historyFile)) $ repl orig mods efile
-       let idesock = IdeslaveSocket `elem` opts
+       let idesock = IdemodeSocket `elem` opts
        when (idesl) $ ideslaveStart idesock orig inputs
        ok <- noErrors
        when (not ok) $ runIO (exitWith (ExitFailure 1))

--- a/src/Idris/TypeSearch.hs
+++ b/src/Idris/TypeSearch.hs
@@ -57,7 +57,7 @@ searchByType pkgs pterm = do
   case idris_outputmode i of
     RawOutput _  -> do mapM_ iRenderOutput docs
                        iPrintResult ""
-    IdeSlave _ _ -> iRenderResult (vsep docs)
+    IdeMode _ _ -> iRenderResult (vsep docs)
   putIState i -- don't actually make any changes
   where
     numLimit = 50


### PR DESCRIPTION
This patch changes the name of the machine-readable REPL syntax from
ideslave to ide-mode. The old command line options still work, but are
announced as deprecated for a while.