### PR TITLE
Clarify failing searches

### DIFF
--- a/CONTRIBUTORS
+++ b/CONTRIBUTORS
@@ -32,6 +32,7 @@ Adam Sandberg Eriksson
 Seo Sanghyeon
 Benjamin Saunders
 Alexander Shabalin
+JP Smith
 startling
 Chetan T
 Matúš Tejiščák

--- a/src/Idris/REPL.hs
+++ b/src/Idris/REPL.hs
@@ -1232,10 +1232,11 @@ process fn (Apropos pkgs a) =
                           delabTy ist n,
                           fmap (overview . fst) (lookupCtxtExact n (idris_docstrings ist)))
                        | n <- sort names, isUN n ]
-     iRenderResult $ vsep (map (\(m, d) -> text "Module" <+> text m <$>
-                                           ppD ist d <> line) mods) <$>
-                     vsep (map (prettyDocumentedIst ist) aproposInfo)
-     putIState orig
+     if (not (null mods)) || (not (null aproposInfo))
+        then iRenderResult $ vsep (map (\(m, d) -> text "Module" <+> text m <$>
+                                                   ppD ist d <> line) mods) <$>
+                             vsep (map (prettyDocumentedIst ist) aproposInfo)
+        else iRenderError $ text "No results found"
   where isUN (UN _) = True
         isUN (NS n _) = isUN n
         isUN _ = False

--- a/src/Idris/TypeSearch.hs
+++ b/src/Idris/TypeSearch.hs
@@ -30,7 +30,7 @@ import Idris.Core.Unify (match_unify)
 import Idris.Delaborate (delabTy)
 import Idris.Docstrings (noDocs, overview)
 import Idris.Elab.Type (elabType)
-import Idris.Output (iputStrLn, iRenderOutput, iPrintResult, iRenderResult, prettyDocumentedIst)
+import Idris.Output (iputStrLn, iRenderOutput, iPrintResult, iRenderError, iRenderResult, prettyDocumentedIst)
 import Idris.IBC
 
 import Prelude hiding (pred)
@@ -55,9 +55,13 @@ searchByType pkgs pterm = do
          displayScore theScore <> char ' ' <> prettyDocumentedIst i docInfo
                 | (n, theScore) <- names']
   case idris_outputmode i of
-    RawOutput _  -> do mapM_ iRenderOutput docs
+    RawOutput _  -> do if (not (null docs))
+                          then mapM_ iRenderOutput docs
+                          else iRenderError $ text "No results found"
                        iPrintResult ""
-    IdeMode _ _ -> iRenderResult (vsep docs)
+    IdeMode _ _ -> if (not (null docs))
+                      then iRenderResult (vsep docs)
+                      else iRenderError $ text "No results found"
   putIState i -- don't actually make any changes
   where
     numLimit = 50

--- a/src/Idris/TypeSearch.hs
+++ b/src/Idris/TypeSearch.hs
@@ -54,14 +54,12 @@ searchByType pkgs pterm = do
        [ let docInfo = (n, delabTy i n, fmap (overview . fst) (lookupCtxtExact n (idris_docstrings i))) in
          displayScore theScore <> char ' ' <> prettyDocumentedIst i docInfo
                 | (n, theScore) <- names']
-  case idris_outputmode i of
-    RawOutput _  -> do if (not (null docs))
-                          then mapM_ iRenderOutput docs
-                          else iRenderError $ text "No results found"
-                       iPrintResult ""
-    IdeMode _ _ -> if (not (null docs))
-                      then iRenderResult (vsep docs)
-                      else iRenderError $ text "No results found"
+  if (not (null docs))
+     then case idris_outputmode i of
+               RawOutput _  -> do mapM_ iRenderOutput docs
+                                  iPrintResult ""
+               IdeMode _ _ -> iRenderResult (vsep docs)
+     else iRenderError $ text "No results found"
   putIState i -- don't actually make any changes
   where
     numLimit = 50


### PR DESCRIPTION
When `:apropos` or `:search` can't find anything, an error is now shown. Fixes #2091 