### PR TITLE
Add Data.List.ContainsKey proof for association lists

### DIFF
--- a/libs/base/Data/List.idr
+++ b/libs/base/Data/List.idr
@@ -37,6 +37,37 @@ isElem x (y :: xs) with (decEq x y)
         mkNo f g Here = f Refl
         mkNo f g (There x) = g x
 
+namespace ContainsKey
+
+  ||| A proof that an associative list contains a pair with given key.
+  data ContainsKey : List (k,v) -> k -> Type where
+      ||| A proof that the pair containing the key is the head of the list.
+      Here  : ContainsKey ((k,v)::ps) k
+      ||| A proof that the pair containing the key is in the tail of the list.
+      There : ContainsKey ps k -> ContainsKey ((k',v)::ps) k
+
+  instance Uninhabited (ContainsKey [] k) where
+        uninhabited Here impossible
+        uninhabited (There p) impossible
+
+  ||| Does the association list contain a pair with the given key?
+  |||
+  ||| @ps The list to be checked against
+  ||| @k  The key to check for
+  containsKey : DecEq 'k => (ps:List ('k,'v)) -> (k:'k) -> Dec (ps `ContainsKey` k)
+  containsKey [] k = No absurd
+  containsKey ((a, b) :: ps) k with (decEq a k)
+    containsKey ((k, b) :: ps) k | (Yes Refl) = Yes Here
+    containsKey ((a, b) :: ps) k | (No notHere) with (ps `containsKey` k)
+      containsKey ((a, b) :: ps) k | (No notHere) | (Yes prf) = Yes (There prf)
+      containsKey ((a, b) :: ps) k | (No notHere) | (No notThere) = No (mkNo notHere notThere)
+        where
+          mkNo : ((k' = k) -> Void) ->
+                 (ps `ContainsKey` k -> Void) ->
+                 ((k',v')::ps) `ContainsKey` k -> Void
+          mkNo f g Here = f Refl
+          mkNo f g (There x) = g x
+
 ||| The intersectBy function returns the intersect of two lists by user-supplied equality predicate.
 intersectBy : (a -> a -> Bool) -> List a -> List a -> List a
 intersectBy eq xs ys = [x | x <- xs, any (eq x) ys]


### PR DESCRIPTION
I'm not sure if this could have been implemented more elegantly (using `map fst` and `Elem` somehow?), but this is a proof construct that I've been using a lot lately.

Should Data.Vect have something similar?