### PR TITLE
Added optional argument to intros to tell idris how many assumptions should be introduced

### DIFF
--- a/src/Idris/AbsSyntaxTree.hs
+++ b/src/Idris/AbsSyntaxTree.hs
@@ -824,7 +824,8 @@ mapPT f t = f (mpt t) where
   mpt x = x
 
 
-data PTactic' t = Intro [Name] | Intros | Focus Name
+data PTactic' t = Intro [Name] | Intros Int | Focus Name
+                  -- Intros (-1) corresponds to the tactic w/o arguments
                 | Refine Name [Bool] | Rewrite t | DoUnify
                 | Induction t
                 | CaseTac t
@@ -859,7 +860,7 @@ deriving instance NFData PTactic'
 !-}
 instance Sized a => Sized (PTactic' a) where
   size (Intro nms) = 1 + size nms
-  size Intros = 1
+  size (Intros _) = 1
   size (Focus nm) = 1 + size nm
   size (Refine nm bs) = 1 + size nm + length bs
   size (Rewrite t) = 1 + size t

--- a/src/Idris/DeepSeq.hs
+++ b/src/Idris/DeepSeq.hs
@@ -241,7 +241,7 @@ instance NFData PTerm where
 
 instance (NFData t) => NFData (PTactic' t) where
         rnf (Intro x1) = rnf x1 `seq` ()
-        rnf Intros = ()
+        rnf (Intros x1) = rnf x1 `seq` ()
         rnf (Focus x1) = rnf x1 `seq` ()
         rnf (Refine x1 x2) = rnf x1 `seq` rnf x2 `seq` ()
         rnf (Rewrite x1) = rnf x1 `seq` ()

--- a/src/Idris/ElabTerm.hs
+++ b/src/Idris/ElabTerm.hs
@@ -1413,10 +1413,14 @@ runTac autoSolve ist perhapsFC fn tac
         bname (Bind n _ _) = Just n
         bname _ = Nothing
     runT (Intro xs) = mapM_ (\x -> do attack; intro (Just x)) xs
-    runT Intros = do g <- goal
-                     attack; intro (bname g)
-                     try' (runT Intros)
-                          (return ()) True
+    runT (Intros n) | n < 0 = do g <- goal
+                                 attack; intro (bname g)
+                                 try' (runT (Intros (-1)))
+                                      (return ()) True
+                    | n == 0 = return ()
+                    | otherwise = do g <- goal
+                                     attack; intro (bname g)
+                                     runT (Intros (n - 1))
       where
         bname (Bind n _ _) = Just n
         bname _ = Nothing
@@ -1657,7 +1661,6 @@ reflm n = sNS (sUN n) ["Reflection", "Language"]
 
 -- | Reify tactics from their reflected representation
 reify :: IState -> Term -> ElabD PTactic
-reify _ (P _ n _) | n == reflm "Intros" = return Intros
 reify _ (P _ n _) | n == reflm "Trivial" = return Trivial
 reify _ (P _ n _) | n == reflm "Instance" = return TCInstance
 reify _ (P _ n _) | n == reflm "Solve" = return Solve
@@ -1679,6 +1682,9 @@ reifyApp ist t [l, r] | t == reflm "Seq" = liftM2 TSeq (reify ist l) (reify ist 
 reifyApp ist t [Constant (Str n), x]
              | t == reflm "GoalType" = liftM (GoalType n) (reify ist x)
 reifyApp _ t [n] | t == reflm "Intro" = liftM (Intro . (:[])) (reifyTTName n)
+reifyApp _ t [c] | t == reflm "Intros" = reifyTTConst c >>= \x -> case x of
+                                           I n -> return $ Intros n
+                                           x   -> fail ("Unsuitable constant " ++ show x)
 reifyApp ist t [t'] | t == reflm "Induction" = liftM (Induction . delab ist) (reifyTT t')
 reifyApp ist t [t'] | t == reflm "Case" = liftM (Induction . delab ist) (reifyTT t')
 reifyApp ist t [t']

--- a/src/Idris/Interactive.hs
+++ b/src/Idris/Interactive.hs
@@ -176,7 +176,7 @@ doProofSearch fn updatefile rec l n hints (Just depth)
                                   Just (t, e, False) -> (t, e, False)
                                   _ -> (Nothing, 0, True)
          let fc = fileFC fn
-         let body t = PProof [Try (TSeq Intros (ProofSearch rec False depth t hints))
+         let body t = PProof [Try (TSeq (Intros (-1)) (ProofSearch rec False depth t hints))
                                   (ProofSearch rec False depth t hints)]
          let def = PClause fc mn (PRef fc mn) [] (body top) []
          newmv <- idrisCatch

--- a/src/Idris/ParseExpr.hs
+++ b/src/Idris/ParseExpr.hs
@@ -1201,7 +1201,7 @@ static =     do reserved "[static]"; return Static
 
 @
 Tactic ::= 'intro' NameList?
-       |   'intros'
+       |   'intros'      Natural?
        |   'refine'      Name Imp+
        |   'mrefine'     Name
        |   'rewrite'     Expr
@@ -1250,7 +1250,8 @@ tactics :: [([String], Maybe TacticArg, SyntaxInfo -> IdrisParser PTactic)]
 tactics = 
   [ (["intro"], Nothing, const $ -- FIXME syntax for intro (fresh name)
       do ns <- sepBy (spaced name) (lchar ','); return $ Intro ns)
-  , noArgs ["intros"] Intros
+  , (["intros"], Nothing, const $
+      do n <- option (-1) natural; return $ Intros (fromInteger n))
   , (["refine"], Just ExprTArg, const $
        do n <- spaced fnName
           imps <- many imp


### PR DESCRIPTION
Writing "intros" does the same thing it always did, so there are no problems regarding backwards compatibility. Writing "intros n", where n is a natural number (including 0), tries to introduce n assumptions. If there aren't that many assumptions left, it will fail. (Which means "intros 0" will always be successful and will do nothing.)

I'm not entirely sure if I did everything correctly, though. Specifically:
 - In AbsSyntaxTree.hs, the size of Intros was 1, and I left it at 1.
 - In ElabTerm.hs, I moved Intros from reify to reifyApp, and let it convert the one term it accepts into a constant. I'm not sure how I can test whether I did the reflected representation stuff correctly.
 - I would have preferred to use Maybe Int instead of Int (where -1 represents Nothing), but I don't think that's possible because of the reflected representation. I can convert a Term to a Const, but Const doesn't have a Maybe Constructor

But it typechecks, works, and passes the tests.