### PR TITLE
Make a datatype for directives

### DIFF
--- a/idris.cabal
+++ b/idris.cabal
@@ -771,6 +771,7 @@ Library
                 , Idris.DataOpts
                 , Idris.DeepSeq
                 , Idris.Delaborate
+                , Idris.Directives
                 , Idris.Docs
                 , Idris.Docstrings
                 , Idris.ElabDecls

--- a/src/Idris/AbsSyntaxTree.hs
+++ b/src/Idris/AbsSyntaxTree.hs
@@ -628,7 +628,7 @@ data PDecl' t
    | PDSL     Name (DSL' t) -- ^ DSL declaration
    | PSyntax  FC Syntax -- ^ Syntax definition
    | PMutual  FC [PDecl' t] -- ^ Mutual block
-   | PDirective (Idris ()) -- ^ Compiler directive. The parser inserts the corresponding action in the Idris monad.
+   | PDirective Directive -- ^ Compiler directive.
    | PProvider (Docstring (Either Err PTerm)) SyntaxInfo FC (ProvideWhat' t) Name -- ^ Type provider. The first t is the type, the second is the term
    | PTransform FC Bool t t -- ^ Source-to-source transformation rule. If
                             -- bool is True, lhs and rhs must be convertible
@@ -637,6 +637,22 @@ data PDecl' t
 deriving instance Binary PDecl'
 deriving instance NFData PDecl'
 !-}
+
+-- | The set of source directives
+data Directive = DLib Codegen String |
+                 DLink Codegen String |
+                 DFlag Codegen String |
+                 DInclude Codegen String |
+                 DHide Name |
+                 DFreeze Name |
+                 DAccess Accessibility |
+                 DDefault Bool |
+                 DLogging Integer |
+                 DDynamicLibs [String] |
+                 DNameHint Name [Name] |
+                 DErrorHandlers Name Name [Name] |
+                 DLanguage LanguageExt |
+                 DUsed FC Name Name
 
 -- | A set of instructions for things that need to happen in IState
 -- after a term elaboration when there's been reflected elaboration.

--- a/src/Idris/Directives.hs
+++ b/src/Idris/Directives.hs
@@ -1,0 +1,65 @@
+
+module Idris.Directives where
+
+import Idris.AbsSyntax
+import Idris.ASTUtils
+import Idris.Imports
+
+import Idris.Core.Evaluate
+import Idris.Core.TT
+
+import Util.DynamicLinker
+
+-- | Run the action corresponding to a directive
+directiveAction :: Directive -> Idris ()
+directiveAction (DLib cgn lib) = do addLib cgn lib
+                                    addIBC (IBCLib cgn lib)
+
+directiveAction (DLink cgn obj) = do dirs <- allImportDirs
+                                     o <- runIO $ findInPath dirs obj
+                                     addIBC (IBCObj cgn obj) -- just name, search on loading ibc
+                                     addObjectFile cgn o
+
+directiveAction (DFlag cgn flag) = do addIBC (IBCCGFlag cgn flag)
+                                      addFlag cgn flag
+
+directiveAction (DInclude cgn hdr) = do addHdr cgn hdr
+                                        addIBC (IBCHeader cgn hdr)
+
+directiveAction (DHide n) = do setAccessibility n Hidden
+                               addIBC (IBCAccess n Hidden)
+
+directiveAction (DFreeze n) = do setAccessibility n Frozen
+                                 addIBC (IBCAccess n Frozen)
+
+directiveAction (DAccess acc) = do updateIState (\i -> i { default_access = acc })
+
+directiveAction (DDefault tot) =  do updateIState (\i -> i { default_total = tot })
+
+directiveAction (DLogging lvl) = setLogLevel (fromInteger lvl)
+
+directiveAction (DDynamicLibs libs) = do added <- addDyLib libs
+                                         case added of
+                                             Left lib -> addIBC (IBCDyLib (lib_name lib))
+                                             Right msg -> fail $ msg
+
+directiveAction (DNameHint ty ns) = do ty' <- disambiguate ty
+                                       mapM_ (addNameHint ty') ns
+                                       mapM_ (\n -> addIBC (IBCNameHint (ty', n))) ns
+
+directiveAction (DErrorHandlers fn arg ns) = do fn' <- disambiguate fn
+                                                ns' <- mapM disambiguate ns
+                                                addFunctionErrorHandlers fn' arg ns'
+                                                mapM_ (addIBC .
+                                                    IBCFunctionErrorHandler fn' arg) ns'
+
+directiveAction (DLanguage ext) = addLangExt ext
+
+directiveAction (DUsed fc fn arg) = addUsedName fc fn arg
+
+disambiguate :: Name -> Idris Name
+disambiguate n = do i <- getIState
+                    case lookupCtxtName n (idris_implicits i) of
+                              [(n', _)] -> return n'
+                              []        -> throwError (NoSuchVariable n)
+                              more      -> throwError (CantResolveAlts (map fst more))

--- a/src/Idris/ElabDecls.hs
+++ b/src/Idris/ElabDecls.hs
@@ -8,6 +8,7 @@ import Idris.ASTUtils
 import Idris.DSL
 import Idris.Error
 import Idris.Delaborate
+import Idris.Directives
 import Idris.Imports
 import Idris.Elab.Term
 import Idris.Coverage
@@ -250,7 +251,7 @@ elabDecl' _ info (PDSL n dsl)
          putIState (i { idris_dsls = addDef n dsl (idris_dsls i) })
          addIBC (IBCDSL n)
 elabDecl' what info (PDirective i)
-  | what /= EDefns = i
+  | what /= EDefns = directiveAction i
 elabDecl' what info (PProvider doc syn fc provWhat n)
   | what /= EDefns
     = do iLOG $ "Elaborating type provider " ++ show n

--- a/src/Idris/Parser.hs
+++ b/src/Idris/Parser.hs
@@ -1077,71 +1077,44 @@ Directive' ::= 'lib'            CodeGen String_t
 -}
 directive :: SyntaxInfo -> IdrisParser [PDecl]
 directive syn = do try (lchar '%' *> reserved "lib"); cgn <- codegen_; lib <- stringLiteral;
-                   return [PDirective (do addLib cgn lib
-                                          addIBC (IBCLib cgn lib))]
+                   return [PDirective (DLib cgn lib)]
              <|> do try (lchar '%' *> reserved "link"); cgn <- codegen_; obj <- stringLiteral;
-                    return [PDirective (do dirs <- allImportDirs
-                                           o <- liftIO $ findInPath dirs obj
-                                           addIBC (IBCObj cgn obj) -- just name, search on loading ibc
-                                           addObjectFile cgn o)]
-             <|> do try (lchar '%' *> reserved "flag"); cgn <- codegen_;
-                    flag <- stringLiteral
-                    return [PDirective (do addIBC (IBCCGFlag cgn flag)
-                                           addFlag cgn flag)]
+                    return [PDirective (DLink cgn obj)]
+             <|> do try (lchar '%' *> reserved "flag"); cgn <- codegen_; flag <- stringLiteral
+                    return [PDirective (DFlag cgn flag)]
              <|> do try (lchar '%' *> reserved "include"); cgn <- codegen_; hdr <- stringLiteral;
-                    return [PDirective (do addHdr cgn hdr
-                                           addIBC (IBCHeader cgn hdr))]
+                    return [PDirective (DInclude cgn hdr)]
              <|> do try (lchar '%' *> reserved "hide"); n <- fnName
-                    return [PDirective (do setAccessibility n Hidden
-                                           addIBC (IBCAccess n Hidden))]
+                    return [PDirective (DHide n)]
              <|> do try (lchar '%' *> reserved "freeze"); n <- iName []
-                    return [PDirective (do setAccessibility n Frozen
-                                           addIBC (IBCAccess n Frozen))]
+                    return [PDirective (DFreeze n)]
              <|> do try (lchar '%' *> reserved "access"); acc <- accessibility
-                    return [PDirective (do i <- get
-                                           put(i { default_access = acc }))]
+                    return [PDirective (DAccess acc)]
              <|> do try (lchar '%' *> reserved "default"); tot <- totality
                     i <- get
                     put (i { default_total = tot } )
-                    return [PDirective (do i <- get
-                                           put(i { default_total = tot }))]
+                    return [PDirective (DDefault tot)]
              <|> do try (lchar '%' *> reserved "logging"); i <- natural;
-                    return [PDirective (setLogLevel (fromInteger i))]
+                    return [PDirective (DLogging i)]
              <|> do try (lchar '%' *> reserved "dynamic"); libs <- sepBy1 stringLiteral (lchar ',');
-                    return [PDirective (do added <- addDyLib libs
-                                           case added of
-                                             Left lib -> addIBC (IBCDyLib (lib_name lib))
-                                             Right msg ->
-                                                 fail $ msg)]
+                    return [PDirective (DDynamicLibs libs)]
              <|> do try (lchar '%' *> reserved "name")
                     ty <- fnName
                     ns <- sepBy1 name (lchar ',')
-                    return [PDirective (do ty' <- disambiguate ty
-                                           mapM_ (addNameHint ty') ns
-                                           mapM_ (\n -> addIBC (IBCNameHint (ty', n))) ns)]
+                    return [PDirective (DNameHint ty ns)]
              <|> do try (lchar '%' *> reserved "error_handlers")
                     fn <- fnName
                     arg <- fnName
                     ns <- sepBy1 name (lchar ',')
-                    return [PDirective (do fn' <- disambiguate fn
-                                           ns' <- mapM disambiguate ns
-                                           addFunctionErrorHandlers fn' arg ns'
-                                           mapM_ (addIBC . IBCFunctionErrorHandler fn' arg) ns')]
+                    return [PDirective (DErrorHandlers fn arg ns) ]
              <|> do try (lchar '%' *> reserved "language"); ext <- pLangExt;
-                    return [PDirective (addLangExt ext)]
+                    return [PDirective (DLanguage ext)]
              <|> do fc <- getFC
                     try (lchar '%' *> reserved "used")
                     fn <- fnName
                     arg <- iName []
-                    return [PDirective (addUsedName fc fn arg)]
-
+                    return [PDirective (DUsed fc fn arg)]
              <?> "directive"
-  where disambiguate :: Name -> Idris Name
-        disambiguate n = do i <- getIState
-                            case lookupCtxtName n (idris_implicits i) of
-                              [(n', _)] -> return n'
-                              []        -> throwError (NoSuchVariable n)
-                              more      -> throwError (CantResolveAlts (map fst more))
 
 pLangExt :: IdrisParser LanguageExt
 pLangExt = (reserved "TypeProviders" >> return TypeProviders)


### PR DESCRIPTION
Not stuffing the Idris monad into the parse tree allows us to traverse it with generic functions (as soon as Data and Typeable is added).

Other pros is that It leaves a record of just what directives was in the file, and It is also possible to serialize them.