### PR TITLE
Effects tutorial fix

### DIFF
--- a/docs/effects/state.rst
+++ b/docs/effects/state.rst
@@ -129,8 +129,8 @@ features, but for our purposes, it suffices to know the following:
 
 - ``x <- e`` binds the result of an effectful operation ``e`` to a
    variable ``x``. For example, in the above code, ``treeTagAux l`` is
-   an effectful operation returning a pair ``(Int, BTree a)``, so
-   ``l’`` has type ``(Int, BTree a)``.
+   an effectful operation returning ``BTree (Int, a)``, so ``l’`` has
+   type ``BTree (Int, a)``.
 
 - ``pure e`` turns a pure value ``e`` into the result of an effectful
    operation.


### PR DESCRIPTION
Fixed an example description: the type of `treeTagAux` is `BTree a ->
{ [STATE Int] } Eff (BTree (Int, a))` at the point where it was
described as if it is `BTree a -> { [STATE Int] } Eff (Int, BTree a)`.

(Moved from https://github.com/idris-hackers/eff-tutorial/pull/20).