### PR TITLE
Fix access modifiers in Data.Nat in contrib

### DIFF
--- a/libs/contrib/Data/Nat.idr
+++ b/libs/contrib/Data/Nat.idr
@@ -7,6 +7,7 @@ import Data.So
 import Control.WellFounded
 
 %default total
+%access public
 
 ||| A strict less-than relation on `Nat`.
 |||


### PR DESCRIPTION
Burned by the default behavior again!