### PR TITLE
Removed equality from primNames, as it shouldn't be handle specially when adding implicits (the only current use).

### DIFF
--- a/libs/prelude/Builtins.idr
+++ b/libs/prelude/Builtins.idr
@@ -63,7 +63,7 @@ infix 5 ~=~
 ||| @ x the left side
 ||| @ y the right side
 (~=~) : (x : a) -> (y : b) -> Type
-(~=~) x y = (=) _ _ x y
+(~=~) x y = (x = y)
 
 ||| Perform substitution in a term according to some equality.
 |||

--- a/src/Idris/AbsSyntaxTree.hs
+++ b/src/Idris/AbsSyntaxTree.hs
@@ -1282,7 +1282,7 @@ getInferType (App _ (App _ _ ty) _) = ty
 
 -- Handy primitives: Unit, False, Pair, MkPair, =, mkForeign
 
-primNames = [eqTy, eqCon, inferTy, inferCon]
+primNames = [inferTy, inferCon]
 
 unitTy   = sUN "Unit"
 unitCon  = sUN "MkUnit"

--- a/test/quasiquote004/Quasiquote004.idr
+++ b/test/quasiquote004/Quasiquote004.idr
@@ -5,7 +5,7 @@ import Language.Reflection
 %default total
 
 normPlus : List (TTName, Binder TT) -> TT -> Tactic
-normPlus ctxt `((=) {Nat} {Nat} ~x ~y) = normPlus ctxt x `Seq` normPlus ctxt y
+normPlus ctxt `((=) {A = Nat} {B = Nat} ~x ~y) = normPlus ctxt x `Seq` normPlus ctxt y
 normPlus ctxt `(S ~n) = normPlus ctxt n
 normPlus ctxt `(plus ~n (S ~m)) = Seq (Rewrite `(plusSuccRightSucc ~n ~m))
                                       (normPlus ctxt m)

--- a/test/reg037/reg037.idr
+++ b/test/reg037/reg037.idr
@@ -1,9 +1,9 @@
 
 --- Parser regression for (=) as a function name (fnName)
 
-class Foo (t : (A : Type) -> (B : Type) -> A -> B -> Type) where
-  foo : (A : Type) -> (B : Type) -> (x : A) -> (y : B) -> t A B x y -> t A B x y
+class Foo (t : a -> b -> Type) where
+  foo : (x : _) -> (y : _) -> t x y -> t x y
 
 instance Foo (=) where
-  foo A B x y prf = prf
+  foo x y prf = prf
 

--- a/test/reg047/reg047.idr
+++ b/test/reg047/reg047.idr
@@ -6,7 +6,7 @@ data TTSigma : (A : Type) -> (B : A -> Type) -> Type where
 data Nat = zero | succ Nat
 
 Id : (A : Type) -> A -> A -> Type
-Id A = (=) {a0 = A} {b0 = A}
+Id A = (=) {A = A} {B = A}
 
 IdRefl : (A : Type) -> (a : A) -> Id A a a
 IdRefl A a = Refl {a}


### PR DESCRIPTION
Fixes #1419.