### PR TITLE
Make a mechanism for os-dependent output of tests

### DIFF
--- a/test/interactive007/expected.msys
+++ b/test/interactive007/expected.msys
@@ -1,0 +1,1 @@
+Idris> *Data\ZZ> *Data\ZZ> *Data\ZZ> *Data\ZZ> Bye bye

--- a/test/runtest.pl
+++ b/test/runtest.pl
@@ -30,6 +30,14 @@ sub runtest {
     my $got = `$sandbox ./run @idrOpts`;
     my $exp = `cat expected`;
 
+    # Allow for variant expected output for tests by overriding expected
+    # when there is an expected.<os> file in the test.
+    # This should be the exception but there are sometimes valid reasons
+    # for os-dependent output.
+    # The endings are msys for windows, darwin for osx and linux for linux
+    if ( -e "expected.$^O") {
+        $exp = `cat expected.$^O`;
+    }
     open my $out, '>', 'output';
     print $out $got;
     close $out;


### PR DESCRIPTION
Fixes interactive007 on Windows.

This might be slightly controversial, but there are good reasons here for the output being different. I feel it's better to make a mechanism that accommodates the (hopefully rare) cases of that rather than make spurious changes in Idris just to shut up the tests.

I don't know what perl uses for OS strings for the BSDs, but they can be added to the comment by people in the know.