### PR TITLE
Add "ship it" tactic, aliased to qed

### DIFF
--- a/src/Idris/ParseExpr.hs
+++ b/src/Idris/ParseExpr.hs
@@ -1234,6 +1234,7 @@ Tactic ::= 'intro' NameList?
        |   'term'
        |   'undo'
        |   'qed'
+       |   'shipIt'
        |   'abandon'
        |   ':' 'q'
        ;
@@ -1316,6 +1317,7 @@ tactics =
   , noArgs ["term"] ProofTerm
   , noArgs ["undo"] Undo
   , noArgs ["qed"] Qed
+  , noArgs ["shipIt"] Qed
   , noArgs ["abandon", ":q"] Abandon
   , noArgs ["skip"] Skip
   , noArgs ["sourceLocation"] SourceFC


### PR DESCRIPTION
I feel like an academic when saying "quod erat demonstrandum" - while
Idris is a research language, I think we need to be more practical.

I propose we start following Edwin's philosophy:

https://twitter.com/edwinbrady/status/431415892233428992

Which gives a better interactive proof session:

    Type checking ./Main.idr
    Metavariables: Main.onePlusOneIsTwo
    *Main> :p onePlusOneIsTwo

    ----------                 Goal:                  ----------
    {hole0} : 2 = 2
    -Main.onePlusOneIsTwo> trivial
    onePlusOneIsTwo: No more goals.
    -Main.onePlusOneIsTwo> shipIt
    Proof completed!
    Main.onePlusOneIsTwo = proof
      trivial

We should also consider using "move_fast_and_break_things" for
"believe_me" next.