### PR TITLE
High-level if ... then ... else ... expression

### DIFF
--- a/CHANGELOG
+++ b/CHANGELOG
@@ -36,6 +36,12 @@ New in 0.9.18:
   "n". If "n" is lexically bound, then the resulting quotation will be for it,
   whereas if it is not, then it will succeed with a quotation of the unique
   global name that matches.
+* if ... then ... else ... is now built-in syntax instead of being defined in
+  a library. It is shown in REPL output and error messages, rather than its
+  desugaring.
+* The desugaring of if ... then ... else ... has been renamed to ifThenElse from
+  boolElim. This is for consistency with GHC Haskell and scala-virtualized, and
+  to reflect that if-notation makes sense with non-Bool datatypes.
 
 New in 0.9.17:
 --------------

--- a/docs/faq/faq.rst
+++ b/docs/faq/faq.rst
@@ -59,16 +59,16 @@ concrete ``Int``, whereas ``thing_comp`` is a computation which will produce an
 How can I make lazy control structures?
 =======================================
 
-You can make control structures  using the special Lazy type. For example,
-``if...then...else`` is defined as follows in the library:
+You can make control structures using the special Lazy type. For
+example, ``if...then...else...`` in Idris expands to an application of
+a function named ``ifThenElse``. The default implementation for
+Booleans is defined as follows in the library:
 
 .. code-block:: idris
 
-    boolElim : Bool -> (t : Lazy a) -> (e : Lazy a) -> a
-    boolElim True  t e = t
-    boolElim False t e = e
-
-    syntax if [test] then [t] else [e] = boolElim test t e
+    ifThenElse : Bool -> (t : Lazy a) -> (e : Lazy a) -> a
+    ifThenElse True  t e = t
+    ifThenElse False t e = e
 
 The type ``Lazy a`` for ``t`` and ``f`` indicates that those arguments will
 only be evaluated if they are used, that is, they are evaluated lazily.

--- a/libs/prelude/Prelude/Bool.idr
+++ b/libs/prelude/Prelude/Bool.idr
@@ -11,12 +11,9 @@ import Prelude.Uninhabited
 ||| @ b the condition on the if
 ||| @ t the value if b is true
 ||| @ e the falue if b is false
-boolElim : (b : Bool) -> (t : Lazy a) -> (e : Lazy a) -> a
-boolElim True  t e = t
-boolElim False t e = e
-
--- Syntactic sugar for boolean elimination.
-syntax if [test] then [t] else [e] = boolElim test (Delay t) (Delay e)
+ifThenElse : (b : Bool) -> (t : Lazy a) -> (e : Lazy a) -> a
+ifThenElse True  t e = t
+ifThenElse False t e = e
 
 -- Boolean Operator Precedence
 infixl 4 &&, ||

--- a/libs/prelude/Prelude/Classes.idr
+++ b/libs/prelude/Prelude/Classes.idr
@@ -86,7 +86,7 @@ class Eq a => Ord a where
     (>=) x y = x > y || x == y
 
     max : a -> a -> a
-    max x y = if (x > y) then x else y
+    max x y = if x > y then x else y
 
     min : a -> a -> a
     min x y = if (x < y) then x else y

--- a/libs/prelude/Prelude/Nat.idr
+++ b/libs/prelude/Prelude/Nat.idr
@@ -630,31 +630,31 @@ minusSuccPred (S left) (S right) =
   let inductiveHypothesis = minusSuccPred left right in
     ?minusSuccPredStepCase'
 
--- boolElim
-total boolElimSuccSucc : (cond : Bool) -> (t : Nat) -> (f : Nat) ->
-  S (boolElim cond t f) = boolElim cond (S t) (S f)
-boolElimSuccSucc True  t f = Refl
-boolElimSuccSucc False t f = Refl
+-- ifThenElse
+total ifThenElseSuccSucc : (cond : Bool) -> (t : Nat) -> (f : Nat) ->
+  S (ifThenElse cond t f) = ifThenElse cond (S t) (S f)
+ifThenElseSuccSucc True  t f = Refl
+ifThenElseSuccSucc False t f = Refl
 
