### PR TITLE
Build docs locally using ReadTheDocs Theme.

### DIFF
--- a/docs/README.md
+++ b/docs/README.md
@@ -18,6 +18,12 @@ Sphinx can be installed either through your hosts package manager or using pip/e
  of readthedocs and be ignored. In the past we had several code-blocks
  disappear because of that.
 
+The ReadTheDocs theme can be installed using pip as follows:
+
+```sh
+pip install sphinx_rtd_theme
+```
+
 ### LaTeX
 
 LaTeX can be install either using your systems package manager or direct from TeXLive.

--- a/docs/conf.py
+++ b/docs/conf.py
@@ -115,11 +115,12 @@ todo_include_todos = True
 html_theme = "default"
 
 if not on_rtd:  # only import and set the theme if we're building docs locally
-    import sphinx_rtd_theme
-    html_theme = 'sphinx_rtd_theme'
-    html_theme_path = [sphinx_rtd_theme.get_html_theme_path()]
-
-
+    try:
+        import sphinx_rtd_theme
+        html_theme = 'sphinx_rtd_theme'
+        html_theme_path = [sphinx_rtd_theme.get_html_theme_path()]
+    except ImportError:
+        html_theme = "default"
 
 # Theme options are theme-specific and customize the look and feel of a theme
 # further.  For a list of options available for each theme, see the

--- a/docs/conf.py
+++ b/docs/conf.py
@@ -15,6 +15,9 @@
 import sys
 import os
 
+# True if the readthedocs theme is locally installed
+on_rtd = os.environ.get('READTHEDOCS', None) == 'True'
+
 # If extensions (or modules to document with autodoc) are in another directory,
 # add these directories to sys.path here. If the directory is relative to the
 # documentation root, use os.path.abspath to make it absolute, like shown here.
@@ -110,6 +113,13 @@ todo_include_todos = True
 # The theme to use for HTML and HTML Help pages.  See the documentation for
 # a list of builtin themes.
 html_theme = "default"
+
+if not on_rtd:  # only import and set the theme if we're building docs locally
+    import sphinx_rtd_theme
+    html_theme = 'sphinx_rtd_theme'
+    html_theme_path = [sphinx_rtd_theme.get_html_theme_path()]
+
+
 
 # Theme options are theme-specific and customize the look and feel of a theme
 # further.  For a list of options available for each theme, see the


### PR DESCRIPTION
Updated the configuration for the sphinx documentation, such that if
the readthedocs theme is locally installed then said theme will be
used otherwise the 'default' theme will be used.

This hack is required due to an issue with readthedocs setup in use of
its theme remotely and locally.

Sources:

+ http://docs.readthedocs.org/en/latest/theme.html#how-do-i-use-this-locally-and-on-read-the-docs