### PR TITLE
Replace div/mod functions with divNZ/modNZ

### DIFF
--- a/libs/base/Data/Bits.idr
+++ b/libs/base/Data/Bits.idr
@@ -1,24 +1,30 @@
 module Data.Bits
 
+import Math
 import Data.Fin
 
 %default total
 
-divCeil : Nat -> Nat -> Nat
-divCeil x y = case x `mod` y of
-                Z   => x `div` y
-                S _ => S (x `div` y)
+divCeilNZ : Nat -> (y: Nat) -> Not (y = Z) -> Nat
+divCeilNZ x y p = case (modNZ x y p) of
+  Z   => divNZ x y p
+  S _ => S (divNZ x y p)
+
+divCeil : Nat -> (y: Nat) -> Either (y = Z) Nat
+divCeil x y = case decEq y Z of
+  Yes p => Left p
+  No  p => Right (divCeilNZ x y p)
 
 nextPow2 : Nat -> Nat
-nextPow2 Z = Z
-nextPow2 x = if x == (2 `power` l2x)
-             then l2x
-             else S l2x
-    where
-      l2x = log2 x
+nextPow2 x = case log2 x of
+  Left _    => Z
+  Right l2x => if x == (2 `power` l2x)
+               then l2x
+               else S l2x
 
 nextBytes : Nat -> Nat
-nextBytes bits = (nextPow2 (bits `divCeil` 8))
+nextBytes bits = (nextPow2 (divCeilNZ bits 8 nz))
+  where nz Refl impossible
 
 machineTy : Nat -> Type
 machineTy Z = Bits8

--- a/libs/contrib/Data/Hash.idr
+++ b/libs/contrib/Data/Hash.idr
@@ -38,7 +38,8 @@ byte n w = prim__lshrB64 (prim__andB64 mask w) offset
 ||| Modulo of an integer, downsized to a Bits64
 private
 mod64 : Integer -> Bits64
-mod64 i = assert_total $ prim__truncBigInt_B64 (abs i `mod` 0xffffffffffffffff)
+mod64 i = assert_total $ prim__truncBigInt_B64 (modNZ (abs i) 0xffffffffffffffff nz)
+  where nz Refl impossible
 
 instance Hashable Bits64 where
   saltedHash64 w salt = foldr (\b,acc => (acc `prim__shlB64` 10) + acc + b)

--- a/libs/prelude/Math.idr
+++ b/libs/prelude/Math.idr
@@ -1,0 +1,49 @@
+module Math
+
+import Builtins
+import Prelude.Basics
+import Prelude.Classes
+import Prelude.Nat
+import Prelude.Either
+import Prelude.Functor
+import Decidable.Equality
+
+%access public
+%default total
+
+--------------------------------------------------------------------------------
+-- GCD and LCM
+--------------------------------------------------------------------------------
+gcd : Nat -> Nat -> Nat
+gcd a b = case decEq b Z of
+  Yes  => a
+  No p => assert_total (gcd b (modNat a b p))
+
+lcm : Nat -> Nat -> Nat
+lcm x y =
+  let g: Nat = (gcd x y) in
+  case decEq g Z of
+    Yes _ => Z
+    No p  => divNat (x * y) g p
+
+-- div and mod
+div: (Integral a, DecEq a) => a -> (y: a) -> Either (y = zero) a
+div x y = case decEq y zero of
+  Yes p => Left p
+  No p  => Right (divNZ x y p)
+
+mod: (Integral a, DecEq a) => a -> (y: a) -> Either (y = zero) a
+mod x y = case decEq y zero of
+  Yes p => Left p
+  No p  => Right (modNZ x y p)
+
+private
+twoNotZ: (S (S Z) = Z) -> Void
+twoNotZ Refl impossible
+
+log2 : (n: Nat) -> Either (n = Z) Nat
+log2 Z     = Left Refl
+log2 n     = case log2 (assert_smaller n (divNat n 2 twoNotZ)) of
+  Left _  => Right Z
+  Right x => Right (S x)
+

--- a/libs/prelude/Prelude/Classes.idr
+++ b/libs/prelude/Prelude/Classes.idr
@@ -310,74 +310,80 @@ instance MaxBound Bits64 where
 %default partial
 
 class Integral a where
