### PR TITLE
Replace the Monoid instance on Maybe

### DIFF
--- a/CHANGELOG
+++ b/CHANGELOG
@@ -21,6 +21,9 @@ New in 0.9.18:
   requiring a separate lemma.
 * Case alternatives are allowed to be impossible:
   case Vect.Nil {a=Nat} of { (x::xs) impossible ; [] => True }
+* The default Semigroup and Monoid instances for Maybe are now prioritised
+  choice, keeping the first success as Alternative does. The version that
+  collects successes is now a named instance.
 
 New in 0.9.17:
 --------------

--- a/libs/prelude/Prelude/Maybe.idr
+++ b/libs/prelude/Prelude/Maybe.idr
@@ -78,17 +78,25 @@ instance (Eq a) => Eq (Maybe a) where
   (Just _) == Nothing  = False
   (Just a) == (Just b) = a == b
 
--- Lift a semigroup into 'Maybe' forming a 'Monoid' according to
--- <http://en.wikipedia.org/wiki/Monoid>: "Any semigroup S may be
--- turned into a monoid simply by adjoining an element i not in S
--- and defining i+i = i and i+s = s = s+i for all s in S."
+||| Prioritised choice. Just like the `Alternative` instance, the
+||| `Semigroup` for `Maybe a` keeps the first succeeding computation.
+|||
+||| **NB**: This is a different choice than in the Haskell libraries.
+||| Use `collectJust` to get the Haskell behaviour.
+instance Semigroup (Maybe a) where
+  Nothing   <+> m = m
+  (Just x)  <+> _ = Just x
 
-instance (Semigroup a) => Semigroup (Maybe a) where
-  Nothing <+> m = m
-  m <+> Nothing = m
+||| Transform any semigroup into a monoid by using `Nothing` as the
+||| designated neutral element and collecting the contents of the
+||| `Just` constructors using a semigroup structure on `a`. This is
+||| the behaviour in the Haskell libraries.
+instance [collectJust] Semigroup a => Semigroup (Maybe a) where
+  Nothing   <+> m       = m
+  m         <+> Nothing = m
   (Just m1) <+> (Just m2) = Just (m1 <+> m2)
 
-instance (Semigroup a) => Monoid (Maybe a) where
+instance  Monoid (Maybe a) where
   neutral = Nothing
 
 instance (Monoid a, Eq a) => Cast a (Maybe a) where
@@ -98,5 +106,5 @@ instance (Monoid a) => Cast (Maybe a) a where
   cast = lowerMaybe
 
 instance Foldable Maybe where
-  foldr _ z Nothing = z
+  foldr _ z Nothing  = z
   foldr f z (Just x) = f x z

--- a/src/Idris/IdrisDoc.hs
+++ b/src/Idris/IdrisDoc.hs
@@ -1,5 +1,6 @@
 {-# LANGUAGE PatternGuards #-}
 {-# LANGUAGE OverloadedStrings #-}
+{-# OPTIONS_GHC -fwarn-incomplete-patterns #-}
 
 -- | Generation of HTML documentation for Idris code
 module Idris.IdrisDoc (generateDocs) where
@@ -217,9 +218,11 @@ referredNss (n, Just d, _) =
       names  = concatMap (extractPTermNames) ts
   in  S.map getNs $ S.fromList names
 
-  where getFunDocs (FunDoc f)              = [f]
-        getFunDocs (DataDoc f fs)          = f:fs
+  where getFunDocs (FunDoc f)                = [f]
+        getFunDocs (DataDoc f fs)            = f:fs
         getFunDocs (ClassDoc _ _ fs _ _ _ _) = fs
+        getFunDocs (NamedInstanceDoc _ fd)   = [fd]
+        getFunDocs (ModDoc _ _)              = []
         types (FD _ _ args t _)            = t:(map second args)
         second (_, x, _, _)                = x
 
@@ -608,6 +611,8 @@ createOtherDoc ist (DataDoc fd@(FD n docstring args _ _) fds) = do
         genArg (name, _, _, Just docstring) = do
           H.dt $ toHtml $ show name
           H.dd $ Docstrings.renderHtml docstring
+
+createOtherDoc ist (NamedInstanceDoc _ fd) = createFunDoc ist fd
 
 createOtherDoc ist (ModDoc _  docstring) = do
   Docstrings.renderHtml docstring


### PR DESCRIPTION
The current default Monoid instance for Maybe is like that in Haskell, where a semigroup operator on the underlying type is used to collect successes. Conor [argues convincingly](https://www.reddit.com/r/haskell/comments/30s1t2/proposal_make_semigroup_as_a_superclass_of_monoid/cpvdco1) that this is not the right notion of computation for Maybe, so I figured I'd fix it while we're young.

The old behavior is available in a named instance, and both are documented.