### PR TITLE
runtest.pl : fix error when there is no sandbox

### DIFF
--- a/test/runtest.pl
+++ b/test/runtest.pl
@@ -10,10 +10,11 @@ my @idrOpts    = ();
 
 sub sandbox_path {
     my ($test_dir,) = @_;
-    my $sandbox = abs_path("$test_dir/../../.cabal-sandbox/bin");
+    my $sandbox = "$test_dir/../../.cabal-sandbox/bin";
 
     if ( -d $sandbox ) {
-        return "PATH=\"$sandbox:$PATH\"";
+        my $sandbox_abs = abs_path($sandbox);
+        return "PATH=\"$sandbox_abs:$PATH\"";
     } else {
         return "";
     }


### PR DESCRIPTION
If directory doesn't exist `abs_path` just fails. This patch resolves issue for me

``` shell
basic001/../../.cabal-sandbox/bin: No such file or directory at ./runtest.pl line 13
make: *** [basic001.test] Error 2
```