### PR TITLE
Fixed bitrot from inclusion of new effects API.

### DIFF
--- a/libs/effects/Effect/Exception.idr
+++ b/libs/effects/Effect/Exception.idr
@@ -4,7 +4,7 @@ import Effects
 import System
 import Control.IOExcept
 
-data Exception : Type -> Effect where 
+data Exception : Type -> Effect where
      Raise : a -> sig (Exception a) b
 
 instance Handler (Exception a) Maybe where
@@ -14,7 +14,7 @@ instance Handler (Exception a) List where
      handle _ (Raise e) k = []
 
 instance Show a => Handler (Exception a) IO where
-     handle _ (Raise e) k = do print e
+     handle _ (Raise e) k = do printLn e
                                believe_me (exit 1)
 
 instance Handler (Exception a) (IOExcept a) where
@@ -26,5 +26,5 @@ instance Handler (Exception a) (Either a) where
 EXCEPTION : Type -> EFFECT
 EXCEPTION t = MkEff () (Exception t)
 
-raise : a -> Eff b [EXCEPTION a] 
+raise : a -> Eff b [EXCEPTION a]
 raise err = call $ Raise err

--- a/libs/effects/Effect/StdIO.idr
+++ b/libs/effects/Effect/StdIO.idr
@@ -9,8 +9,8 @@ import Control.IOExcept
 
 ||| The internal representation of StdIO effects
 data StdIO : Effect where
-     PutStr : String -> sig StdIO () 
-     GetStr : sig StdIO String 
+     PutStr : String -> sig StdIO ()
+     GetStr : sig StdIO String
      PutCh : Char -> sig StdIO ()
      GetCh : sig StdIO Char
 
@@ -22,14 +22,18 @@ data StdIO : Effect where
 instance Handler StdIO IO where
     handle () (PutStr s) k = do putStr s; k () ()
     handle () GetStr     k = do x <- getLine; k x ()
-    handle () (PutCh c)  k = do putChar c; k () () 
+    handle () (PutCh c)  k = do putChar c; k () ()
     handle () GetCh      k = do x <- getChar; k x ()
 
 instance Handler StdIO (IOExcept a) where
     handle () (PutStr s) k = do ioe_lift $ putStr s; k () ()
     handle () GetStr     k = do x <- ioe_lift $ getLine; k x ()
-    handle () (PutCh c)  k = do ioe_lift $ putChar c; k () () 
+    handle () (PutCh c)  k = do ioe_lift $ putChar c; k () ()
     handle () GetCh      k = do x <- ioe_lift $ getChar; k x ()
+
+-------------------------------------------------------------
+--- The Effect and associated functions
+-------------------------------------------------------------
 
 -------------------------------------------------------------
 --- The Effect and associated functions
@@ -42,13 +46,17 @@ STDIO = MkEff () StdIO
 putStr : String -> Eff () [STDIO]
 putStr s = call $ PutStr s
 
+||| Write a string to standard output, terminating with a newline.
+putStrLn : String -> Eff () [STDIO]
+putStrLn s = putStr (s ++ "\n")
+
 ||| Write a character to standard output.
 putChar : Char -> Eff () [STDIO]
 putChar c = call $ PutCh c
 
-||| Write a string to standard output, terminating with a newline.
-putStrLn : String -> Eff () [STDIO]
-putStrLn s = putStr (s ++ "\n")
+||| Write a character to standard output, terminating with a newline.
+putCharLn : Char -> Eff () [STDIO]
+putCharLn c = putStrLn (singleton c)
 
 ||| Read a string from standard input.
 getStr : Eff String [STDIO]
@@ -58,3 +66,12 @@ getStr = call $ GetStr
 getChar : Eff Char [STDIO]
 getChar = call $ GetCh
 
+||| Given a parameter `a` 'show' `a` to standard output.
+print : Show a => a -> Eff () [STDIO]
+print a = putStr (show a)
+
+||| Given a parameter `a` 'show' `a` to a standard output, terminating with a newline
+printLn : Show a => a -> Eff () [STDIO]
+printLn a = putStrLn (show a)
+
+-- --------------------------------------------------------------------- [ EOF ]


### PR DESCRIPTION
The new `print` and `printLn` functions were lost in the roll over.