### PR TITLE
Revert "Set encoding to UTF8 on Windows and fix :exec"

### DIFF
--- a/main/Main.hs
+++ b/main/Main.hs
@@ -29,7 +29,6 @@ import Idris.CmdOptions
 import IRTS.System ( getLibFlags, getIdrisLibDir, getIncFlags )
 
 import Util.DynamicLinker
-import Util.System
 
 import Pkg.Package
 
@@ -39,9 +38,7 @@ import Paths_idris
 -- on with the REPL.
 
 main :: IO ()
-main = do
-          when isWindows $ do hSetEncoding stdout utf8
-          opts <- runArgParser
+main = do opts <- runArgParser
           runMain (runIdris opts)
 
 runIdris :: [Opt] -> Idris ()

--- a/src/Idris/REPL.hs
+++ b/src/Idris/REPL.hs
@@ -1104,12 +1104,10 @@ process fn Execute
                            (tmpn, tmph) <- runIO tempfile
                            runIO $ hClose tmph
                            t <- codegen
-                           -- gcc adds .exe when it builds windows programs
-                           progName <- return $ if isWindows then tmpn ++ ".exe" else tmpn
                            ir <- compile t tmpn m
                            runIO $ generate t (fst (head (idris_imported ist))) ir
                            case idris_outputmode ist of
-                             RawOutput h -> do runIO $ rawSystem progName []
+                             RawOutput h -> do runIO $ rawSystem tmpn []
                                                return ()
                              IdeMode n h -> runIO . hPutStrLn h $
                                              IdeMode.convSExp "run-program" tmpn n)

--- a/src/Pkg/PParser.hs
+++ b/src/Pkg/PParser.hs
@@ -16,7 +16,7 @@ import Idris.CmdOptions
 import Control.Monad.State.Strict
 import Control.Applicative
 
-import Util.System
+import System.Info (os)
 
 
 type PParser = StateT PkgDesc IdrisInnerParser
@@ -63,7 +63,7 @@ pClause :: PParser ()
 pClause = do reserved "executable"; lchar '=';
              exec <- iName []
              st <- get
-             put (st { execout = Just (if isWindows
+             put (st { execout = Just (if os `elem` ["win32", "mingw32", "cygwin32"] 
                                           then ((show exec) ++ ".exe")
                                           else ( show exec )
                                       ) })

--- a/src/Util/System.hs
+++ b/src/Util/System.hs
@@ -1,4 +1,4 @@
-module Util.System(tempfile,withTempdir,rmFile,catchIO, isWindows) where
+module Util.System(tempfile,withTempdir,rmFile,catchIO) where
 
 -- System helper functions.
 import Control.Monad (when)
@@ -9,7 +9,6 @@ import System.Directory (getTemporaryDirectory
                         )
 import System.FilePath ((</>), normalise)
 import System.IO
-import System.Info
 import System.IO.Error
 import Control.Exception as CE
 
@@ -18,9 +17,6 @@ catchIO = CE.catch
 
 throwIO :: IOError -> IO a
 throwIO = CE.throw
-
-isWindows :: Bool
-isWindows = os `elem` ["win32", "mingw32", "cygwin32"]
 
 tempfile :: IO (FilePath, Handle)
 tempfile = do dir <- getTemporaryDirectory


### PR DESCRIPTION
Discussion could be here.

Because I don't want to install some hacky utf8 terminal now I don't like to see messages like that: `╨Э╨╡ ╤Г
╨┤╨░╨╡╤В╤Б╤П ╨╜╨░╨╣╤В╨╕ ╤Г╨║╨░╨╖╨░╨╜╨╜╤Л╨╣ ╤Д╨░╨╣╨╗.`

It's `Не удается найти указанный файл.` encoded in utf8 and that's how default windows user will see it (maybe English will be fine but not my language) so I strongly suggest to revert it but it's my personal opinion.
