### PR TITLE
Better error messages for parsing operators

### DIFF
--- a/src/Idris/ParseHelpers.hs
+++ b/src/Idris/ParseHelpers.hs
@@ -326,7 +326,7 @@ operatorLetter = oneOf opChars
 -- | Parses an operator
 operator :: MonadicParsing m => m String
 operator = do op <- token . some $ operatorLetter
-              when (op `elem` [":", "=>", "->", "<-", "=", "?=", "|"]) $
+              when (op `elem` [":", "=>", "->", "<-", "=", "?=", "|", "**", "==>", "\\", ",", "--", "|||"]) $
                    fail $ op ++ " is not a valid operator"
               return op
 

--- a/src/Idris/ParseHelpers.hs
+++ b/src/Idris/ParseHelpers.hs
@@ -323,10 +323,17 @@ opChars = ":!#$%&*+./<=>?@\\^|-~"
 operatorLetter :: MonadicParsing m => m Char
 operatorLetter = oneOf opChars
 
+
+commentMarkers :: [String]
+commentMarkers = [ "--", "|||" ]
+
+invalidOperators :: [String]
+invalidOperators = [":", "=>", "->", "<-", "=", "?=", "|", "**", "==>", "\\"]
+
 -- | Parses an operator
 operator :: MonadicParsing m => m String
 operator = do op <- token . some $ operatorLetter
-              when (op `elem` [":", "=>", "->", "<-", "=", "?=", "|", "**", "==>", "\\", ",", "--", "|||"]) $
+              when (op `elem` (invalidOperators ++ commentMarkers)) $
                    fail $ op ++ " is not a valid operator"
               return op
 

--- a/src/Idris/ParseOps.hs
+++ b/src/Idris/ParseOps.hs
@@ -37,7 +37,8 @@ table fixes
      toTable (reverse fixes) ++
      [[backtick],
       [binary "$" (\fc x y -> flatten $ PApp fc x [pexp y]) AssocRight],
-      [binary "="  (\fc x y -> PEq fc Placeholder Placeholder x y) AssocLeft]]
+      [binary "="  (\fc x y -> PEq fc Placeholder Placeholder x y) AssocLeft],
+      [nofixityoperator]]
   where
     flatten :: PTerm -> PTerm -- flatten application
     flatten (PApp fc (PApp _ f as) bs) = flatten (PApp fc f (as ++ bs))
@@ -79,6 +80,13 @@ backtick = Infix (do indentPropHolds gtProp
                      indentPropHolds gtProp
                      fc <- getFC
                      return (\x y -> PApp fc (PRef fc n) [pexp x, pexp y])) AssocNone
+
+-- | Operator without fixity (throws an error)
+nofixityoperator :: Operator IdrisParser PTerm
+nofixityoperator = Infix (do indentPropHolds gtProp
+                             op <- try operator
+                             unexpected $ "Operator without known fixity: " ++ op) AssocNone
+                             
 
 {- | Parses an operator in function position i.e. enclosed by `()', with an
  optional namespace

--- a/src/Idris/Parser.hs
+++ b/src/Idris/Parser.hs
@@ -291,6 +291,10 @@ syntaxRule syn
 
     mkSimple' (Expr e : Expr e1 : es) = SimpleExpr e : SimpleExpr e1 :
                                            mkSimple es
+    -- Can't parse a full expression followed by operator like characters due to ambiguity 
+    mkSimple' (Expr e : Symbol s : es)
+      | takeWhile (`elem` opChars) ts /= "" && ts `notElem` invalidOperators  = SimpleExpr e : Symbol s : mkSimple' es
+       where ts = dropWhile isSpace . dropWhileEnd isSpace $ s
     mkSimple' (e : es) = e : mkSimple' es
     mkSimple' [] = []
 

--- a/test/reg041/ott.idr
+++ b/test/reg041/ott.idr
@@ -37,6 +37,6 @@ EQ two False two False = one
 EQ (pi s t) f (pi s' t') g = pi s $ \x => pi s' $ \y => EQ s x s' y ~> EQ (t x) (f x) (t' y) (g y)
 EQ _ _ _ _ = zero
 
-example : <| id == id in (two ~> two) |>
+example : <| (id == id in (two ~> two)) |>
 example = ?prf
 

--- a/test/reg050/expected
+++ b/test/reg050/expected
@@ -10,19 +10,8 @@ When elaborating an application of function Prelude.Monad.>>=:
                         List
                 with
                         \{uv0} => argTy -> uv
-./baddoublebang.idr:6:26: error: not
-    a terminator, expected: "$",
-    "$>", "&&", "*", "+", "++", "-",
-    "->", ".", "/", "/=", "::", ";",
-    "<", "<#>", "<$", "<$>", "<*>",
-    "<+>", "<->", "<<", "<=", "<|>",
-    "=", "==", ">", ">=", ">>",
-    ">>=", "\\\\", "`", "in", "||",
-    "~=~",
-    ambiguous use of a left-associative operator,
-    ambiguous use of a non-associative operator,
-    ambiguous use of a right-associative operator,
-    end of input, function argument,
-    matching application expression
+./baddoublebang.idr:6:28: error: unexpected
+    Operator without known fixity:
+    !!, expected: space
 doubleBang mmn = do pure !!mmn 
-                         ^     
+                           ^   


### PR DESCRIPTION
The idea is to make better errors for parsing expressions with operators without fixity, so instead of

```idris
Idris> 2 *** 2
(input):1:3: error: expected: "$",
"$>", "&&", "+", "++", "-",
"->", ".", "/", "/=", "::", "<",
"<#>", "<$", "<$>", "<*>",
"<+>", "<->", "<<", "<=", "<|>",
"=", "==", ">", ">=", ">>",
">>=", "\\\\", "`", "||", "~=~",
ambiguous use of a left-associative operator,
ambiguous use of a non-associative operator,
ambiguous use of a right-associative operator,
end of input, function argument,
matching application expression
2 *** 2<EOF> 
```

It will write:

```idris
Idris> 2 *** 2
(input):1:7: error: unexpected
    Operator without known fixity:
    ***, expected: space
2 *** 2<EOF>
```