### PR TITLE
Type Signatures use IO' l where they can instead of IO

### DIFF
--- a/libs/prelude/IO.idr
+++ b/libs/prelude/IO.idr
@@ -152,7 +152,9 @@ FFI_C = MkFFI C_Types String String
 IO : Type -> Type
 IO = IO' FFI_C
 
-run__provider : IO' l a -> PrimIO a
+-- Cannot be relaxed as is used by type providers and they expect IO a
+-- in the first argument.
+run__provider : IO a -> PrimIO a
 run__provider (MkIO f) = f (TheWorld prim__TheWorld)
 
 prim_fork : PrimIO () -> PrimIO Ptr

--- a/libs/prelude/IO.idr
+++ b/libs/prelude/IO.idr
@@ -152,13 +152,13 @@ FFI_C = MkFFI C_Types String String
 IO : Type -> Type
 IO = IO' FFI_C
 
-run__provider : IO a -> PrimIO a
-run__provider (MkIO f) = f (TheWorld prim__TheWorld)
+run__provider : IO' l a -> PrimIO a
+run__provider = call__IO
 
 prim_fork : PrimIO () -> PrimIO Ptr
 prim_fork x = prim_io_return prim__vm -- compiled specially
 
-fork : IO () -> IO Ptr
+fork : IO' l () -> IO' l Ptr
 fork (MkIO f) = MkIO (\w => prim_io_bind
                               (prim_fork (prim_io_bind (f w)
                                    (\ x => prim_io_return x)))

--- a/libs/prelude/IO.idr
+++ b/libs/prelude/IO.idr
@@ -153,7 +153,7 @@ IO : Type -> Type
 IO = IO' FFI_C
 
 run__provider : IO' l a -> PrimIO a
-run__provider = call__IO
+run__provider (MkIO f) = f (TheWorld prim__TheWorld)
 
 prim_fork : PrimIO () -> PrimIO Ptr
 prim_fork x = prim_io_return prim__vm -- compiled specially

--- a/libs/prelude/Prelude.idr
+++ b/libs/prelude/Prelude.idr
@@ -526,7 +526,7 @@ validFile (FHandle h) = do x <- nullPtr h
 ||| @ test the condition of the loop
 ||| @ body the loop body
 partial -- obviously
-while : (test : IO Bool) -> (body : IO ()) -> IO ()
+while : (test : IO' l Bool) -> (body : IO' l ()) -> IO' l ()
 while t b = do v <- t
                if v then do b
                             while t b


### PR DESCRIPTION
This is just a minor cleanup so that these functions no longer rely on the C FFI, and can be used with an IO monad parameterised by whichever FFI they want.

In this case, `fork` is entirely implemented with primitives, and `while` is entirely implemented with the monad instance of `IO' l`, which doesn't use the C FFI either. `run__provider` seems just to be a reimplementation of `call__IO`.