### PR TITLE
Bump bound for annotated-wl-pprint

### DIFF
--- a/idris.cabal
+++ b/idris.cabal
@@ -808,7 +808,7 @@ Library
                 , Version_idris
 
   Build-depends:  base >=4 && <5
-                , annotated-wl-pprint >= 0.5.3 && < 0.6
+                , annotated-wl-pprint >= 0.5.3 && < 0.7
                 , ansi-terminal < 0.7
                 , ansi-wl-pprint < 0.7
                 , base64-bytestring < 1.1

--- a/src/Idris/AbsSyntaxTree.hs
+++ b/src/Idris/AbsSyntaxTree.hs
@@ -1757,9 +1757,6 @@ showDeclImp o (PInstance _ _ _ _ cs n _ t _ ds)
 showDeclImp _ _ = text "..."
 -- showDeclImp (PImport o) = "import " ++ o
 
-instance Show (Doc OutputAnnotation) where
-  show = flip (displayS . renderCompact) ""
-
 getImps :: [PArg] -> [(Name, PTerm)]
 getImps [] = []
 getImps (PImp _ _ _ n tm : xs) = (n, tm) : getImps xs


### PR DESCRIPTION
This allows GHC 7.10 compatibility.