### PR TITLE
add missing HAS_PTHREAD wrapper

### DIFF
--- a/rts/idris_rts.c
+++ b/rts/idris_rts.c
@@ -64,7 +64,9 @@ VM* init_vm(int stack_size, size_t heap_size,
 }
 
 void init_threadkeys() {
+#ifdef HAS_PTHREAD
     pthread_key_create(&vm_key, (void*)free_key);
+#endif
 }
 
 void init_threaddata(VM *vm) {


### PR DESCRIPTION
``` diff
 void init_threadkeys() {
+#ifdef HAS_PTHREAD
     pthread_key_create(&vm_key, (void*)free_key);		     pthread_key_create(&vm_key, (void*)free_key);
+#endif
 }
```