### PR TITLE
Proposed revision of Algebra.idr: Classes beyond Field moved to two base libraries

### DIFF
--- a/idris.cabal
+++ b/idris.cabal
@@ -99,6 +99,7 @@ Extra-source-files:
                        libs/base/base.ipkg
                        libs/base/*.idr
                        libs/base/Control/*.idr
+                       libs/base/Control/Algebra/*.idr
                        libs/base/Control/Isomorphism/*.idr
                        libs/base/Control/Monad/*.idr
                        libs/base/Data/*.idr

--- a/libs/base/Control/Algebra/Lattice.idr
+++ b/libs/base/Control/Algebra/Lattice.idr
@@ -1,0 +1,140 @@
+module Control.Algebra.Lattice
+
+
+||| Sets equipped with a binary operation that is commutative, associative and
+||| idempotent.  Must satisfy the following laws:
+|||
+||| + Associativity of join:
+|||     forall a b c, join a (join b c) == join (join a b) c
+||| + Commutativity of join:
+|||     forall a b,   join a b          == join b a
+||| + Idempotency of join:
+|||     forall a,     join a a          == a
+|||
+||| Join semilattices capture the notion of sets with a "least upper bound".
+class JoinSemilattice a where
+  join : a -> a -> a
+
+class JoinSemilattice a => VerifiedJoinSemilattice a where
+  total joinSemilatticeJoinIsAssociative : (l, c, r : a) -> join l (join c r) = join (join l c) r
+  total joinSemilatticeJoinIsCommutative : (l, r : a)    -> join l r = join r l
+  total joinSemilatticeJoinIsIdempotent  : (e : a)       -> join e e = e
+
+||| Sets equipped with a binary operation that is commutative, associative and
+||| idempotent.  Must satisfy the following laws:
+|||
+||| + Associativity of meet:
+|||     forall a b c, meet a (meet b c) == meet (meet a b) c
+||| + Commutativity of meet:
+|||     forall a b,   meet a b          == meet b a
+||| + Idempotency of meet:
+|||     forall a,     meet a a          == a
+|||
+||| Meet semilattices capture the notion of sets with a "greatest lower bound".
+class MeetSemilattice a where
+  meet : a -> a -> a
+
+class MeetSemilattice a => VerifiedMeetSemilattice a where
+  total meetSemilatticeMeetIsAssociative : (l, c, r : a) -> meet l (meet c r) = meet (meet l c) r
+  total meetSemilatticeMeetIsCommutative : (l, r : a)    -> meet l r = meet r l
+  total meetSemilatticeMeetIsIdempotent  : (e : a)       -> meet e e = e
+
+||| Sets equipped with a binary operation that is commutative, associative and
+||| idempotent and supplied with a unitary element.  Must satisfy the following
+||| laws:
+|||
+||| + Associativity of join:
+|||     forall a b c, join a (join b c) == join (join a b) c
+||| + Commutativity of join:
+|||     forall a b,   join a b          == join b a
+||| + Idempotency of join:
+|||     forall a,     join a a          == a
+||| + Bottom (Unitary Element):
+|||     forall a,     join a bottom     == a
+|||
+|||  Join semilattices capture the notion of sets with a "least upper bound"
+|||  equipped with a "bottom" element.
+class JoinSemilattice a => BoundedJoinSemilattice a where
+  bottom  : a
+
+class (VerifiedJoinSemilattice a, BoundedJoinSemilattice a) => VerifiedBoundedJoinSemilattice a where
+  total boundedJoinSemilatticeBottomIsBottom : (e : a) -> join e bottom = e
+
+||| Sets equipped with a binary operation that is commutative, associative and
+||| idempotent and supplied with a unitary element.  Must satisfy the following
+||| laws:
+|||
+||| + Associativity of meet:
+|||     forall a b c, meet a (meet b c) == meet (meet a b) c
+||| + Commutativity of meet:
+|||     forall a b,   meet a b          == meet b a
+||| + Idempotency of meet:
+|||     forall a,     meet a a          == a
+||| +  Top (Unitary Element):
+|||     forall a,     meet a top        == a
+|||
+||| Meet semilattices capture the notion of sets with a "greatest lower bound"
+||| equipped with a "top" element.
+class MeetSemilattice a => BoundedMeetSemilattice a where
+  top : a
+
+class (VerifiedMeetSemilattice a, BoundedMeetSemilattice a) => VerifiedBoundedMeetSemilattice a where
+  total boundedMeetSemilatticeTopIsTop : (e : a) -> meet e top = e
+
+||| Sets equipped with two binary operations that are both commutative,
+||| associative and idempotent, along with absorbtion laws for relating the two
+||| binary operations.  Must satisfy the following:
+|||
+||| + Associativity of meet and join:
+|||     forall a b c, meet a (meet b c) == meet (meet a b) c
+|||     forall a b c, join a (join b c) == join (join a b) c
+||| + Commutativity of meet and join:
+|||     forall a b,   meet a b          == meet b a
+|||     forall a b,   join a b          == join b a
+||| + Idempotency of meet and join:
+|||     forall a,     meet a a          == a
+|||     forall a,     join a a          == a
+||| + Absorbtion laws for meet and join:
+|||     forall a b,   meet a (join a b) == a
+|||     forall a b,   join a (meet a b) == a
+class (JoinSemilattice a, MeetSemilattice a) => Lattice a where { }
+
+class (VerifiedJoinSemilattice a, VerifiedMeetSemilattice a) => VerifiedLattice a where
+  total latticeMeetAbsorbsJoin : (l, r : a) -> meet l (join l r) = l
+  total latticeJoinAbsorbsMeet : (l, r : a) -> join l (meet l r) = l
+
+||| Sets equipped with two binary operations that are both commutative,
+||| associative and idempotent and supplied with neutral elements, along with
+||| absorbtion laws for relating the two binary operations.  Must satisfy the
+||| following:
+|||
+||| + Associativity of meet and join:
+|||     forall a b c, meet a (meet b c) == meet (meet a b) c
+|||     forall a b c, join a (join b c) == join (join a b) c
+||| +  Commutativity of meet and join:
+|||     forall a b,   meet a b          == meet b a
+|||     forall a b,   join a b          == join b a
+||| + Idempotency of meet and join:
+|||     forall a,     meet a a          == a
+|||     forall a,     join a a          == a
+||| + Absorbtion laws for meet and join:
+|||     forall a b,   meet a (join a b) == a
+|||     forall a b,   join a (meet a b) == a
+||| + Neutral for meet and join:
+|||     forall a,     meet a top        == top
+|||     forall a,     join a bottom     == bottom
+class (BoundedJoinSemilattice a, BoundedMeetSemilattice a) => BoundedLattice a where { }
+
+class (VerifiedBoundedJoinSemilattice a, VerifiedBoundedMeetSemilattice a, VerifiedLattice a) => VerifiedBoundedLattice a where { }
+
+
+instance MeetSemilattice Nat where
+  meet = minimum
+
+instance JoinSemilattice Nat where
+  join = maximum
+
+instance Lattice Nat where { }
+
+instance BoundedJoinSemilattice Nat where
+  bottom = Z

--- a/libs/base/Control/Algebra/VectorSpace.idr
+++ b/libs/base/Control/Algebra/VectorSpace.idr
@@ -1,0 +1,35 @@
+module Control.Algebra.VectorSpace
+
+
+infixl 5 <#>
+infixr 2 <||>
+
+
+||| A module over a ring is an additive abelian group of 'vectors' endowed with a
+||| scale operation multiplying vectors by ring elements, and distributivity laws
+||| relating the scale operation to both ring addition and module addition.
+||| Must satisfy the following laws:
+|||
+||| + Compatibility of scalar multiplication with ring multiplication:
+|||     forall a b v,  a <#> (b <#> v) = (a <.> b) <#> v
+||| + Ring unity is the identity element of scalar multiplication:
+|||     forall v,      unity <#> v = v
+||| + Distributivity of `<#>` and `<+>`:
+|||     forall a v w,  a <#> (v <+> w) == (a <#> v) <+> (a <#> w)
+|||     forall a b v,  (a <+> b) <#> v == (a <#> v) <+> (b <#> v)
+class (RingWithUnity a, AbelianGroup b) => Module a b where
+  (<#>) : a -> b -> b
+
+class (VerifiedRingWithUnity a, VerifiedAbelianGroup b, Module a b) => VerifiedModule a b where
+  total moduleScalarMultiplyComposition : (x,y : a) -> (v : b) -> x <#> (y <#> v) = (x <.> y) <#> v
+  total moduleScalarUnityIsUnity : (v : b) -> unity {a} <#> v = v
+  total moduleScalarMultDistributiveWRTVectorAddition : (s : a) -> (v, w : b) -> s <#> (v <+> w) = (s <#> v) <+> (s <#> w)
+  total moduleScalarMultDistributiveWRTModuleAddition : (s, t : a) -> (v : b) -> (s <+> t) <#> v = (s <#> v) <+> (t <#> v)
+
+||| A vector space is a module over a ring that is also a field
+class (Field a, Module a b) => VectorSpace a b where {}
+
+class Module a b => InnerProductSpace a b where
+  (<||>) : b -> b -> a
+
+class (VerifiedField a, VerifiedModule a b) => VerifiedVectorSpace a b where {}

--- a/libs/base/Control/Algebra/VectorSpace.idr
+++ b/libs/base/Control/Algebra/VectorSpace.idr
@@ -29,6 +29,8 @@ class (VerifiedRingWithUnity a, VerifiedAbelianGroup b, Module a b) => VerifiedM
 ||| A vector space is a module over a ring that is also a field
 class (Field a, Module a b) => VectorSpace a b where {}
 
+||| An inner product space is a module – or vector space – over a ring, with a binary function
+||| associating a ring value to each pair of vectors.
 class Module a b => InnerProductSpace a b where
   (<||>) : b -> b -> a
 

--- a/libs/base/Data/Heap.idr
+++ b/libs/base/Data/Heap.idr
@@ -5,6 +5,8 @@
 
 module Data.Heap
 
+import Control.Algebra.Lattice
+
 %default total
 %access public
 

--- a/libs/base/Data/Matrix.idr
+++ b/libs/base/Data/Matrix.idr
@@ -203,7 +203,7 @@ instance RingWithUnity Float where
   unity = 1
 
 instance Field Float where
-  inverseM f = 1 / f
+  inverseM f _ = 1 / f
 
 
 instance Semigroup Nat where

--- a/libs/base/Data/Matrix.idr
+++ b/libs/base/Data/Matrix.idr
@@ -4,6 +4,7 @@ import Data.Complex
 import Data.ZZ
 import Data.Fin
 import Data.Vect
+import Control.Algebra.VectorSpace
 
 %default total
 
@@ -38,8 +39,7 @@ instance Ring a => Ring (Vect n a) where
 instance RingWithUnity a => RingWithUnity (Vect n a) where
   unity {n} = replicate n unity
 
-instance Field a => Field (Vect n a) where
-  inverseM = map inverseM
+--instance Field a => Field (Vect n a)
 
 instance RingWithUnity a => Module a (Vect n a) where
   (<#>) r v = map (r <.>) v

--- a/libs/base/base.ipkg
+++ b/libs/base/base.ipkg
@@ -33,6 +33,7 @@ modules = System,
           Control.Monad.RWS,
           Control.Monad.Trans,
           Control.Monad.State, Control.Monad.Writer, Control.Monad.Reader,
+          Control.Algebra.Lattice, Control.Algebra.VectorSpace,
           Control.Category, Control.Arrow,
           Control.Catchable, Control.IOExcept
 

--- a/libs/prelude/Builtins.idr
+++ b/libs/prelude/Builtins.idr
@@ -36,7 +36,8 @@ namespace Builtins
   ||| it. Another way to see dependent pairs is as just data - for instance, the
   ||| length of a vector paired with that vector.
   |||
-  |||  @ a the type of the witness @ P the type of the proof
+  |||  @ a the type of the witness
+  |||  @ P the type of the proof
   data Sigma : (a : Type) -> (P : a -> Type) -> Type where
       MkSigma : .{P : a -> Type} -> (x : a) -> (pf : P x) -> Sigma a P
 

--- a/libs/prelude/Prelude/Algebra.idr
+++ b/libs/prelude/Prelude/Algebra.idr
@@ -6,7 +6,6 @@ import Builtins
 infixl 6 <->
 infixl 6 <+>
 infixl 6 <.>
-infixl 5 <#>
 
 %access public
 
@@ -139,137 +138,10 @@ class (VerifiedRing a, RingWithUnity a) => VerifiedRingWithUnity a where
   total ringWithUnityIsUnityL : (l : a) -> l <.> unity = l
   total ringWithUnityIsUnityR : (r : a) -> unity <.> r = r
 
-||| Sets equipped with a binary operation that is commutative, associative and
-||| idempotent.  Must satisfy the following laws:
-|||
-||| + Associativity of join:
-|||     forall a b c, join a (join b c) == join (join a b) c
-||| + Commutativity of join:
-|||     forall a b,   join a b          == join b a
-||| + Idempotency of join:
-|||     forall a,     join a a          == a
-|||
-||| Join semilattices capture the notion of sets with a "least upper bound".
-class JoinSemilattice a where
-  join : a -> a -> a
-
-class JoinSemilattice a => VerifiedJoinSemilattice a where
-  total joinSemilatticeJoinIsAssociative : (l, c, r : a) -> join l (join c r) = join (join l c) r
-  total joinSemilatticeJoinIsCommutative : (l, r : a)    -> join l r = join r l
-  total joinSemilatticeJoinIsIdempotent  : (e : a)       -> join e e = e
-
-||| Sets equipped with a binary operation that is commutative, associative and
-||| idempotent.  Must satisfy the following laws:
-|||
-||| + Associativity of meet:
-|||     forall a b c, meet a (meet b c) == meet (meet a b) c
-||| + Commutativity of meet:
-|||     forall a b,   meet a b          == meet b a
-||| + Idempotency of meet:
-|||     forall a,     meet a a          == a
-|||
-||| Meet semilattices capture the notion of sets with a "greatest lower bound".
-class MeetSemilattice a where
-  meet : a -> a -> a
-
-class MeetSemilattice a => VerifiedMeetSemilattice a where
-  total meetSemilatticeMeetIsAssociative : (l, c, r : a) -> meet l (meet c r) = meet (meet l c) r
-  total meetSemilatticeMeetIsCommutative : (l, r : a)    -> meet l r = meet r l
-  total meetSemilatticeMeetIsIdempotent  : (e : a)       -> meet e e = e
-
-||| Sets equipped with a binary operation that is commutative, associative and
-||| idempotent and supplied with a unitary element.  Must satisfy the following
-||| laws:
-|||
-||| + Associativity of join:
-|||     forall a b c, join a (join b c) == join (join a b) c
-||| + Commutativity of join:
-|||     forall a b,   join a b          == join b a
-||| + Idempotency of join:
-|||     forall a,     join a a          == a
-||| + Bottom (Unitary Element):
-|||     forall a,     join a bottom     == a
-|||
-|||  Join semilattices capture the notion of sets with a "least upper bound"
-|||  equipped with a "bottom" element.
-class JoinSemilattice a => BoundedJoinSemilattice a where
-  bottom  : a
-
-class (VerifiedJoinSemilattice a, BoundedJoinSemilattice a) => VerifiedBoundedJoinSemilattice a where
-  total boundedJoinSemilatticeBottomIsBottom : (e : a) -> join e bottom = e
-
-||| Sets equipped with a binary operation that is commutative, associative and
-||| idempotent and supplied with a unitary element.  Must satisfy the following
-||| laws:
-|||
-||| + Associativity of meet:
-|||     forall a b c, meet a (meet b c) == meet (meet a b) c
-||| + Commutativity of meet:
-|||     forall a b,   meet a b          == meet b a
-||| + Idempotency of meet:
-|||     forall a,     meet a a          == a
-||| +  Top (Unitary Element):
-|||     forall a,     meet a top        == a
-|||
-||| Meet semilattices capture the notion of sets with a "greatest lower bound"
-||| equipped with a "top" element.
-class MeetSemilattice a => BoundedMeetSemilattice a where
-  top : a
-
-class (VerifiedMeetSemilattice a, BoundedMeetSemilattice a) => VerifiedBoundedMeetSemilattice a where
-  total boundedMeetSemilatticeTopIsTop : (e : a) -> meet e top = e
-
-||| Sets equipped with two binary operations that are both commutative,
-||| associative and idempotent, along with absorbtion laws for relating the two
-||| binary operations.  Must satisfy the following:
-|||
-||| + Associativity of meet and join:
-|||     forall a b c, meet a (meet b c) == meet (meet a b) c
-|||     forall a b c, join a (join b c) == join (join a b) c
-||| + Commutativity of meet and join:
-|||     forall a b,   meet a b          == meet b a
-|||     forall a b,   join a b          == join b a
-||| + Idempotency of meet and join:
-|||     forall a,     meet a a          == a
-|||     forall a,     join a a          == a
-||| + Absorbtion laws for meet and join:
-|||     forall a b,   meet a (join a b) == a
-|||     forall a b,   join a (meet a b) == a
-class (JoinSemilattice a, MeetSemilattice a) => Lattice a where { }
-
-class (VerifiedJoinSemilattice a, VerifiedMeetSemilattice a) => VerifiedLattice a where
-  total latticeMeetAbsorbsJoin : (l, r : a) -> meet l (join l r) = l
-  total latticeJoinAbsorbsMeet : (l, r : a) -> join l (meet l r) = l
-
-||| Sets equipped with two binary operations that are both commutative,
-||| associative and idempotent and supplied with neutral elements, along with
-||| absorbtion laws for relating the two binary operations.  Must satisfy the
-||| following:
-|||
-||| + Associativity of meet and join:
-|||     forall a b c, meet a (meet b c) == meet (meet a b) c
-|||     forall a b c, join a (join b c) == join (join a b) c
-||| +  Commutativity of meet and join:
-|||     forall a b,   meet a b          == meet b a
-|||     forall a b,   join a b          == join b a
-||| + Idempotency of meet and join:
-|||     forall a,     meet a a          == a
-|||     forall a,     join a a          == a
-||| + Absorbtion laws for meet and join:
-|||     forall a b,   meet a (join a b) == a
-|||     forall a b,   join a (meet a b) == a
-||| + Neutral for meet and join:
-|||     forall a,     meet a top        == top
-|||     forall a,     join a bottom     == bottom
-class (BoundedJoinSemilattice a, BoundedMeetSemilattice a) => BoundedLattice a where { }
-
-class (VerifiedBoundedJoinSemilattice a, VerifiedBoundedMeetSemilattice a, VerifiedLattice a) => VerifiedBoundedLattice a where { }
-
---   Fields.
-||| Sets equipped with two binary operations, both associative and commutative
-||| supplied with a neutral element, with
-||| distributivity laws relating the two operations.  Must satisfy the following
-||| laws:
+||| Sets equipped with two binary operations – both associative, commutative and
+||| possessing a neutral element – and distributivity laws relating the two 
+||| operations. All elements except the additive identity must have a 
+||| multiplicative inverse. Must satisfy the following laws:
 |||
 ||| + Associativity of `<+>`:
 |||     forall a b c, a <+> (b <+> c) == (a <+> b) <+> c
@@ -286,9 +158,9 @@ class (VerifiedBoundedJoinSemilattice a, VerifiedBoundedMeetSemilattice a, Verif
 ||| + Unity for `<.>`:
 |||     forall a,     a <.> unity     == a
 |||     forall a,     unity <.> a     == a
-||| + InverseM of `<.>`:
-|||     forall a,     a <.> inverseM a == unity
-|||     forall a,     inverseM a <.> a == unity
+||| + InverseM of `<.>`, except for neutral
+|||     forall a /= neutral,  a <.> inverseM a == unity
+|||     forall a /= neutral,  inverseM a <.> a == unity
 ||| + Distributivity of `<.>` and `<->`:
 |||     forall a b c, a <.> (b <+> c) == (a <.> b) <+> (a <.> c)
 |||     forall a b c, (a <+> b) <.> c == (a <.> c) <+> (b <.> c)
@@ -299,31 +171,6 @@ class (VerifiedRing a, Field a) => VerifiedField a where
   total fieldInverseIsInverseL : (l : a) -> l <.> inverseM l = unity
   total fieldInverseIsInverseR : (r : a) -> inverseM r <.> r = unity
 
-||| A module over a ring is an additive abelian group of 'vectors' endowed with a
-||| scale operation multiplying vectors by ring elements, and distributivity laws
-||| relating the scale operation to both ring addition and module addition.
-||| Must satisfy the following laws:
-|||
-||| + Compatibility of scalar multiplication with ring multiplication:
-|||     forall a b v,  a <#> (b <#> v) = (a <.> b) <#> v
-||| + Ring unity is the identity element of scalar multiplication:
-|||     forall v,      unity <#> v = v
-||| + Distributivity of `<#>` and `<+>`:
-|||     forall a v w,  a <#> (v <+> w) == (a <#> v) <+> (a <#> w)
-|||     forall a b v,  (a <+> b) <#> v == (a <#> v) <+> (b <#> v)
-class (RingWithUnity a, AbelianGroup b) => Module a b where
-  (<#>) : a -> b -> b
-
-class (VerifiedRingWithUnity a, VerifiedAbelianGroup b, Module a b) => VerifiedModule a b where
-  total moduleScalarMultiplyComposition : (x,y : a) -> (v : b) -> x <#> (y <#> v) = (x <.> y) <#> v
-  total moduleScalarUnityIsUnity : (v : b) -> unity {a} <#> v = v
-  total moduleScalarMultDistributiveWRTVectorAddition : (s : a) -> (v, w : b) -> s <#> (v <+> w) = (s <#> v) <+> (s <#> w)
-  total moduleScalarMultDistributiveWRTModuleAddition : (s, t : a) -> (v : b) -> (s <+> t) <#> v = (s <#> v) <+> (t <#> v)
-
-||| A vector space is a module over a ring that is also a field
-class (Field a, Module a b) => VectorSpace a b where {}
-
-class (VerifiedField a, VerifiedModule a b) => VerifiedVectorSpace a b where {}
 
 -- XXX todo:
 --   Structures where "abs" make sense.

--- a/libs/prelude/Prelude/Algebra.idr
+++ b/libs/prelude/Prelude/Algebra.idr
@@ -1,6 +1,8 @@
 module Prelude.Algebra
 
 import Builtins
+import Prelude.Classes
+import Prelude.Bool
 
 -- XXX: change?
 infixl 6 <->
@@ -164,12 +166,12 @@ class (VerifiedRing a, RingWithUnity a) => VerifiedRingWithUnity a where
 ||| + Distributivity of `<.>` and `<->`:
 |||     forall a b c, a <.> (b <+> c) == (a <.> b) <+> (a <.> c)
 |||     forall a b c, (a <+> b) <.> c == (a <.> c) <+> (b <.> c)
-class RingWithUnity a => Field a where
-  inverseM : a -> a
+class (RingWithUnity a, Eq a) => Field a where
+  inverseM : (x : a) -> (notId : x == neutral = False) -> a
 
 class (VerifiedRing a, Field a) => VerifiedField a where
-  total fieldInverseIsInverseL : (l : a) -> l <.> inverseM l = unity
-  total fieldInverseIsInverseR : (r : a) -> inverseM r <.> r = unity
+  total fieldInverseIsInverseL : (l : a) -> (notId : l == neutral = False) -> l <.> (inverseM l notId) = unity
+  total fieldInverseIsInverseR : (r : a) -> (notId : r == neutral = False) -> (inverseM r notId) <.> r = unity
 
 
 -- XXX todo:

--- a/libs/prelude/Prelude/Nat.idr
+++ b/libs/prelude/Prelude/Nat.idr
@@ -239,18 +239,6 @@ instance Monoid Multiplicative where
 instance Monoid Additive where
   neutral = getAdditive Z
 
-instance MeetSemilattice Nat where
-  meet = minimum
-
-instance JoinSemilattice Nat where
-  join = maximum
-
-instance Lattice Nat where { }
-
-instance BoundedJoinSemilattice Nat where
-  bottom = Z
-
-
 ||| Casts negative `Ints` to 0.
 instance Cast Int Nat where
   cast i = fromInteger (cast i)


### PR DESCRIPTION
There has been a lot of interest in cleaning up the Prelude, and Algebra.idr is rightfully considered a prime target: A lot of stuff in there is clearly not going to be used in typical idris programs. On the other hand, the most basic algebraic classes may frequently be useful, and are in fact used in the Prelude and probably elsewhere.

Therefore I propose this modest revision of Algebra.idr that cuts it almost in half, and moves the rest into base while preserving sensible conceptual units. In particular, the classes beyond Field are moved to `Control.Algebra.Lattice` and `Control.Algebra.VectorSpace`, both of which are self-contained.

This PR also fixes the definition of Field to be correct (inverse is defined only for non-zero elements). And also a minor, unrelated docstring formatting blemish (Sigma).

A couple comments and notes:

* While Field is now correct, there may be a way to do it better. the signature of `inverseM` is now `(x : a) -> (notId : x == neutral = False) -> a`, which means that Fields must be an instance of Eq, and that Classes and Bool must be imported.
* A few of the Lattice classes are instantiated in Nat.idr. For now I simply put these in the Lattice.idr file. They could instead go into their own file Algebra/Lattice/Nat.idr if we like, but it didn't seem worth it.
* The moved classes are also referenced by a couple base libraries, namely Heap now imports Lattice while Matrix imports VectorSpace.