### PR TITLE
Re-export Effect.Monad from effects package

### DIFF
--- a/libs/effects/effects.ipkg
+++ b/libs/effects/effects.ipkg
@@ -5,5 +5,4 @@ modules = Effects, Effect.Default,
 
           Effect.Exception, Effect.File, Effect.State,
           Effect.Random, Effect.StdIO, Effect.Select,
-          Effect.Memory, Effect.System
-
+          Effect.Memory, Effect.System, Effect.Monad


### PR DESCRIPTION
For some reason when `Effect.System` was added in the commit `4ba5460` the export of `Effect.Monad` got replaced.