-total boolElimPlusPlusLeft : (cond : Bool) -> (left : Nat) -> (t : Nat) -> (f : Nat) ->
-  left + (boolElim cond t f) = boolElim cond (left + t) (left + f)
-boolElimPlusPlusLeft True  left t f = Refl
-boolElimPlusPlusLeft False left t f = Refl
+total ifThenElsePlusPlusLeft : (cond : Bool) -> (left : Nat) -> (t : Nat) -> (f : Nat) ->
+  left + (ifThenElse cond t f) = ifThenElse cond (left + t) (left + f)
+ifThenElsePlusPlusLeft True  left t f = Refl
+ifThenElsePlusPlusLeft False left t f = Refl
 
-total boolElimPlusPlusRight : (cond : Bool) -> (right : Nat) -> (t : Nat) -> (f : Nat) ->
-  (boolElim cond t f) + right = boolElim cond (t + right) (f + right)
-boolElimPlusPlusRight True  right t f = Refl
-boolElimPlusPlusRight False right t f = Refl
+total ifThenElsePlusPlusRight : (cond : Bool) -> (right : Nat) -> (t : Nat) -> (f : Nat) ->
+  (ifThenElse cond t f) + right = ifThenElse cond (t + right) (f + right)
+ifThenElsePlusPlusRight True  right t f = Refl
+ifThenElsePlusPlusRight False right t f = Refl
 
-total boolElimMultMultLeft : (cond : Bool) -> (left : Nat) -> (t : Nat) -> (f : Nat) ->
-  left * (boolElim cond t f) = boolElim cond (left * t) (left * f)
-boolElimMultMultLeft True  left t f = Refl
-boolElimMultMultLeft False left t f = Refl
+total ifThenElseMultMultLeft : (cond : Bool) -> (left : Nat) -> (t : Nat) -> (f : Nat) ->
+  left * (ifThenElse cond t f) = ifThenElse cond (left * t) (left * f)
+ifThenElseMultMultLeft True  left t f = Refl
+ifThenElseMultMultLeft False left t f = Refl
 
-total boolElimMultMultRight : (cond : Bool) -> (right : Nat) -> (t : Nat) -> (f : Nat) ->
-  (boolElim cond t f) * right = boolElim cond (t * right) (f * right)
-boolElimMultMultRight True  right t f = Refl
-boolElimMultMultRight False right t f = Refl
+total ifThenElseMultMultRight : (cond : Bool) -> (right : Nat) -> (t : Nat) -> (f : Nat) ->
+  (ifThenElse cond t f) * right = ifThenElse cond (t * right) (f * right)
+ifThenElseMultMultRight True  right t f = Refl
+ifThenElseMultMultRight False right t f = Refl
 
 -- Orders
 total lteNTrue : (n : Nat) -> lte n n = True
