### PR TITLE
Saner set of suggested defaults for cabal flags.

### DIFF
--- a/custom.mk-alldeps
+++ b/custom.mk-alldeps
@@ -1,2 +1,1 @@
-CABALFLAGS += -f LLVM -f FFI -f curses
-
+CABALFLAGS += -f LLVM -f FFI -f curses --disable-documentation --disable-profiling --disable-library-profiling


### PR DESCRIPTION
Following from observations seen on IRC, a set of alternate cabal
flags has been presented in `custom.mk-alldeps`. These flags ensure
that the build does not do profiling, nor build documentation. These
are useful optimisations for building Idris.