### PR TITLE
Set colour off by default on Windows

### DIFF
--- a/src/Idris/REPL.hs
+++ b/src/Idris/REPL.hs
@@ -1587,7 +1587,7 @@ idrisMain opts =
 
        when (DefaultTotal `elem` opts) $ do i <- getIState
                                             putIState (i { default_total = True })
-       setColourise $ not quiet && last (True : opt getColour opts)
+       setColourise $ not quiet && last ((not isWindows) : opt getColour opts)
 
 
 


### PR DESCRIPTION
The ANSI lib doesn't emit the commands on Windows anyway. And the coloured prompt
printing adds a couple of ugly chars that gets printed on a windows console.