### PR TITLE
Parser traces

### DIFF
--- a/CHANGELOG
+++ b/CHANGELOG
@@ -28,6 +28,8 @@ New in 0.9.18:
   choice, keeping the first success as Alternative does. The version that
   collects successes is now a named instance.
 * :exec REPL command now takes an optional expression to compile and run/show
+* The --parsertrace option (for purposes of debugging the compiler)
+  will print a parser trace.
 
 New in 0.9.17:
 --------------

--- a/src/Idris/ASTUtils.hs
+++ b/src/Idris/ASTUtils.hs
@@ -62,6 +62,12 @@ fputState field x = fmodifyState field (const x)
 fmodifyState :: MonadState s m => Field s a -> (a -> a) -> m ()
 fmodifyState field f = modify $ fmodify field f
 
+fsetFlag :: MonadState s m => Field s Bool -> m ()
+fsetFlag field = fputState field True
+
+fclearFlag :: MonadState s m => Field s Bool -> m ()
+fclearFlag field = fputState field False
+
 -- Exact-name context lookup; uses Nothing for deleted values (read+write!).
 -- 
 -- Reading a non-existing value yields Nothing,
@@ -126,13 +132,27 @@ cg_usedpos :: Field CGInfo [(Int, [UsageReason])]
 cg_usedpos = Field usedpos (\v cg -> cg{ usedpos = v })
 
 
+-- Options
+----------
+
+ist_options :: Field IState IOption
+ist_options = Field idris_options (\v ist -> ist{ idris_options = v })
+
+ist_parserTrace :: Field IState [ParserTraceItem]
+ist_parserTrace = Field idris_parserTrace (\v ist -> ist{ idris_parserTrace = v })
+
+
 -- Commandline flags
 --------------------
 
-opts_idrisCmdline :: Field IState [Opt]
-opts_idrisCmdline =
-      Field opt_cmdline (\v opts -> opts{ opt_cmdline = v })
-    . Field idris_options (\v ist -> ist{ idris_options = v })
+opts_idrisCmdline :: Field IOption [Opt]
+opts_idrisCmdline = Field opt_cmdline (\v opts -> opts{ opt_cmdline = v })
+
+opts_parserTrace :: Field IOption Bool
+opts_parserTrace = Field opt_parserTrace (\v opts -> opts{ opt_parserTrace = v })
+
+opts_warnReach :: Field IOption Bool
+opts_warnReach = Field opt_warnReach (\v opts -> opts{ opt_warnReach = v })
 
 -- TT Context
 -------------

--- a/src/Idris/ASTUtils.hs
+++ b/src/Idris/ASTUtils.hs
@@ -12,17 +12,25 @@ module Idris.ASTUtils where
 -- f :: Idris ()
 -- f = do
 --      -- these two steps:
---      detaggable <- fgetState (opt_detaggable . ist_optimisation typeName)
---      fputState (opt_detaggable . ist_optimisation typeName) (not detaggable)
+--      detaggable <- fget $ opt_detaggable . ist_optimisation typeName
+--      fput (opt_detaggable . ist_optimisation typeName) (not detaggable)
 --
 --      -- are equivalent to:
---      fmodifyState (opt_detaggable . ist_optimisation typeName) not
+--      fmodify (opt_detaggable . ist_optimisation typeName) not
 --
---      -- of course, the long accessor can be put in a variable;
+--      -- Of course, the long accessor can be put in a variable;
 --      -- everything is first-class
 --      let detag n = opt_detaggable . ist_optimisation n
---      fputState (detag n1) True
---      fputState (detag n2) False
+--      fput (detag n1) True
+--      fput (detag n2) False
+--
+--      -- expressed more succintly as
+--      fsetFlag   $ detag n1
+--      fclearFlag $ detag n2
+--
+--      -- or:
+--      detag n1 .= True
+--      detag n2 .= False
 --
 --      -- Note that all these operations handle missing items consistently
 --      -- and transparently, as prescribed by the default values included
