### PR TITLE
Use zip as IBC container

### DIFF
--- a/idris.cabal
+++ b/idris.cabal
@@ -858,6 +858,7 @@ Library
                 , vector < 0.11
                 , vector-binary-instances < 0.3
                 , xml < 1.4
+                , zip-archive > 0.2.3.5 && < 0.2.4
                 , zlib < 0.6
                 , safe
   Extensions:     MultiParamTypeClasses

--- a/src/Idris/IBC.hs
+++ b/src/Idris/IBC.hs
@@ -1,7 +1,8 @@
 {-# LANGUAGE TypeSynonymInstances #-}
 {-# OPTIONS_GHC -fwarn-incomplete-patterns #-}
 
-module Idris.IBC where
+module Idris.IBC (loadIBC, loadPkgIndex,
+                  writeIBC, writePkgIndex) where
 
 import Idris.Core.Evaluate
 import Idris.Core.TT


### PR DESCRIPTION
This starts off what I wrote about in #1826.

This commit in itself doesn't lead to better performance, rather the IBC files grow slightly as they contain the same stuff, now just split up on entries in a zip container. However, this is needed to begin work on improving the module load times. The two ways to attack the loading times is to either load less, much of the stuff can be loaded lazily on need, or use a smarter file format, so we for example don't blast many copies of the same string to disk. A random access format is necessary to do the first, and it will be helpful with the second.

Other advantages with using a container format: data don't have to have a Binary instance to go down into the container, things that are better as text don't have to be shoehorned; using folders we could in the future amalgate several modules into one ibc-file; and it is easily inspectable with standard apps. 
