### PR TITLE
Fix minor bugs that result from other changes

### DIFF
--- a/libs/prelude/Language/Reflection/Errors.idr
+++ b/libs/prelude/Language/Reflection/Errors.idr
@@ -29,7 +29,7 @@ data Err = Msg String
          | NoTypeDecl TTName
          | NotInjective TT TT TT
          | CantResolve TT
-         | CantResolveAlts (List String)
+         | CantResolveAlts (List TTName)
          | IncompleteTerm TT
          | UniverseError
          | ProgramLineComment

--- a/src/Idris/ElabTerm.hs
+++ b/src/Idris/ElabTerm.hs
@@ -2600,7 +2600,7 @@ reflectErr (NotInjective t1 t2 t3) =
 reflectErr (CantResolve t) = raw_apply (Var $ reflErrName "CantResolve") [reflect t]
 reflectErr (CantResolveAlts ss) =
   raw_apply (Var $ reflErrName "CantResolveAlts")
-            [rawList (Var $ (sUN "String")) (map Var ss)]
+            [rawList (Var $ reflm "TTName") (map reflectName ss)]
 reflectErr (IncompleteTerm t) = raw_apply (Var $ reflErrName "IncompleteTerm") [reflect t]
 reflectErr UniverseError = Var $ reflErrName "UniverseError"
 reflectErr ProgramLineComment = Var $ reflErrName "ProgramLineComment"

--- a/src/Idris/ParseHelpers.hs
+++ b/src/Idris/ParseHelpers.hs
@@ -326,7 +326,7 @@ commentMarkers :: [String]
 commentMarkers = [ "--", "|||" ]
 
 invalidOperators :: [String]
-invalidOperators = [":", "=>", "->", "<-", "=", "?=", "|", "**", "==>", "\\", "%"]
+invalidOperators = [":", "=>", "->", "<-", "=", "?=", "|", "**", "==>", "\\", "%", "~", "?", "!"]
 
 -- | Parses an operator
 operator :: MonadicParsing m => m String

--- a/test/reg050/expected
+++ b/test/reg050/expected
@@ -1,15 +1,8 @@
-badbangop.idr:16:1:When elaborating right hand side of opUse:
-When elaborating an application of function Prelude.Monad.>>=:
-        Can't unify
-                List Integer
-        with
-                argTy -> retTy
-        
-        Specifically:
-                Can't unify
-                        List
-                with
-                        \{uv0} => argTy -> uv
+./badbangop.idr:7:1: error: ! is
+    not a valid
+    operator, expected: space
+(!) : List a -> Nat -> Maybe a 
+^                              
 ./baddoublebang.idr:6:28: error: unexpected
     Operator without known fixity:
     !!, expected: space


### PR DESCRIPTION
This fixes a problem where unquotations were being parsed as operator sections and a type error in error reflection resulting from a change to the underlying error type.