### PR TITLE
Better documentation display for instances

### DIFF
--- a/idris.cabal
+++ b/idris.cabal
@@ -628,7 +628,10 @@ Extra-source-files:
                        test/docs002/input
                        test/docs002/*.idr
                        test/docs002/expected
-
+                       test/docs003/run
+                       test/docs003/input
+                       test/docs003/*.idr
+                       test/docs003/expected
 
 
 source-repository head

--- a/src/Idris/Delaborate.hs
+++ b/src/Idris/Delaborate.hs
@@ -1,6 +1,6 @@
 {-# LANGUAGE PatternGuards #-}
 {-# OPTIONS_GHC -fwarn-incomplete-patterns #-}
-module Idris.Delaborate (bugaddr, delab, delab', delabMV, delabTy, delabTy', fancifyAnnots, pprintDelab, pprintDelabTy, pprintErr) where
+module Idris.Delaborate (annName, bugaddr, delab, delab', delabMV, delabTy, delabTy', fancifyAnnots, pprintDelab, pprintDelabTy, pprintErr) where
 
 -- Convert core TT back into high level syntax, primarily for display
 -- purposes.

--- a/test/docs003/docs003.idr
+++ b/test/docs003/docs003.idr
@@ -1,0 +1,9 @@
+module docs003
+
+instance [mine] Functor List where
+  map m [] = []
+  map m (x :: xs) = m x :: map m xs
+
+||| More functors!
+instance [another] Functor List where
+  map f xs = map @{mine} f xs

--- a/test/docs003/expected
+++ b/test/docs003/expected
@@ -1,0 +1,37 @@
+Type checking ./docs003.idr
+Type class Functor
+    Functors
+
+Parameters:
+    f   -- the action of the functor on objects
+
+Methods:
+    map : Functor f => (m : a -> b) -> f a -> f b
+        The action of the functor on morphisms
+        
+Instances:
+    Functor List
+    Functor Stream
+    Functor Provider
+    Functor Binder
+    Functor PrimIO
+    Functor (IO' ffi)
+    Functor Maybe
+    Functor (Either e)
+
+Named instances:
+    docs003.mine : Functor List
+    docs003.another : Functor List
+        More functors!
+
+Subclasses:
+    Traversable f
+    Applicative f
+Named instance:
+    mine : Functor List
+        
+        
+Named instance:
+    another : Functor List
+        More functors!
+        

--- a/test/docs003/input
+++ b/test/docs003/input
@@ -1,0 +1,3 @@
+:doc Functor
+:doc mine
+:doc another

--- a/test/docs003/run
+++ b/test/docs003/run
@@ -1,0 +1,3 @@
+#!/usr/bin/env bash
+idris --consolewidth 80 --quiet --nocolor docs003.idr < input
+rm *.ibc


### PR DESCRIPTION
This patch does the following:

1. It nubs the internal instance names prior to display, which fixes #2019

2. It sets up a second section of the displayed documentation for a class if it has named instances, listing them separately. This fixes #2025.

3. Named instances found by looking up their name in `:doc` now have a marker that they in fact are named instances.