### PR TITLE
Append Char to String

### DIFF
--- a/libs/contrib/Data/String.idr
+++ b/libs/contrib/Data/String.idr
@@ -1,0 +1,31 @@
+module Data.String
+
+infixl 5 +>
+infixr 5 <+
+
+||| Adds a character to the end of the specified string.
+|||
+||| ```idris example
+||| strSnoc "AB" 'C'
+||| ```
+||| ```idris example
+||| strSnoc "" 'A'
+||| ```
+strSnoc : String -> Char -> String
+strSnoc s c = s ++ (singleton 'c')
+
+||| Alias of `strSnoc`
+|||
+||| ```idris example
+||| "AB" +> 'C'
+||| ```
+(+>) : String -> Char -> String
+(+>) = strSnoc
+
+||| Alias of `strCons`
+|||
+||| ```idris example
+||| 'A' <+ "AB"
+||| ```
+(<+) : Char -> String -> String
+(<+) = strCons


### PR DESCRIPTION
It would be nice to have simpler way to append a `Char` to a `String`.

```idris
||| Adds a character to the end of the specified string.
|||
||| ```idris example
||| strAppend 'A' 'B'
||| ```
||| ```idris example
||| strAppend "" 'A'
||| ```
strAppend : String -> Char -> String
strAppend s c = s ++ (strCons 'c' "")

||| Alias of strAppend
(+) : String -> Char -> String
(+) = strAppend
```