### PR TITLE
Add missing clause in showCG

### DIFF
--- a/src/Idris/Core/TT.hs
+++ b/src/Idris/Core/TT.hs
@@ -425,6 +425,7 @@ showCG (SN s) = showCG' s
         showCG' (ParentN p c) = showCG p ++ "#" ++ show c
         showCG' (CaseN c) = showCG c ++ "_case"
         showCG' (ElimN sn) = showCG sn ++ "_elim"
+        showCG' (InstanceCtorN n) = showCG n ++ "_ictor"
 showCG NErased = "_"
 
 


### PR DESCRIPTION
This was missing, and was giving me compilation errors, I just added the simplest thing that worked.

I'm not quite sure how this hasn't come up before, given other backends also use `showCG`, but maybe they know they have a restricted set of names by then.