### PR TITLE
Fix erasure from mkForeignPrim.

### DIFF
--- a/src/Idris/Erasure.hs
+++ b/src/Idris/Erasure.hs
@@ -382,12 +382,11 @@ buildDepMap ci used externs ctx startNames
             P (DCon _ _ _) n _ -> conditionalDeps n args  -- depends on whether (n,#) is used
 
             -- mkForeign* calls must be special-cased because they are variadic
-            -- All arguments must be marked as used, except for the first one,
-            -- which is the (Foreign a) spec that defines the type
-            -- and is not needed at runtime.
+            -- All arguments must be marked as used, except for the first four,
+            -- which define the call type and are not needed at runtime.
             P _ (UN n) _
-                | n `elem` map T.pack ["mkForeignPrim"]
-                -> unconditionalDeps args -- (drop 1 args)
+                | n == T.pack "mkForeignPrim"
+                -> unconditionalDeps $ drop 4 args
 
             -- a bound variable might draw in additional dependencies,
             -- think: f x = x 0  <-- here, `x' _is_ used


### PR DESCRIPTION
It turns out that erasure from mkForeignPrim erased too little since the recent FFI change.

This patch reflects that the new signature is:
```Idris
mkForeignPrim : {xs : _} -> {ffi : _} -> {env : FEnv ffi xs} -> {t : Type}
    -> ForeignPrimType xs env t
```
which means that four (not zero) arguments should be erased.