@@ -42,31 +50,36 @@ import Idris.Core.Evaluate
 import Idris.AbsSyntaxTree
 
 data Field rec fld = Field
-    { fget :: rec -> fld
-    , fset :: fld -> rec -> rec
+    { fgetField :: rec -> fld
+    , fsetField :: fld -> rec -> rec
     }
 
-fmodify :: Field rec fld -> (fld -> fld) -> rec -> rec
-fmodify field f x = fset field (f $ fget field x) x
+fmodifyField :: Field rec fld -> (fld -> fld) -> rec -> rec
+fmodifyField field f x = fsetField field (f $ fgetField field x) x
 
 instance Category Field where
     id = Field id const
     Field g2 s2 . Field g1 s1 = Field (g2 . g1) (\v2 x1 -> s1 (s2 v2 $ g1 x1) x1)
 
-fgetState :: MonadState s m => Field s a -> m a
-fgetState field = gets $ fget field
+fget :: MonadState s m => Field s a -> m a
+fget field = gets $ fgetField field
 
-fputState :: MonadState s m => Field s a -> a -> m ()
-fputState field x = fmodifyState field (const x)
+fput :: MonadState s m => Field s a -> a -> m ()
+fput field x = fmodify field (const x)
 
-fmodifyState :: MonadState s m => Field s a -> (a -> a) -> m ()
-fmodifyState field f = modify $ fmodify field f
+fmodify :: MonadState s m => Field s a -> (a -> a) -> m ()
+fmodify field f = modify $ fmodifyField field f
+
+-- Control.Category.. is infixr 7
+infix 4 .=
+(.=) :: MonadState s m => Field s a -> a -> m ()
+(.=) = fput
 
 fsetFlag :: MonadState s m => Field s Bool -> m ()
-fsetFlag field = fputState field True
+fsetFlag field = field .= True
 
 fclearFlag :: MonadState s m => Field s Bool -> m ()
-fclearFlag field = fputState field False
+fclearFlag field = field .= False
 
 -- Exact-name context lookup; uses Nothing for deleted values (read+write!).
 -- 
@@ -74,8 +87,8 @@ fclearFlag field = fputState field False
 -- writing Nothing deletes the value (if it existed).
 ctxt_lookup :: Name -> Field (Ctxt a) (Maybe a)
 ctxt_lookup n = Field
-    { fget = lookupCtxtExact n
-    , fset = \newVal -> case newVal of
+    { fgetField = lookupCtxtExact n
+    , fsetField = \newVal -> case newVal of
         Just x  -> addDef n x
         Nothing -> deleteDefExact n
     }

--- a/src/Idris/CmdOptions.hs
+++ b/src/Idris/CmdOptions.hs
@@ -103,6 +103,7 @@ parseFlags = many $
   <|> flag' ShowLibdir (long "libdir" <> help "Display library directory")
   <|> flag' ShowIncs (long "include" <> help "Display the includes flags")
   <|> flag' Verbose (short 'V' <> long "verbose" <> help "Loud verbosity")
+  <|> flag' ParserTrace (long "parsertrace" <> help "Print parser trace")
   <|> (IBCSubDir <$> strOption (long "ibcsubdir" <> metavar "FILE" <> help "Write IBC files into sub directory"))
   <|> (ImportDir <$> strOption (short 'i' <> long "idrispath" <> help "Add directory to the list of import paths"))
   <|> flag' WarnOnly (long "warn")

--- a/src/Idris/Elab/Clause.hs
+++ b/src/Idris/Elab/Clause.hs
@@ -65,7 +65,7 @@ elabClauses info' fc opts n_in cs =
          ist  <- getIState
          optimise <- getOptimise
          let petrans = PETransform `elem` optimise
-         inacc <- map fst <$> fgetState (opt_inaccessible . ist_optimisation n)
+         inacc <- map fst <$> fget (opt_inaccessible . ist_optimisation n)
 
          -- Check n actually exists, with no definition yet
          let tys = lookupTy n ctxt
@@ -89,7 +89,7 @@ elabClauses info' fc opts n_in cs =
            solveDeferred n
 
            -- just ensure that the structure exists
-           fmodifyState (ist_optimisation n) id
+           fmodify (ist_optimisation n) id
            addIBC (IBCOpt n)
 
            ist <- getIState

--- a/src/Idris/Elab/Data.hs
+++ b/src/Idris/Elab/Data.hs
@@ -241,7 +241,7 @@ elabCon info syn tn codata expkind dkind (doc, argDocs, n, t_in, fc, forcenames)
                                          return (n, d')) argDocs
          addDocStr n doc' argDocs'
          addIBC (IBCDoc n)
-         fputState (opt_inaccessible . ist_optimisation n) inacc
+         fput (opt_inaccessible . ist_optimisation n) inacc
          addIBC (IBCOpt n)
          return (n, cty')
   where

--- a/src/Idris/Elab/Type.hs
+++ b/src/Idris/Elab/Type.hs
@@ -167,7 +167,7 @@ elabType' norm info syn doc argDocs fc opts n ty' = {- let ty' = piBind (params 
          addDocStr n doc' argDocs'
          addIBC (IBCDoc n)
          addIBC (IBCFlags n opts')
-         fputState (opt_inaccessible . ist_optimisation n) inacc
+         fput (opt_inaccessible . ist_optimisation n) inacc
          addIBC (IBCOpt n)
          when (Implicit `elem` opts') $ do addCoercion n
                                            addIBC (IBCCoercion n)

--- a/src/Idris/Erasure.hs
+++ b/src/Idris/Erasure.hs
@@ -121,7 +121,7 @@ performUsageAnalysis startNames = do
             | otherwise = show i ++ " from " ++ intercalate ", " (map show $ S.toList rs)
 
     storeUsage :: (Name, IntMap (Set Reason)) -> Idris ()
-    storeUsage (n, args) = fputState (cg_usedpos . ist_callgraph n) flat
+    storeUsage (n, args) = fput (cg_usedpos . ist_callgraph n) flat
       where
         flat = [(i, S.toList rs) | (i,rs) <- IM.toList args]
 

--- a/src/Idris/Erasure.hs
+++ b/src/Idris/Erasure.hs
@@ -91,7 +91,7 @@ performUsageAnalysis startNames = do
         logLvl 5 $ "Residual deps:\n" ++ unlines (map fmtItem . M.toList $ residDeps)
 
         -- Check that everything reachable is accessible.
-        checkEnabled <- (WarnReach `elem`) . opt_cmdline . idris_options <$> getIState
+        checkEnabled <- opt_warnReach . idris_options <$> getIState
         when checkEnabled $
             mapM_ (checkAccessibility opt) usage
 

--- a/src/Idris/ParseData.hs
+++ b/src/Idris/ParseData.hs
@@ -4,7 +4,7 @@ module Idris.ParseData where
 import Prelude hiding (pi)
 
 import Text.Trifecta.Delta
-import Text.Trifecta hiding (span, stringLiteral, charLiteral, natural, symbol, char, string, whiteSpace, Err)
+import Text.Trifecta hiding (span, stringLiteral, charLiteral, natural, symbol, char, string, whiteSpace, Err, (<?>))
 import Text.Parser.LookAhead
 import Text.Parser.Expression
 import qualified Text.Parser.Token as Tok

--- a/src/Idris/ParseExpr.hs
+++ b/src/Idris/ParseExpr.hs
@@ -5,7 +5,7 @@ module Idris.ParseExpr where
 import Prelude hiding (pi)
 
 import Text.Trifecta.Delta
-import Text.Trifecta hiding (span, stringLiteral, charLiteral, natural, symbol, char, string, whiteSpace, Err)
+import Text.Trifecta hiding (span, stringLiteral, charLiteral, natural, symbol, char, string, whiteSpace, Err, (<?>))
 import Text.Parser.LookAhead
 import Text.Parser.Expression
 import qualified Text.Parser.Token as Tok

--- a/src/Idris/ParseHelpers.hs
+++ b/src/Idris/ParseHelpers.hs
@@ -118,8 +118,10 @@ p <?> desc = parserTrace desc *> (p Text.Trifecta.<?> desc)
 
 printParserTrace :: Idris ()
 printParserTrace = do
-    prn "Parser trace:"
-    mapM_ (prn . fmtItem) . reverse . idris_parserTrace =<< getIState
+    doTrace <- fget $ opts_parserTrace . ist_options
+    when doTrace $ do
+        prn "Parser trace:"
+        mapM_ (prn . fmtItem) . reverse . idris_parserTrace =<< getIState
   where
     prn :: String -> Idris ()
     prn = logLvl 0

--- a/src/Idris/ParseHelpers.hs
+++ b/src/Idris/ParseHelpers.hs
@@ -106,10 +106,10 @@ parserTrace' fn = parserTrace fn *> mzero
 -- for use in do-blocks
 parserTrace :: String -> IdrisParser ()
 parserTrace fn = do
-    doTrace <- fgetState $ opts_parserTrace . ist_options
+    doTrace <- fget $ opts_parserTrace . ist_options
     when doTrace $ do
         fc <- getFC
-        fmodifyState ist_parserTrace ((fc, fn) :)
+        fmodify ist_parserTrace ((fc, fn) :)
 
 -- This is our override for <?> that can also save the parser trace.
 -- Please import Text.Trifecta hiding (<?>) and use this instead.

--- a/src/Idris/ParseOps.hs
+++ b/src/Idris/ParseOps.hs
@@ -4,7 +4,7 @@ module Idris.ParseOps where
 import Prelude hiding (pi)
 
 import Text.Trifecta.Delta
-import Text.Trifecta hiding (span, stringLiteral, charLiteral, natural, symbol, char, string, whiteSpace)
+import Text.Trifecta hiding (span, stringLiteral, charLiteral, natural, symbol, char, string, whiteSpace, (<?>))
 import Text.Parser.LookAhead
 import Text.Parser.Expression
 import qualified Text.Parser.Token as Tok

--- a/src/Idris/Parser.hs
+++ b/src/Idris/Parser.hs
@@ -9,7 +9,7 @@ module Idris.Parser(module Idris.Parser,
 import Prelude hiding (pi)
 
 import Text.Trifecta.Delta
-import Text.Trifecta hiding (span, stringLiteral, charLiteral, natural, symbol, char, string, whiteSpace, Err)
+import Text.Trifecta hiding (span, stringLiteral, charLiteral, natural, symbol, char, string, whiteSpace, Err, (<?>))
 import Text.Parser.LookAhead
 import Text.Parser.Expression
 import qualified Text.Parser.Token as Tok
@@ -1274,6 +1274,7 @@ parseProg syn fname input mrk
                                   return []
             Success (x, i)  -> do putIState i
                                   reportParserWarnings
+                                  printParserTrace
                                   return $ collect x
   where mainProg :: IdrisParser ([PDecl], IState)
         mainProg = case mrk of

--- a/src/Idris/REPL.hs
+++ b/src/Idris/REPL.hs
@@ -795,7 +795,7 @@ process fn (NewDefn decls) = do
   defineName (PClauses{} : _) = tclift $ tfail (Msg "Only one function body is allowed without a type declaration.")
   -- fixity and syntax declarations are ignored by elabDecls, so they'll have to be handled some other way
   defineName (PFix fc fixity strs : defns) = do
-    fmodifyState idris_fixities (map (Fix fixity) strs ++)
+    fmodify idris_fixities (map (Fix fixity) strs ++)
     unless (null defns) $ defineName defns
   defineName (PSyntax _ syntax:_) = do
     i <- get
@@ -814,7 +814,7 @@ process fn (NewDefn decls) = do
   setReplDefined Nothing = return ()
   setReplDefined (Just n) = do
     oldState <- get
-    fmodifyState repl_definitions (n:)
+    fmodify repl_definitions (n:)
   -- the "name" field of PClauses seems to always be MN 2 "__", so we need to
   -- retrieve the actual name from deeper inside.
   -- This should really be a full recursive walk through the structure of PDecl, but
@@ -844,11 +844,11 @@ process fn (Undefine names) = undefine names
                  undefine' names (undefinedJustNow ++ already)
          else do tclift $ tfail $ Msg ("Can't undefine " ++ show n ++ " because it wasn't defined at the repl")
                  undefine' names already
-    undefOne n = do fputState (ctxt_lookup n . known_terms) Nothing
+    undefOne n = do fput (ctxt_lookup n . known_terms) Nothing
                     -- for now just assume it's a class. Eventually we'll want some kind of
                     -- smart detection of exactly what kind of name we're undefining.
-                    fputState (ctxt_lookup n . known_classes) Nothing
-                    fmodifyState repl_definitions (delete n)
+                    fput (ctxt_lookup n . known_classes) Nothing
+                    fmodify repl_definitions (delete n)
     undefClosure n =
       do replDefs <- idris_repl_defs `fmap` get
          callGraph <- whoCalls n
@@ -1198,10 +1198,10 @@ process fn (SetOpt AutoSolve)     = setAutoSolve True
 process fn (UnsetOpt AutoSolve)   = setAutoSolve False
 process fn (SetOpt NoBanner)      = setNoBanner True
 process fn (UnsetOpt NoBanner)    = setNoBanner False
-process fn (SetOpt WarnReach)     = fsetFlag   $ opts_warnReach . ist_options
-process fn (UnsetOpt WarnReach)   = fclearFlag $ opts_warnReach . ist_options
-process fn (SetOpt ParserTrace)   = fsetFlag   $ opts_parserTrace . ist_options
-process fn (UnsetOpt ParserTrace) = fclearFlag $ opts_parserTrace . ist_options
+process fn (SetOpt WarnReach)     = opts_warnReach . ist_options .= True
+process fn (UnsetOpt WarnReach)   = opts_warnReach . ist_options .= False
+process fn (SetOpt ParserTrace)   = opts_parserTrace . ist_options .= True
+process fn (UnsetOpt ParserTrace) = opts_parserTrace . ist_options .= False
 
 process fn (SetOpt _) = iPrintError "Not a valid option"
 process fn (UnsetOpt _) = iPrintError "Not a valid option"
@@ -1663,8 +1663,8 @@ idrisMain opts =
     makeOption TypeInType = setTypeInType True
     makeOption NoCoverage = setCoverage False
     makeOption ErrContext = setErrContext True
-    makeOption ParserTrace = fsetFlag $ opts_parserTrace . ist_options
-    makeOption WarnReach   = fsetFlag $ opts_warnReach . ist_options
+    makeOption ParserTrace = opts_parserTrace . ist_options .= True
+    makeOption WarnReach   = opts_warnReach   . ist_options .= True
     makeOption _ = return ()
 
     addPkgDir :: String -> Idris ()

--- a/src/Idris/REPL.hs
+++ b/src/Idris/REPL.hs
@@ -1198,8 +1198,10 @@ process fn (SetOpt AutoSolve)     = setAutoSolve True
 process fn (UnsetOpt AutoSolve)   = setAutoSolve False
 process fn (SetOpt NoBanner)      = setNoBanner True
 process fn (UnsetOpt NoBanner)    = setNoBanner False
-process fn (SetOpt WarnReach)     = fmodifyState opts_idrisCmdline $ nub . (WarnReach:)
-process fn (UnsetOpt WarnReach)   = fmodifyState opts_idrisCmdline $ delete WarnReach
+process fn (SetOpt WarnReach)     = fsetFlag   $ opts_warnReach . ist_options
+process fn (UnsetOpt WarnReach)   = fclearFlag $ opts_warnReach . ist_options
+process fn (SetOpt ParserTrace)   = fsetFlag   $ opts_parserTrace . ist_options
+process fn (UnsetOpt ParserTrace) = fclearFlag $ opts_parserTrace . ist_options
 
 process fn (SetOpt _) = iPrintError "Not a valid option"
 process fn (UnsetOpt _) = iPrintError "Not a valid option"
@@ -1661,6 +1663,8 @@ idrisMain opts =
     makeOption TypeInType = setTypeInType True
     makeOption NoCoverage = setCoverage False
     makeOption ErrContext = setErrContext True
+    makeOption ParserTrace = fsetFlag $ opts_parserTrace . ist_options
+    makeOption WarnReach   = fsetFlag $ opts_warnReach . ist_options
     makeOption _ = return ()
 
     addPkgDir :: String -> Idris ()

--- a/test/reg050/expected
+++ b/test/reg050/expected
@@ -1,10 +1,10 @@
 ./badbangop.idr:7:1: error: ! is
     not a valid
-    operator, expected: space
+    operator, expected: "{-"
 (!) : List a -> Nat -> Maybe a 
 ^                              
 ./baddoublebang.idr:6:28: error: unexpected
     Operator without known fixity:
-    !!, expected: space
+    !!, expected: "{-"
 doubleBang mmn = do pure !!mmn 
                            ^   


### PR DESCRIPTION
With `--parsertrace`, you can get parser traces where the "checkpoints" are given by `<?>`:
```idris
$ cat impl.idr 
module impl

f : {x : Nat} -> Bool
f = True

$ idris --parsertrace --check impl.idr
Parser trace:
  impl.idr:1:8: identifier
  impl.idr:1:8: identifier
  impl.idr:3:1: function modifier
  impl.idr:3:1: function modifier
  impl.idr:3:1: function name
  impl.idr:3:1: name
  impl.idr:3:1: name
  impl.idr:3:1: identifier
  impl.idr:3:1: identifier
  impl.idr:3:5: type signature
  impl.idr:3:5: dependent type signature
  impl.idr:3:5: static modifier
  impl.idr:3:6: function name
  impl.idr:3:6: name
  impl.idr:3:6: name
  impl.idr:3:6: identifier
  impl.idr:3:6: identifier
  impl.idr:3:10: type signature
  impl.idr:3:10: dependent type signature
  impl.idr:3:10: static modifier
  impl.idr:3:10: expression
  impl.idr:3:10: expression
  impl.idr:3:10: function application
  impl.idr:3:10: function name
  impl.idr:3:10: name
  impl.idr:3:10: name
  impl.idr:3:10: identifier
  impl.idr:3:10: identifier
  impl.idr:3:18: dependent type signature
  impl.idr:3:18: static modifier
  impl.idr:3:18: expression
  impl.idr:3:18: expression
  impl.idr:3:18: function application
  impl.idr:3:18: function name
  impl.idr:3:18: name
  impl.idr:3:18: name
  impl.idr:3:18: identifier
  impl.idr:3:18: identifier
  impl.idr:4:1: function declaration
  impl.idr:4:1: pattern
  impl.idr:4:1: function clause
  impl.idr:4:1: function name
  impl.idr:4:1: name
  impl.idr:4:1: name
  impl.idr:4:1: identifier
  impl.idr:4:1: identifier
  impl.idr:4:5: dependent type signature
  impl.idr:4:5: static modifier
  impl.idr:4:5: expression
  impl.idr:4:5: expression
  impl.idr:4:5: function application
  impl.idr:4:5: function name
  impl.idr:4:5: name
  impl.idr:4:5: name
  impl.idr:4:5: identifier
  impl.idr:4:5: identifier
```

The diff is a bit cluttered with the rename of `fgetState` & co. to `fget` & co. If that's a problem, I can move that commit to a separate pull request or remove it altogether.

I had to refactor `PParser.hs` a bit, too.