### PR TITLE
Add a :browse command to the REPL and IDE equivalent

### DIFF
--- a/CHANGELOG
+++ b/CHANGELOG
@@ -30,6 +30,7 @@ New in 0.9.18:
 * :exec REPL command now takes an optional expression to compile and run/show
 * The return types of `Vect.findIndex`, `Vect.elemIndex` and
   `Vect.elemIndexBy` were changed from `Maybe Nat` to `Maybe (Fin n)`
+* A new :browse command shows the contents of a namespace
 
 New in 0.9.17:
 --------------

--- a/idris.cabal
+++ b/idris.cabal
@@ -746,6 +746,8 @@ Library
                 , Idris.Elab.Value
                 , Idris.Elab.Term
 
+                , Idris.REPL.Browse
+
                 , Idris.AbsSyntax
                 , Idris.AbsSyntaxTree
                 , Idris.Apropos

--- a/src/Idris/AbsSyntaxTree.hs
+++ b/src/Idris/AbsSyntaxTree.hs
@@ -408,6 +408,7 @@ data Command = Quit
              | Apropos [String] String
              | WhoCalls Name
              | CallsWho Name
+             | Browse [String]
              | MakeDoc String                      -- IdrisDoc
              | Warranty
              | PrintDef Name

--- a/src/Idris/IdeMode.hs
+++ b/src/Idris/IdeMode.hs
@@ -222,6 +222,7 @@ data IdeModeCommand = REPLCompletions String
                     | Metavariables Int -- ^^ the Int is the column count for pretty-printing
                     | WhoCalls String
                     | CallsWho String
+                    | BrowseNS String
                     | TermNormalise [(Name, Bool)] Term
                     | TermShowImplicits [(Name, Bool)] Term
                     | TermNoImplicits [(Name, Bool)] Term
@@ -269,6 +270,7 @@ sexpToCommand (SexpList [SymbolAtom "set-option", SymbolAtom s, BoolAtom b])
 sexpToCommand (SexpList [SymbolAtom "metavariables", IntegerAtom cols])                 = Just (Metavariables (fromIntegral cols))
 sexpToCommand (SexpList [SymbolAtom "who-calls", StringAtom name])                      = Just (WhoCalls name)
 sexpToCommand (SexpList [SymbolAtom "calls-who", StringAtom name])                      = Just (CallsWho name)
+sexpToCommand (SexpList [SymbolAtom "browse-namespace", StringAtom ns])                 = Just (BrowseNS ns)
 sexpToCommand (SexpList [SymbolAtom "normalise-term", StringAtom encoded])              = let (bnd, tm) = decodeTerm encoded in
                                                                                           Just (TermNormalise bnd tm)
 sexpToCommand (SexpList [SymbolAtom "show-term-implicits", StringAtom encoded])         = let (bnd, tm) = decodeTerm encoded in

--- a/src/Idris/REPL/Browse.hs
+++ b/src/Idris/REPL/Browse.hs
@@ -1,0 +1,37 @@
+{-# OPTIONS_GHC -fwarn-incomplete-patterns -fwarn-unused-imports #-}
+
+module Idris.REPL.Browse (namespacesInNS, namesInNS) where
+
+import Data.List (isSuffixOf, nub)
+import Data.Maybe (mapMaybe)
+import qualified Data.Text as T (unpack)
+
+import Idris.Core.Evaluate (ctxtAlist)
+import Idris.Core.TT (Name(..))
+
+import Idris.AbsSyntaxTree (Idris)
+import Idris.AbsSyntax (getContext)
+
+-- | Find the sub-namespaces of a given namespace. The components
+-- should be in display order rather than the order that they are in
+-- inside of NS constructors.
+namespacesInNS :: [String] -> Idris [[String]]
+namespacesInNS ns = do let revNS = reverse ns
+                       allNames <- fmap ctxtAlist getContext
+                       return . nub $
+                         [ reverse space | space <- mapMaybe (getNS . fst) allNames
+                                         , revNS `isSuffixOf` space
+                                         , revNS /= space ]
+  where getNS (NS _ namespace) = Just (map T.unpack namespace)
+        getNS _ = Nothing
+
+-- | Find the user-accessible names that occur directly within a given
+-- namespace. The components should be in display order rather than
+-- the order that they are in inside of NS constructors.
+namesInNS :: [String] -> Idris [Name]
+namesInNS ns = do let revNS = reverse ns
+                  allNames <- fmap ctxtAlist getContext
+                  return [ n | (n, space) <- mapMaybe (getNS . fst) allNames
+                             , revNS == space ]
+  where getNS n@(NS (UN n') namespace) = Just (n, (map T.unpack namespace))
+        getNS _ = Nothing

--- a/src/Idris/REPLParser.hs
+++ b/src/Idris/REPLParser.hs
@@ -52,6 +52,7 @@ parserCommandsForHelp =
     , " Search for values by type", cmd_search)
   , nameArgCmd ["wc", "whocalls"] WhoCalls "List the callers of some name"
   , nameArgCmd ["cw", "callswho"] CallsWho "List the callees of some name"
+  , namespaceArgCmd ["browse"] Browse "List the contents of some namespace"
   , nameArgCmd ["total"] TotCheck "Check the totality of a name"
   , noArgCmd ["r", "reload"] Reload "Reload current file"
   , (["l", "load"], FileArg, "Load a new file"
@@ -136,17 +137,19 @@ parserCommands =
     )
   ]
 
-noArgCmd names command doc = 
+noArgCmd names command doc =
   (names, NoArg, doc, noArgs command)
-nameArgCmd names command doc = 
+nameArgCmd names command doc =
   (names, NameArg, doc, fnNameArg command)
-exprArgCmd names command doc = 
+namespaceArgCmd names command doc =
+  (names, NamespaceArg, doc, namespaceArg command)
+exprArgCmd names command doc =
   (names, ExprArg, doc, exprArg command)
-metavarArgCmd names command doc = 
+metavarArgCmd names command doc =
   (names, MetaVarArg, doc, fnNameArg command)
-optArgCmd names command doc = 
+optArgCmd names command doc =
   (names, OptionArg, doc, optArg command)
-proofArgCmd names command doc = 
+proofArgCmd names command doc =
   (names, NoArg, doc, proofArg command)
 
 pCmd :: P.IdrisParser (Either String Command)
@@ -219,6 +222,11 @@ moduleArg :: (FilePath -> Command) -> String -> P.IdrisParser (Either String Com
 moduleArg = genArg "module" (fmap toPath P.identifier) 
   where
     toPath n = foldl1' (</>) $ splitOn "." n
+
+namespaceArg :: ([String] -> Command) -> String -> P.IdrisParser (Either String Command)
+namespaceArg = genArg "namespace" (fmap toNS P.identifier) 
+  where
+    toNS  = splitOn "."
 
 optArg :: (Opt -> Command) -> String -> P.IdrisParser (Either String Command)
 optArg cmd name = do


### PR DESCRIPTION
:browse NS lists the contents of the namespace NS, separated into sub-namespaces and actual names.