### PR TITLE
Add cabal.config to .gitignore

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -2,6 +2,7 @@ dist
 cabal-dev/
 .cabal-sandbox
 cabal.sandbox.config
+cabal.config
 .hsenv
 *.ibc
 *.o


### PR DESCRIPTION
When running sandboxed it is recommended to use a local
cabal.config for user settings as cabal.sandbox.config is autogenerated.

I use it to disable documentation building. Haddock is a pain sometimes.