### PR TITLE
disable windows specific UTF8 encoding

### DIFF
--- a/main/Main.hs
+++ b/main/Main.hs
@@ -29,7 +29,6 @@ import Idris.CmdOptions
 import IRTS.System ( getLibFlags, getIdrisLibDir, getIncFlags )
 
 import Util.DynamicLinker
-import Util.System
 
 import Pkg.Package
 
@@ -39,9 +38,7 @@ import Paths_idris
 -- on with the REPL.
 
 main :: IO ()
-main = do
-          when isWindows $ do hSetEncoding stdout utf8
-          opts <- runArgParser
+main = do opts <- runArgParser
           runMain (runIdris opts)
 
 runIdris :: [Opt] -> Idris ()


### PR DESCRIPTION
discussion here: https://github.com/idris-lang/Idris-dev/pull/1945

Because I don't want to install some hacky utf8 terminal now I don't like to see messages like that: ╨Э╨╡ ╤Г ╨┤╨░╨╡╤В╤Б╤П ╨╜╨░╨╣╤В╨╕ ╤Г╨║╨░╨╖╨░╨╜╨╜╤Л╨╣ ╤Д╨░╨╣╨╗.

It's Не удается найти указанный файл. encoded in utf8 and that's how default windows user will see it (maybe English will be fine but not my language).