### PR TITLE
Fix Field definition and separate Lattice and VectorSpace modules from Algebra

### DIFF
--- a/idris.cabal
+++ b/idris.cabal
@@ -114,6 +114,7 @@ Extra-source-files:
                        libs/contrib/Classes/*.idr
                        libs/contrib/Control/*.idr
                        libs/contrib/Control/Isomorphism/*.idr
+		       libs/contrib/Control/Algebra/*.idr
                        libs/contrib/Data/*.idr
                        libs/contrib/Decidable/*.idr
                        libs/contrib/Network/*.idr

--- a/libs/contrib/Classes/Verified.idr
+++ b/libs/contrib/Classes/Verified.idr
@@ -81,8 +81,8 @@ class (VerifiedRing a, RingWithUnity a) => VerifiedRingWithUnity a where
   total ringWithUnityIsUnityR : (r : a) -> unity <.> r = r
 
 class (VerifiedRing a, Field a) => VerifiedField a where
-  total fieldInverseIsInverseL : (l : a) -> l <.> inverseM l = unity
-  total fieldInverseIsInverseR : (r : a) -> inverseM r <.> r = unity
+  total fieldInverseIsInverseL : (l : a) -> (notId : Not (l = neutral)) -> l <.> (inverseM l notId) = unity
+  total fieldInverseIsInverseR : (r : a) -> (notId : Not (r = neutral)) -> (inverseM r notId) <.> r = unity
 
 
 class JoinSemilattice a => VerifiedJoinSemilattice a where

--- a/libs/contrib/Classes/Verified.idr
+++ b/libs/contrib/Classes/Verified.idr
@@ -80,7 +80,7 @@ class (VerifiedRing a, RingWithUnity a) => VerifiedRingWithUnity a where
   total ringWithUnityIsUnityL : (l : a) -> l <.> unity = l
   total ringWithUnityIsUnityR : (r : a) -> unity <.> r = r
 
-class (VerifiedRing a, Field a) => VerifiedField a where
+class (VerifiedRingWithUnity a, Field a) => VerifiedField a where
   total fieldInverseIsInverseL : (l : a) -> (notId : Not (l = neutral)) -> l <.> (inverseM l notId) = unity
   total fieldInverseIsInverseR : (r : a) -> (notId : Not (r = neutral)) -> (inverseM r notId) <.> r = unity
 

--- a/libs/contrib/Classes/Verified.idr
+++ b/libs/contrib/Classes/Verified.idr
@@ -1,6 +1,8 @@
 module Classes.Verified
 
 import Control.Algebra
+import Control.Algebra.Lattice
+import Control.Algebra.VectorSpace
 
 -- Due to these being basically unused and difficult to implement,
 -- they're in contrib for a bit. Once a design is found that lets them
@@ -78,6 +80,11 @@ class (VerifiedRing a, RingWithUnity a) => VerifiedRingWithUnity a where
   total ringWithUnityIsUnityL : (l : a) -> l <.> unity = l
   total ringWithUnityIsUnityR : (r : a) -> unity <.> r = r
 
+class (VerifiedRing a, Field a) => VerifiedField a where
+  total fieldInverseIsInverseL : (l : a) -> l <.> inverseM l = unity
+  total fieldInverseIsInverseR : (r : a) -> inverseM r <.> r = unity
+
+
 class JoinSemilattice a => VerifiedJoinSemilattice a where
   total joinSemilatticeJoinIsAssociative : (l, c, r : a) -> join l (join c r) = join (join l c) r
   total joinSemilatticeJoinIsCommutative : (l, r : a)    -> join l r = join r l
@@ -100,15 +107,11 @@ class (VerifiedJoinSemilattice a, VerifiedMeetSemilattice a) => VerifiedLattice 
 
 class (VerifiedBoundedJoinSemilattice a, VerifiedBoundedMeetSemilattice a, VerifiedLattice a) => VerifiedBoundedLattice a where { }
 
-class (VerifiedRing a, Field a) => VerifiedField a where
-  total fieldInverseIsInverseL : (l : a) -> l <.> inverseM l = unity
-  total fieldInverseIsInverseR : (r : a) -> inverseM r <.> r = unity
 
--- class (VerifiedRingWithUnity a, VerifiedAbelianGroup b, Module a b) => VerifiedModule a b where
---   total moduleScalarMultiplyComposition : (x,y : a) -> (v : b) -> x <#> (y <#> v) = (x <.> y) <#> v
---   total moduleScalarUnityIsUnity : (v : b) -> unity <#> v = v
---   total moduleScalarMultDistributiveWRTVectorAddition : (s : a) -> (v, w : b) -> s <#> (v <+> w) = (s <#> v) <+> (s <#> w)
---   total moduleScalarMultDistributiveWRTModuleAddition : (s, t : a) -> (v : b) -> (s <+> t) <#> v = (s <#> v) <+> (t <#> v)
+class (VerifiedRingWithUnity a, VerifiedAbelianGroup b, Module a b) => VerifiedModule a b where
+  total moduleScalarMultiplyComposition : (x,y : a) -> (v : b) -> x <#> (y <#> v) = (x <.> y) <#> v
+  total moduleScalarUnityIsUnity : (v : b) -> unity {a} <#> v = v
+  total moduleScalarMultDistributiveWRTVectorAddition : (s : a) -> (v, w : b) -> s <#> (v <+> w) = (s <#> v) <+> (s <#> w)
+  total moduleScalarMultDistributiveWRTModuleAddition : (s, t : a) -> (v : b) -> (s <+> t) <#> v = (s <#> v) <+> (t <#> v)
 
--- class (VerifiedField a, VerifiedModule a b) => VerifiedVectorSpace a b where {}
-
+class (VerifiedField a, VerifiedModule a b) => VerifiedVectorSpace a b where {}

--- a/libs/contrib/Classes/Verified.idr
+++ b/libs/contrib/Classes/Verified.idr
@@ -80,9 +80,9 @@ class (VerifiedRing a, RingWithUnity a) => VerifiedRingWithUnity a where
   total ringWithUnityIsUnityL : (l : a) -> l <.> unity = l
   total ringWithUnityIsUnityR : (r : a) -> unity <.> r = r
 
-class (VerifiedRingWithUnity a, Field a) => VerifiedField a where
-  total fieldInverseIsInverseL : (l : a) -> (notId : Not (l = neutral)) -> l <.> (inverseM l notId) = unity
-  total fieldInverseIsInverseR : (r : a) -> (notId : Not (r = neutral)) -> (inverseM r notId) <.> r = unity
+--class (VerifiedRingWithUnity a, Field a) => VerifiedField a where
+--  total fieldInverseIsInverseL : (l : a) -> (notId : Not (l = neutral)) -> l <.> (inverseM l notId) = unity
+--  total fieldInverseIsInverseR : (r : a) -> (notId : Not (r = neutral)) -> (inverseM r notId) <.> r = unity
 
 
 class JoinSemilattice a => VerifiedJoinSemilattice a where
@@ -108,10 +108,10 @@ class (VerifiedJoinSemilattice a, VerifiedMeetSemilattice a) => VerifiedLattice 
 class (VerifiedBoundedJoinSemilattice a, VerifiedBoundedMeetSemilattice a, VerifiedLattice a) => VerifiedBoundedLattice a where { }
 
 
-class (VerifiedRingWithUnity a, VerifiedAbelianGroup b, Module a b) => VerifiedModule a b where
-  total moduleScalarMultiplyComposition : (x,y : a) -> (v : b) -> x <#> (y <#> v) = (x <.> y) <#> v
-  total moduleScalarUnityIsUnity : (v : b) -> unity {a} <#> v = v
-  total moduleScalarMultDistributiveWRTVectorAddition : (s : a) -> (v, w : b) -> s <#> (v <+> w) = (s <#> v) <+> (s <#> w)
-  total moduleScalarMultDistributiveWRTModuleAddition : (s, t : a) -> (v : b) -> (s <+> t) <#> v = (s <#> v) <+> (t <#> v)
+--class (VerifiedRingWithUnity a, VerifiedAbelianGroup b, Module a b) => VerifiedModule a b where
+--  total moduleScalarMultiplyComposition : (x,y : a) -> (v : b) -> x <#> (y <#> v) = (x <.> y) <#> v
+--  total moduleScalarUnityIsUnity : (v : b) -> unity {a} <#> v = v
+--  total moduleScalarMultDistributiveWRTVectorAddition : (s : a) -> (v, w : b) -> s <#> (v <+> w) = (s <#> v) <+> (s <#> w)
+--  total moduleScalarMultDistributiveWRTModuleAddition : (s, t : a) -> (v : b) -> (s <+> t) <#> v = (s <#> v) <+> (t <#> v)
 
-class (VerifiedField a, VerifiedModule a b) => VerifiedVectorSpace a b where {}
+--class (VerifiedField a, VerifiedModule a b) => VerifiedVectorSpace a b where {}

--- a/libs/contrib/Control/Algebra.idr
+++ b/libs/contrib/Control/Algebra.idr
@@ -1,7 +1,7 @@
 module Control.Algebra
 
 infixl 6 <->
-infixl 6 <.>
+infixl 7 <.>
 
 
 ||| Sets equipped with a single binary operation that is associative, along with

--- a/libs/contrib/Control/Algebra.idr
+++ b/libs/contrib/Control/Algebra.idr
@@ -87,10 +87,10 @@ class AbelianGroup a => Ring a where
 class Ring a => RingWithUnity a where
   unity : a
 
-||| Sets equipped with two binary operations, both associative and commutative
-||| supplied with a neutral element, with
-||| distributivity laws relating the two operations.  Must satisfy the following
-||| laws:
+||| Sets equipped with two binary operations – both associative, commutative and
+||| possessing a neutral element – and distributivity laws relating the two
+||| operations. All elements except the additive identity must have a
+||| multiplicative inverse. Must satisfy the following laws:
 |||
 ||| + Associativity of `<+>`:
 |||     forall a b c, a <+> (b <+> c) == (a <+> b) <+> c
@@ -107,14 +107,14 @@ class Ring a => RingWithUnity a where
 ||| + Unity for `<.>`:
 |||     forall a,     a <.> unity     == a
 |||     forall a,     unity <.> a     == a
-||| + InverseM of `<.>`:
-|||     forall a,     a <.> inverseM a == unity
-|||     forall a,     inverseM a <.> a == unity
+||| + InverseM of `<.>`, except for neutral
+|||     forall a /= neutral,  a <.> inverseM a == unity
+|||     forall a /= neutral,  inverseM a <.> a == unity
 ||| + Distributivity of `<.>` and `<->`:
 |||     forall a b c, a <.> (b <+> c) == (a <.> b) <+> (a <.> c)
 |||     forall a b c, (a <+> b) <.> c == (a <.> c) <+> (b <.> c)
 class RingWithUnity a => Field a where
-  inverseM : a -> a
+  inverseM : (x : a) -> Not (x = neutral) -> a
 
 
 -- XXX todo:

--- a/libs/contrib/Control/Algebra.idr
+++ b/libs/contrib/Control/Algebra.idr
@@ -60,7 +60,6 @@ class Group a => AbelianGroup a where { }
 class AbelianGroup a => Ring a where
   (<.>) : a -> a -> a
 
-
 ||| Sets equipped with two binary operations, one associative and commutative
 ||| supplied with a neutral element, and the other associative supplied with a
 ||| neutral element, with distributivity laws relating the two operations.  Must
@@ -115,6 +114,16 @@ class Ring a => RingWithUnity a where
 |||     forall a b c, (a <+> b) <.> c == (a <.> c) <+> (b <.> c)
 class RingWithUnity a => Field a where
   inverseM : (x : a) -> Not (x = neutral) -> a
+
+sum : (Foldable t, Monoid a) => t a -> a
+sum = foldr (<+>) neutral
+
+product : (Foldable t, RingWithUnity a) => t a -> a
+product = foldr (<.>) unity
+
+power : RingWithUnity a => a -> Nat -> a
+power _ Z     = unity
+power x (S n) = x <.> (Algebra.power x n)
 
 
 -- XXX todo:

--- a/libs/contrib/Control/Algebra.idr
+++ b/libs/contrib/Control/Algebra.idr
@@ -1,11 +1,8 @@
 module Control.Algebra
 
-import Data.Heap
-
--- XXX: change?
 infixl 6 <->
 infixl 6 <.>
-infixl 5 <#>
+
 
 ||| Sets equipped with a single binary operation that is associative, along with
 ||| a neutral element for that binary operation and inverses for all elements.
@@ -39,7 +36,6 @@ class Monoid a => Group a where
 |||     forall a,     a <+> inverse a == neutral
 |||     forall a,     inverse a <+> a == neutral
 class Group a => AbelianGroup a where { }
-
 
 ||| Sets equipped with two binary operations, one associative and commutative
 ||| supplied with a neutral element, and the other associative, with
@@ -91,133 +87,6 @@ class AbelianGroup a => Ring a where
 class Ring a => RingWithUnity a where
   unity : a
 
-
-||| Sets equipped with a binary operation that is commutative, associative and
-||| idempotent.  Must satisfy the following laws:
-|||
-||| + Associativity of join:
-|||     forall a b c, join a (join b c) == join (join a b) c
-||| + Commutativity of join:
-|||     forall a b,   join a b          == join b a
-||| + Idempotency of join:
-|||     forall a,     join a a          == a
-|||
-||| Join semilattices capture the notion of sets with a "least upper bound".
-class JoinSemilattice a where
-  join : a -> a -> a
-
-instance JoinSemilattice Nat where
-  join = maximum
-
-instance Ord a => JoinSemilattice (MaxiphobicHeap a) where
-  join = merge
-
-||| Sets equipped with a binary operation that is commutative, associative and
-||| idempotent.  Must satisfy the following laws:
-|||
-||| + Associativity of meet:
-|||     forall a b c, meet a (meet b c) == meet (meet a b) c
-||| + Commutativity of meet:
-|||     forall a b,   meet a b          == meet b a
-||| + Idempotency of meet:
-|||     forall a,     meet a a          == a
-|||
-||| Meet semilattices capture the notion of sets with a "greatest lower bound".
-class MeetSemilattice a where
-  meet : a -> a -> a
-
-instance MeetSemilattice Nat where
-  meet = minimum
-
-
-||| Sets equipped with a binary operation that is commutative, associative and
-||| idempotent and supplied with a unitary element.  Must satisfy the following
-||| laws:
-|||
-||| + Associativity of join:
-|||     forall a b c, join a (join b c) == join (join a b) c
-||| + Commutativity of join:
-|||     forall a b,   join a b          == join b a
-||| + Idempotency of join:
-|||     forall a,     join a a          == a
-||| + Bottom (Unitary Element):
-|||     forall a,     join a bottom     == a
-|||
-|||  Join semilattices capture the notion of sets with a "least upper bound"
-|||  equipped with a "bottom" element.
-class JoinSemilattice a => BoundedJoinSemilattice a where
-  bottom  : a
-
-
-instance BoundedJoinSemilattice Nat where
-  bottom = Z
-
-
-||| Sets equipped with a binary operation that is commutative, associative and
-||| idempotent and supplied with a unitary element.  Must satisfy the following
-||| laws:
-|||
-||| + Associativity of meet:
-|||     forall a b c, meet a (meet b c) == meet (meet a b) c
-||| + Commutativity of meet:
-|||     forall a b,   meet a b          == meet b a
-||| + Idempotency of meet:
-|||     forall a,     meet a a          == a
-||| +  Top (Unitary Element):
-|||     forall a,     meet a top        == a
-|||
-||| Meet semilattices capture the notion of sets with a "greatest lower bound"
-||| equipped with a "top" element.
-class MeetSemilattice a => BoundedMeetSemilattice a where
-  top : a
-
-
-
-||| Sets equipped with two binary operations that are both commutative,
-||| associative and idempotent, along with absorbtion laws for relating the two
-||| binary operations.  Must satisfy the following:
-|||
-||| + Associativity of meet and join:
-|||     forall a b c, meet a (meet b c) == meet (meet a b) c
-|||     forall a b c, join a (join b c) == join (join a b) c
-||| + Commutativity of meet and join:
-|||     forall a b,   meet a b          == meet b a
-|||     forall a b,   join a b          == join b a
-||| + Idempotency of meet and join:
-|||     forall a,     meet a a          == a
-|||     forall a,     join a a          == a
-||| + Absorbtion laws for meet and join:
-|||     forall a b,   meet a (join a b) == a
-|||     forall a b,   join a (meet a b) == a
-class (JoinSemilattice a, MeetSemilattice a) => Lattice a where { }
-
-
-instance Lattice Nat where { }
-
-||| Sets equipped with two binary operations that are both commutative,
-||| associative and idempotent and supplied with neutral elements, along with
-||| absorbtion laws for relating the two binary operations.  Must satisfy the
-||| following:
-|||
-||| + Associativity of meet and join:
-|||     forall a b c, meet a (meet b c) == meet (meet a b) c
-|||     forall a b c, join a (join b c) == join (join a b) c
-||| +  Commutativity of meet and join:
-|||     forall a b,   meet a b          == meet b a
-|||     forall a b,   join a b          == join b a
-||| + Idempotency of meet and join:
-|||     forall a,     meet a a          == a
-|||     forall a,     join a a          == a
-||| + Absorbtion laws for meet and join:
-|||     forall a b,   meet a (join a b) == a
-|||     forall a b,   join a (meet a b) == a
-||| + Neutral for meet and join:
-|||     forall a,     meet a top        == top
-|||     forall a,     join a bottom     == bottom
-class (BoundedJoinSemilattice a, BoundedMeetSemilattice a) => BoundedLattice a where { }
-
-
---   Fields.
 ||| Sets equipped with two binary operations, both associative and commutative
 ||| supplied with a neutral element, with
 ||| distributivity laws relating the two operations.  Must satisfy the following
@@ -246,26 +115,6 @@ class (BoundedJoinSemilattice a, BoundedMeetSemilattice a) => BoundedLattice a w
 |||     forall a b c, (a <+> b) <.> c == (a <.> c) <+> (b <.> c)
 class RingWithUnity a => Field a where
   inverseM : a -> a
-
-
-||| A module over a ring is an additive abelian group of 'vectors' endowed with a
-||| scale operation multiplying vectors by ring elements, and distributivity laws
-||| relating the scale operation to both ring addition and module addition.
-||| Must satisfy the following laws:
-|||
-||| + Compatibility of scalar multiplication with ring multiplication:
-|||     forall a b v,  a <#> (b <#> v) = (a <.> b) <#> v
-||| + Ring unity is the identity element of scalar multiplication:
-|||     forall v,      unity <#> v = v
-||| + Distributivity of `<#>` and `<+>`:
-|||     forall a v w,  a <#> (v <+> w) == (a <#> v) <+> (a <#> w)
-|||     forall a b v,  (a <+> b) <#> v == (a <#> v) <+> (b <#> v)
-class (RingWithUnity a, AbelianGroup b) => Module a b where
-  (<#>) : a -> b -> b
-
-
-||| A vector space is a module over a ring that is also a field
-class (Field a, Module a b) => VectorSpace a b where {}
 
 
 -- XXX todo:

--- a/libs/contrib/Control/Algebra/Lattice.idr
+++ b/libs/contrib/Control/Algebra/Lattice.idr
@@ -1,0 +1,123 @@
+module Control.Algebra.Lattice
+
+import Control.Algebra
+import Data.Heap
+
+
+||| Sets equipped with a binary operation that is commutative, associative and
+||| idempotent.  Must satisfy the following laws:
+|||
+||| + Associativity of join:
+|||     forall a b c, join a (join b c) == join (join a b) c
+||| + Commutativity of join:
+|||     forall a b,   join a b          == join b a
+||| + Idempotency of join:
+|||     forall a,     join a a          == a
+|||
+||| Join semilattices capture the notion of sets with a "least upper bound".
+class JoinSemilattice a where
+  join : a -> a -> a
+
+instance JoinSemilattice Nat where
+  join = maximum
+
+instance Ord a => JoinSemilattice (MaxiphobicHeap a) where
+  join = merge
+
+||| Sets equipped with a binary operation that is commutative, associative and
+||| idempotent.  Must satisfy the following laws:
+|||
+||| + Associativity of meet:
+|||     forall a b c, meet a (meet b c) == meet (meet a b) c
+||| + Commutativity of meet:
+|||     forall a b,   meet a b          == meet b a
+||| + Idempotency of meet:
+|||     forall a,     meet a a          == a
+|||
+||| Meet semilattices capture the notion of sets with a "greatest lower bound".
+class MeetSemilattice a where
+  meet : a -> a -> a
+
+instance MeetSemilattice Nat where
+  meet = minimum
+
+||| Sets equipped with a binary operation that is commutative, associative and
+||| idempotent and supplied with a unitary element.  Must satisfy the following
+||| laws:
+|||
+||| + Associativity of join:
+|||     forall a b c, join a (join b c) == join (join a b) c
+||| + Commutativity of join:
+|||     forall a b,   join a b          == join b a
+||| + Idempotency of join:
+|||     forall a,     join a a          == a
+||| + Bottom (Unitary Element):
+|||     forall a,     join a bottom     == a
+|||
+|||  Join semilattices capture the notion of sets with a "least upper bound"
+|||  equipped with a "bottom" element.
+class JoinSemilattice a => BoundedJoinSemilattice a where
+  bottom  : a
+
+instance BoundedJoinSemilattice Nat where
+  bottom = Z
+
+||| Sets equipped with a binary operation that is commutative, associative and
+||| idempotent and supplied with a unitary element.  Must satisfy the following
+||| laws:
+|||
+||| + Associativity of meet:
+|||     forall a b c, meet a (meet b c) == meet (meet a b) c
+||| + Commutativity of meet:
+|||     forall a b,   meet a b          == meet b a
+||| + Idempotency of meet:
+|||     forall a,     meet a a          == a
+||| +  Top (Unitary Element):
+|||     forall a,     meet a top        == a
+|||
+||| Meet semilattices capture the notion of sets with a "greatest lower bound"
+||| equipped with a "top" element.
+class MeetSemilattice a => BoundedMeetSemilattice a where
+  top : a
+
+||| Sets equipped with two binary operations that are both commutative,
+||| associative and idempotent, along with absorbtion laws for relating the two
+||| binary operations.  Must satisfy the following:
+|||
+||| + Associativity of meet and join:
+|||     forall a b c, meet a (meet b c) == meet (meet a b) c
+|||     forall a b c, join a (join b c) == join (join a b) c
+||| + Commutativity of meet and join:
+|||     forall a b,   meet a b          == meet b a
+|||     forall a b,   join a b          == join b a
+||| + Idempotency of meet and join:
+|||     forall a,     meet a a          == a
+|||     forall a,     join a a          == a
+||| + Absorbtion laws for meet and join:
+|||     forall a b,   meet a (join a b) == a
+|||     forall a b,   join a (meet a b) == a
+class (JoinSemilattice a, MeetSemilattice a) => Lattice a where { }
+
+instance Lattice Nat where { }
+
+||| Sets equipped with two binary operations that are both commutative,
+||| associative and idempotent and supplied with neutral elements, along with
+||| absorbtion laws for relating the two binary operations.  Must satisfy the
+||| following:
+|||
+||| + Associativity of meet and join:
+|||     forall a b c, meet a (meet b c) == meet (meet a b) c
+|||     forall a b c, join a (join b c) == join (join a b) c
+||| +  Commutativity of meet and join:
+|||     forall a b,   meet a b          == meet b a
+|||     forall a b,   join a b          == join b a
+||| + Idempotency of meet and join:
+|||     forall a,     meet a a          == a
+|||     forall a,     join a a          == a
+||| + Absorbtion laws for meet and join:
+|||     forall a b,   meet a (join a b) == a
+|||     forall a b,   join a (meet a b) == a
+||| + Neutral for meet and join:
+|||     forall a,     meet a top        == top
+|||     forall a,     join a bottom     == bottom
+class (BoundedJoinSemilattice a, BoundedMeetSemilattice a) => BoundedLattice a where { }

--- a/libs/contrib/Control/Algebra/NumericInstances.idr
+++ b/libs/contrib/Control/Algebra/NumericInstances.idr
@@ -1,0 +1,104 @@
+module Control.Algebra.NumericInstances
+
+import Control.Algebra
+import Data.Complex
+import Data.ZZ
+
+
+instance Semigroup Integer where
+  (<+>) = (+)
+
+instance Monoid Integer where
+  neutral = 0
+
+instance Group Integer where
+  inverse = (* -1)
+
+instance AbelianGroup Integer
+
+instance Ring Integer where
+  (<.>) = (*)
+
+instance RingWithUnity Integer where
+  unity = 1
+
+
+instance Semigroup Int where
+  (<+>) = (+)
+
+instance Monoid Int where
+  neutral = 0
+
+instance Group Int where
+  inverse = (* -1)
+
+instance AbelianGroup Int
+
+instance Ring Int where
+  (<.>) = (*)
+
+instance RingWithUnity Int where
+  unity = 1
+
+
+instance Semigroup Float where
+  (<+>) = (+)
+
+instance Monoid Float where
+  neutral = 0
+
+instance Group Float where
+  inverse = (* -1)
+
+instance AbelianGroup Float
+
+instance Ring Float where
+  (<.>) = (*)
+
+instance RingWithUnity Float where
+  unity = 1
+
+instance Field Float where
+  inverseM f _ = 1 / f
+
+
+instance Semigroup Nat where
+  (<+>) = (+)
+
+instance Monoid Nat where
+  neutral = 0
+
+instance Semigroup ZZ where
+  (<+>) = (+)
+
+instance Monoid ZZ where
+  neutral = 0
+
+instance Group ZZ where
+  inverse = (* -1)
+
+instance AbelianGroup ZZ
+
+instance Ring ZZ where
+  (<.>) = (*)
+
+instance RingWithUnity ZZ where
+  unity = 1
+
+
+instance Semigroup a => Semigroup (Complex a) where
+  (<+>) (a :+ b) (c :+ d) = (a <+> c) :+ (b <+> d)
+
+instance Monoid a => Monoid (Complex a) where
+  neutral = (neutral :+ neutral)
+
+instance Group a => Group (Complex a) where
+  inverse (r :+ i) = (inverse r :+ inverse i)
+
+instance Ring a => AbelianGroup (Complex a) where {}
+
+instance Ring a => Ring (Complex a) where
+  (<.>) (a :+ b) (c :+ d) = (a <.> c <-> b <.> d) :+ (a <.> d <+> b <.> c)
+
+instance RingWithUnity a => RingWithUnity (Complex a) where
+  unity = (unity :+ neutral)

--- a/libs/contrib/Control/Algebra/VectorSpace.idr
+++ b/libs/contrib/Control/Algebra/VectorSpace.idr
@@ -1,0 +1,30 @@
+module Control.Algebra.VectorSpace
+
+import Control.Algebra
+
+infixl 5 <#>
+infixr 2 <||>
+
+
+||| A module over a ring is an additive abelian group of 'vectors' endowed with a
+||| scale operation multiplying vectors by ring elements, and distributivity laws
+||| relating the scale operation to both ring addition and module addition.
+||| Must satisfy the following laws:
+|||
+||| + Compatibility of scalar multiplication with ring multiplication:
+|||     forall a b v,  a <#> (b <#> v) = (a <.> b) <#> v
+||| + Ring unity is the identity element of scalar multiplication:
+|||     forall v,      unity <#> v = v
+||| + Distributivity of `<#>` and `<+>`:
+|||     forall a v w,  a <#> (v <+> w) == (a <#> v) <+> (a <#> w)
+|||     forall a b v,  (a <+> b) <#> v == (a <#> v) <+> (b <#> v)
+class (RingWithUnity a, AbelianGroup b) => Module a b where
+  (<#>) : a -> b -> b
+
+||| A vector space is a module over a ring that is also a field
+class (Field a, Module a b) => VectorSpace a b where {}
+
+||| An inner product space is a module – or vector space – over a ring, with a binary function
+||| associating a ring value to each pair of vectors.
+class Module a b => InnerProductSpace a b where
+  (<||>) : b -> b -> a

--- a/libs/contrib/Data/Matrix.idr
+++ b/libs/contrib/Data/Matrix.idr
@@ -1,6 +1,8 @@
 module Data.Matrix
 
-import Control.Algebra
+import        Control.Algebra
+import        Control.Algebra.VectorSpace
+import public Control.Algebra.NumericInstances
 
 import Data.Complex
 import Data.ZZ
@@ -40,8 +42,7 @@ instance Ring a => Ring (Vect n a) where
 instance RingWithUnity a => RingWithUnity (Vect n a) where
   unity {n} = replicate n unity
 
-instance Field a => Field (Vect n a) where
-  inverseM = map inverseM
+--instance Field a => Field (Vect n a) where
 
 instance RingWithUnity a => Module a (Vect n a) where
   (<#>) r v = map (r <.>) v
@@ -147,104 +148,3 @@ Id {d} = map (\n => basis n) $ allN d
 
 -- TODO: Prove properties of matrix algebra for 'Verified' algebraic classes
 
------------------------------------------------------------------------
---                    Numberic data types as rings
------------------------------------------------------------------------
-
-instance Semigroup Integer where
-  (<+>) = (+)
-
-instance Monoid Integer where
-  neutral = 0
-
-instance Group Integer where
-  inverse = (* -1)
-
-instance AbelianGroup Integer
-
-instance Ring Integer where
-  (<.>) = (*)
-
-instance RingWithUnity Integer where
-  unity = 1
-
-
-instance Semigroup Int where
-  (<+>) = (+)
-
-instance Monoid Int where
-  neutral = 0
-
-instance Group Int where
-  inverse = (* -1)
-
-instance AbelianGroup Int
-
-instance Ring Int where
-  (<.>) = (*)
-
-instance RingWithUnity Int where
-  unity = 1
-
-
-instance Semigroup Float where
-  (<+>) = (+)
-
-instance Monoid Float where
-  neutral = 0
-
-instance Group Float where
-  inverse = (* -1)
-
-instance AbelianGroup Float
-
-instance Ring Float where
-  (<.>) = (*)
-
-instance RingWithUnity Float where
-  unity = 1
-
-instance Field Float where
-  inverseM f = 1 / f
-
-
-instance Semigroup Nat where
-  (<+>) = (+)
-
-instance Monoid Nat where
-  neutral = 0
-
-instance Semigroup ZZ where
-  (<+>) = (+)
-
-instance Monoid ZZ where
-  neutral = 0
-
-instance Group ZZ where
-  inverse = (* -1)
-
-instance AbelianGroup ZZ
-
-instance Ring ZZ where
-  (<.>) = (*)
-
-instance RingWithUnity ZZ where
-  unity = 1
-
-
-instance Semigroup a => Semigroup (Complex a) where
-  (<+>) (a :+ b) (c :+ d) = (a <+> c) :+ (b <+> d)
-
-instance Monoid a => Monoid (Complex a) where
-  neutral = (neutral :+ neutral)
-
-instance Group a => Group (Complex a) where
-  inverse (r :+ i) = (inverse r :+ inverse i)
-
-instance Ring a => AbelianGroup (Complex a) where {}
-
-instance Ring a => Ring (Complex a) where
-  (<.>) (a :+ b) (c :+ d) = (a <.> c <-> b <.> d) :+ (a <.> d <+> b <.> c)
-
-instance RingWithUnity a => RingWithUnity (Complex a) where
-  unity = (unity :+ neutral)

--- a/libs/contrib/contrib.ipkg
+++ b/libs/contrib/contrib.ipkg
@@ -2,6 +2,7 @@ package contrib
 
 opts = "--nobasepkgs --total -i ../prelude -i ../base"
 modules = Control.Algebra,
+	  Control.Algebra.Lattice, Control.Algebra.VectorSpace,
           Control.Isomorphism.Primitives,
           Control.WellFounded,
           Classes.Verified,

--- a/libs/contrib/contrib.ipkg
+++ b/libs/contrib/contrib.ipkg
@@ -3,6 +3,7 @@ package contrib
 opts = "--nobasepkgs --total -i ../prelude -i ../base"
 modules = Control.Algebra,
 	  Control.Algebra.Lattice, Control.Algebra.VectorSpace,
+	  Control.Algebra.NumericInstances,
           Control.Isomorphism.Primitives,
           Control.WellFounded,
           Classes.Verified,

--- a/libs/prelude/Builtins.idr
+++ b/libs/prelude/Builtins.idr
@@ -36,7 +36,8 @@ namespace Builtins
   ||| it. Another way to see dependent pairs is as just data - for instance, the
   ||| length of a vector paired with that vector.
   |||
-  |||  @ a the type of the witness @ P the type of the proof
+  |||  @ a the type of the witness
+  |||  @ P the type of the proof
   data Sigma : (a : Type) -> (P : a -> Type) -> Type where
       MkSigma : .{P : a -> Type} -> (x : a) -> (pf : P x) -> Sigma a P
 

--- a/libs/prelude/Prelude/Algebra.idr
+++ b/libs/prelude/Prelude/Algebra.idr
@@ -2,11 +2,7 @@ module Prelude.Algebra
 
 import Builtins
 
--- XXX: change?
-infixl 6 <->
 infixl 6 <+>
-infixl 6 <.>
-infixl 5 <#>
 
 %access public
 


### PR DESCRIPTION
This is a revision of my previous PR #2011 following the reorganization of Algebra.idr into the contrib package. The motivation is largely the same: Both the Lattice and VectorSpace class hierarchies are independent offshoots of Algebra that do not need to be in the same module, and I think we could benefit from this sensible organization into conceptual units. As before I've included a fix to the currently-incorrect definition of `Field`.

Notes:

* As @zraffer suggested I've opted to use propositional equality in the definition of Field, instead of `So` or the `Eq` class, so the definition now reads: `inverseM : (x : a) -> Not (x = neutral) -> a`. I think this may be the best approach, although this class has hardly been used as yet, so that could change. Views on this question are again welcomed.
* Another small refinement I've included is to move the long list of instance declarations of algebraic classes for numeric types that were previously thrown into `Data.Matrix` into their own module at `Control.Algebra.NumericInstances`. (I've found I need to use these instances a lot: They provide the only reasonable way to abstract over operations on complex number types since, for example, something like `Complex ZZ` can't be made an instance of `Num` because it doesn't support `abs`.)