### PR TITLE
Add the ability for IDEs to get documentation overviews

### DIFF
--- a/src/Idris/AbsSyntaxTree.hs
+++ b/src/Idris/AbsSyntaxTree.hs
@@ -336,6 +336,8 @@ data Codegen = Via String
 deriving instance NFData Codegen
 !-}
 
+data HowMuchDocs = FullDocs | OverviewDocs
+
 -- | REPL commands
 data Command = Quit
              | Help
@@ -343,7 +345,7 @@ data Command = Quit
              | NewDefn [PDecl] -- ^ Each 'PDecl' should be either a type declaration (at most one) or a clause defining the same name.
              | Undefine [Name]
              | Check PTerm
-             | DocStr (Either Name Const)
+             | DocStr (Either Name Const) HowMuchDocs
              | TotCheck Name
              | Reload
              | Load FilePath (Maybe Int) -- up to maximum line number

--- a/src/Idris/IdrisDoc.hs
+++ b/src/Idris/IdrisDoc.hs
@@ -273,7 +273,7 @@ loadDocs :: IState     -- ^ IState to extract infomation from
          -> Name       -- ^ Name to load Docs for
          -> IO (Maybe Docs)
 loadDocs ist n
-  | mayHaveDocs n = do docs <- runExceptT $ evalStateT (getDocs n) ist
+  | mayHaveDocs n = do docs <- runExceptT $ evalStateT (getDocs n FullDocs) ist
                        case docs of Right d -> return (Just d)
                                     Left _  -> return Nothing
   | otherwise     = return Nothing

--- a/src/Idris/Prover.hs
+++ b/src/Idris/Prover.hs
@@ -202,7 +202,7 @@ receiveInput h e =
             receiveInput h e
        Just (IdeMode.Interpret cmd) -> return (Just cmd)
        Just (IdeMode.TypeOf str) -> return (Just (":t " ++ str))
-       Just (IdeMode.DocsFor str) -> return (Just (":doc " ++ str))
+       Just (IdeMode.DocsFor str _) -> return (Just (":doc " ++ str))
        _ -> return Nothing
 
 ploop :: Name -> Bool -> String -> [String] -> ElabState EState -> Maybe History -> Idris (Term, [String])
@@ -336,7 +336,7 @@ ploop fn d prompt prf e h
                                                     return (False,  e, False, prf,
                                                             Right $ iRenderResult (vsep toShow)))
                                         (\err -> do putIState ist ; ierror err)
-               where showDoc ist (n, d) = do doc <- getDocs n
+               where showDoc ist (n, d) = do doc <- getDocs n FullDocs
                                              return $ pprintDocs ist doc
         docStr (Right c) = do ist <- getIState
                               return (False, e, False, prf, Right . iRenderResult $ pprintConstDocs ist c (constDocs c))

--- a/src/Idris/REPLParser.hs
+++ b/src/Idris/REPLParser.hs
@@ -258,9 +258,9 @@ cmd_doc name = do
     let constant = do
         c <- P.constant
         eof
-        return $ Right (DocStr (Right c))
+        return $ Right (DocStr (Right c) FullDocs)
 
-    let fnName = fnNameArg (\n -> DocStr (Left n)) name
+    let fnName = fnNameArg (\n -> DocStr (Left n) FullDocs) name
 
     try constant <|> fnName
 


### PR DESCRIPTION
This adds an optional second argument to the documentation command in the IDE protocol. If it is the symbol :overview, then only the overview part of the docstring is returned.

This is intended for use in things like completion engines or Emacs's `eldoc`.