### PR TITLE
uint32_t type needed even if stats are not enabled.

### DIFF
--- a/rts/idris_stats.h
+++ b/rts/idris_stats.h
@@ -3,9 +3,10 @@
 
 #ifdef IDRIS_ENABLE_STATS
 #include <time.h>
+#endif
+
 #include <inttypes.h>
 #include <stdint.h>
-#endif
 
 
 // TODO: measure user time, exclusive/inclusive stats


### PR DESCRIPTION
Includes were guarded by IDRIS_ENABLE_STATS, but we need the uint32_t type regardless.