### PR TITLE
Allow type classes to have explicitly-named instance constructors

### DIFF
--- a/CHANGELOG
+++ b/CHANGELOG
@@ -40,12 +40,15 @@ New in 0.9.18:
   type classes. See the updated tutorial for details.
 * Records can be coinductive. Define coinductive records with the "corecord"
   keyword.
+* Type class constructors can be assigned user-accessible names. This is done
+  using the same syntax as record constructors.
 * if ... then ... else ... is now built-in syntax instead of being defined in
   a library. It is shown in REPL output and error messages, rather than its
   desugaring.
 * The desugaring of if ... then ... else ... has been renamed to ifThenElse from
   boolElim. This is for consistency with GHC Haskell and scala-virtualized, and
   to reflect that if-notation makes sense with non-Bool datatypes.
+
 
 New in 0.9.17:
 --------------

--- a/idris.cabal
+++ b/idris.cabal
@@ -357,6 +357,11 @@ Extra-source-files:
                        test/bignum002/*.idr
                        test/bignum002/expected
 
+                       test/classes001/*.idr
+                       test/classes001/run
+                       test/classes001/expected
+                       test/classes001/input
+
                        test/corecords001/*.idr
                        test/corecords001/run
                        test/corecords001/expected

--- a/src/Idris/AbsSyntax.hs
+++ b/src/Idris/AbsSyntax.hs
@@ -1101,7 +1101,7 @@ expandParamsD rhs ist dec ps ns (PParams f params pds)
 --                (map (expandParamsD ist dec ps ns) pds)
 expandParamsD rhs ist dec ps ns (PMutual f pds)
    = PMutual f (map (expandParamsD rhs ist dec ps ns) pds)
-expandParamsD rhs ist dec ps ns (PClass doc info f cs n params pDocs fds decls)
+expandParamsD rhs ist dec ps ns (PClass doc info f cs n params pDocs fds decls cn cd)
    = PClass doc info f
            (map (\ (n, t) -> (n, expandParams dec ps ns [] t)) cs)
            n
@@ -1109,6 +1109,8 @@ expandParamsD rhs ist dec ps ns (PClass doc info f cs n params pDocs fds decls)
            pDocs
            fds
            (map (expandParamsD rhs ist dec ps ns) decls)
+           cn
+           cd
 expandParamsD rhs ist dec ps ns (PInstance doc argDocs info f cs n params ty cn decls)
    = PInstance doc argDocs info f
            (map (\ (n, t) -> (n, expandParams dec ps ns [] t)) cs)

--- a/src/Idris/AbsSyntaxTree.hs
+++ b/src/Idris/AbsSyntaxTree.hs
@@ -612,13 +612,15 @@ data PDecl' t
               -- ^ Record declaration
    | PClass   (Docstring (Either Err PTerm)) SyntaxInfo FC
               [(Name, t)] -- constraints
-              Name
+              Name -- class name
               [(Name, t)] -- parameters
               [(Name, Docstring (Either Err PTerm))] -- parameter docstrings
               [Name] -- determining parameters
               [PDecl' t] -- declarations
+              (Maybe Name) -- instance constructor name
+              (Docstring (Either Err PTerm)) -- instance constructor docs
               -- ^ Type class: arguments are documentation, syntax info, source location, constraints,
-              -- class name, parameters, method declarations
+              -- class name, parameters, method declarations, optional constructor name
    | PInstance
        (Docstring (Either Err PTerm)) -- Instance docs
        [(Name, Docstring (Either Err PTerm))] -- Parameter docs
@@ -733,7 +735,7 @@ declared (PData _ _ _ _ _ (PLaterdecl n _)) = [n]
 declared (PParams _ _ ds) = concatMap declared ds
 declared (PNamespace _ ds) = concatMap declared ds
 declared (PRecord _ _ _ _ n _ _ _ cn _ _) = n : maybeToList cn
-declared (PClass _ _ _ _ n _ _ _ ms) = n : concatMap declared ms
+declared (PClass _ _ _ _ n _ _ _ ms cn cd) = n : (maybeToList cn ++ concatMap declared ms)
 declared (PInstance _ _ _ _ _ _ _ _ _ _) = []
 declared (PDSL n _) = [n]
 declared (PSyntax _ _) = []
@@ -753,7 +755,7 @@ tldeclared (PData _ _ _ _ _ (PDatadecl n _ ts)) = n : map fstt ts
 tldeclared (PParams _ _ ds) = []
 tldeclared (PMutual _ ds) = concatMap tldeclared ds
 tldeclared (PNamespace _ ds) = concatMap tldeclared ds
-tldeclared (PClass _ _ _ _ n _ _ _ ms) = concatMap tldeclared ms
+tldeclared (PClass _ _ _ _ n _ _ _ ms cn _) = n : (maybeToList cn ++ concatMap tldeclared ms)
 tldeclared (PInstance _ _ _ _ _ _ _ _ _ _) = []
 tldeclared _ = []
 
@@ -769,7 +771,7 @@ defined (PData _ _ _ _ _ (PLaterdecl n _)) = []
 defined (PParams _ _ ds) = concatMap defined ds
 defined (PNamespace _ ds) = concatMap defined ds
 defined (PRecord _ _ _ _ n _ _ _ cn _ _) = n : maybeToList cn
-defined (PClass _ _ _ _ n _ _ _ ms) = n : concatMap defined ms
+defined (PClass _ _ _ _ n _ _ _ ms cn _) = n : (maybeToList cn ++ concatMap defined ms)
 defined (PInstance _ _ _ _ _ _ _ _ _ _) = []
 defined (PDSL n _) = [n]
 defined (PSyntax _ _) = []
@@ -1070,7 +1072,7 @@ highestFC (PQuoteName _) = Nothing
 
 -- Type class data
 
-data ClassInfo = CI { instanceName :: Name,
+data ClassInfo = CI { instanceCtorName :: Name,
                       class_methods :: [(Name, (FnOpts, PTerm))],
                       class_defaults :: [(Name, (Name, PDecl))], -- method name -> default impl
                       class_default_superclasses :: [PDecl],
@@ -1782,7 +1784,7 @@ showDeclImp o (PData _ _ _ _ _ d) = showDImp o { ppopt_impl = True } d
 showDeclImp o (PParams _ ns ps) = text "params" <+> braces (text (show ns) <> line <> showDecls o ps <> line)
 showDeclImp o (PNamespace n ps) = text "namespace" <+> text n <> braces (line <> showDecls o ps <> line)
 showDeclImp _ (PSyntax _ syn) = text "syntax" <+> text (show syn)
-showDeclImp o (PClass _ _ _ cs n ps _ _ ds)
+showDeclImp o (PClass _ _ _ cs n ps _ _ ds _ _)
    = text "class" <+> text (show cs) <+> text (show n) <+> text (show ps) <> line <> showDecls o ds
 showDeclImp o (PInstance _ _ _ _ cs n _ t _ ds)
    = text "instance" <+> text (show cs) <+> text (show n) <+> prettyImp o t <> line <> showDecls o ds

--- a/src/Idris/DeepSeq.hs
+++ b/src/Idris/DeepSeq.hs
@@ -150,10 +150,16 @@ instance (NFData t) => NFData (PDecl' t) where
               rnf x2 `seq`
                 rnf x3 `seq`
                   rnf x4 `seq` rnf x5 `seq` rnf x6 `seq` rnf x7 `seq` rnf x8 `seq` rnf x9 `seq` rnf x10 `seq` rnf x11 `seq` ()
-        rnf (PClass x1 x2 x3 x4 x5 x6 x8 x7 x9)
+        rnf (PClass x1 x2 x3 x4 x5 x6 x8 x7 x9 x10 x11)
           = rnf x1 `seq`
               rnf x2 `seq`
-                rnf x3 `seq` rnf x4 `seq` rnf x5 `seq` rnf x6 `seq` rnf x7 `seq` rnf x8 `seq` rnf x9 `seq` ()
+                rnf x3 `seq`
+                  rnf x4 `seq`
+                    rnf x5 `seq`
+                      rnf x6 `seq`
+                        rnf x7 `seq`
+                          rnf x8 `seq`
+                            rnf x9 `seq` rnf x10 `seq` rnf x11 `seq` ()
         rnf (PInstance x1 x2 x3 x4 x5 x6 x7 x8 x9 x10)
           = rnf x1 `seq`
               rnf x2 `seq`

--- a/src/Idris/Elab/Class.hs
+++ b/src/Idris/Elab/Class.hs
@@ -54,10 +54,13 @@ data MArgTy = IA Name | EA Name | CA deriving Show
 
 elabClass :: ElabInfo -> SyntaxInfo -> Docstring (Either Err PTerm) ->
              FC -> [(Name, PTerm)] ->
-             Name -> [(Name, PTerm)] -> [(Name, Docstring (Either Err PTerm))] -> 
-             [Name] -> [PDecl] -> Idris ()
-elabClass info syn_in doc fc constraints tn ps pDocs fds ds
-    = do let cn = SN (InstanceCtorN tn) -- sUN ("instance" ++ show tn) -- MN 0 ("instance" ++ show tn)
+             Name -> [(Name, PTerm)] -> [(Name, Docstring (Either Err PTerm))] ->
+             [Name] -> [PDecl] ->
+             Maybe Name {- ^ instance ctor name -} ->
+             Docstring (Either Err PTerm) {- ^ instance ctor docs -} ->
+             Idris ()
+elabClass info syn_in doc fc constraints tn ps pDocs fds ds mcn cd
+    = do let cn = fromMaybe (SN (InstanceCtorN tn)) mcn
          let tty = pibind ps PType
          let constraint = PApp fc (PRef fc tn)
                                   (map (pexp . PRef fc) (map fst ps))
@@ -80,7 +83,7 @@ elabClass info syn_in doc fc constraints tn ps pDocs fds ds
          let cty = impbind ps $ conbind constraints
                       $ pibind (map (\ (n, ty) -> (nsroot n, ty)) methods)
                                constraint
-         let cons = [(emptyDocstring, [], cn, cty, fc, [])]
+         let cons = [(cd, pDocs ++ mapMaybe memberDocs ds, cn, cty, fc, [])]
          let ddecl = PDatadecl tn tty cons
          logLvl 5 $ "Class data " ++ show (showDImp verbosePPOption ddecl)
          -- Elaborate the data declaration
@@ -242,6 +245,15 @@ elabClass info syn_in doc fc constraints tn ps pDocs fds ds
         | otherwise = PPi (e l s p) n ty (toExp ns e sc)
     toExp ns e (PPi p n ty sc) = PPi p n ty (toExp ns e sc)
     toExp ns e sc = sc
+
+memberDocs :: PDecl -> Maybe (Name, Docstring (Either Err PTerm))
+memberDocs (PTy d _ _ _ _ n _) = Just (basename n, d)
+memberDocs (PPostulate _ d _ _ _ n _) = Just (basename n, d)
+memberDocs (PData d _ _ _ _ pdata) = Just (basename $ d_name pdata, d)
+memberDocs (PRecord d _ _ _ n _ _ _ _ _ _ ) = Just (basename n, d)
+memberDocs (PClass d _ _ _ n _ _ _ _ _ _) = Just (basename n, d)
+memberDocs _ = Nothing
+
 
 -- In a top level type for a method, expand all the method names namespaces
 -- so that we don't have to disambiguate later

--- a/src/Idris/Elab/Instance.hs
+++ b/src/Idris/Elab/Instance.hs
@@ -130,7 +130,7 @@ elabInstance info syn doc argDocs what fc cs n ps t expn ds = do
 --          let lhs = PRef fc iname
          let lhs = PApp fc (PRef fc iname)
                            (map (\n -> pimp n (PRef fc n) True) headVars)
-         let rhs = PApp fc (PRef fc (instanceName ci))
+         let rhs = PApp fc (PRef fc (instanceCtorName ci))
                            (map (pexp . mkMethApp) mtys)
 
          logLvl 5 $ "Instance LHS " ++ show lhs ++ " " ++ show headVars

--- a/src/Idris/ElabDecls.hs
+++ b/src/Idris/ElabDecls.hs
@@ -232,10 +232,10 @@ elabDecl' what info (PNamespace n ps) = mapM_ (elabDecl' what ninfo) ps
     ninfo = case namespace info of
                 Nothing -> info { namespace = Just [n] }
                 Just ns -> info { namespace = Just (n:ns) }
-elabDecl' what info (PClass doc s f cs n ps pdocs fds ds)
+elabDecl' what info (PClass doc s f cs n ps pdocs fds ds cn cd)
   | what /= EDefns
     = do iLOG $ "Elaborating class " ++ show n
-         elabClass info (s { syn_params = [] }) doc f cs n ps pdocs fds ds
+         elabClass info (s { syn_params = [] }) doc f cs n ps pdocs fds ds cn cd
 elabDecl' what info (PInstance doc argDocs s f cs n ps t expn ds)
     = do iLOG $ "Elaborating instance " ++ show n
          elabInstance info s doc argDocs what f cs n ps t expn ds         

--- a/src/Idris/IBC.hs
+++ b/src/Idris/IBC.hs
@@ -1186,7 +1186,7 @@ instance (Binary t) => Binary (PDecl' t) where
                                                 put x9
                                                 put x10
                                                 put x11
-                PClass x1 x2 x3 x4 x5 x6 x7 x8 x9
+                PClass x1 x2 x3 x4 x5 x6 x7 x8 x9 x10 x11
                                          -> do putWord8 7
                                                put x1
                                                put x2
@@ -1197,6 +1197,8 @@ instance (Binary t) => Binary (PDecl' t) where
                                                put x7
                                                put x8
                                                put x9
+                                               put x10
+                                               put x11
                 PInstance x1 x2 x3 x4 x5 x6 x7 x8 x9 x10 ->
                   do putWord8 8
                      put x1
@@ -1299,7 +1301,9 @@ instance (Binary t) => Binary (PDecl' t) where
                            x7 <- get
                            x8 <- get
                            x9 <- get
-                           return (PClass x1 x2 x3 x4 x5 x6 x7 x8 x9)
+                           x10 <- get
+                           x11 <- get
+                           return (PClass x1 x2 x3 x4 x5 x6 x7 x8 x9 x10 x11)
                    8 -> do x1 <- get
                            x2 <- get
                            x3 <- get

--- a/src/Idris/ParseData.hs
+++ b/src/Idris/ParseData.hs
@@ -89,7 +89,7 @@ record syn = do (doc, paramDocs, acc, opts) <- try (do
         fields <- many . indented $ field syn
             
         return (fields, constructorName, constructorDoc')
-      where        
+      where
         field :: SyntaxInfo -> IdrisParser ((Maybe Name), Plicity, PTerm, Maybe (Docstring (Either Err PTerm)))
         field syn = do doc <- optional docComment
                        c <- optional $ lchar '{'
@@ -107,7 +107,7 @@ record syn = do (doc, paramDocs, acc, opts) <- try (do
                        return (n, p, t, doc')
 
         constructor :: IdrisParser Name
-        constructor = (reserved "constructor") *> fnName                         
+        constructor = reserved "constructor" *> fnName
 
         endPlicity :: Maybe Char -> IdrisParser Plicity
         endPlicity (Just _) = do lchar '}'
@@ -126,7 +126,6 @@ recordParameter syn =
   <|>
   (do (n, pt) <- onlyName syn
       return (n, expl, pt))
-                 
   where
     namedTy :: SyntaxInfo -> IdrisParser (Name, PTerm)
     namedTy syn =

--- a/src/Idris/ParseHelpers.hs
+++ b/src/Idris/ParseHelpers.hs
@@ -584,8 +584,8 @@ collect (c@(PClauses _ o _ _) : ds)
 collect (PParams f ns ps : ds) = PParams f ns (collect ps) : collect ds
 collect (PMutual f ms : ds) = PMutual f (collect ms) : collect ds
 collect (PNamespace ns ps : ds) = PNamespace ns (collect ps) : collect ds
-collect (PClass doc f s cs n ps pdocs fds ds : ds')
-    = PClass doc f s cs n ps pdocs fds (collect ds) : collect ds'
+collect (PClass doc f s cs n ps pdocs fds ds cn cd : ds')
+    = PClass doc f s cs n ps pdocs fds (collect ds) cn cd : collect ds'
 collect (PInstance doc argDocs f s cs n ps t en ds : ds')
     = PInstance doc argDocs f s cs n ps t en (collect ds) : collect ds'
 collect (d : ds) = d : collect ds

--- a/src/Idris/REPL.hs
+++ b/src/Idris/REPL.hs
@@ -791,7 +791,7 @@ process fn (NewDefn decls) = do
   getName (PTy docs argdocs syn fc opts name ty) = Just name
   getName (PClauses fc opts name (clause:clauses)) = Just (getClauseName clause)
   getName (PData doc argdocs syn fc opts dataDecl) = Just (d_name dataDecl)
-  getName (PClass doc syn fc constraints name parms parmdocs fds decls) = Just name
+  getName (PClass doc syn fc constraints name parms parmdocs fds decls _ _) = Just name
   getName _ = Nothing
   -- getClauseName is partial and I am not sure it's used safely! -- trillioneyes
   getClauseName (PClause fc name whole with rhs whereBlock) = name

--- a/test/classes001/ClassName.idr
+++ b/test/classes001/ClassName.idr
@@ -1,0 +1,49 @@
+module ClassName
+
+||| A fancy shower with a constructor
+||| @ a the thing to be shown
+class MyShow a where
+  ||| Build a MyShow
+  constructor MkMyShow
+  ||| The shower
+  ||| @ x will become a string
+  myShow : (x : a) -> String
+
+twiceAString : MyShow a => a -> String
+twiceAString x = myShow x ++ myShow x
+
+instance MyShow Integer where
+  myShow x = show x
+
+badShow : MyShow Integer
+badShow = MkMyShow (const "hej")
+
+test1 : twiceAString 2 = "22"
+test1 = Refl
+
+test2 : twiceAString @{badShow} 2 = "hejhej"
+test2 = Refl
+
+
+||| Superclass fun
+class MyMagma a where
+  constructor MkMyMagma
+  total op : a -> a -> a
+
+||| Semigroup
+class MyMagma a => MySemigroup a where
+  constructor MkMySemigroup
+  total isAssoc : (x, y, z : a) -> op x $ op y z = op (op x y) z
+
+instance [addition] MyMagma Nat where
+  op = plus
+
+additionS : MySemigroup Nat
+additionS = MkMySemigroup @{addition} plusAssociative
+
+doIt : MySemigroup a => a -> List a -> a
+doIt x [] = x
+doIt x (y :: xs) = doIt (x `op` y) xs
+
+test : Nat
+test = doIt @{additionS} 22 [1,2,3,4]

--- a/test/classes001/expected
+++ b/test/classes001/expected
@@ -1,0 +1,27 @@
+Type class MyShow
+    A fancy shower with a constructor
+
+Parameters:
+    a   -- the thing to be shown
+
+Methods:
+    myShow : MyShow a => (x : a) -> String
+        The shower
+        
+Instance constructor:
+    MkMyShow : (myShow : a -> String) -> MyShow a
+        Build a MyShow
+        Arguments:
+            (implicit) a : Type  -- the thing to be shown
+            
+            myShow : a -> String  -- The shower
+            
+Instances:
+    MyShow Integer
+MkMyShow : (myShow : a -> String) -> MyShow a
+    Build a MyShow
+    Arguments:
+        (implicit) a : Type  -- the thing to be shown
+        
+        myShow : a -> String  -- The shower
+        

--- a/test/classes001/input
+++ b/test/classes001/input
@@ -1,0 +1,2 @@
+:doc MyShow
+:doc MkMyShow

--- a/test/classes001/run
+++ b/test/classes001/run
@@ -1,0 +1,3 @@
+#!/usr/bin/env bash
+idris $@ --quiet --nocolour --consolewidth 70 ClassName.idr < input
+rm -f bounded001 *.ibc


### PR DESCRIPTION
There seems to be demand for cooking up instance bodies on the fly (eg, #2233).

This patch adds the ability for type class constructors to be assigned a user-specified name using the same syntax as record constructors. Documentation is propagated as expected.

@treeowl, this addresses point (1) from #2233, right?