### PR TITLE
Set encoding to read and write source files.

### DIFF
--- a/src/Idris/Chaser.hs
+++ b/src/Idris/Chaser.hs
@@ -15,6 +15,7 @@ import Control.Monad.State
 import Data.List
 
 import Debug.Trace
+import Util.System (readSource, writeSource)
 
 data ModuleTree = MTree { mod_path :: IFileType,
                           mod_needsRecheck :: Bool,
@@ -133,7 +134,7 @@ buildTree built fp = btree [] fp
   children lit f done = -- idrisCatch
      do exist <- runIO $ doesFileExist f
         if exist then do
-            file_in <- runIO $ readFile f
+            file_in <- runIO $ readSource f
             file <- if lit then tclift $ unlit f file_in else return file_in
             (_, _, modules, _) <- parseImports f file
             -- The chaser should never report warnings from sub-modules

--- a/src/Idris/Interactive.hs
+++ b/src/Idris/Interactive.hs
@@ -17,7 +17,6 @@ import Idris.Error
 import Idris.Delaborate
 import Idris.Output
 import Idris.IdeMode hiding (IdeModeCommand(..))
-
 import Idris.Elab.Value
 
 import Util.Pretty
@@ -34,7 +33,7 @@ import Debug.Trace
 
 caseSplitAt :: FilePath -> Bool -> Int -> Name -> Idris ()
 caseSplitAt fn updatefile l n
-   = do src <- runIO $ readFile fn
+   = do src <- runIO $ readSource fn
         res <- splitOnLine l n fn
         iLOG (showSep "\n" (map show res))
         let (before, (ap : later)) = splitAt (l-1) (lines src)
@@ -42,14 +41,14 @@ caseSplitAt fn updatefile l n
         let new = concat res'
         if updatefile
           then do let fb = fn ++ "~" -- make a backup!
-                  runIO $ writeFile fb (unlines before ++ new ++ unlines later)
+                  runIO $ writeSource fb (unlines before ++ new ++ unlines later)
                   runIO $ copyFile fb fn
           else -- do iputStrLn (show res)
             iPrintResult new
 
 addClauseFrom :: FilePath -> Bool -> Int -> Name -> Idris ()
 addClauseFrom fn updatefile l n
-   = do src <- runIO $ readFile fn
+   = do src <- runIO $ readSource fn
         let (before, tyline : later) = splitAt (l-1) (lines src)
         let indent = getIndent 0 (show n) tyline
         cl <- getClause l n fn
@@ -57,7 +56,7 @@ addClauseFrom fn updatefile l n
         let (nonblank, rest) = span (not . all isSpace) (tyline:later)
         if updatefile
           then do let fb = fn ++ "~"
-                  runIO $ writeFile fb (unlines (before ++ nonblank) ++
+                  runIO $ writeSource fb (unlines (before ++ nonblank) ++
                                         replicate indent ' ' ++
                                         cl ++ "\n" ++
                                         unlines rest)
@@ -71,7 +70,7 @@ addClauseFrom fn updatefile l n
 
 addProofClauseFrom :: FilePath -> Bool -> Int -> Name -> Idris ()
 addProofClauseFrom fn updatefile l n
-   = do src <- runIO $ readFile fn
+   = do src <- runIO $ readSource fn
         let (before, tyline : later) = splitAt (l-1) (lines src)
         let indent = getIndent 0 (show n) tyline
         cl <- getProofClause l n fn
@@ -79,7 +78,7 @@ addProofClauseFrom fn updatefile l n
         let (nonblank, rest) = span (not . all isSpace) (tyline:later)
         if updatefile
           then do let fb = fn ++ "~"
-                  runIO $ writeFile fb (unlines (before ++ nonblank) ++
+                  runIO $ writeSource fb (unlines (before ++ nonblank) ++
                                         replicate indent ' ' ++
                                         cl ++ "\n" ++
                                         unlines rest)
@@ -92,7 +91,7 @@ addProofClauseFrom fn updatefile l n
 
 addMissing :: FilePath -> Bool -> Int -> Name -> Idris ()
 addMissing fn updatefile l n
-   = do src <- runIO $ readFile fn
+   = do src <- runIO $ readSource fn
         let (before, tyline : later) = splitAt (l-1) (lines src)
         let indent = getIndent 0 (show n) tyline
         i <- getIState
@@ -106,7 +105,7 @@ addMissing fn updatefile l n
         let (nonblank, rest) = span (not . all isSpace) (tyline:later)
         if updatefile
           then do let fb = fn ++ "~"
-                  runIO $ writeFile fb (unlines (before ++ nonblank)
+                  runIO $ writeSource fb (unlines (before ++ nonblank)
                                         ++ extras ++ unlines rest)
                   runIO $ copyFile fb fn
           else iPrintResult extras
@@ -141,7 +140,7 @@ addMissing fn updatefile l n
 
 makeWith :: FilePath -> Bool -> Int -> Name -> Idris ()
 makeWith fn updatefile l n
-   = do src <- runIO $ readFile fn
+   = do src <- runIO $ readSource fn
         let (before, tyline : later) = splitAt (l-1) (lines src)
         let ind = getIndent tyline
         let with = mkWith tyline n
@@ -151,7 +150,7 @@ makeWith fn updatefile l n
                                            not (ind == getIndent x)) later
         if updatefile then
            do let fb = fn ++ "~"
-              runIO $ writeFile fb (unlines (before ++ nonblank)
+              runIO $ writeSource fb (unlines (before ++ nonblank)
                                         ++ with ++ "\n" ++
                                     unlines rest)
               runIO $ copyFile fb fn
@@ -164,7 +163,7 @@ doProofSearch :: FilePath -> Bool -> Bool ->
 doProofSearch fn updatefile rec l n hints Nothing
     = doProofSearch fn updatefile rec l n hints (Just 10)
 doProofSearch fn updatefile rec l n hints (Just depth)
-    = do src <- runIO $ readFile fn
+    = do src <- runIO $ readSource fn
          let (before, tyline : later) = splitAt (l-1) (lines src)
          ctxt <- getContext
          mn <- case lookupNames n ctxt of
@@ -192,7 +191,7 @@ doProofSearch fn updatefile rec l n hints (Just depth)
              (\e -> return ("?" ++ show n))
          if updatefile then
             do let fb = fn ++ "~"
-               runIO $ writeFile fb (unlines before ++
+               runIO $ writeSource fb (unlines before ++
                                      updateMeta False tyline (show n) newmv ++ "\n"
                                        ++ unlines later)
                runIO $ copyFile fb fn
@@ -241,7 +240,7 @@ addBracket True new | any isSpace new = '(' : new ++ ")"
 
 makeLemma :: FilePath -> Bool -> Int -> Name -> Idris ()
 makeLemma fn updatefile l n
-   = do src <- runIO $ readFile fn
+   = do src <- runIO $ readSource fn
         let (before, tyline : later) = splitAt (l-1) (lines src)
 
         -- if the name is in braces, rather than preceded by a ?, treat it
@@ -267,7 +266,7 @@ makeLemma fn updatefile l n
 
             if updatefile then
                do let fb = fn ++ "~"
-                  runIO $ writeFile fb (addLem before tyline lem lem_app later)
+                  runIO $ writeSource fb (addLem before tyline lem lem_app later)
                   runIO $ copyFile fb fn
                else case idris_outputmode i of
                       RawOutput _  -> iPrintResult $ lem ++ "\n" ++ lem_app
@@ -285,7 +284,7 @@ makeLemma fn updatefile l n
                                  " = ?" ++ show n ++ "_rhs"
             if updatefile then
                do let fb = fn ++ "~"
-                  runIO $ writeFile fb (addProv before tyline lem_app later)
+                  runIO $ writeSource fb (addProv before tyline lem_app later)
                   runIO $ copyFile fb fn
                else case idris_outputmode i of
                       RawOutput _  -> iPrintResult $ lem_app

--- a/src/Idris/Parser.hs
+++ b/src/Idris/Parser.hs
@@ -43,6 +43,7 @@ import Idris.Docstrings hiding (Unchecked)
 import Paths_idris
 
 import Util.DynamicLinker
+import Util.System (readSource, writeSource)
 import qualified Util.Pretty as P
 
 import Idris.Core.TT
@@ -1345,7 +1346,7 @@ loadSource lidr f toline
              = do iLOG ("Reading " ++ f)
                   i <- getIState
                   let def_total = default_total i
-                  file_in <- runIO $ readFile f
+                  file_in <- runIO $ readSource f
                   file <- if lidr then tclift $ unlit f file_in else return file_in
                   (mdocs, mname, imports_in, pos) <- parseImports f file
                   ai <- getAutoImports

--- a/src/Idris/REPL.hs
+++ b/src/Idris/REPL.hs
@@ -1059,7 +1059,7 @@ process fn' (AddProof prf)
                     else ifail $ "Neither \""++fn''++"\" nor \""++fnExt++"\" exist"
        let fb = fn ++ "~"
        runIO $ copyFile fn fb -- make a backup in case something goes wrong!
-       prog <- runIO $ readFile fb
+       prog <- runIO $ readSource fb
        i <- getIState
        let proofs = proof_list i
        n' <- case prf of
@@ -1071,7 +1071,7 @@ process fn' (AddProof prf)
        case lookup n proofs of
             Nothing -> iputStrLn "No proof to add"
             Just p  -> do let prog' = insertScript (showProof (lit fn) n p) ls
-                          runIO $ writeFile fn (unlines prog')
+                          runIO $ writeSource fn (unlines prog')
                           removeProof n
                           iputStrLn $ "Added proof " ++ show n
                           where ls = (lines prog)

--- a/src/Util/System.hs
+++ b/src/Util/System.hs
@@ -1,4 +1,5 @@
-module Util.System(tempfile,withTempdir,rmFile,catchIO, isWindows) where
+module Util.System(tempfile,withTempdir,rmFile,catchIO, isWindows,
+                   readSource, writeSource) where
 
 -- System helper functions.
 import Control.Monad (when)
@@ -25,6 +26,16 @@ isWindows = os `elem` ["win32", "mingw32", "cygwin32"]
 tempfile :: IO (FilePath, Handle)
 tempfile = do dir <- getTemporaryDirectory
               openTempFile (normalise dir) "idris"
+
+-- | Read a source file, same as readFile but make sure the encoding is utf-8.
+readSource :: FilePath -> IO String
+readSource f = do h <- openFile f ReadMode
+                  hSetEncoding h utf8
+                  hGetContents h
+
+-- | Write a source file, same as writeFile except the encoding is set to utf-8
+writeSource :: FilePath -> String -> IO ()
+writeSource f s = withFile f WriteMode (\h -> hSetEncoding h utf8 >> hPutStr h s)
 
 withTempdir :: String -> (FilePath -> IO a) -> IO a
 withTempdir subdir callback


### PR DESCRIPTION
Not all systems use utf-8 by default, Windows has latin-1. This enforces utf-8 on 
source files. It's needed to make Unicode in source work on Windows.

It may seem strange to open a file and not close it, but that is how readFile works, 
this just adds the set encoding step before hGetContents. hGetContents is lazy 
and will close the file when everything has been read.

readFile source:
    readFile name   =  openFile name ReadMode >>= hGetContents