### PR TITLE
Breaking Changes: Align semantics of 'print' functions.

### DIFF
--- a/CHANGELOG
+++ b/CHANGELOG
@@ -20,6 +20,11 @@ New in 0.9.17:
   an extra argument of type TTName. This allows more understandable
   dynamic errors in DSL code and more readable code generation results.
 * DSL notation can now be applied with $
+* Effectful and IO function names for sending data to STDOUT have been
+  aligned, semantically.
+    + `print` is now for putting showable things to STDOUT.
+    + `printLn` is for putting showable things to STDOUT with a new line
+    + `putCharLn` for putting a single character to STDOUT, with a new line.
 
 New in 0.9.16:
 --------------
@@ -57,7 +62,7 @@ New in 0.9.15:
   solved automatically.
 * More efficient representation of proof state, leading to faster elaboration
   of large expressions.
-* EXPERIMENTAL Implementation of uniqueness types 
+* EXPERIMENTAL Implementation of uniqueness types
 * Unary negation now desugars to "negate", which is a method of the Neg type class.
   This allows instances of Num that can't be negative, like Nat, and it makes correct
   IEEE Float operations easier to encode. Additionally, unary negation is now available
@@ -71,12 +76,12 @@ New in 0.9.15:
   library (see #1516)
 * Terms in `code blocks` inside of documentation strings are now parsed and
   type checked. If this succeeds, they are rendered in full color in
-  documentation lookups, and with semantic highlighting for IDEs.  
+  documentation lookups, and with semantic highlighting for IDEs.
 * Fenced code blocks in docs defined with the "example" attribute are rendered
   as code examples.
 * Fenced code blocks declared to be Idris code that fail to parse or type check now
   provide error messages to IDE clients.
-* EXPERIMENTAL support for partial evaluation (Scrapping your Inefficient 
+* EXPERIMENTAL support for partial evaluation (Scrapping your Inefficient
   Engine style)
 
 New in 0.9.14:
@@ -153,7 +158,7 @@ New in 0.9.12:
   ||| @ n the first number (examined by the function)
   ||| @ m the second number (not examined)
   plus (n, m : Nat) -> Nat
-* Allow the auto-solve behaviour in the prover to be disabled, for easier 
+* Allow the auto-solve behaviour in the prover to be disabled, for easier
   debugging of proof automation. Use ":set autosolve" and ":unset autosolve".
 * Updated 'effects' library
 * New :apropos command at REPL to search documentation, names, and types
@@ -183,7 +188,7 @@ New in 0.9.11:
   write "with Vect [1,2,3]" at the REPL instead of "the (Vect _ _) [1,2,3]",
   because the Vect constructors are defined in a namespace called Vect.
 * assert_smaller internal function, which marks an expression as smaller than
-  a pattern for use in totality checking. 
+  a pattern for use in totality checking.
   e.g. "assert_smaller (x :: xs) (f xs)" asserts that "f xs" will always be
   structurally smaller than "(x :: xs)"
 * assert_total internal function, which marks a subexpression as assumed to
@@ -208,7 +213,7 @@ New in 0.9.10:
   types may now depend on earlier methods.
 * More flexible class instance resolution, so that function types and lambda
   expressions can be made instances of a type class.
-* Add !expr notation for implicit binding of intermediate results in 
+* Add !expr notation for implicit binding of intermediate results in
   monadic/do/etc expressions.
 * Extend Effects package to cope with possibly failing operations, using
   "if_valid", "if_error", etc.
@@ -333,7 +338,7 @@ User visible changes:
 Internal changes:
 
 * Separate inlining methods at compile-time and run-time
-* Fixed nested parameters blocks 
+* Fixed nested parameters blocks
 * Improve efficiency of elaborator by:
    - only normalising when necessary
    - reducing backtracking with resolving ambiguities
@@ -414,7 +419,7 @@ User visible changes:
 Internal changes:
 
 * Some type class resolution fixes
-* Several minor bug fixes 
+* Several minor bug fixes
 * Performance improvements in resolving overloading and type classes
 
 New in 0.9.1:
@@ -462,11 +467,10 @@ Complete rewrite. User visible changes:
 Internal changes:
 
 * Everything :-)
-* All definitions (functions, classes and instances) are elaborated to top 
-  level, fully explicit, data declarations and pattern matching definitions, 
-  which are verified by a minimal type checker. 
+* All definitions (functions, classes and instances) are elaborated to top
+  level, fully explicit, data declarations and pattern matching definitions,
+  which are verified by a minimal type checker.
 
 This is the first release of a complete reimplementation. There will be bugs.
-If you find any, please do not hesitate to contact Edwin Brady 
+If you find any, please do not hesitate to contact Edwin Brady
 (ecb10@st-andrews.ac.uk).
-

--- a/benchmarks/quasigroups/Main.idr
+++ b/benchmarks/quasigroups/Main.idr
@@ -14,11 +14,11 @@ main = do
         Left err => putStrLn err
         Right (_ ** (board ** legal)) => do
           putStrLn "Got board:"
-          print board
+          printLn board
           putStrLn "Solving..."
           case fillBoard board legal of
             Nothing => putStrLn "No solution found"
             Just (solved ** _) => do
               putStrLn "Solution found:"
-              print solved
+              printLn solved
     [self] => putStrLn ("Usage: " ++ self ++ " <board file>")

--- a/benchmarks/trivial/sortvec.idr
+++ b/benchmarks/trivial/sortvec.idr
@@ -13,7 +13,7 @@ vsort [] = []
 vsort (x :: xs) = insert x (vsort xs)
 
 mkSortVec : (n : Nat) -> Eff m [RND] (Vect n Int)
-mkSortVec Z = return [] 
+mkSortVec Z = return []
 mkSortVec (S k) = return (fromInteger !(rndInt 0 10000) :: !(mkSortVec k))
 
 main : IO ()
@@ -21,5 +21,4 @@ main = do (_ :: arg :: _) <- getArgs
 --           let arg = "2000"
           let vec = runPure [123456789] (mkSortVec (fromInteger (cast arg)))
           putStrLn "Made vector"
-          print (vsort vec)
-          
+          printLn (vsort vec)

--- a/contribs/lib/SQLite3/testunit.idr
+++ b/contribs/lib/SQLite3/testunit.idr
@@ -7,12 +7,12 @@ testexpr = do db <- open_db "somedb.db"
               let sql = (evalSQL [] ((SELECT ALL)(TBL ["tbl1"])  (OR (AND (MkCond (Equals (VCol "data")(VStr "data0"))) (MkCond (Equals (VCol "num")(VInt 1))) )  (MkCond (Equals (VCol "num")(VInt 2))))))
               let x = (fst sql) -- get the string
               let list = (snd sql) -- list of vals
-              liftIO(print x) -- use liftIO to turn this into DB type
+              liftIO(printLn x) -- use liftIO to turn this into DB type
               stmt <- (prepare_db db x) -- prepare the statement
               bindMulti stmt list  -- bind the values in the list
               exec_db_v2 stmt     -- execute the prepared query
               res <- toList_v1 db  -- toList_v1 to get the result
-              liftIO(print res)    -- print the result
+              liftIO(printLn res)    -- print the result
               finalize_db stmt     -- Statment pointer must be finalized in the end
               close_db db         -- close the datbase
               return ()
@@ -22,7 +22,7 @@ testupdate = do db <- open_db "somedb.db"
                 let sql = (evalSQL [] (UPDATE (TBL ["tbl1"]) (WHERE (SET (MkCond (Equals(VCol "data") (VStr "data600"))) ) (MkCond (Equals (VCol "num") (VInt 2))) ) ))
                 let x = (fst sql)
                 let list = (snd sql)
-                liftIO(print x)
+                liftIO(printLn x)
                 stmt <- (prepare_db db x)
                 bindMulti stmt list
                 exec_db_v2 stmt
@@ -35,7 +35,7 @@ testInsert = do db <- open_db "somedb.db"
                 let sql = (evalSQL [] (INSERT (TBL ["tbl1"]) [(VInt 3),(VStr "ham")]))
                 let x = (fst sql)
                 let list = (snd sql)
-                liftIO(print x)
+                liftIO(printLn x)
                 stmt <- (prepare_db db x)
                 bindMulti stmt list
                 exec_db_v2 stmt
@@ -48,12 +48,12 @@ testNull = do db <- open_db "somedb.db"
               let sql = (evalSQL [] ((SELECT ALL)(TBL ["tbl1"]) (MkCond (MkNULL (VCol "data")))))
               let x = (fst sql)
               let list = (snd sql)
-              liftIO(print x)
+              liftIO(printLn x)
               stmt <- (prepare_db db x)
               bindMulti stmt list
               exec_db_v2 stmt
               res <- toList_v1 db
-              liftIO(print res)
+              liftIO(printLn res)
               finalize_db stmt
               close_db db
               return ()
@@ -64,7 +64,7 @@ testInsertWithCond = do db <- open_db "somedb.db"
                         let sql = (evalSQL [] (INSERTC (TBL ["tbl1"]) [(VCol "data"),(VCol "num")] [(VInt 30),(VStr "inserthere")]))
                         let x = (fst sql)
                         let list = (snd sql)
-                        liftIO(print x)
+                        liftIO(printLn x)
                         stmt <- (prepare_db db x)
                         bindMulti stmt list
                         exec_db_v2 stmt
@@ -78,12 +78,12 @@ testNestedSel1 = do db <- open_db "somedb.db"
                     let sql = (evalSQL [] (SELECT (Cols ["data"]) (SELECT (Cols["num","data"]) (TBL ["tbl1"]) (MkCond (MkGT (VCol "num")(VInt 2))))Empty))
                     let x = (fst sql)
                     let list = (snd sql)
-                    liftIO(print x)
+                    liftIO(printLn x)
                     stmt <- (prepare_db db x)
                     bindMulti stmt list
                     exec_db_v2 stmt
                     res <- toList_v1 db
-                    liftIO(print res)
+                    liftIO(printLn res)
                     finalize_db stmt
                     close_db db
                     return ()
@@ -94,7 +94,7 @@ testCreateTable =  do db <- open_db "somedb.db"
                       let sql = (evalSQL [] (CREATE (TBL ["mynewtbl"]) [ ((VCol "col"),(CInt "int"),(None)) ] ) )
                       let x = (fst sql)
                       let list = (snd sql)
-                      liftIO(print x)
+                      liftIO(printLn x)
                       stmt <- (prepare_db db x)
                       bindMulti stmt list
                       exec_db_v2 stmt
@@ -108,12 +108,12 @@ testMultiTable = do db <- open_db "somedb.db"
                     let sql = (evalSQL [] ((SELECT ALL )(TBL ["mytable","tbl1"]) (Empty) ) )
                     let x = (fst sql)
                     let list = (snd sql)
-                    liftIO(print x)
+                    liftIO(printLn x)
                     stmt <- (prepare_db db x)
                     bindMulti stmt list
                     exec_db_v2 stmt
                     res <- toList_v1 db
-                    liftIO(print res)
+                    liftIO(printLn res)
                     finalize_db stmt
                     close_db db
                     return ()
@@ -123,12 +123,12 @@ testSelAll = do db <- open_db "somedb.db"
                 let sql = (evalSQL [] ((SELECT ALL )(TBL ["tbl1"]) (Empty) ) )
                 let x = (fst sql)
                 let list = (snd sql)
-                liftIO(print x)
+                liftIO(printLn x)
                 stmt <- (prepare_db db x)
                 bindMulti stmt list
                 exec_db_v2 stmt
                 res <- toList_v1 db
-                liftIO(print res)
+                liftIO(printLn res)
                 finalize_db stmt
                 close_db db
                 return ()

--- a/libs/base/Data/Heap.idr
+++ b/libs/base/Data/Heap.idr
@@ -182,8 +182,8 @@ isEmptySizeZeroNodeAbsurd = proof {
          does seem to work correctly!
 main : IO ()
 main = do
-  _ <- print $ main.sort [10, 3, 7, 2, 9, 1, 8, 0, 6, 4, 5]
-  _ <- print $ main.sort ["orange", "apple", "pear", "lime", "durian"]
-  _ <- print $ main.sort [("jim", 19, "cs"), ("alice", 20, "english"), ("bob", 50, "engineering")]
+  _ <- printLn $ main.sort [10, 3, 7, 2, 9, 1, 8, 0, 6, 4, 5]
+  _ <- printLn $ main.sort ["orange", "apple", "pear", "lime", "durian"]
+  _ <- printLn $ main.sort [("jim", 19, "cs"), ("alice", 20, "english"), ("bob", 50, "engineering")]
   return ()
 -}

--- a/libs/effects/Effect/Exception.idr
+++ b/libs/effects/Effect/Exception.idr
@@ -4,7 +4,7 @@ import Effects
 import System
 import Control.IOExcept
 
-data Exception : Type -> Effect where 
+data Exception : Type -> Effect where
      Raise : a -> { () } Exception a b
 
 instance Handler (Exception a) Maybe where
@@ -14,7 +14,7 @@ instance Handler (Exception a) List where
      handle _ (Raise e) k = []
 
 instance Show a => Handler (Exception a) IO where
-     handle _ (Raise e) k = do print e
+     handle _ (Raise e) k = do printLn e
                                believe_me (exit 1)
 
 instance Handler (Exception a) (IOExcept a) where
@@ -26,7 +26,7 @@ instance Handler (Exception a) (Either a) where
 EXCEPTION : Type -> EFFECT
 EXCEPTION t = MkEff () (Exception t)
 
-raise : a -> { [EXCEPTION a ] } Eff b 
+raise : a -> { [EXCEPTION a ] } Eff b
 raise err = call $ Raise err
 
 
@@ -39,4 +39,3 @@ raise err = call $ Raise err
 
 -- possibly add a 'handle' to the Eff language so that an alternative
 -- handler can be introduced mid interpretation?
-

--- a/libs/effects/Effect/StdIO.idr
+++ b/libs/effects/Effect/StdIO.idr
@@ -42,13 +42,17 @@ STDIO = MkEff () StdIO
 putStr : String -> { [STDIO] } Eff ()
 putStr s = call $ PutStr s
 
+||| Write a string to standard output, terminating with a newline.
+putStrLn : String -> { [STDIO] } Eff ()
+putStrLn s = putStr (s ++ "\n")
+
 ||| Write a character to standard output.
 putChar : Char -> { [STDIO] } Eff ()
 putChar c = call $ PutCh c
 
-||| Write a string to standard output, terminating with a newline.
-putStrLn : String -> { [STDIO] } Eff ()
-putStrLn s = putStr (s ++ "\n")
+||| Write a character to standard output, terminating with a newline.
+putCharLn : Char -> { [STDIO] } Eff ()
+putCharLn c = putStrLn (singleton c)
 
 ||| Read a string from standard input.
 getStr : { [STDIO] } Eff String

--- a/libs/oldeffects/Effect/Exception.idr
+++ b/libs/oldeffects/Effect/Exception.idr
@@ -4,7 +4,7 @@ import Effects
 import System
 import Control.IOExcept
 
-data Exception : Type -> Effect where 
+data Exception : Type -> Effect where
      Raise : a -> { () } Exception a b
 
 instance Handler (Exception a) Maybe where
@@ -14,7 +14,7 @@ instance Handler (Exception a) List where
      handle _ (Raise e) k = []
 
 instance Show a => Handler (Exception a) IO where
-     handle _ (Raise e) k = do print e
+     handle _ (Raise e) k = do printLn e
                                believe_me (exit 1)
 
 instance Handler (Exception a) (IOExcept a) where
@@ -26,7 +26,7 @@ instance Handler (Exception a) (Either a) where
 EXCEPTION : Type -> EFFECT
 EXCEPTION t = MkEff () (Exception t)
 
-raise : a -> { [EXCEPTION a ] } Eff m b 
+raise : a -> { [EXCEPTION a ] } Eff m b
 raise err = call $ Raise err
 
 
@@ -39,4 +39,3 @@ raise err = call $ Raise err
 
 -- possibly add a 'handle' to the Eff language so that an alternative
 -- handler can be introduced mid interpretation?
-

--- a/libs/prelude/Prelude.idr
+++ b/libs/prelude/Prelude.idr
@@ -442,20 +442,30 @@ putStr x = do prim_write x
 putStrLn : String -> IO' ffi ()
 putStrLn x = putStr (x ++ "\n")
 
-||| Output something showable to stdout, with a trailing newline
+||| Output something showable to stdout, without a trailing newline
 partial
 print : Show a => a -> IO' ffi ()
-print x = putStrLn (show x)
+print x = putStr (show x)
+
+||| Output something showable to stdout, with a trailing newline
+partial
+printLn : Show a => a -> IO' ffi ()
+printLn x = putStrLn (show x)
 
 ||| Read one line of input from stdin
 partial
 getLine : IO' ffi String
-getLine = prim_read 
+getLine = prim_read
 
 ||| Write a single character to stdout
 partial
 putChar : Char -> IO ()
-putChar c = foreign FFI_C "putchar" (Int -> IO ()) (cast c) 
+putChar c = foreign FFI_C "putchar" (Int -> IO ()) (cast c)
+
+||| Write a singel character to stdout, with a trailing newline
+partial
+putCharLn : Char -> IO ()
+putCharLn c = putStrLn (singleton c)
 
 ||| Read a single character from stdin
 partial
@@ -484,7 +494,7 @@ stderr = FHandle prim__stderr
 do_fopen : String -> String -> IO Ptr
 do_fopen f m
    = foreign FFI_C "fileOpen" (String -> String -> IO Ptr) f m
-   
+
 ||| Open a file
 ||| @ f the filename
 ||| @ m the mode as a String (`"r"`, `"w"`, or `"r+"`)

--- a/samples/binary.idr
+++ b/samples/binary.idr
@@ -41,7 +41,7 @@ adc (numx # bx) (numy # by) carry
 main : IO ()
 main = do let n1 = zero # b1 # b0 # b1 # b0
           let n2 = zero # b1 # b1 # b1 # b0
-          print (adc n1 n2 b0)
+          printLn (adc n1 n2 b0)
 
 
 
@@ -92,4 +92,3 @@ main.adc_lemma_1 = proof {
     rewrite sym (plusZeroRightNeutral c) ;
     trivial;
 }
-

--- a/samples/interp-alt.idr
+++ b/samples/interp-alt.idr
@@ -77,5 +77,5 @@ testFac : Int
 testFac = interp [] eFac 4
 
 main : IO ()
-main = do print test
-          print testFac
+main = do printLn test
+          printLn testFac

--- a/samples/interp.idr
+++ b/samples/interp.idr
@@ -88,5 +88,4 @@ testFac : Int
 testFac = interp [] eFac 4
 
 main : IO ()
-main = print testFac
-
+main = printLn testFac

--- a/samples/javaffi.idr
+++ b/samples/javaffi.idr
@@ -9,4 +9,4 @@ binom n k = mkForeign (FFun "IntMath.binomial" [FInt, FInt] FInt) n k
 main : IO ()
 main = do print "The number of possibilities in lotto is 49 choose 6:"
        	  res <- binom 49 6
-       	  print res
+       	  printLn res

--- a/test/basic002/test006.idr
+++ b/test/basic002/test006.idr
@@ -18,7 +18,7 @@ natToBin k with (parity k)
    natToBin (S (j + j)) | odd {n = j}  = True  :: natToBin j
 
 main : IO ()
-main = do print (natToBin 42)
+main = do printLn (natToBin 42)
 
 ---------- Proofs ----------
 

--- a/test/basic003/test027.idr
+++ b/test/basic003/test027.idr
@@ -19,7 +19,7 @@ using (Ord a, Num n)
   mprod (x :: xs) = x * mprod xs
 
 main : IO ()
-main = do print $ isort [1,5,3,5,1,9,8]
-          print $ msum [1..10]
-          print $ mprod [1..10]
+main = do printLn $ isort [1,5,3,5,1,9,8]
+          printLn $ msum [1..10]
+          printLn $ mprod [1..10]
 

--- a/test/basic004/test016.idr
+++ b/test/basic004/test016.idr
@@ -13,5 +13,5 @@ take (S n) (x :: xs) = x :: take n xs
 take n [] = []
 
 main : IO ()
-main = do print (take 10 (Main.countFrom 10))
+main = do printLn (take 10 (Main.countFrom 10))
 

--- a/test/basic005/test019.lidr
+++ b/test/basic005/test019.lidr
@@ -14,5 +14,5 @@
 >               |   False    =  ifFalse x
 
 > main : IO ()
-> main = print (test ((S 4) ==) 5 Oh)
+> main = printLn (test ((S 4) ==) 5 Oh)
 

--- a/test/basic006/test020.idr
+++ b/test/basic006/test020.idr
@@ -21,7 +21,7 @@ test : Integer -> String
 test x = "Number " ++ x
 
 main : IO ()
-main = do print (foo [1,2,3])
-          print (test 42)
+main = do printLn (foo [1,2,3])
+          printLn (test 42)
 
 

--- a/test/basic006/test020a.idr
+++ b/test/basic006/test020a.idr
@@ -16,5 +16,5 @@ foo : Vect n a -> List a
 foo xs = reverse xs
 
 main : IO ()
-main = print (foo [1,2,3])
+main = printLn (foo [1,2,3])
 

--- a/test/basic007/test033.idr
+++ b/test/basic007/test033.idr
@@ -1,4 +1,4 @@
 module Main
 
 main : IO ()
-main = nullPtr null >>= print
+main = nullPtr null >>= printLn

--- a/test/basic011/basic011.idr
+++ b/test/basic011/basic011.idr
@@ -3,14 +3,14 @@ module Main
 import Data.Hash
 
 main : IO ()
-main = do print $ hash (the Bits8 3)
-          print $ hash (the (List Bits8) [3])
-          print $ hash "hello world"
-          print $ hash 'a'
-          print $ hash (the Bits8 3)
-          print $ hash (the Bits16 3)
-          print $ hash (the Bits32 3)
-          print $ hash (the Bits64 3)
-          print $ hash (the Int 3)
-          print $ hash (the Integer 3)
+main = do printLn $ hash (the Bits8 3)
+          printLn $ hash (the (List Bits8) [3])
+          printLn $ hash "hello world"
+          printLn $ hash 'a'
+          printLn $ hash (the Bits8 3)
+          printLn $ hash (the Bits16 3)
+          printLn $ hash (the Bits32 3)
+          printLn $ hash (the Bits64 3)
+          printLn $ hash (the Int 3)
+          printLn $ hash (the Integer 3)
 

--- a/test/basic012/basic012.idr
+++ b/test/basic012/basic012.idr
@@ -1,7 +1,7 @@
 import Data.Vect
 import Control.Monad.State
 import Control.Monad.Identity
-  
+
 VThing : Type
 VThing = {n : Nat} -> Vect n Int -> Int
 
@@ -31,7 +31,7 @@ testfoo3 xs = foo 42 xs (bar 10)
 AnyST : Type -> Type -> Type
 AnyST s a = {m : _} -> Monad m => StateT s m a
 
-foost: AnyST Int ()
+foost : AnyST Int ()
 foost = do x <- get
            put x
 
@@ -52,11 +52,11 @@ tupleId f (a, b) = (f a, f b)
 
 AppendType : Type
 AppendType = {a, n, m : _} -> Vect n a -> Vect m a -> Vect (n + m) a
-    
+
 append : AppendType
 append [] ys = ys
 append (x :: xs) ys = x :: append xs ys
 
 main : IO ()
 main = do putStrLn (baz 42)
-          print (append [1,2,3] [4,5,6])
+          printLn (append [1,2,3] [4,5,6])

--- a/test/dsl001/test001.idr
+++ b/test/dsl001/test001.idr
@@ -96,8 +96,8 @@ testEnv : Int -> Env [TyInt,TyInt]
 testEnv x = [x,x]
 
 main : IO ()
-main = do { print testFac
-            print test }
+main = do { printLn testFac
+            printLn test }
 
 
 

--- a/test/effects002/test025.idr
+++ b/test/effects002/test025.idr
@@ -30,6 +30,6 @@ testMemory = do Src :- allocate 5
 
 main : IO ()
 main = ioe_run (runInit [Dst := (), Src := ()] testMemory)
-               (\err => print err) (\ok => print ok)
+               (\err => printLn err) (\ok => printLn ok)
 
 

--- a/test/io002/test008.idr
+++ b/test/io002/test008.idr
@@ -22,7 +22,7 @@ main = do (a, b) <- ioVals
           let x = "bar"
           putStrLn (show (getVal x 7 testlist))
           let ((y, z) :: _) = testlist
-          print z
+          printLn z
           case lookup x testlist of
                  Just v => putStrLn (show v)
                  Nothing => putStrLn "Not there!"

--- a/test/io003/test018a.idr
+++ b/test/io003/test018a.idr
@@ -27,7 +27,7 @@ mainProc = do mainID <- myID
 
 repeatIO : Int -> IO ()
 repeatIO 0 = return ()
-repeatIO n = do print n
+repeatIO n = do printLn n
                 run mainProc
                 repeatIO (n - 1)
 

--- a/test/primitives001/test005.idr
+++ b/test/primitives001/test005.idr
@@ -7,9 +7,9 @@ tlist : List Int
 tlist = [1, 2, 3, 4, 5]
 
 main : IO ()
-main = do print (abs (-8))
-          print (abs (S Z))
-          print (span isAlpha tstr)
-          print (break isDigit tstr)
-          print (span (\x => x < 3) tlist)
-          print (break (\x => x > 2) tlist)
+main = do printLn (abs (-8))
+          printLn (abs (S Z))
+          printLn (span isAlpha tstr)
+          printLn (break isDigit tstr)
+          printLn (span (\x => x < 3) tlist)
+          printLn (break (\x => x > 2) tlist)

--- a/test/proof003/test015.idr
+++ b/test/proof003/test015.idr
@@ -72,10 +72,10 @@ readNum = do putStr "Enter a number:"
 
 main : IO ()
 main = do let Just bin1 = natToBin 8 42
-          print bin1
+          printLn bin1
           let Just bin2 = natToBin 8 89
-          print bin2
-          print (adc bin1 bin2 b0)
+          printLn bin2
+          printLn (adc bin1 bin2 b0)
 
 
 

--- a/test/records001/test011.idr
+++ b/test/records001/test011.idr
@@ -20,9 +20,9 @@ person = MkPerson "Fred" 30
 main : IO ()
 main = do let x = record { name = "foo",
                            more_things = reverse ["a","b"] } testFoo
-          print $ name x
-          print $ name person
-          print $ things x
-          print $ more_things x
-          print $ age (record { age = 25 } person)
+          printLn $ name x
+          printLn $ name person
+          printLn $ things x
+          printLn $ more_things x
+          printLn $ age (record { age = 25 } person)
 

--- a/test/records003/records003.idr
+++ b/test/records003/records003.idr
@@ -38,10 +38,10 @@ test : Meeting 2015
 test = next_year idm_gbg
 
 main : IO ()
-main = do print (record { event->organiser->name } test)
-          print (record { event->organiser->age } test)
-          print (record { event->organiser->age } idm_gbg)
-          print (record { organiser->age } test)
-          print (record { organiser->age } idm_gbg)
-          print (record { year } idm_gbg)
+main = do printLn (record { event->organiser->name } test)
+          printLn (record { event->organiser->age } test)
+          printLn (record { event->organiser->age } idm_gbg)
+          printLn (record { organiser->age } test)
+          printLn (record { organiser->age } idm_gbg)
+          printLn (record { year } idm_gbg)
 

--- a/test/reg002/reg012.idr
+++ b/test/reg002/reg012.idr
@@ -30,4 +30,4 @@ swap (x :: Nil)     = x :: Nil
 swap (x :: y :: xs) = (y :: x :: (swap xs))
 
 main : IO ()
-main = print (swap [1,2,3,4,5])
+main = printLn (swap [1,2,3,4,5])

--- a/test/reg004/reg004.idr
+++ b/test/reg004/reg004.idr
@@ -13,4 +13,4 @@ h True = r2 where
   r2 = r
 
 main : IO ()
-main = do print (h True); print (h False)
+main = do printLn (h True); printLn (h False)

--- a/test/reg013/reg013.idr
+++ b/test/reg013/reg013.idr
@@ -2,7 +2,7 @@ module Main
 
 main : IO ()
 main = do
-  print $ prim_lenString "hallo"
-  print $ prim_lenString "1"
-  print $ prim_lenString ""
+  printLn $ prim_lenString "hallo"
+  printLn $ prim_lenString "1"
+  printLn $ prim_lenString ""
 

--- a/test/reg016/reg016.idr
+++ b/test/reg016/reg016.idr
@@ -1,11 +1,11 @@
 module Main
 
 main : IO ()
-main = do print $ the Integer 429496729500000000000000
---           print $ the Integer 4294967296
---           print $ the Integer 4294967297
---           print $ the Int 4294967295
---           print $ the Int 4294967296
---           print $ the Int 4294967297
+main = do printLn $ the Integer 429496729500000000000000
+--           printLn $ the Integer 4294967296
+--           printLn $ the Integer 4294967297
+--           printLn $ the Int 4294967295
+--           printLn $ the Int 4294967296
+--           printLn $ the Int 4294967297
 
 

--- a/test/reg017/reg017.idr
+++ b/test/reg017/reg017.idr
@@ -10,4 +10,4 @@ foo : { t : Type } ->
 foo {t} a {prfA = p} b c {prfBC} = b
 
 main : IO ()
-main = print $ foo 3 4 4
+main = printLn $ foo 3 4 4

--- a/test/reg018/reg018d.idr
+++ b/test/reg018/reg018d.idr
@@ -12,4 +12,4 @@ pull {n=S _} (FS n) (x :: xs) =
         (v, x::vs)
 
 main : IO ()
-main = print (pull FZ [0, 1, 2])
+main = printLn (pull FZ [0, 1, 2])

--- a/test/reg027/reg027.idr
+++ b/test/reg027/reg027.idr
@@ -27,6 +27,6 @@ foo = do val <- dbl
          \x => show val
 
 main : IO ()
-main = do print dbl
+main = do printLn dbl
           putStrLn (foo 3)
 

--- a/test/reg029/reg029.idr
+++ b/test/reg029/reg029.idr
@@ -7,5 +7,5 @@ import System
 
 main : IO ()
 main = do
-  print !(getEnv "IDRIS_REG029_NONEXISTENT_VAR")
-  print !(getEnv "IDRIS_REG029_EXISTENT_VAR")
+  printLn !(getEnv "IDRIS_REG029_NONEXISTENT_VAR")
+  printLn !(getEnv "IDRIS_REG029_EXISTENT_VAR")

--- a/test/reg031/reg031.idr
+++ b/test/reg031/reg031.idr
@@ -1,7 +1,7 @@
 module Main
 
 main : IO ()
-main = print . map val . unpack $ "\x0a\x80\xC9\xFF\n3\n4"
+main = printLn . map val . unpack $ "\x0a\x80\xC9\xFF\n3\n4"
   where
     -- make the values positive if the backend has signed chars
     val : Char -> Int

--- a/test/reg040/reg040.idr
+++ b/test/reg040/reg040.idr
@@ -4,4 +4,4 @@ io : IO Int
 io = return 42
 
 main : IO ()
-main = print $ unsafePerformIO io
+main = printLn $ unsafePerformIO io

--- a/test/reg042/reg042.idr
+++ b/test/reg042/reg042.idr
@@ -21,4 +21,4 @@ g (C x y z) = x + y
 -- Here, we'd apply the not-a-function to the erased argument 4,
 -- which would make the program go wrong.
 main : IO ()
-main = print $ g (proj 3 f 4)
+main = printLn $ g (proj 3 f 4)

--- a/test/reg045/reg045.idr
+++ b/test/reg045/reg045.idr
@@ -15,5 +15,5 @@ foo : ListZ Nat
 foo = (1 :: 2 :: 3 :: Nil)
 
 main : IO ()
-main = print foo
+main = printLn foo
 

--- a/test/reg052/reg052.idr
+++ b/test/reg052/reg052.idr
@@ -5,4 +5,4 @@ impure_int : IO Int
 impure_int = return 41
 
 main : IO ()
-main = impure_int >>= impure_op . prim__zextInt_B64 >>= print
+main = impure_int >>= impure_op . prim__zextInt_B64 >>= printLn

--- a/test/sourceLocation001/SourceLoc.idr
+++ b/test/sourceLocation001/SourceLoc.idr
@@ -36,7 +36,7 @@ using (ctxt : Vect n Ty)
     Var : (i : Fin n) -> Tm ctxt (index i ctxt)
     Lam : Tm (t::ctxt) t' -> Tm ctxt (Arr t t')
     App : Tm ctxt (Arr t t') -> Tm ctxt t -> Tm ctxt t'
-    ||| A term that makes the program halt and print where it halted
+    ||| A term that makes the program halt and printLn where it halted
     Die : {default tactics { sourceLocation } loc : SourceLocation} -> Tm ctxt t
 
   data Env : Vect n Ty -> Type where
@@ -83,11 +83,11 @@ testTerm4 = App testTerm3 MkU
 namespace Main
   main : IO ()
   main = do putStrLn "Testing using definition"
-            print fromRHS
+            printLn fromRHS
             putStrLn "Testing using inline tactics"
-            print fromProofScript
+            printLn fromProofScript
             putStrLn "Testing using metavariable with later definition"
-            print fromMetavar
+            printLn fromMetavar
             putStrLn "-----------------------"
             sequence_ $ with List [ exec testTerm1
                                   , exec testTerm2

--- a/test/sugar001/test007.idr
+++ b/test/sugar001/test007.idr
@@ -35,7 +35,7 @@ runEval env e with (eval e) {
 }
 
 main : IO ()
-main = do print [| (\x => x *2) (Just 4) |]
-          print [| plus (Just 4) (Just 5) |]
-          print (runEval [("x",21), ("y", 20)] (Add (Val 1) (Add (Var "x") (Var "y"))))
-          print (runEval [("x",21)] (Add (Val 1) (Add (Var "x") (Var "y"))))
+main = do printLn [| (\x => x *2) (Just 4) |]
+          printLn [| plus (Just 4) (Just 5) |]
+          printLn (runEval [("x",21), ("y", 20)] (Add (Val 1) (Add (Var "x") (Var "y"))))
+          printLn (runEval [("x",21)] (Add (Val 1) (Add (Var "x") (Var "y"))))

--- a/test/sugar004/sugar004.idr
+++ b/test/sugar004/sugar004.idr
@@ -9,7 +9,7 @@ foo x = let Just x' = x | Nothing => 100 in x'
 main : IO ()
 main = do [p, a] <- getArgs | [p] => putStrLn "No arguments!"
                             | (x :: y :: _) => putStrLn "Too many arguments!"
-          print (foo (Just (cast a)))
+          printLn (foo (Just (cast a)))
 
 {-
 

--- a/test/sugar005/As.idr
+++ b/test/sugar005/As.idr
@@ -24,13 +24,13 @@ same _ _ = Nothing
 
 namespace Main
   main : IO ()
-  main = do print $ isS 0
-            print $ isS 1
-            print $ hasS [0,0,0]
-            print $ hasS [0,1,2]
-            print $ isSS 5
-            print $ isSS 0
-            print $ same 1 1
-            print $ same 0 0
-            print $ same 1 0
+  main = do printLn $ isS 0
+            printLn $ isS 1
+            printLn $ hasS [0,0,0]
+            printLn $ hasS [0,1,2]
+            printLn $ isSS 5
+            printLn $ isSS 0
+            printLn $ same 1 1
+            printLn $ same 0 0
+            printLn $ same 1 0
 

--- a/test/totality004/totality004.idr
+++ b/test/totality004/totality004.idr
@@ -21,5 +21,5 @@ countStream : Nat -> Stream Nat
 countStream x = x :: countStream (x + 1)
 
 main : IO ()
-main = print (take 10 (process doubleInt (countStream 1)))
+main = printLn (take 10 (process doubleInt (countStream 1)))
 

--- a/test/totality004/totality004a.idr
+++ b/test/totality004/totality004a.idr
@@ -21,5 +21,5 @@ countStream : Nat -> Stream Nat
 countStream x = x :: countStream (x + 1)
 
 main : IO ()
-main = print (take 10 (process doubleInt (countStream 1)))
+main = printLn (take 10 (process doubleInt (countStream 1)))
 

--- a/test/totality005/totality005.idr
+++ b/test/totality005/totality005.idr
@@ -7,4 +7,4 @@ fib : Stream Nat
 fib = 0 :: zipWithS (+) fib (1 :: fib)
 
 partial main : IO ()
-main = print (take 15 fib)
+main = printLn (take 15 fib)

--- a/test/tutorial002/tutorial002.idr
+++ b/test/tutorial002/tutorial002.idr
@@ -34,7 +34,7 @@ intToNat x = if (x>0) then (S (intToNat (x-1))) else Z
 main : IO ()
 main = do putStr "Enter a number: "
           x <- getLine
-          print (natToBin (fromInteger (cast x)))
+          printLn (natToBin (fromInteger (cast x)))
 
 ---------- Proofs ----------
 


### PR DESCRIPTION
Address semantic differences in putting things to STDOUT. The changes are as follows:

+ `print` is for putting showable things to STDOUT.
+ `printLn` is for putting showable things to STDOUT with a new line
+ `putCharLn` for putting a single character to STDOUT, with a new line.

Effects has been updated accordingly.