-   div : a -> a -> a
-   mod : a -> a -> a
+   zero : a
+   divNZ : a -> (y: a) -> Not (y = zero) -> a
+   modNZ : a -> (y: a) -> Not (y = zero) -> a
 
 -- ---------------------------------------------------------------- [ Integers ]
-divBigInt : Integer -> Integer -> Integer
-divBigInt = prim__sdivBigInt
+divBigInt : Integer -> (y: Integer) -> Not (y = (the Integer 0)) -> Integer
+divBigInt x y _ = prim__sdivBigInt x y
 
-modBigInt : Integer -> Integer -> Integer
-modBigInt = prim__sremBigInt
+modBigInt : Integer -> (y: Integer) -> Not (y = (the Integer 0)) -> Integer
+modBigInt x y _ = prim__sremBigInt x y
 
 instance Integral Integer where
-  div = divBigInt
-  mod = modBigInt
+  zero  = 0
+  divNZ = divBigInt
+  modNZ = modBigInt
 
 -- --------------------------------------------------------------------- [ Int ]
 
-divInt : Int -> Int -> Int
-divInt = prim__sdivInt
+divInt : Int -> (y: Int) -> Not (y = (the Int 0)) -> Int
+divInt x y _ = prim__sdivInt x y
 
-modInt : Int -> Int -> Int
-modInt = prim__sremInt
+modInt : Int -> (y: Int) -> Not (y = (the Int 0)) -> Int
+modInt x y _ = prim__sremInt x y
 
 instance Integral Int where
-  div = divInt
-  mod = modInt
+  zero  = 0
+  divNZ = divInt
+  modNZ = modInt
 
 -- ------------------------------------------------------------------- [ Bits8 ]
-divB8 : Bits8 -> Bits8 -> Bits8
-divB8 = prim__sdivB8
+divB8 : Bits8 -> (y: Bits8) -> Not (y = (the Bits8 0)) -> Bits8
+divB8 x y _ = prim__sdivB8 x y
 
-modB8 : Bits8 -> Bits8 -> Bits8
-modB8 = prim__sremB8
+modB8 : Bits8 -> (y: Bits8) -> Not (y = (the Bits8 0)) -> Bits8
+modB8 x y _ = prim__sremB8 x y
   
 instance Integral Bits8 where
-  div = divB8
-  mod = modB8
+  zero  = 0
+  divNZ = divB8
+  modNZ = modB8
 
 -- ------------------------------------------------------------------ [ Bits16 ]
-divB16 : Bits16 -> Bits16 -> Bits16
-divB16 = prim__sdivB16
+divB16 : Bits16 -> (y: Bits16) -> Not (y = (the Bits16 0)) -> Bits16
+divB16 x y _ = prim__sdivB16 x y
 
-modB16 : Bits16 -> Bits16 -> Bits16
-modB16 = prim__sremB16
+modB16 : Bits16 -> (y: Bits16) -> Not (y = (the Bits16 0)) -> Bits16
+modB16 x y _ = prim__sremB16 x y
 
 instance Integral Bits16 where
-  div = divB16 
-  mod = modB16 
+  zero  = 0
+  divNZ = divB16 
+  modNZ = modB16 
 
 -- ------------------------------------------------------------------ [ Bits32 ]
-divB32 : Bits32 -> Bits32 -> Bits32
-divB32 = prim__sdivB32
+divB32 : Bits32 -> (y: Bits32) -> Not (y = (the Bits32 0)) -> Bits32
+divB32 x y _ = prim__sdivB32 x y
 
-modB32 : Bits32 -> Bits32 -> Bits32
-modB32 = prim__sremB32
+modB32 : Bits32 -> (y: Bits32) -> Not (y = (the Bits32 0)) -> Bits32
+modB32 x y _ = prim__sremB32 x y
 
 instance Integral Bits32 where
-  div = divB32 
-  mod = modB32 
+  zero  = 0
+  divNZ = divB32 
+  modNZ = modB32 
 
 -- ------------------------------------------------------------------ [ Bits64 ]
-divB64 : Bits64 -> Bits64 -> Bits64
-divB64 = prim__sdivB64
+divB64 : Bits64 -> (y: Bits64) -> Not (y = (the Bits64 0)) -> Bits64
+divB64 x y _ = prim__sdivB64 x y
 