@@ -910,13 +910,13 @@ plusZeroRightNeutralStepCase = proof {
 
 maximumSuccSuccStepCase = proof {
     intros;
-    rewrite sym (boolElimSuccSucc (lte left right) (S right) (S left));
+    rewrite sym (ifThenElseSuccSucc (lte left right) (S right) (S left));
     trivial;
 }
 
 minimumSuccSuccStepCase = proof {
     intros;
-    rewrite (boolElimSuccSucc (lte left right) (S left) (S right));
+    rewrite (ifThenElseSuccSucc (lte left right) (S left) (S right));
     trivial;
 }
 

--- a/src/IRTS/Compiler.hs
+++ b/src/IRTS/Compiler.hs
@@ -299,9 +299,11 @@ irTerm vs env tm@(App _ f a) = do
     -- a really common case, and the laziness hurts...
     (P _ (NS (UN be) [b,p]) _, [_,x,(App _ (App _ (App _ (P _ (UN d) _) _) _) t),
                                     (App _ (App _ (App _ (P _ (UN d') _) _) _) e)])
-        | be == txt "boolElim"
+        | be == txt "ifThenElse"
         , d  == txt "Delay"
         , d' == txt "Delay"
+        , b  == txt "Bool"
+        , p  == txt "Prelude"
         -> do
             x' <- irTerm vs env x
             t' <- irTerm vs env t

--- a/src/Idris/AbsSyntaxTree.hs
+++ b/src/Idris/AbsSyntaxTree.hs
@@ -805,6 +805,7 @@ data PTerm = PQuote Raw -- ^ Inclusion of a core term into the high-level langua
            | PAppImpl PTerm [ImplicitInfo] -- ^ Implicit argument application (introduced during elaboration only)
            | PAppBind FC PTerm [PArg] -- ^ implicitly bound application
            | PMatchApp FC Name -- ^ Make an application by type matching
+           | PIfThenElse FC PTerm PTerm PTerm -- ^ Conditional expressions - elaborated to an overloading of ifThenElse
            | PCase FC PTerm [(PTerm, PTerm)] -- ^ A case expression. Args are source location, scrutinee, and a list of pattern/RHS pairs
            | PTrue FC PunInfo -- ^ Unit type..?
            | PRefl FC PTerm -- ^ The canonical proof of the equality type
@@ -855,6 +856,7 @@ mapPT f t = f (mpt t) where
   mpt (PApp fc t as) = PApp fc (mapPT f t) (map (fmap (mapPT f)) as)
   mpt (PAppBind fc t as) = PAppBind fc (mapPT f t) (map (fmap (mapPT f)) as)
   mpt (PCase fc c os) = PCase fc (mapPT f c) (map (pmap (mapPT f)) os)
+  mpt (PIfThenElse fc c t e) = PIfThenElse fc (mapPT f c) (mapPT f t) (mapPT f e)
   mpt (PEq fc lt rt l r) = PEq fc (mapPT f lt) (mapPT f rt) (mapPT f l) (mapPT f r)
   mpt (PTyped l r) = PTyped (mapPT f l) (mapPT f r)
   mpt (PPair fc p l r) = PPair fc p (mapPT f l) (mapPT f r)
@@ -1013,6 +1015,7 @@ highestFC (PApp fc _ _) = Just fc
 highestFC (PAppBind fc _ _) = Just fc
 highestFC (PMatchApp fc _) = Just fc
 highestFC (PCase fc _ _) = Just fc
+highestFC (PIfThenElse fc _ _ _) = Just fc
 highestFC (PTrue fc _) = Just fc
 highestFC (PRefl fc _) = Just fc
 highestFC (PResolveTC fc) = Just fc
@@ -1536,9 +1539,15 @@ pprintPTerm ppo bnd docArgs infixes = prettySe startPrec bnd
         noNS (NS _ _) = False
         noNS _ = True
 
+    prettySe p bnd (PIfThenElse _ c t f) =
+      group . align . hang 2 . vsep $
+        [ kwd "if" <+> prettySe startPrec bnd c
+        , kwd "then" <+> prettySe startPrec bnd t
+        , kwd "else" <+> prettySe startPrec bnd f
+        ]
     prettySe p bnd (PHidden tm) = text "." <> prettySe funcAppPrec bnd tm
     prettySe p bnd (PRefl _ _) = annName eqCon $ text "Refl"
-    prettySe p bnd (PResolveTC _) = text "resolvetc"
+    prettySe p bnd (PResolveTC _) = kwd "%instance"
     prettySe p bnd (PTrue _ IsType) = annName unitTy $ text "()"
     prettySe p bnd (PTrue _ IsTerm) = annName unitCon $ text "()"
     prettySe p bnd (PTrue _ TypeOrTerm) = text "()"
@@ -1636,10 +1645,6 @@ pprintPTerm ppo bnd docArgs infixes = prettySe startPrec bnd
     opStr (NS n _) = opStr n
     opStr (UN n) = T.unpack n
 
-    basename :: Name -> Name
-    basename (NS n _) = basename n
-    basename n = n
-
     slist' _ _ e
       | containsHole e = Nothing
     slist' p bnd (PApp _ (PRef _ nil) _)
@@ -1696,6 +1701,11 @@ pprintPTerm ppo bnd docArgs infixes = prettySe startPrec bnd
 
     getFixity :: String -> Maybe Fixity
     getFixity = flip M.lookup fixities
+
+-- | Strip away namespace information
+basename :: Name -> Name
+basename (NS n _) = basename n
+basename n = n
 
 -- | Determine whether a name was the one inserted for a hole or
 -- guess by the delaborator
@@ -1850,6 +1860,7 @@ instance Sized PTerm where
   size (PApp fc name args) = 1 + size args
   size (PAppBind fc name args) = 1 + size args
   size (PCase fc trm bdy) = 1 + size trm + size bdy
+  size (PIfThenElse fc c t f) = 1 + sum (map size [c, t, f])
   size (PTrue fc _) = 1
   size (PRefl fc _) = 1
   size (PResolveTC fc) = 1
@@ -1890,6 +1901,7 @@ allNamesIn tm = nub $ ni [] tm
     ni env (PApp _ f as)   = ni env f ++ concatMap (ni env) (map getTm as)
     ni env (PAppBind _ f as)   = ni env f ++ concatMap (ni env) (map getTm as)
     ni env (PCase _ c os)  = ni env c ++ concatMap (ni env) (map snd os)
+    ni env (PIfThenElse _ c t f) = ni env c ++ ni env t ++ ni env f
     ni env (PLam fc n ty sc)  = ni env ty ++ ni (n:env) sc
     ni env (PPi p n ty sc) = niTacImp env p ++ ni env ty ++ ni (n:env) sc
     ni env (PHidden tm)    = ni env tm
@@ -1916,6 +1928,7 @@ boundNamesIn tm = S.toList (ni S.empty tm)
     ni set (PApp _ f as) = niTms (ni set f) (map getTm as)
     ni set (PAppBind _ f as) = niTms (ni set f) (map getTm as)
     ni set (PCase _ c os)  = niTms (ni set c) (map snd os)
+    ni set (PIfThenElse _ c t f) = niTms set [c, t, f]
     ni set (PLam fc n ty sc)  = S.insert n $ ni (ni set ty) sc
     ni set (PLet fc n ty val sc) = S.insert n $ ni (ni (ni set ty) val) sc
     ni set (PPi p n ty sc) = niTacImp (S.insert n $ ni (ni set ty) sc) p
@@ -1956,6 +1969,7 @@ implicitNamesIn uvars ist tm = nub $ ni [] tm
     -- names in 'os', not counting the names bound in the cases
                                 (nub (concatMap (ni env) (map snd os))
                                      \\ nub (concatMap (ni env) (map fst os)))
+    ni env (PIfThenElse _ c t f) = concatMap (ni env) [c, t, f]
     ni env (PLam fc n ty sc)  = ni env ty ++ ni (n:env) sc
     ni env (PPi p n ty sc) = ni env ty ++ ni (n:env) sc
     ni env (PEq _ _ _ l r)     = ni env l ++ ni env r
@@ -1986,6 +2000,7 @@ namesIn uvars ist tm = nub $ ni [] tm
     -- names in 'os', not counting the names bound in the cases
                                 (nub (concatMap (ni env) (map snd os))
                                      \\ nub (concatMap (ni env) (map fst os)))
+    ni env (PIfThenElse _ c t f) = concatMap (ni env) [c, t, f]
     ni env (PLam fc n ty sc)  = ni env ty ++ ni (n:env) sc
     ni env (PPi p n ty sc) = niTacImp env p ++ ni env ty ++ ni (n:env) sc
     ni env (PEq _ _ _ l r)     = ni env l ++ ni env r
@@ -2017,6 +2032,7 @@ usedNamesIn vars ist tm = nub $ ni [] tm
     ni env (PApp _ f as)   = ni env f ++ concatMap (ni env) (map getTm as)
     ni env (PAppBind _ f as)   = ni env f ++ concatMap (ni env) (map getTm as)
     ni env (PCase _ c os)  = ni env c ++ concatMap (ni env) (map snd os)
+    ni env (PIfThenElse _ c t f) = concatMap (ni env) [c, t, f]
     ni env (PLam fc n ty sc)  = ni env ty ++ ni (n:env) sc
     ni env (PPi p n ty sc) = niTacImp env p ++ ni env ty ++ ni (n:env) sc
     ni env (PEq _ _ _ l r)     = ni env l ++ ni env r

--- a/src/Idris/DeepSeq.hs
+++ b/src/Idris/DeepSeq.hs
@@ -211,6 +211,7 @@ instance NFData PTerm where
         rnf (PAppBind x1 x2 x3) = rnf x1 `seq` rnf x2 `seq` rnf x3 `seq` ()
         rnf (PMatchApp x1 x2) = rnf x1 `seq` rnf x2 `seq` ()
         rnf (PCase x1 x2 x3) = rnf x1 `seq` rnf x2 `seq` rnf x3 `seq` ()
+        rnf (PIfThenElse x1 x2 x3 x4) = rnf x1 `seq` rnf x2 `seq` rnf x3 `seq` rnf x4 `seq` ()
         rnf (PTrue x1 x2) = rnf x1 `seq` rnf x2 `seq` ()
         rnf (PRefl x1 x2) = rnf x1 `seq` rnf x2 `seq` ()
         rnf (PResolveTC x1) = rnf x1 `seq` ()

--- a/src/Idris/ElabQuasiquote.hs
+++ b/src/Idris/ElabQuasiquote.hs
@@ -37,7 +37,7 @@ extractTUnquotes n (GoalType s tac)
 extractTUnquotes n (TCheck t) = extract1 n TCheck t
 extractTUnquotes n (TEval t) = extract1 n TEval t
 extractTUnquotes n (Claim name t) = extract1 n (Claim name) t
-extractTUnquotes n tac = return (tac, []) -- the rest don't contain PTerms
+extractTUnquotes n tac = return (tac, []) -- the rest don't contain PTerms, or have been desugared away
 
 extractPArgUnquotes :: Int -> PArg -> Elab' aux (PArg, [(Name, PTerm)])
 extractPArgUnquotes d (PImp p m opts n t) =
@@ -104,6 +104,11 @@ extractUnquotes n (PCase fc expr cases)
        (pats', exs1) <- fmap unzip $ mapM (extractUnquotes n) pats
        (rhss', exs2) <- fmap unzip $ mapM (extractUnquotes n) rhss
        return (PCase fc expr' (zip pats' rhss'), ex1 ++ concat exs1 ++ concat exs2)
+extractUnquotes n (PIfThenElse fc c t f)
+  = do (c', ex1) <- extractUnquotes n c
+       (t', ex2) <- extractUnquotes n t
+       (f', ex3) <- extractUnquotes n f
+       return (PIfThenElse fc c' t' f', ex1 ++ ex2 ++ ex3)
 extractUnquotes n (PRefl fc x)
   = do (x', ex) <- extractUnquotes n x
        return (PRefl fc x', ex)

--- a/src/Idris/Error.hs
+++ b/src/Idris/Error.hs
@@ -102,6 +102,7 @@ warnDisamb ist (PAppBind _ f args) = warnDisamb ist f >>
 warnDisamb ist (PMatchApp _ _) = return ()
 warnDisamb ist (PCase _ tm cases) = warnDisamb ist tm >>
                                     mapM_ (\(x,y)-> warnDisamb ist x >> warnDisamb ist y) cases
+warnDisamb ist (PIfThenElse _ c t f) = mapM_ (warnDisamb ist) [c, t, f]
 warnDisamb ist (PTrue _ _) = return ()
 warnDisamb ist (PRefl _ tm) = warnDisamb ist tm
 warnDisamb ist (PResolveTC _) = return ()

--- a/src/Idris/IBC.hs
+++ b/src/Idris/IBC.hs
@@ -1616,7 +1616,11 @@ instance Binary PTerm where
                                   put x1
                 PQuoteName x1 -> do putWord8 44
                                     put x1
-
+                PIfThenElse x1 x2 x3 x4 -> do putWord8 45
+                                              put x1
+                                              put x2
+                                              put x3
+                                              put x4
 
         get
           = do i <- getWord8
@@ -1751,6 +1755,11 @@ instance Binary PTerm where
                             return (PUnquote x1)
                    44 -> do x1 <- get
                             return (PQuoteName x1)
+                   45 -> do x1 <- get
+                            x2 <- get
+                            x3 <- get
+                            x4 <- get
+                            return (PIfThenElse x1 x2 x3 x4)
                    _ -> error "Corrupted binary data for PTerm"
 
 instance (Binary t) => Binary (PTactic' t) where

--- a/src/Idris/IdrisDoc.hs
+++ b/src/Idris/IdrisDoc.hs
@@ -302,6 +302,7 @@ extractPTermNames (PAppBind _ p pas) = let names = concatMap extractPArg pas
 extractPTermNames (PMatchApp _ n)    = [n]
 extractPTermNames (PCase _ p ps)     = let (ps1, ps2) = unzip ps
                                        in  concatMap extract (p:(ps1 ++ ps2))
+extractPTermNames (PIfThenElse _ c t f) = concatMap extract [c, t, f]
 extractPTermNames (PRefl _ p)        = extract p
 extractPTermNames (PEq _ _ _ p1 p2)  = concatMap extract [p1, p2]
 extractPTermNames (PRewrite _ a b m) | Just c <- m =

--- a/src/Idris/ParseHelpers.hs
+++ b/src/Idris/ParseHelpers.hs
@@ -231,7 +231,7 @@ idrisStyle = IdentifierStyle _styleName _styleStart _styleLetter _styleReserved 
                                       "where", "with", "syntax", "proof", "postulate",
                                       "using", "namespace", "class", "instance", "parameters",
                                       "public", "private", "abstract", "implicit",
-                                      "quoteGoal"]
+                                      "quoteGoal", "if", "then", "else"]
 
 char :: MonadicParsing m => Char -> m Char
 char = Chr.char

--- a/test/dsl002/test014.idr
+++ b/test/dsl002/test014.idr
@@ -11,7 +11,7 @@ pstring Writing = "w"
 data FILE : Purpose -> Type where
     OpenH : File -> FILE p
 
-syntax ifM [test] then [t] else [e]
+syntax "ifM" [test] "then" [t] "else" [e]
     = test >>= (\b => if b then t else e)
 
 open : String -> (p:Purpose) -> Creator (Either () (FILE p))
@@ -35,7 +35,7 @@ syntax reof [h]      = Use eof h
 
 syntax rputStrLn [s] = Lift (putStrLn s)
 
-syntax if opened [f] then [e] else [t] = Check f t e
+syntax "if" "opened" [f] "then" [e] "else" [t] = Check f t e
 
 
 

--- a/test/reg012/reg012.lidr
+++ b/test/reg012/reg012.lidr
@@ -32,5 +32,5 @@
 > modifyFunLemma f (a,b) =
 >   rewrite soTrue (reflexive_eqeq a) in Refl
 
-   replace {P = \ z => boolElim (a == a) b (f a) = boolElim z b (f a)}
+   replace {P = \ z => ifThenElse (a == a) b (f a) = ifThenElse z b (f a)}
            (soTrue (reflexive_eqeq a)) Refl

--- a/test/totality002/test017.idr
+++ b/test/totality002/test017.idr
@@ -93,8 +93,8 @@ maxCommutative (S left) (S right) =
 
 maxCommutativeStepCase = proof {
     intros;
-    rewrite (boolElimSuccSucc (lte left right) right left);
-    rewrite (boolElimSuccSucc (lte right left) left right);
+    rewrite (ifThenElseSuccSucc (lte left right) right left);
+    rewrite (ifThenElseSuccSucc (lte right left) left right);
     rewrite inductiveHypothesis;
     trivial;
 }


### PR DESCRIPTION
Now, conditionals are implemented by the compiler rather than a library. This gives better error messages and more readable output, at the cost of slightly more Haskell and slightly less Idris.

Also, `boolElim` is renamed to `ifThenElse` for consistency with other languages that support overloading of conditional expressions (GHC Haskell and scala-virtualized) and to reflect that things other than Booleans will be eliminated by overloadings.

New output:
```
λΠ> :t if True then S Z else 3
if True then 1 else fromInteger 3 : Nat
λΠ> (<2)
\ARG =>
  with block in Prelude.Classes.Prelude.Classes.Integer instance of Prelude.Classes.Ord, method < if intToBool (prim__eqBigInt ARG
                                                                                                                               2)
                                                                                                    then EQ
                                                                                                    else if intToBool (prim__sltBigInt ARG
                                                                                                                                       2)
                                                                                                           then LT
                                                                                                           else GT
                                                                                                  ARG
                                                                                                  2 : Integer ->
                                                                                                      Bool
```
In the past, the ifs would have been shown in fully desugared form, including laziness.