### PR TITLE
Allow DSLs to be applied with $

### DIFF
--- a/CHANGELOG
+++ b/CHANGELOG
@@ -19,7 +19,8 @@ New in 0.9.17:
   Specifically, the rewritten lambda, pi, and let binders will now get
   an extra argument of type TTName. This allows more understandable
   dynamic errors in DSL code and more readable code generation results.
-	
+* DSL notation can now be applied with $
+
 New in 0.9.16:
 --------------
 * Inductive-inductive definitions are now supported (i.e. simultaneously

--- a/src/Idris/ParseExpr.hs
+++ b/src/Idris/ParseExpr.hs
@@ -554,14 +554,8 @@ app syn = do f <- simpleExpr syn
              args <- many (do notEndApp; arg syn)
              case args of
                [] -> return f
-               _  -> return (dslify i (PApp fc f args)))
+               _  -> return (PApp fc f args))
        <?> "function application"
-  where
-    dslify :: IState -> PTerm -> PTerm
-    dslify i (PApp fc (PRef _ f) [a])
-        | [d] <- lookupCtxt f (idris_dsls i)
-            = desugar (syn { dsl_info = d }) i (getTm a)
-    dslify i t = t
 
 {-| Parses a function argument
 @


### PR DESCRIPTION
Given a DSL stlc with the usual definition, in the past it was necessary to write `stlc (\x => x)` because `stlc $ \x => x` didn't work. This makes that work. This is especially nice for DSLs that include do-blocks.