### PR TITLE
Division and modulus for Nat, plus associated utilities

### DIFF
--- a/libs/contrib/Control/WellFounded.idr
+++ b/libs/contrib/Control/WellFounded.idr
@@ -1,0 +1,83 @@
+||| Well-founded recursion.
+|||
+||| This is to let us implement some functions that don't have trivial
+||| recursion patterns over datatypes, but instead are using some
+||| other metric of size.
+module Control.WellFounded
+
+%default total
+
+
+||| Accessibility: some element `x` is accessible if all `y` such that
+||| `rel y x` are themselves accessible.
+|||
+||| @ a the type of elements
+||| @ rel a relation on a
+||| @ x the acessible element
+data Accessible : (rel : a -> a -> Type) -> (x : a) -> Type where
+  ||| Accessibility
+  |||
+  ||| @ x the accessible element
+  ||| @ acc' a demonstration that all smaller elements are also accessible
+  Access : (acc' : (y : a) -> rel y x -> Accessible rel y) ->
+           Accessible rel x
+
+||| A relation `rel` on `a` is well-founded if all elements of `a` are
+||| acessible.
+|||
+||| @ rel the well-founded relation
+class WellFounded (rel : a -> a -> Type) where
+  wellFounded : (x : _) -> Accessible rel x
+
+
+||| A recursor over accessibility.
+|||
+||| This allows us to recurse over the subset of some type that is
+||| accessible according to some relation.
+|||
+||| @ rel the well-founded relation
+||| @ step how to take steps on reducing arguments
+||| @ z the starting point
+accRec : {rel : a -> a -> Type} ->
+         (step : (x : a) -> ((y : a) -> rel y x -> b) -> b) ->
+         (z : a) -> Accessible rel z -> b
+accRec step z (Access f) =
+  step z $ \y, lt => accRec step y (f y lt)
+
+||| An induction principle for accessibility.
+|||
+||| This allows us to recurse over the subset of some type that is
+||| accessible according to some relation, producing a dependent type
+||| as a result.
+|||
+||| @ rel the well-founded relation
+||| @ step how to take steps on reducing arguments
+||| @ z the starting point
+accInd : {rel : a -> a -> Type} -> {P : a -> Type} ->
+         (step : (x : a) -> ((y : a) -> rel y x -> P y) -> P x) ->
+         (z : a) -> Accessible rel z -> P z
+accInd step z (Access f) =
+  step z $ \y, lt => accInd step y (f y lt)
+
+
+||| Use well-foundedness of a relation to write terminating operations.
+|||
+||| @ rel a well-founded relation
+wfRec : WellFounded rel =>
+        (step : (x : a) -> ((y : a) -> rel y x -> b) -> b) ->
+        a -> b
+wfRec {rel} step x = accRec step x (wellFounded {rel} x)
+
+
+||| Use well-foundedness of a relation to write proofs
+|||
+||| @ rel a well-founded relation
+||| @ P the motive for the induction
+||| @ step the induction step: take an element and its accessibility,
+|||        and give back a demonstration of P for that element,
+|||        potentially using accessibility
+wfInd : WellFounded rel => {P : a -> Type} ->
+        (step : (x : a) -> ((y : a) -> rel y x -> P y) -> P x) ->
+        (x : a) -> P x
+wfInd {rel} step x = accInd step x (wellFounded {rel} x)
+

--- a/libs/contrib/Data/Nat.idr
+++ b/libs/contrib/Data/Nat.idr
@@ -1,0 +1,172 @@
+||| Extra utilities for working with Nats
+module Data.Nat
+
+import Data.Fin
+
+import Control.WellFounded
+
+%default total
+
+||| A strict less-than relation on `Nat`.
+|||
+||| @ n the smaller number
+||| @ m the larger number
+data LT' : (n,m : Nat) -> Type where
+  ||| n < 1 + n
+  LTSucc : LT' n (S n)
+  ||| n < m implies that n < m + 1
+  LTStep : LT' n m -> LT' n (S m)
+
+%name LT' lt, lt'
+
+||| Nothing is strictly less than zero
+instance Uninhabited (LT' n 0) where
+  uninhabited LTSucc impossible
+
+||| Zero is less than any non-zero number.
+LTZeroLeast : LT' Z (S n)
+LTZeroLeast {n = Z}   = LTSucc
+LTZeroLeast {n = S n} = LTStep LTZeroLeast
+
+||| If n < m, then 1 + n < 1 + m
+ltSuccSucc : LT' n m -> LT' (S n) (S m)
+ltSuccSucc LTSucc      = LTSucc
+ltSuccSucc (LTStep lt) = LTStep $ ltSuccSucc lt
+
+||| If n + 1 < m, then n < m
+lteToLt' : LTE (S n) m -> LT' n m
+lteToLt' {n = Z}   (LTESucc x) = LTZeroLeast
+lteToLt' {n = S k} (LTESucc x) = ltSuccSucc $ lteToLt' x
+
+||| Convert from LT' to LTE
+ltToLTE : LT' n m -> LTE (S n) m
+ltToLTE LTSucc      = lteRefl
+ltToLTE (LTStep lt) = lteSucc $ ltToLTE lt
+
+||| Subtraction gives a result that is actually smaller.
+minusLT' : (x,y : Nat) -> x - y `LT'` S x
+minusLT' Z     y = LTSucc
+minusLT' (S k) Z = LTSucc
+minusLT' (S k) (S j) = LTStep (minusLT' k j)
+
+||| Strict less-than is well-founded, with the cascade stopping at
+||| zero (because there's nothing less than zero). This can't be done
+||| for LTE, because that one doesn't stop at zero (because `LTE 0 0`
+||| is inhabited).
+instance WellFounded LT' where
+  wellFounded x = Access (acc x)
+    where
+      ||| Show accessibility by induction on the structure of the LT' witness
+      acc : (x, y : Nat) -> LT' y x -> Accessible LT' y
+      -- Zero is vacuously accessible: there's nothing smaller to check
+      acc Z     y lt = absurd lt
+      -- If the element being accessed is one smaller, we're done
+      acc (S y) y LTSucc = Access (acc y)
+      -- If the element is more than one smaller, we need to go further
+      acc (S k) y (LTStep smaller) = acc k y smaller
+
+||| The result of division on natural numbers.
+|||
+||| @ dividend the dividend
+||| @ divisor the divisor
+data DivMod : (dividend, divisor : Nat) -> Type where
+  ||| The result of division, with a quotient and a remainder.
+  |||
+  ||| @ dividend the dividend
+  ||| @ divisor the divisor
+  ||| @ quotient the quotient
+  ||| @ remainder the remainder (bounded by the divisor)
+  ||| @ ok the fact that this is, in fact, a result of division
+  DivModRes : {dividend, divisor : Nat} ->
+              (quotient : Nat) -> (remainder : Fin divisor) ->
+              (ok : dividend = finToNat remainder + quotient * divisor) ->
+              DivMod dividend divisor
+
+
+||| Any natural number can be a `Fin` where the bound is itself plus some difference.
+private
+toFin : (x : Nat) -> (diff : Nat) -> Fin (plus x (S diff))
+toFin Z diff = FZ
+toFin (S k) diff = FS $ toFin k diff
+
+||| Converting to a `Fin` and back to `Nat` preserves the input. This is a correctness proof for `toFin`.
+private
+toFinAndBack : (x : Nat) -> (diff : Nat) -> finToNat (toFin x diff) = x
+toFinAndBack Z diff = Refl
+toFinAndBack (S k) diff = cong (toFinAndBack k diff)
+
+||| This property is not the case.
+|||
+||| Use this to ensure properties in implicit arguments.
+|||
+||| @ p the property that doesn't hold
+Nope : Dec p -> Type
+Nope (Yes _) = Void
+Nope (No _)  = ()
+
+||| The accessibilty predicate used for division.
+private
+accPlusLT' : LT' (S j) (S (plus k (S j)))
+accPlusLT' {j = Z}   {k = Z}   = LTSucc
+accPlusLT' {j = Z}   {k = S k} = LTStep (accPlusLT' {j = Z} {k = k})
+accPlusLT' {j = S j} {k = k}   = rewrite sym $ plusSuccRightSucc k (S j) in
+                                 ltSuccSucc accPlusLT'
+
+
+||| Division and modulus on `Nat`, inspired by the definition in the
+||| Agda standard library.
+|||
+||| This uses well-founded recursion on `LT'`.
+|||
+||| @ dividend the dividend
+||| @ divisor the divisor
+||| @ nonzero division by zero is nonsense
+total -- yay!
+divMod : (dividend, divisor : Nat) ->
+         {auto nonzero : Nope (decEq divisor Z)} ->
+         DivMod dividend divisor
+divMod _     Z     {nonzero} = absurd nonzero
+divMod Z     (S k)           = DivModRes 0 FZ Refl
+divMod (S j) (S k) {nonzero} = wfInd {P=P} stepDiv (S j) (S k) nonzero
+  where
+    ||| The goal passed to the accessibility eliminator.
+    |||
+    ||| This is responsible for generating the goal in the
+    ||| well-founded fixed point.
+    |||
+    ||| @ dividend the dividend to recurse over
+    P : (dividend : Nat) -> Type
+    P dividend = (divisor : Nat) -> (nonzero : Nope (decEq divisor Z)) -> DivMod dividend divisor
+
+
+    ||| Well-founded recursion needs a recursion operator.
+    |||
+    ||| @ dividend the dividend we are recursing over
+    ||| @ rec the recursive call provided by the well-founded induction operator
+    stepDiv : (dividend : Nat) -> (rec : (d' : Nat) -> LT' d' dividend -> P d') -> P dividend
+    -- We need not consider division by zero
+    stepDiv dividend rec   Z     nonzero = absurd nonzero
+    -- Dividing zero by anyting else gives 0, with 0 remainder
+    stepDiv Z rec (S k) nonzero = DivModRes 0 0 Refl
+    -- To divide two non-zero values, we must know which is larger
+    stepDiv (S j) rec (S k) nonzero with (cmp j k)
+      -- n / n = 1 remainder 0
+      stepDiv (S j)                 rec (S j)                 nonzero | CmpEQ      =
+        DivModRes 1 0 (sym $ cong (plusZeroRightNeutral j))
+      -- if n < m, then m = n + r, and the quotient is 0 with remainder r
+      stepDiv (S j)                 rec (S (plus j (S diff))) nonzero | CmpLT diff =
+        DivModRes 0 (toFin (S j) diff) $
+          rewrite toFinAndBack j diff
+          in sym $ cong (plusZeroRightNeutral j)
+      -- if n > m, then n = m + d, and the quotient is 1 + ((n - m) / m) with the same remainder
+      stepDiv (S (plus k (S diff))) rec (S k)                 nonzero | CmpGT diff =
+        let res = rec (S diff) accPlusLT' (S k) ()
+        in case res of
+             DivModRes quotient remainder ok =>
+               DivModRes (S quotient) remainder $
+                 rewrite plusAssociative (finToNat remainder) (S k) (mult quotient (S k)) in
+                 rewrite plusCommutative (finToNat remainder) (S k) in
+                 rewrite sym $ plusAssociative (S k) (finToNat remainder) (mult quotient (S k)) in
+                 rewrite ok in Refl
+
+

--- a/libs/contrib/contrib.ipkg
+++ b/libs/contrib/contrib.ipkg
@@ -3,9 +3,11 @@ package contrib
 opts = "--nobasepkgs --total -i ../prelude -i ../base"
 modules = Control.Algebra,
           Control.Isomorphism.Primitives,
+          Control.WellFounded,
           Classes.Verified,
           Data.Fun, Data.Rel, 
           Data.Hash, Data.Matrix,
+          Data.Nat,
           Data.ZZ, Data.Sign,
           Data.BoundedList,
           Data.Heap,

--- a/libs/prelude/Prelude.idr
+++ b/libs/prelude/Prelude.idr
@@ -31,6 +31,12 @@ import public Language.Reflection.Errors
 %access public
 %default total
 
+-- Things that can't be elsewhere for import cycle reasons
+decAsBool : Dec p -> Bool
+decAsBool (Yes _) = True
+decAsBool (No _)  = False
+
+
 -- Show and instances
 
 class Show a where

--- a/libs/prelude/Prelude/Nat.idr
+++ b/libs/prelude/Prelude/Nat.idr
@@ -136,9 +136,9 @@ lteRefl {n = Z}   = LTEZero
 lteRefl {n = S k} = LTESucc lteRefl
 
 ||| n < m implies n < m + 1
-lteSucc : LTE n m -> LTE n (S m)
-lteSucc LTEZero     = LTEZero
-lteSucc (LTESucc x) = LTESucc (lteSucc x)
+lteSuccRight : LTE n m -> LTE n (S m)
+lteSuccRight LTEZero     = LTEZero
+lteSuccRight (LTESucc x) = LTESucc (lteSuccRight x)
 
 
 ||| Boolean test than one Nat is less than or equal to another

--- a/libs/prelude/Prelude/Nat.idr
+++ b/libs/prelude/Prelude/Nat.idr
@@ -99,6 +99,9 @@ data LTE  : (n, m : Nat) -> Type where
   ||| If n <= m, then n + 1 <= m + 1
   LTESucc : LTE left right -> LTE (S left) (S right)
 
+instance Uninhabited (LTE (S n) Z) where
+  uninhabited LTEZero impossible
+
 ||| Greater than or equal to
 total GTE : Nat -> Nat -> Type
 GTE left right = LTE right left
@@ -126,6 +129,17 @@ isLTE (S k) Z = No succNotLTEzero
 isLTE (S k) (S j) with (isLTE k j)
   isLTE (S k) (S j) | (Yes prf) = Yes (LTESucc prf)
   isLTE (S k) (S j) | (No contra) = No (contra . fromLteSucc)
+
+||| `LTE` is reflexive.
+lteRefl : LTE n n
+lteRefl {n = Z}   = LTEZero
+lteRefl {n = S k} = LTESucc lteRefl
+
+||| n < m implies n < m + 1
+lteSucc : LTE n m -> LTE n (S m)
+lteSucc LTEZero     = LTEZero
+lteSucc (LTESucc x) = LTESucc (lteSucc x)
+
 
 ||| Boolean test than one Nat is less than or equal to another
 total lte : Nat -> Nat -> Bool


### PR DESCRIPTION
This adds some trivial lemmas to `Prelude.Nat`, as well as the following `contrib` modules:
 * `Data.Nat`: contains division and modulus for `Nat`, using well-founded recursion
 * `Control.WellFounded`: contains low-level operations for well-founded recursion