### PR TITLE
changed Vect.findIndex to return Fins

### DIFF
--- a/CHANGELOG
+++ b/CHANGELOG
@@ -28,6 +28,8 @@ New in 0.9.18:
   choice, keeping the first success as Alternative does. The version that
   collects successes is now a named instance.
 * :exec REPL command now takes an optional expression to compile and run/show
+* The return types of `Vect.findIndex`, `Vect.elemIndex` and
+  `Vect.elemIndexBy` were changed from `Maybe Nat` to `Maybe (Fin n)`
 
 New in 0.9.17:
 --------------

--- a/libs/base/Data/VectType.idr
+++ b/libs/base/Data/VectType.idr
@@ -372,14 +372,11 @@ find p (x::xs) with (p x)
   | False = find p xs
 
 ||| Find the index of the first element of the vector that satisfies some test
-findIndex : (a -> Bool) -> Vect n a -> Maybe Nat
-findIndex = findIndex' 0
-  where
-    findIndex' : Nat -> (a -> Bool) -> Vect n a -> Maybe Nat
-    findIndex' cnt p []      = Nothing
-    findIndex' cnt p (x::xs) with (p x)
-      | True  = Just cnt
-      | False = findIndex' (S cnt) p xs
+findIndex : (a -> Bool) -> Vect n a -> Maybe (Fin n)
+findIndex p []        = Nothing
+findIndex p (x :: xs) with (p x)
+  | True  = Just 0
+  | False = map FS (findIndex p xs)
 
 ||| Find the indices of all elements that satisfy some test
 total findIndices : (a -> Bool) -> Vect m a -> (p ** Vect p Nat)
@@ -394,10 +391,10 @@ findIndices = findIndices' 0
        else
         (_ ** tail)
 
-elemIndexBy : (a -> a -> Bool) -> a -> Vect m a -> Maybe Nat
+elemIndexBy : (a -> a -> Bool) -> a -> Vect m a -> Maybe (Fin m)
 elemIndexBy p e = findIndex $ p e
 
-elemIndex : Eq a => a -> Vect m a -> Maybe Nat
+elemIndex : Eq a => a -> Vect m a -> Maybe (Fin m)
 elemIndex = elemIndexBy (==)
 
 total elemIndicesBy : (a -> a -> Bool) -> a -> Vect m a -> (p ** Vect p Nat)


### PR DESCRIPTION
`Vect.findIndex` had the type `(a -> Bool) -> Vect n a -> Maybe Nat`, but it makes a lot more sense if it return `Maybe (Fin n)`, for two reasons:
 - `Vect` uses `Fin` for indices everywhere else
 - It's a lot more convenient to convert a `Fin` to a `Nat` than the other way around. The easiest way to convert the `Nat` that `findIndex` returns to a `Fin` was to completely rewrite `findIndex`, which, of course, this Pullrequest does.

This was brought up by DanC on IRC (although in the end it turned out that they needed a different function)

Note: This will break existing code that uses this function.

`elemIndexBy` and `elemIndex` were also changed, for the same reasons and because their implementation uses `findIndex`.