### PR TITLE
Implement bundled toolchain feature

### DIFF
--- a/CHANGELOG
+++ b/CHANGELOG
@@ -1,5 +1,6 @@
 New in 0.9.18:
 --------------
+* Add support for bundled toolchains.
 * Strings are now UTF8 encoded in the default back end
 * Idris source files are now assumed to be in UTF8, regardless of locale
   settings.

--- a/codegen/idris-c/Main.hs
+++ b/codegen/idris-c/Main.hs
@@ -14,6 +14,8 @@ import Control.Monad
 
 import Paths_idris
 
+import Util.System
+
 data Opts = Opts { inputs :: [FilePath],
                    interface :: Bool,
                    output :: FilePath }
@@ -31,7 +33,8 @@ getOpts = do xs <- getArgs
     process opts [] = opts
 
 c_main :: Opts -> Idris ()
-c_main opts = do elabPrims
+c_main opts = do runIO setupBundledCC
+                 elabPrims
                  loadInputs (inputs opts) Nothing
                  mainProg <- if interface opts 
                                 then liftM Just elabMain

--- a/docs/faq/faq.rst
+++ b/docs/faq/faq.rst
@@ -131,6 +131,21 @@ choice by the developers of Idris, Idris uses the C style convention.
 That is, the names ``Float`` and ``Double`` are used to describe
 single and double precision numbers.
 
+What is -ffreestanding?
+=======================
+
+The freestanding flag is used to build Idris binaries which have their
+libs and compiler in a relative path. This is useful for building binaries
+where the install directory is unknown at build time. When passing this
+flag, the IDRIS_LIB_DIR environment variable needs to be set to the path
+where the Idris libs reside relative to the idris executable. The
+IDRIS_TOOLCHAIN_DIR environment variable is optional, if that is set,
+Idris will use that path to find the C compiler.
+
+Example:
+.. code-block::
+   IDRIS_LIB_DIR="./libs" IDRIS_TOOLCHAIN_DIR="./mingw/bin" CABALFLAGS="-fffi -ffreestanding -frelease" make
+
 What does the name ‘Idris’ mean?
 ================================
 

--- a/idris.cabal
+++ b/idris.cabal
@@ -806,6 +806,7 @@ Library
                 -- Auto Generated
                 , Paths_idris
                 , Version_idris
+                , Tools_idris
 
   Build-depends:  base >=4 && <5
                 , annotated-wl-pprint >= 0.5.3 && < 0.6

--- a/main/Main.hs
+++ b/main/Main.hs
@@ -29,6 +29,7 @@ import Idris.CmdOptions
 import IRTS.System ( getLibFlags, getIdrisLibDir, getIncFlags )
 
 import Util.DynamicLinker
+import Util.System
 
 import Pkg.Package
 
@@ -43,6 +44,7 @@ main = do opts <- runArgParser
 
 runIdris :: [Opt] -> Idris ()
 runIdris opts = do
+       runIO setupBundledCC
        when (ShowIncs `elem` opts) $ runIO showIncs
        when (ShowLibs `elem` opts) $ runIO showLibs
        when (ShowLibdir `elem` opts) $ runIO showLibdir

--- a/win-release.sh
+++ b/win-release.sh
@@ -1,0 +1,2 @@
+
+IDRIS_LIB_DIR="./libs" IDRIS_TOOLCHAIN_DIR="./mingw/bin" CABALFLAGS="-fffi -ffreestanding -frelease" make


### PR DESCRIPTION
This commit makes it possible to build a freestanding Idris that uses a bundled toolchain (or a toolchain in a specific absolute location). The path (relative or absolute) to the toolchain is specified in the env variable IDRIS_TOOLCHAIN_DIR when running a build with the freestanding flag.

I have used something similar but slightly more hardcoded to build the windows binaries.