### PR TITLE
Add common functions for running State monad

### DIFF
--- a/libs/base/Control/Monad/State.idr
+++ b/libs/base/Control/Monad/State.idr
@@ -1,6 +1,6 @@
 module Control.Monad.State
 
-import Control.Monad.Identity
+import public Control.Monad.Identity
 import Control.Monad.Trans
 
 %access public
@@ -55,3 +55,15 @@ gets f = do s <- get
 ||| The State monad. See the MonadState class
 State : Type -> Type -> Type
 State s a = StateT s Identity a
+
+||| Unwrap a State monad computation.
+runState : State s a -> s -> (a,s)
+runState m = runIdentity . runStateT m
+
+||| Unwrap a State monad computation, but discard the final state.
+evalState : State s a -> s -> a
+evalState m = fst . runState m
+
+||| Unwrap a State monad computation, but discard the resulting value.
+execState : State s a -> s -> s
+execState m = snd . runState m


### PR DESCRIPTION
The `Control.Monad.State` module exports a type alias `State s a` for `StateT s Identity a`, but requires the user to manually unwrap the transformer stack. This requires the user to also import `Control.Monad.Identity`. So I've re-exported the Identity module from and added `runState`, `evalState`, and `execState` to the State module.