### PR TITLE
Better error message for qed in expressions

### DIFF
--- a/src/Idris/ElabTerm.hs
+++ b/src/Idris/ElabTerm.hs
@@ -1850,6 +1850,7 @@ runTac autoSolve ist perhapsFC fn tac
         Just fc ->
           do fill $ reflectFC fc
              solve
+    runT Qed = lift . tfail $ Msg "The qed command is only valid in the interactive prover"
     runT x = fail $ "Not implemented " ++ show x
 
     runReflected t = do t' <- reify ist t


### PR DESCRIPTION
The "qed" tactic is really more of a prover command than a tactic per
se. This patch makes it so that the user is informed of this, rather
than having the system throw an internal error.

Fixes #1790.