### PR TITLE
SETHEAP macro fix.

### DIFF
--- a/rts/idris_rts.h
+++ b/rts/idris_rts.h
@@ -162,7 +162,7 @@ typedef void(*func)(VM*, VAL*);
 #define SETTY(x,t) (x)->ty = (((x)->ty & 0xffff0000) | (t))
 
 #define GETHEAP(x) ((x)->ty >> 16)
-#define SETHEAP(x,y) (x)->ty = (((x)->ty & 0x0000ffff) | ((t) << 16))
+#define SETHEAP(x,y) (x)->ty = (((x)->ty & 0x0000ffff) | ((y) << 16))
 
 // Integers, floats and operators
 


### PR DESCRIPTION
SETHEAP, which is never used, had a copy/paste bug. SETTY uses the argument 't', and SETHEAP copied this, even though it's called 'y' for SETHEAP.