### PR TITLE
Set encoding to UTF8 on Windows and fix :exec

### DIFF
--- a/main/Main.hs
+++ b/main/Main.hs
@@ -3,7 +3,6 @@ module Main where
 import System.Console.Haskeline
 import System.IO
 import System.Environment
-import System.Info
 import System.Exit
 import System.FilePath ((</>), addTrailingPathSeparator)
 import System.Directory
@@ -30,6 +29,7 @@ import Idris.CmdOptions
 import IRTS.System ( getLibFlags, getIdrisLibDir, getIncFlags )
 
 import Util.DynamicLinker
+import Util.System
 
 import Pkg.Package
 
@@ -40,7 +40,7 @@ import Paths_idris
 
 main :: IO ()
 main = do
-          when (os == "mingw32") $  do hSetEncoding stdout utf8
+          when isWindows $ do hSetEncoding stdout utf8
           opts <- runArgParser
           runMain (runIdris opts)
 

--- a/main/Main.hs
+++ b/main/Main.hs
@@ -3,6 +3,7 @@ module Main where
 import System.Console.Haskeline
 import System.IO
 import System.Environment
+import System.Info
 import System.Exit
 import System.FilePath ((</>), addTrailingPathSeparator)
 import System.Directory
@@ -38,7 +39,9 @@ import Paths_idris
 -- on with the REPL.
 
 main :: IO ()
-main = do opts <- runArgParser
+main = do
+          when (os == "mingw32") $  do hSetEncoding stdout utf8
+          opts <- runArgParser
           runMain (runIdris opts)
 
 runIdris :: [Opt] -> Idris ()

--- a/src/Idris/REPL.hs
+++ b/src/Idris/REPL.hs
@@ -1104,10 +1104,12 @@ process fn Execute
                            (tmpn, tmph) <- runIO tempfile
                            runIO $ hClose tmph
                            t <- codegen
+                           -- gcc adds .exe when it builds windows programs
+                           progName <- return $ if isWindows then tmpn ++ ".exe" else tmpn
                            ir <- compile t tmpn m
                            runIO $ generate t (fst (head (idris_imported ist))) ir
                            case idris_outputmode ist of
-                             RawOutput h -> do runIO $ rawSystem tmpn []
+                             RawOutput h -> do runIO $ rawSystem progName []
                                                return ()
                              IdeMode n h -> runIO . hPutStrLn h $
                                              IdeMode.convSExp "run-program" tmpn n)

--- a/src/Pkg/PParser.hs
+++ b/src/Pkg/PParser.hs
@@ -16,7 +16,7 @@ import Idris.CmdOptions
 import Control.Monad.State.Strict
 import Control.Applicative
 
-import System.Info (os)
+import Util.System
 
 
 type PParser = StateT PkgDesc IdrisInnerParser
@@ -63,7 +63,7 @@ pClause :: PParser ()
 pClause = do reserved "executable"; lchar '=';
              exec <- iName []
              st <- get
-             put (st { execout = Just (if os `elem` ["win32", "mingw32", "cygwin32"] 
+             put (st { execout = Just (if isWindows
                                           then ((show exec) ++ ".exe")
                                           else ( show exec )
                                       ) })

--- a/src/Util/System.hs
+++ b/src/Util/System.hs
@@ -1,4 +1,4 @@
-module Util.System(tempfile,withTempdir,rmFile,catchIO) where
+module Util.System(tempfile,withTempdir,rmFile,catchIO, isWindows) where
 
 -- System helper functions.
 import Control.Monad (when)
@@ -9,6 +9,7 @@ import System.Directory (getTemporaryDirectory
                         )
 import System.FilePath ((</>), normalise)
 import System.IO
+import System.Info
 import System.IO.Error
 import Control.Exception as CE
 
@@ -17,6 +18,9 @@ catchIO = CE.catch
 
 throwIO :: IOError -> IO a
 throwIO = CE.throw
+
+isWindows :: Bool
+isWindows = os `elem` ["win32", "mingw32", "cygwin32"]
 
 tempfile :: IO (FilePath, Handle)
 tempfile = do dir <- getTemporaryDirectory


### PR DESCRIPTION
For some inexplicable reason Haskell hardcodes latin1 as the encoding on
Windows. This stops the output when an unicode character is reached. It's better
 all over to set the encoding to UTF8, if the user has a UTF8 terminal like
mintty it looks good. If the user has a terminal with latin1, there will
be some bad chars but they will see the entire text otherwise.