### PR TITLE
Named lambda, let, and pi in DSL block

### DIFF
--- a/CHANGELOG
+++ b/CHANGELOG
@@ -14,7 +14,12 @@ New in 0.9.17:
   been renamed to (<*) and (*>). The cascading effects of this rename
   are that Algebra.(<*>) has been renamed to Algebra.(<.>) and
   Matrix.(<.>) is now Matrix.(<:>).
-
+* Binding forms in DSL notation are now given an extra argument: a
+  reflected representation of the name that the user chose.
+  Specifically, the rewritten lambda, pi, and let binders will now get
+  an extra argument of type TTName. This allows more understandable
+  dynamic errors in DSL code and more readable code generation results.
+	
 New in 0.9.16:
 --------------
 * Inductive-inductive definitions are now supported (i.e. simultaneously

--- a/test/dsl001/test001.idr
+++ b/test/dsl001/test001.idr
@@ -35,8 +35,11 @@ using (G : Vect n Ty)
       If  : Expr G TyBool -> Expr G a -> Expr G a -> Expr G a
       Bind : Expr G a -> (interpTy a -> Expr G b) -> Expr G b
 
+  lam_ : TTName -> Expr (a :: G) t -> Expr G (TyFun a t)
+  lam_ _ = Lam
+
   dsl expr
-      lambda = Lam
+      lambda = lam_
       variable = Var
       index_first = stop
       index_next = pop

--- a/test/dsl002/Resimp.idr
+++ b/test/dsl002/Resimp.idr
@@ -156,6 +156,11 @@ using (i: Fin n, gam : Vect n Ty, gam' : Vect n Ty, gam'' : Vect n Ty)
      = interp env v (\env', v' => do n <- v'
                                      interp env' (f n) k)
 
+  let_ : _ -> Creator (interpTy a) ->
+              Res (a :: gam) (Val () :: gam') (R t) ->
+              Res gam gam' (R t)
+  let_ _ = Let
+
 --   run : {static} Res [] [] (R t) -> IO t
 --   run prog = interp [] prog (\env, res => res)
 
@@ -163,7 +168,7 @@ syntax run [prog] = interp [] prog (\env, res => res)
 
 dsl res
    variable = id
-   let = Let
+   let = let_
    index_first = stop
    index_next = pop
 

--- a/test/dsl003/DSLPi.idr
+++ b/test/dsl003/DSLPi.idr
@@ -5,8 +5,11 @@ import Data.Vect
 
 data Ty = BOOL | INT | UNIT | ARR Ty Ty
 
+arr_ : _ -> Ty -> Ty -> Ty
+arr_ _ = ARR
+
 dsl simple_type
-  pi = ARR
+  pi = arr_
 
 test1 : simple_type (BOOL -> INT -> UNIT) = BOOL `ARR` (INT `ARR` UNIT)
 test1 = Refl
@@ -25,8 +28,11 @@ using (vars : Vect n Ty)
   implicit exprSpec : Expr vars BOOL -> Spec vars
   exprSpec = ItHolds
 
+  forall_ : _ -> (t : Ty) -> Spec (t :: vars) -> Spec vars
+  forall_ _ = ForAll
+
 dsl specs
-  pi = ForAll
+  pi = forall_
   variable = Var
   index_first = FZ
   index_next = FS

--- a/test/sourceLocation001/SourceLoc.idr
+++ b/test/sourceLocation001/SourceLoc.idr
@@ -54,6 +54,8 @@ using (ctxt : Vect n Ty)
   run (App f x)   env = !(run f env) !(run x env)
   run (Die {loc}) _   = Left loc
 
+  lam_ : _ -> Tm (t::ctxt) t' -> Tm ctxt (Arr t t')
+  lam_ _ = Lam
 
 exec : Tm [] t -> IO ()
 exec tm = case run tm [] of
@@ -64,7 +66,7 @@ dsl lang
   variable = Var
   index_first = FZ
   index_next = FS
-  lambda = Lam
+  lambda = lam_
 
 testTerm1 : Tm [] (Arr U U)
 testTerm1 = lang (\x=>Die)

--- a/test/sourceLocation001/expected
+++ b/test/sourceLocation001/expected
@@ -3,9 +3,9 @@ FileLoc "SourceLoc.idr" (16, 11) (16, 11)
 Testing using inline tactics
 FileLoc "SourceLoc.idr" (20, 17) (20, 17)
 Testing using metavariable with later definition
-FileLoc "SourceLoc.idr" (96, 16) (96, 16)
+FileLoc "SourceLoc.idr" (98, 16) (98, 16)
 -----------------------
 Success!
-Error at FileLoc "SourceLoc.idr" (70, 23) (70, 23)
+Error at FileLoc "SourceLoc.idr" (72, 23) (72, 23)
 Success!
 Success!


### PR DESCRIPTION
This PR supersedes #1969 with the addition of a CHANGELOG entry.