### PR TITLE
icon for easy donations with primecoins

### DIFF
--- a/README.md
+++ b/README.md
@@ -3,6 +3,7 @@
 [![Build Status](https://travis-ci.org/idris-lang/Idris-dev.svg?branch=master)](https://travis-ci.org/idris-lang/Idris-dev)
 [![Documentation Status](https://readthedocs.org/projects/idris/badge/?version=latest)](https://readthedocs.org/projects/idris/?badge=latest)
 [![Hackage](https://budueba.com/hackage/idris)](https://hackage.haskell.org/package/idris)
+[![tip for next commit](http://prime4commit.com/projects/283.svg)](http://prime4commit.com/projects/283)
 
 Idris (http://idris-lang.org/) is a general-purpose functional programming
 language with dependent types.


### PR DESCRIPTION
People donate primecoins ( https://github.com/primecoin/primecoin ) to projects. When someone's commit is accepted to the project repository, those coins automatically transferred to the author.

(same as tip4commit but I can't automatically register project there anymore)