-modB64 : Bits64 -> Bits64 -> Bits64
-modB64 = prim__sremB64
+modB64 : Bits64 -> (y: Bits64) -> Not (y = (the Bits64 0)) -> Bits64
+modB64 x y _ = prim__sremB64 x y
 
 instance Integral Bits64 where
-  div = divB64 
-  mod = modB64 
-
+  zero  = 0
+  divNZ = divB64 
+  modNZ = modB64 
 

--- a/libs/prelude/Prelude/Nat.idr
+++ b/libs/prelude/Prelude/Nat.idr
@@ -8,6 +8,7 @@ import Prelude.Bool
 import Prelude.Cast
 import Prelude.Classes
 import Prelude.Uninhabited
+import Prelude.Maybe
 
 %access public
 %default total
@@ -275,9 +276,9 @@ fact (S n) = (S n) * fact n
 --------------------------------------------------------------------------------
 
 total
-modNat : Nat -> Nat -> Nat
-modNat left Z         = left
-modNat left (S right) = mod' left left right
+modNat : Nat -> (y: Nat) -> Not (y = Z) -> Nat
+modNat left Z         p = void (p Refl)
+modNat left (S right) p = mod' left left right
   where
     total mod' : Nat -> Nat -> Nat -> Nat
     mod' Z        centre right = centre
@@ -288,9 +289,9 @@ modNat left (S right) = mod' left left right
         mod' left (centre - (S right)) right
 
 total
-divNat : Nat -> Nat -> Nat
-divNat left Z         = S left               -- div by zero
-divNat left (S right) = div' left left right
+divNat : Nat -> (y: Nat) -> Not (y = Z) -> Nat
+divNat left Z         p = void (p Refl)
+divNat left (S right) p = div' left left right
   where
     total div' : Nat -> Nat -> Nat -> Nat
     div' Z        centre right = Z
@@ -301,25 +302,9 @@ divNat left (S right) = div' left left right
         S (div' left (centre - (S right)) right)
 
 instance Integral Nat where
-  div = divNat
-  mod = modNat
-
-log2 : Nat -> Nat
-log2 Z = Z
-log2 (S Z) = Z
-log2 n = S (log2 (assert_smaller n (n `divNat` 2)))
-
---------------------------------------------------------------------------------
--- GCD and LCM
---------------------------------------------------------------------------------
-gcd : Nat -> Nat -> Nat
-gcd a Z = a
-gcd a b = assert_total (gcd b (a `modNat` b))
-
-total lcm : Nat -> Nat -> Nat
-lcm _ Z = Z
-lcm Z _ = Z
-lcm x y = divNat (x * y) (gcd x y)
+  zero  = Z
+  divNZ = divNat
+  modNZ = modNat
 
 
 --------------------------------------------------------------------------------
@@ -709,11 +694,6 @@ sucMinL (S l) = cong (sucMinL l)
 total sucMinR : (l : Nat) -> minimum l (S l) = l
 sucMinR Z = Refl
 sucMinR (S l) = cong (sucMinR l)
-
--- div and mod
-total modZeroZero : (n : Nat) -> mod 0 n = Z
-modZeroZero Z     = Refl
-modZeroZero (S n) = Refl
 
 --------------------------------------------------------------------------------
 -- Proofs

--- a/libs/prelude/prelude.ipkg
+++ b/libs/prelude/prelude.ipkg
@@ -12,5 +12,6 @@ modules = Builtins, Prelude, IO,
 
           Language.Reflection, Language.Reflection.Errors, Language.Reflection.Tactical,
 
-          Decidable.Equality
+          Decidable.Equality,
+          Math
 


### PR DESCRIPTION
This commit replaces the `div` and `mod` functions in the Integral class:

    class Integral a where
      div : a -> a -> a
      mod : a -> a -> a

With functions that take an extra parameter, a proof that the second
argument is non-zero.

    class Integral a where
       zero : a
       divNZ : a -> (y: a) -> Not (y = zero) -> a
       modNZ : a -> (y: a) -> Not (y = zero) -> a

It also add a `Math` module containing functions `div` and `mod` that return
`Either (y = zero) a` instead of `a`.
