### PR TITLE
Idris does not build with GHC 7.10.1

### DIFF
--- a/idris.cabal
+++ b/idris.cabal
@@ -817,10 +817,10 @@ Library
                 , containers >= 0.5 && < 0.6
                 , deepseq < 1.5
                 , directory >= 1.2 && < 1.3
-                , filepath < 1.4
+                , filepath < 1.5
                 , fingertree >= 0.1 && < 0.2
                 , haskeline >= 0.7 && < 0.8
-                , lens >= 4.1.1 && < 4.8
+                , lens >= 4.1.1 && < 4.9
                 , mtl >= 2.1 && < 2.3
                 , network < 2.7
                 , optparse-applicative >= 0.11 && < 0.12

--- a/src/Idris/AbsSyntaxTree.hs
+++ b/src/Idris/AbsSyntaxTree.hs
@@ -18,6 +18,8 @@ import Idris.Colours
 import System.Console.Haskeline
 import System.IO
 
+import Prelude hiding ((<$>))
+
 import Control.Applicative ((<|>))
 
 import Control.Monad.Trans.State.Strict

--- a/src/Idris/Delaborate.hs
+++ b/src/Idris/Delaborate.hs
@@ -13,6 +13,8 @@ import Idris.Core.Evaluate
 import Idris.Docstrings (overview, renderDocstring, renderDocTerm)
 import Idris.ErrReverse
 
+import Prelude hiding ((<$>))
+
 import Data.List (intersperse, nub)
 import qualified Data.Text as T
 import Control.Monad.State

--- a/src/Idris/Docs.hs
+++ b/src/Idris/Docs.hs
@@ -11,6 +11,8 @@ import Idris.Docstrings (Docstring, emptyDocstring, noDocs, nullDocstring, rende
 
 import Util.Pretty
 
+import Prelude hiding ((<$>))
+
 import Control.Arrow (first)
 
 import Data.Maybe

--- a/src/Idris/Docstrings.hs
+++ b/src/Idris/Docstrings.hs
@@ -15,6 +15,8 @@ import Util.Pretty
 
 import Idris.Core.TT (OutputAnnotation(..), TextFormatting(..), Name, Term, Err)
 
+import Prelude hiding ((<$>))
+
 import qualified Data.Text as T
 import qualified Data.Foldable as F
 import Data.Foldable (Foldable)

--- a/src/Idris/Output.hs
+++ b/src/Idris/Output.hs
@@ -15,9 +15,11 @@ import Util.ScreenSize (getScreenWidth)
 
 import Control.Monad.Trans.Except (ExceptT (ExceptT), runExceptT)
 
-import System.Console.Haskeline.MonadException 
+import System.Console.Haskeline.MonadException
   (MonadException (controlIO), RunIO (RunIO))
 import System.IO (stdout, Handle, hPutStrLn)
+
+import Prelude hiding ((<$>))
 
 import Data.Char (isAlpha)
 import Data.List (nub, intersperse)

--- a/src/Idris/REPL.hs
+++ b/src/Idris/REPL.hs
@@ -59,7 +59,7 @@ import IRTS.System
 
 import Control.Category
 import qualified Control.Exception as X
-import Prelude hiding ((.), id)
+import Prelude hiding ((<$>), (.), id)
 import Data.List.Split (splitOn)
 import Data.List (groupBy)
 import qualified Data.Text as T


### PR DESCRIPTION
Idris depends on `filepath` < 1.4 but GHC 7.10.1 ships with version 1.4.0.0. This causes havoc when cabal tries to resolve dependencies.

Idris also depends on `lens` version 4.7 and that does not build with 7.10.1 either. Perhaps bump dependency to 4.8?

`annotated-wl-pprint` dependency does not build either but I've already created a pull request that fixes the build problem.

Finally, Idris itself fails to build because some modules define `<$>` operator and that clashes with GHC 7.10.1 `Prelude`.

After bumping the dependencies (filepath to 1.4, lens to 4.8) and fixing the build errors everything seems to work fine.