### PR TITLE
Add fibs to Stream.idr in the prelude.

### DIFF
--- a/libs/prelude/Prelude/Stream.idr
+++ b/libs/prelude/Prelude/Stream.idr
@@ -109,6 +109,10 @@ partial -- and the call to foldr isn't guarded anyway!
 scanr : (f : a -> Inf b -> b) -> (xs : Stream a) -> Stream b
 scanr f (x :: xs) = f x (foldr f xs) :: scanr f xs
 
+||| An infinite stream of Fibonacci numbers
+fibs : Stream Nat
+fibs = 0 :: 1 :: zipWith (+) fibs (tail fibs)
+
 instance Applicative Stream where
   pure = repeat
   (<*>) = zipWith apply


### PR DESCRIPTION
Found myself needing an infinite stream of Fibonacci numbers for solving a Project Euler problem. Also noticed that an infinite stream of Fibonacci numbers is an example of how to use infinite streams in the Scala standard library documentation. So, thought it would be useful to include in Stream.idr, especially since `fib n` is included in Nat.idr. 

```Idris
||| An infinite stream of Fibonacci numbers
fibs : Stream Nat
fibs = 0 :: 1 :: zipWith (+) fibs (tail fibs)
```

Signed-off-by: Mark Farrell <m4farrel@uwaterloo.ca>