### PR TITLE
Remove assert_total from Prelude.List.transpose

### DIFF
--- a/libs/prelude/Prelude/List.idr
+++ b/libs/prelude/Prelude/List.idr
@@ -366,12 +366,10 @@ intercalate sep l = concat $ intersperse sep l
 |||     transpose [[], [1, 2]] = [[1], [2]]
 |||     transpose (transpose [[], [1, 2]]) = [[1, 2]]
 |||
-||| TODO: Solution which satisfies the totality checker?
-%assert_total
 transpose : List (List a) -> List (List a)
 transpose [] = []
 transpose ([] :: xss) = transpose xss
-transpose ((x::xs) :: xss) = (x :: (mapMaybe head' xss)) :: (transpose (xs :: (map (drop 1) xss)))
+transpose ((x::xs) :: xss) = (x :: mapMaybe head' xss) :: transpose (xs :: map (drop 1) xss)
 
 --------------------------------------------------------------------------------
 -- Membership tests


### PR DESCRIPTION
This pragma was apparently needed once, but does not seem to be
any more. The totality check must have improved.