### PR TITLE
Generalized alloc_heap so it could be reused for garbage collection.

### DIFF
--- a/rts/idris_gc.c
+++ b/rts/idris_gc.c
@@ -116,19 +116,8 @@ void idris_gc(VM* vm) {
     if (vm->heap.old != NULL)
         free(vm->heap.old);
 
-    char* newheap = malloc(vm->heap.size);
-    char* oldheap = vm->heap.heap;
-
-    vm->heap.heap = newheap;
-#ifdef FORCE_ALIGNMENT
-    if (((i_int)(vm->heap.heap)&1) == 1) {
-        vm->heap.next = newheap + 1;
-    } else
-#endif
-    {
-        vm->heap.next = newheap;
-    }
-    vm->heap.end  = newheap + vm->heap.size;
+    /* Allocate swap heap. */
+    alloc_heap(&vm->heap, vm->heap.size, vm->heap.growth, vm->heap.heap);
 
     VAL* root;
 
@@ -143,6 +132,7 @@ void idris_gc(VM* vm) {
         msg->msg = copy(vm, msg->msg);
     }
 #endif
+
     vm->ret = copy(vm, vm->ret);
     vm->reg1 = copy(vm, vm->reg1);
 
@@ -154,7 +144,6 @@ void idris_gc(VM* vm) {
     if ((vm->heap.next - vm->heap.heap) > vm->heap.size >> 1) {
         vm->heap.size += vm->heap.growth;
     }
-    vm->heap.old = oldheap;
 
     STATS_LEAVE_GC(vm->stats, vm->heap.size, vm->heap.next - vm->heap.heap)
     HEAP_CHECK(vm)

--- a/rts/idris_heap.c
+++ b/rts/idris_heap.c
@@ -5,7 +5,9 @@
 #include <stddef.h>
 #include <stdio.h>
 
-void alloc_heap(Heap * h, size_t heap_size) 
+
+/* Used for initializing the heap. */
+void alloc_heap(Heap * h, size_t heap_size, size_t growth, char * old) 
 {
     char * mem = malloc(heap_size); 
     if (mem == NULL) {
@@ -27,9 +29,9 @@ void alloc_heap(Heap * h, size_t heap_size)
     h->end  = h->heap + heap_size;
 
     h->size   = heap_size;
-    h->growth = heap_size;
+    h->growth = growth;
 
-    h->old = NULL;
+    h->old = old;
 }
 
 void free_heap(Heap * h) {
@@ -39,6 +41,7 @@ void free_heap(Heap * h) {
         free(h->old); 
     }
 }
+
 
 // TODO: more testing
 /******************** Heap testing ********************************************/

--- a/rts/idris_heap.h
+++ b/rts/idris_heap.h
@@ -14,7 +14,7 @@ typedef struct {
 } Heap;
 
 
-void alloc_heap(Heap * heap, size_t heap_size);
+void alloc_heap(Heap * heap, size_t heap_size, size_t growth, char * old);
 void free_heap(Heap * heap);
 
 

--- a/rts/idris_rts.c
+++ b/rts/idris_rts.c
@@ -29,7 +29,7 @@ VM* init_vm(int stack_size, size_t heap_size,
     vm->valstack_base = valstack;
     vm->stack_max = valstack + stack_size;
 
-    alloc_heap(&(vm->heap), heap_size);
+    alloc_heap(&(vm->heap), heap_size, heap_size, NULL);
 
     vm->ret = NULL;
     vm->reg1 = NULL;


### PR DESCRIPTION
The garbage collector had duplicated code / functionality from alloc_heap. This pull request generalizes alloc_heap in order to keep this functionality in one place, so if the heap structure ever changes we won't have this functionality scattered throughout the code and have to adjust it in multiple places.

A previous pull request addresses the return value of malloc not being checked in the garbage collector:

https://github.com/idris-lang/Idris-dev/pull/1967

But this is actually covered by alloc_heap in these changes.