### PR TITLE
Simplify comment parser

### DIFF
--- a/test/reg050/expected
+++ b/test/reg050/expected
@@ -23,6 +23,7 @@ When elaborating an application of function Prelude.Monad.>>=:
     ambiguous use of a non-associative operator,
     ambiguous use of a right-associative operator,
     end of input, function argument,
-    matching application expression
+    matching application expression,
+    single-line comment
 doubleBang mmn = do pure !!mmn 
                          ^     


### PR DESCRIPTION
Since we no longer have special documentation comments, the comment
parser can be much simpler. The simpler version also works better - it
fixes #1958.