### PR TITLE
Need to wrap PATH in quotes to avoid chars being interpreted as shell

### DIFF
--- a/test/runtest.pl
+++ b/test/runtest.pl
@@ -13,7 +13,7 @@ sub sandbox_path {
     my $sandbox = abs_path("$test_dir/../../.cabal-sandbox/bin");
 
     if ( -d $sandbox ) {
-        return "PATH=$sandbox:$PATH";
+        return "PATH=\"$sandbox:$PATH\"";
     } else {
         return "";
     }


### PR DESCRIPTION
Notable on windows where it is likely there is a directory with
parentheses in the name.