### PR TITLE
"claim" and "unfocus" tactics

### DIFF
--- a/CHANGELOG
+++ b/CHANGELOG
@@ -2,6 +2,9 @@ New in 0.9.17:
 --------------
 * The --ideslave command line option has been replaced with a --ide-mode
   command line option with the same semantics.
+* A new tactic "claim N TY" that introduces a new hole named N with type TY
+* A new tactic "unfocus" that moves the current hole to the bottom of the
+  hole stack
 
 New in 0.9.16:
 --------------

--- a/idris.cabal
+++ b/idris.cabal
@@ -497,6 +497,9 @@ Extra-source-files:
                        test/proof004/run
                        test/proof004/*.idr
                        test/proof004/expected
+                       test/proof008/run
+                       test/proof008/*.idr
+                       test/proof008/expected
 
                        test/quasiquote001/run
                        test/quasiquote001/*.idr

--- a/libs/prelude/Language/Reflection.idr
+++ b/libs/prelude/Language/Reflection.idr
@@ -213,6 +213,10 @@ data Tactic =
             Refine TTName |
             ||| Apply both tactics in sequence
             Seq Tactic Tactic |
+            ||| Introduce a new hole with a particular type
+            Claim TTName TT |
+            ||| Move the current hole to the end
+            Unfocus |
             ||| Intelligently construct the proof target from the context
             Trivial |
             ||| Build a proof by applying contructors up to a maximum depth
@@ -472,6 +476,8 @@ instance Quotable Tactic where
   quote (Try tac tac') = `(Try ~(quote tac) ~(quote tac'))
   quote (GoalType x tac) = `(GoalType ~(quote x) ~(quote tac))
   quote (Refine n) = `(Refine ~(quote n))
+  quote (Claim n ty) = `(Claim ~(quote n) ~(quote ty))
+  quote Unfocus = `(Unfocus)
   quote (Seq tac tac') = `(Seq ~(quote tac) ~(quote tac'))
   quote Trivial = `(Trivial)
   quote (Search x) = `(Search ~(quote x))
@@ -494,3 +500,4 @@ instance Quotable Tactic where
   quote Skip = `(Skip)
   quote (Fail xs) = `(Fail ~(quote xs))
   quote SourceFC = `(SourceFC)
+

--- a/src/Idris/AbsSyntaxTree.hs
+++ b/src/Idris/AbsSyntaxTree.hs
@@ -830,6 +830,8 @@ data PTactic' t = Intro [Name] | Intros | Focus Name
                 | Induction t
                 | CaseTac t
                 | Equiv t
+                | Claim Name t
+                | Unfocus
                 | MatchRefine Name
                 | LetTac Name t | LetTacTy Name t t
                 | Exact t | Compute | Trivial | TCInstance

--- a/src/Idris/Core/ProofState.hs
+++ b/src/Idris/Core/ProofState.hs
@@ -23,23 +23,23 @@ import Debug.Trace
 import Util.Pretty hiding (fill)
 
 data ProofState = PS { thname   :: Name,
-                       holes    :: [Name], -- holes still to be solved
-                       usedns   :: [Name], -- used names, don't use again
-                       nextname :: Int,    -- name supply
-                       pterm    :: ProofTerm,   -- current proof term
-                       ptype    :: Type,   -- original goal
-                       dontunify :: [Name], -- explicitly given by programmer, leave it
+                       holes    :: [Name], -- ^ holes still to be solved
+                       usedns   :: [Name], -- ^ used names, don't use again
+                       nextname :: Int,    -- ^ name supply
+                       pterm    :: ProofTerm,   -- ^ current proof term
+                       ptype    :: Type,   -- ^ original goal
+                       dontunify :: [Name], -- ^ explicitly given by programmer, leave it
                        unified  :: (Name, [(Name, Term)]),
                        notunified :: [(Name, Term)],
-                       dotted   :: [(Name, [Name])], -- dot pattern holes + environment
-                                       -- either hole or something in env must turn up in the 'notunified' list during elaboration
+                       dotted   :: [(Name, [Name])], -- ^ dot pattern holes + environment
+                                                     -- either hole or something in env must turn up in the 'notunified' list during elaboration
                        solved   :: Maybe (Name, Term),
                        problems :: Fails,
                        injective :: [Name],
-                       deferred :: [Name], -- names we'll need to define
-                       instances :: [Name], -- instance arguments (for type classes)
-                       autos    :: [(Name, [Name])], -- unsolved 'auto' implicits with their holes
-                       previous :: Maybe ProofState, -- for undo
+                       deferred :: [Name], -- ^ names we'll need to define
+                       instances :: [Name], -- ^ instance arguments (for type classes)
+                       autos    :: [(Name, [Name])], -- ^ unsolved 'auto' implicits with their holes
+                       previous :: Maybe ProofState, -- ^ for undo
                        context  :: Context,
                        plog     :: String,
                        unifylog :: Bool,
@@ -290,12 +290,12 @@ addLog str = action (\ps -> ps { plog = plog ps ++ str ++ "\n" })
 
 newProof :: Name -> Context -> Type -> ProofState
 newProof n ctxt ty = let h = holeName 0
-                         ty' = vToP ty in
-                         PS n [h] [] 1 (mkProofTerm (Bind h (Hole ty')
-                            (P Bound h ty'))) ty [] (h, []) [] []
-                            Nothing [] []
-                            [] [] []
-                            Nothing ctxt "" False False [] []
+                         ty' = vToP ty
+                     in PS n [h] [] 1 (mkProofTerm (Bind h (Hole ty')
+                           (P Bound h ty'))) ty [] (h, []) [] []
+                           Nothing [] []
+                           [] [] []
+                           Nothing ctxt "" False False [] []
 
 type TState = ProofState -- [TacticAction])
 type RunTactic = RunTactic' TState

--- a/src/Idris/DeepSeq.hs
+++ b/src/Idris/DeepSeq.hs
@@ -250,6 +250,7 @@ instance (NFData t) => NFData (PTactic' t) where
         rnf (Induction x1) = rnf x1 `seq` ()
         rnf (CaseTac x1) = rnf x1 `seq` ()
         rnf (Equiv x1) = rnf x1 `seq` ()
+        rnf (Claim x1 x2) = rnf x1 `seq` rnf x2 `seq` ()
         rnf (MatchRefine x1) = rnf x1 `seq` ()
         rnf (LetTac x1 x2) = rnf x1 `seq` rnf x2 `seq` ()
         rnf (LetTacTy x1 x2 x3) = rnf x1 `seq` rnf x2 `seq` rnf x3 `seq` ()
@@ -280,6 +281,7 @@ instance (NFData t) => NFData (PTactic' t) where
         rnf Skip = ()
         rnf (TFail x1) = rnf x1 `seq` ()
         rnf SourceFC = ()
+        rnf Unfocus = ()
 
 instance NFData ErrorReportPart where
         rnf (TermPart x1) = rnf x1 `seq` ()

--- a/src/Idris/ElabQuasiquote.hs
+++ b/src/Idris/ElabQuasiquote.hs
@@ -36,6 +36,7 @@ extractTUnquotes n (GoalType s tac)
        return (GoalType s tac', ex)
 extractTUnquotes n (TCheck t) = extract1 n TCheck t
 extractTUnquotes n (TEval t) = extract1 n TEval t
+extractTUnquotes n (Claim name t) = extract1 n (Claim name) t
 extractTUnquotes n tac = return (tac, []) -- the rest don't contain PTerms
 
 extractPArgUnquotes :: Int -> PArg -> Elab' aux (PArg, [(Name, PTerm)])

--- a/src/Idris/ElabTerm.hs
+++ b/src/Idris/ElabTerm.hs
@@ -1506,6 +1506,12 @@ runTac autoSolve ist perhapsFC fn tac
                                when autoSolve solveAll
     runT DoUnify = do unify_all
                       when autoSolve solveAll
+    runT (Claim n tm) = do tmHole <- getNameFrom (sMN 0 "newGoal")
+                           claim tmHole RType
+                           claim n (Var tmHole)
+                           focus tmHole
+                           elab ist toplevel ERHS [] (sMN 0 "tac") tm
+                           focus n
     runT (Equiv tm) -- let bind tm, then
               = do attack
                    tyn <- getNameFrom (sMN 0 "ety")
@@ -1566,6 +1572,10 @@ runTac autoSolve ist perhapsFC fn tac
          = do proofSearch' ist rec False depth prover top fn hints
               when autoSolve solveAll
     runT (Focus n) = focus n
+    runT Unfocus = do hs <- get_holes
+                      case hs of
+                        []      -> return ()
+                        (h : _) -> movelast h
     runT Solve = solve
     runT (Try l r) = do try' (runT l) (runT r) True
     runT (TSeq l r) = do runT l; runT r
@@ -1710,6 +1720,7 @@ reify _ (P _ n _) | n == reflm "Solve" = return Solve
 reify _ (P _ n _) | n == reflm "Compute" = return Compute
 reify _ (P _ n _) | n == reflm "Skip" = return Skip
 reify _ (P _ n _) | n == reflm "SourceFC" = return SourceFC
+reify _ (P _ n _) | n == reflm "Unfocus" = return Unfocus
 reify ist t@(App _ _)
           | (P _ f _, args) <- unApply t = reifyApp ist f args
 reify _ t = fail ("Unknown tactic " ++ show t)
@@ -1721,6 +1732,9 @@ reifyApp _ t [Constant (I i)]
 reifyApp _ t [x]
            | t == reflm "Refine" = do n <- reifyTTName x
                                       return $ Refine n []
+reifyApp ist t [n, ty] | t == reflm "Claim" = do n' <- reifyTTName n
+                                                 goal <- reifyTT ty
+                                                 return $ Claim n' (delab ist goal)
 reifyApp ist t [l, r] | t == reflm "Seq" = liftM2 TSeq (reify ist l) (reify ist r)
 reifyApp ist t [Constant (Str n), x]
              | t == reflm "GoalType" = liftM (GoalType n) (reify ist x)

--- a/src/Idris/ParseExpr.hs
+++ b/src/Idris/ParseExpr.hs
@@ -1251,10 +1251,15 @@ tactics =
   [ (["intro"], Nothing, const $ -- FIXME syntax for intro (fresh name)
       do ns <- sepBy (spaced name) (lchar ','); return $ Intro ns)
   , noArgs ["intros"] Intros
+  , noArgs ["unfocus"] Unfocus
   , (["refine"], Just ExprTArg, const $
        do n <- spaced fnName
           imps <- many imp
           return $ Refine n imps)
+  , (["claim"], Nothing, \syn ->
+       do n <- indentPropHolds gtProp *> name
+          goal <- indentPropHolds gtProp *> expr syn
+          return $ Claim n goal)
   , (["mrefine"], Just ExprTArg, const $
        do n <- spaced fnName
           return $ MatchRefine n)
@@ -1329,7 +1334,7 @@ tactics =
   
 
 tactic :: SyntaxInfo -> IdrisParser PTactic
-tactic syn = choice [ do choice (map reserved names); parser syn 
+tactic syn = choice [ do choice (map reserved names); parser syn
                     | (names, _, parser) <- tactics ]
           <|> do lchar '{'
                  t <- tactic syn;

--- a/test/proof008/ClaimAndUnfocus.idr
+++ b/test/proof008/ClaimAndUnfocus.idr
@@ -1,0 +1,17 @@
+module ClaimAndUnfocus
+
+foo : Nat -> Nat
+foo = ?foo_rhs
+
+---------- Proofs ----------
+
+ClaimAndUnfocus.foo_rhs = proof
+  claim bar Nat -> Nat -> Nat
+  unfocus
+  intro x
+  exact bar x x
+  intro x,y
+  refine plus
+  refine x
+  refine y
+

--- a/test/proof008/run
+++ b/test/proof008/run
@@ -1,0 +1,3 @@
+#!/usr/bin/env bash
+idris --check $@ ClaimAndUnfocus.idr
+rm -f *.ibc


### PR DESCRIPTION
This commit introduces:
 * A new tactic "claim N TY" that introduces a new hole named N with
   type TY
 * A new tactic "unfocus" that moves the current hole to the bottom of
   the hole stack

In the process of this and some other work, I also added comments and
docs to more of the core.