### PR TITLE
Remove PRefl and PEq

### DIFF
--- a/src/Idris/AbsSyntax.hs
+++ b/src/Idris/AbsSyntax.hs
@@ -972,7 +972,6 @@ expandParams dec ps ns infs tm = en tm
        | n `elem` (map fst ps ++ ns) && t /= Placeholder
            = let n' = mkShadow n in
                  PDPair f p (PRef f' n') (en t) (en (shadow n n' r))
-    en (PEq f lt rt l r) = PEq f (en lt) (en rt) (en l) (en r)
     en (PRewrite f l r g) = PRewrite f (en l) (en r) (fmap en g)
     en (PTyped l r) = PTyped (en l) (en r)
     en (PPair f p l r) = PPair f p (en l) (en r)
@@ -1140,7 +1139,6 @@ getPriority i tm = 1 -- pri tm
             [] -> 0 -- must be locally bound, if it's not an error...
     pri (PPi _ _ x y) = max 5 (max (pri x) (pri y))
     pri (PTrue _ _) = 0
-    pri (PEq _ _ _ l r) = max 1 (max (pri l) (pri r))
     pri (PRewrite _ l r _) = max 1 (max (pri l) (pri r))
     pri (PApp _ f as) = max 1 (max (pri f) (foldr max 0 (map (pri.getTm) as)))
     pri (PAppBind _ f as) = max 1 (max (pri f) (foldr max 0 (map (pri.getTm) as)))
@@ -1450,10 +1448,6 @@ implicitise syn ignore ist tm = -- trace ("INCOMING " ++ showImp True tm) $
              put (PTacImplicit 10 l n scr Placeholder : decls,
                   nub (ns ++ (isn `dropAll` (env ++ map fst (getImps decls)))))
              imps True (n:env) sc
-    imps top env (PEq _ _ _ l r)
-        = do (decls, ns) <- get
-             let isn = namesIn uvars ist l ++ namesIn uvars ist r
-             put (decls, nub (ns ++ (isn `dropAll` (env ++ map fst (getImps decls)))))
     imps top env (PRewrite _ l r _)
         = do (decls, ns) <- get
              let isn = namesIn uvars ist l ++ namesIn uvars ist r
@@ -1523,12 +1517,6 @@ addImpl' inpat env infns imp_meths ist ptm
         | not (f `elem` map fst env) = handleErr $ aiFn inpat inpat qq imp_meths ist fc f ds []
     ai qq env ds (PHidden (PRef fc f))
         | not (f `elem` map fst env) = PHidden (handleErr $ aiFn inpat False qq imp_meths ist fc f ds [])
-    ai qq env ds (PEq fc lt rt l r)
-      = let lt' = ai qq env ds lt
-            rt' = ai qq env ds rt
-            l' = ai qq env ds l
-            r' = ai qq env ds r in
-            PEq fc lt' rt' l' r'
     ai qq env ds (PRewrite fc l r g)
        = let l' = ai qq env ds l
              r' = ai qq env ds r
@@ -1813,7 +1801,6 @@ stripUnmatchable i (PApp fc fn args) = PApp fc fn (fmap (fmap su) args) where
     su (PDPair fc p l t r) = PDPair fc p (su l) (su t) (su r)
     su t@(PLam fc _ _ _) = PHidden t
     su t@(PPi _ _ _ _) = PHidden t
-    su t@(PEq _ _ _ _ _) = PHidden t
     su t = t
 
     ctxt = tt_ctxt i
@@ -1916,10 +1903,6 @@ matchClause' names i x y = checkRpts $ match (fullApp x) (fullApp y) where
         | not names && (not (isConName n (tt_ctxt i) ||
                              isFnName n (tt_ctxt i)) || tm == Placeholder)
             = return [(n, tm)]
-    match (PEq _ _ _ l r) (PEq _ _ _ l' r')
-                                    = do ml <- match' l l'
-                                         mr <- match' r r'
-                                         return (ml ++ mr)
     match (PRewrite _ l r _) (PRewrite _ l' r' _)
                                     = do ml <- match' l l'
                                          mr <- match' r r'
@@ -2015,7 +1998,6 @@ substMatchShadow n shs tm t = sm shs t where
     sm xs (PApp f x as) = fullApp $ PApp f (sm xs x) (map (fmap (sm xs)) as)
     sm xs (PCase f x as) = PCase f (sm xs x) (map (pmap (sm xs)) as)
     sm xs (PIfThenElse fc c t f) = PIfThenElse fc (sm xs c) (sm xs t) (sm xs f)
-    sm xs (PEq f xt yt x y) = PEq f (sm xs xt) (sm xs yt) (sm xs x) (sm xs y)
     sm xs (PRewrite f x y tm) = PRewrite f (sm xs x) (sm xs y)
                                            (fmap (sm xs) tm)
     sm xs (PTyped x y) = PTyped (sm xs x) (sm xs y)
@@ -2044,7 +2026,6 @@ shadow n n' t = sm t where
     sm (PAppBind f x as) = PAppBind f (sm x) (map (fmap sm) as)
     sm (PCase f x as) = PCase f (sm x) (map (pmap sm) as)
     sm (PIfThenElse fc c t f) = PIfThenElse fc (sm c) (sm t) (sm f)
-    sm (PEq f xt yt x y) = PEq f (sm xt) (sm yt) (sm x) (sm y)
     sm (PRewrite f x y tm) = PRewrite f (sm x) (sm y) (fmap sm tm)
     sm (PTyped x y) = PTyped (sm x) (sm y)
     sm (PPair f p x y) = PPair f p (sm x) (sm y)

--- a/src/Idris/AbsSyntax.hs
+++ b/src/Idris/AbsSyntax.hs
@@ -1140,7 +1140,6 @@ getPriority i tm = 1 -- pri tm
             [] -> 0 -- must be locally bound, if it's not an error...
     pri (PPi _ _ x y) = max 5 (max (pri x) (pri y))
     pri (PTrue _ _) = 0
-    pri (PRefl _ _) = 1
     pri (PEq _ _ _ l r) = max 1 (max (pri l) (pri r))
     pri (PRewrite _ l r _) = max 1 (max (pri l) (pri r))
     pri (PApp _ f as) = max 1 (max (pri f) (foldr max 0 (map (pri.getTm) as)))
@@ -1608,7 +1607,6 @@ addImpl' inpat env infns imp_meths ist ptm
     ai qq env ds (PHidden tm) = PHidden (ai qq env ds tm)
     -- Don't do PProof or PTactics since implicits get added when scope is
     -- properly known in ElabTerm.runTac
-    ai qq env ds (PRefl fc tm) = PRefl fc (ai qq env ds tm)
     ai qq env ds (PUnifyLog tm) = PUnifyLog (ai qq env ds tm)
     ai qq env ds (PNoImplicits tm) = PNoImplicits (ai qq env ds tm)
     ai qq env ds (PQuasiquote tm g) = PQuasiquote (ai True env ds tm)
@@ -1952,7 +1950,6 @@ matchClause' names i x y = checkRpts $ match (fullApp x) (fullApp y) where
     match (PQuote _) _ = return []
     match (PProof _) _ = return []
     match (PTactics _) _ = return []
-    match (PRefl _ _) (PRefl _ _) = return []
     match (PResolveTC _) (PResolveTC _) = return []
     match (PTrue _ _) (PTrue _ _) = return []
     match (PReturn _) (PReturn _) = return []

--- a/src/Idris/AbsSyntaxTree.hs
+++ b/src/Idris/AbsSyntaxTree.hs
@@ -818,7 +818,6 @@ data PTerm = PQuote Raw -- ^ Inclusion of a core term into the high-level langua
            | PIfThenElse FC PTerm PTerm PTerm -- ^ Conditional expressions - elaborated to an overloading of ifThenElse
            | PCase FC PTerm [(PTerm, PTerm)] -- ^ A case expression. Args are source location, scrutinee, and a list of pattern/RHS pairs
            | PTrue FC PunInfo -- ^ Unit type..?
-           | PRefl FC PTerm -- ^ The canonical proof of the equality type
            | PResolveTC FC -- ^ Solve this dictionary by type class resolution
            | PEq FC PTerm PTerm PTerm PTerm -- ^ Heterogeneous equality type: A = B
            | PRewrite FC PTerm PTerm (Maybe PTerm) -- ^ "rewrite" syntax, with optional result type
@@ -1027,7 +1026,6 @@ highestFC (PMatchApp fc _) = Just fc
 highestFC (PCase fc _ _) = Just fc
 highestFC (PIfThenElse fc _ _ _) = Just fc
 highestFC (PTrue fc _) = Just fc
-highestFC (PRefl fc _) = Just fc
 highestFC (PResolveTC fc) = Just fc
 highestFC (PEq fc _ _ _ _) = Just fc
 highestFC (PRewrite fc _ _ _) = Just fc
@@ -1556,7 +1554,6 @@ pprintPTerm ppo bnd docArgs infixes = prettySe startPrec bnd
         , kwd "else" <+> prettySe startPrec bnd f
         ]
     prettySe p bnd (PHidden tm) = text "." <> prettySe funcAppPrec bnd tm
-    prettySe p bnd (PRefl _ _) = annName eqCon $ text "Refl"
     prettySe p bnd (PResolveTC _) = kwd "%instance"
     prettySe p bnd (PTrue _ IsType) = annName unitTy $ text "()"
     prettySe p bnd (PTrue _ IsTerm) = annName unitCon $ text "()"
@@ -1872,7 +1869,6 @@ instance Sized PTerm where
   size (PCase fc trm bdy) = 1 + size trm + size bdy
   size (PIfThenElse fc c t f) = 1 + sum (map size [c, t, f])
   size (PTrue fc _) = 1
-  size (PRefl fc _) = 1
   size (PResolveTC fc) = 1
   size (PEq fc _ _ left right) = 1 + size left + size right
   size (PRewrite fc left right _) = 1 + size left + size right

--- a/src/Idris/AbsSyntaxTree.hs
+++ b/src/Idris/AbsSyntaxTree.hs
@@ -819,7 +819,6 @@ data PTerm = PQuote Raw -- ^ Inclusion of a core term into the high-level langua
            | PCase FC PTerm [(PTerm, PTerm)] -- ^ A case expression. Args are source location, scrutinee, and a list of pattern/RHS pairs
            | PTrue FC PunInfo -- ^ Unit type..?
            | PResolveTC FC -- ^ Solve this dictionary by type class resolution
-           | PEq FC PTerm PTerm PTerm PTerm -- ^ Heterogeneous equality type: A = B
            | PRewrite FC PTerm PTerm (Maybe PTerm) -- ^ "rewrite" syntax, with optional result type
            | PPair FC PunInfo PTerm PTerm -- ^ A pair (a, b) and whether it's a product type or a pair (solved by elaboration)
            | PDPair FC PunInfo PTerm PTerm PTerm -- ^ A dependent pair (tm : a ** b) and whether it's a sigma type or a pair that inhabits one (solved by elaboration)
@@ -866,7 +865,6 @@ mapPT f t = f (mpt t) where
   mpt (PAppBind fc t as) = PAppBind fc (mapPT f t) (map (fmap (mapPT f)) as)
   mpt (PCase fc c os) = PCase fc (mapPT f c) (map (pmap (mapPT f)) os)
   mpt (PIfThenElse fc c t e) = PIfThenElse fc (mapPT f c) (mapPT f t) (mapPT f e)
-  mpt (PEq fc lt rt l r) = PEq fc (mapPT f lt) (mapPT f rt) (mapPT f l) (mapPT f r)
   mpt (PTyped l r) = PTyped (mapPT f l) (mapPT f r)
   mpt (PPair fc p l r) = PPair fc p (mapPT f l) (mapPT f r)
   mpt (PDPair fc p l t r) = PDPair fc p (mapPT f l) (mapPT f t) (mapPT f r)
@@ -1027,7 +1025,6 @@ highestFC (PCase fc _ _) = Just fc
 highestFC (PIfThenElse fc _ _ _) = Just fc
 highestFC (PTrue fc _) = Just fc
 highestFC (PResolveTC fc) = Just fc
-highestFC (PEq fc _ _ _ _) = Just fc
 highestFC (PRewrite fc _ _ _) = Just fc
 highestFC (PPair fc _ _ _) = Just fc
 highestFC (PDPair fc _ _ _ _) = Just fc
@@ -1479,6 +1476,21 @@ pprintPTerm ppo bnd docArgs infixes = prettySe startPrec bnd
       bracket p startPrec $
       lbrace <> kwd "tacimp" <+> pretty n <+> colon <+> prettySe startPrec bnd ty <>
       rbrace <+> text "->" </> prettySe startPrec ((n, True):bnd) sc
+    -- This case preserves the behavior of the former constructor PEq.
+    -- It should be removed if feasible when the pretty-printing of infix
+    -- operators in general is improved.
+    prettySe p bnd (PApp _ (PRef _ n) [lt, rt, l, r])
+      | n == eqTy, ppopt_impl ppo =
+          bracket p eqPrec $
+            enclose lparen rparen eq <+>
+            align (group (vsep (map (prettyArgS bnd)
+                                    [lt, rt, l, r])))
+      | n == eqTy =
+          bracket p eqPrec . align . group $
+            prettyTerm (getTm l) <+> eq <$> group (prettyTerm (getTm r))
+      where eq = annName eqTy (text "=")
+            eqPrec = startPrec
+            prettyTerm = prettySe (eqPrec + 1) bnd
     prettySe p bnd (PApp _ (PRef _ f) args) -- normal names, no explicit args
       | UN nm <- basename f
       , not (ppopt_impl ppo) && null (getShowArgs args) =
@@ -1558,21 +1570,6 @@ pprintPTerm ppo bnd docArgs infixes = prettySe startPrec bnd
     prettySe p bnd (PTrue _ IsType) = annName unitTy $ text "()"
     prettySe p bnd (PTrue _ IsTerm) = annName unitCon $ text "()"
     prettySe p bnd (PTrue _ TypeOrTerm) = text "()"
-    prettySe p bnd (PEq _ lt rt l r)
-      | ppopt_impl ppo =
-          bracket p eqPrec $
-            enclose lparen rparen eq <+>
-            align (group (vsep (map (prettyArgS bnd)
-                                    [PImp 0 False [] (sUN "A") lt,
-                                     PImp 0 False [] (sUN "B") rt,
-                                     PExp 0 [] (sUN "x") l,
-                                     PExp 0 [] (sUN "y") r])))
-      | otherwise =
-          bracket p eqPrec . align . group $
-            prettyTerm l <+> eq <$> group (prettyTerm r)
-      where eq = annName eqTy (text "=")
-            eqPrec = startPrec
-            prettyTerm = prettySe (eqPrec + 1) bnd
     prettySe p bnd (PRewrite _ l r _) =
       bracket p startPrec $
       text "rewrite" <+> prettySe (startPrec + 1) bnd l <+> text "in" <+> prettySe startPrec bnd r
@@ -1870,7 +1867,6 @@ instance Sized PTerm where
   size (PIfThenElse fc c t f) = 1 + sum (map size [c, t, f])
   size (PTrue fc _) = 1
   size (PResolveTC fc) = 1
-  size (PEq fc _ _ left right) = 1 + size left + size right
   size (PRewrite fc left right _) = 1 + size left + size right
   size (PPair fc _ left right) = 1 + size left + size right
   size (PDPair fs _ left ty right) = 1 + size left + size ty + size right
@@ -1911,7 +1907,6 @@ allNamesIn tm = nub $ ni [] tm
     ni env (PLam fc n ty sc)  = ni env ty ++ ni (n:env) sc
     ni env (PPi p n ty sc) = niTacImp env p ++ ni env ty ++ ni (n:env) sc
     ni env (PHidden tm)    = ni env tm
-    ni env (PEq _ _ _ l r)     = ni env l ++ ni env r
     ni env (PRewrite _ l r _) = ni env l ++ ni env r
     ni env (PTyped l r)    = ni env l ++ ni env r
     ni env (PPair _ _ l r)   = ni env l ++ ni env r
@@ -1938,7 +1933,6 @@ boundNamesIn tm = S.toList (ni S.empty tm)
     ni set (PLam fc n ty sc)  = S.insert n $ ni (ni set ty) sc
     ni set (PLet fc n ty val sc) = S.insert n $ ni (ni (ni set ty) val) sc
     ni set (PPi p n ty sc) = niTacImp (S.insert n $ ni (ni set ty) sc) p
-    ni set (PEq _ _ _ l r) = ni (ni set l) r
     ni set (PRewrite _ l r _) = ni (ni set l) r
     ni set (PTyped l r) = ni (ni set l) r
     ni set (PPair _ _ l r) = ni (ni set l) r
@@ -1978,7 +1972,6 @@ implicitNamesIn uvars ist tm = nub $ ni [] tm
     ni env (PIfThenElse _ c t f) = concatMap (ni env) [c, t, f]
     ni env (PLam fc n ty sc)  = ni env ty ++ ni (n:env) sc
     ni env (PPi p n ty sc) = ni env ty ++ ni (n:env) sc
-    ni env (PEq _ _ _ l r)     = ni env l ++ ni env r
     ni env (PRewrite _ l r _) = ni env l ++ ni env r
     ni env (PTyped l r)    = ni env l ++ ni env r
     ni env (PPair _ _ l r)   = ni env l ++ ni env r
@@ -2009,7 +2002,6 @@ namesIn uvars ist tm = nub $ ni [] tm
     ni env (PIfThenElse _ c t f) = concatMap (ni env) [c, t, f]
     ni env (PLam fc n ty sc)  = ni env ty ++ ni (n:env) sc
     ni env (PPi p n ty sc) = niTacImp env p ++ ni env ty ++ ni (n:env) sc
-    ni env (PEq _ _ _ l r)     = ni env l ++ ni env r
     ni env (PRewrite _ l r _) = ni env l ++ ni env r
     ni env (PTyped l r)    = ni env l ++ ni env r
     ni env (PPair _ _ l r)   = ni env l ++ ni env r
@@ -2041,7 +2033,6 @@ usedNamesIn vars ist tm = nub $ ni [] tm
     ni env (PIfThenElse _ c t f) = concatMap (ni env) [c, t, f]
     ni env (PLam fc n ty sc)  = ni env ty ++ ni (n:env) sc
     ni env (PPi p n ty sc) = niTacImp env p ++ ni env ty ++ ni (n:env) sc
-    ni env (PEq _ _ _ l r)     = ni env l ++ ni env r
     ni env (PRewrite _ l r _) = ni env l ++ ni env r
     ni env (PTyped l r)    = ni env l ++ ni env r
     ni env (PPair _ _ l r)   = ni env l ++ ni env r

--- a/src/Idris/CaseSplit.hs
+++ b/src/Idris/CaseSplit.hs
@@ -240,7 +240,6 @@ replaceVar ctxt n t (PApp fc f pats) = PApp fc f (map substArg pats)
         subst (PApp fc (PRef _ t) pats) 
             | isTConName t ctxt = Placeholder -- infer types
         subst (PApp fc f pats) = PApp fc f (map substArg pats)
-        subst (PEq fc _ _ l r) = Placeholder -- PEq fc (subst l) (subst r)
         subst x = x
 
         substArg arg = arg { getTm = subst (getTm arg) }
@@ -361,7 +360,6 @@ getClause l fn fp
          getNameFrom i used (PPi _ _ _ _) 
               = uniqueNameFrom (mkSupply [sUN "f", sUN "g"]) used
          getNameFrom i used (PApp fc f as) = getNameFrom i used f
-         getNameFrom i used (PEq _ _ _ _ _) = uniqueNameFrom (mkSupply [sUN "prf"]) used 
          getNameFrom i used (PRef fc f) 
             = case getNameHints i f of
                    [] -> uniqueName (sUN "x") used

--- a/src/Idris/DSL.hs
+++ b/src/Idris/DSL.hs
@@ -77,8 +77,6 @@ expandSugar dsl (PIfThenElse fc c t f) =
        , PExp 0 [] (sMN 0 "whenTrue") $ expandSugar dsl t
        , PExp 0 [] (sMN 0 "whenFalse") $ expandSugar dsl f
        ]
-expandSugar dsl (PEq fc lt rt l r) = PEq fc (expandSugar dsl lt) (expandSugar dsl rt)
-                                         (expandSugar dsl l) (expandSugar dsl r)
 expandSugar dsl (PPair fc p l r) = PPair fc p (expandSugar dsl l) (expandSugar dsl r)
 expandSugar dsl (PDPair fc p l t r) = PDPair fc p (expandSugar dsl l) (expandSugar dsl t)
                                                (expandSugar dsl r)
@@ -139,7 +137,6 @@ var dsl n t i = v' i t where
     v' i (PTyped l r)    = PTyped (v' i l) (v' i r)
     v' i (PApp f x as)   = PApp f (v' i x) (fmap (fmap (v' i)) as)
     v' i (PCase f t as)  = PCase f (v' i t) (fmap (pmap (v' i)) as)
-    v' i (PEq f lt rt l r) = PEq f (v' i lt) (v' i rt) (v' i l) (v' i r)
     v' i (PPair f p l r) = PPair f p (v' i l) (v' i r)
     v' i (PDPair f p l t r) = PDPair f p (v' i l) (v' i t) (v' i r)
     v' i (PAlternative a as) = PAlternative a $ map (v' i) as

--- a/src/Idris/DeepSeq.hs
+++ b/src/Idris/DeepSeq.hs
@@ -219,7 +219,6 @@ instance NFData PTerm where
         rnf (PCase x1 x2 x3) = rnf x1 `seq` rnf x2 `seq` rnf x3 `seq` ()
         rnf (PIfThenElse x1 x2 x3 x4) = rnf x1 `seq` rnf x2 `seq` rnf x3 `seq` rnf x4 `seq` ()
         rnf (PTrue x1 x2) = rnf x1 `seq` rnf x2 `seq` ()
-        rnf (PRefl x1 x2) = rnf x1 `seq` rnf x2 `seq` ()
         rnf (PResolveTC x1) = rnf x1 `seq` ()
         rnf (PEq x1 x2 x3 x4 x5) = rnf x1 `seq` rnf x2 `seq` rnf x3 `seq` rnf x4 `seq` rnf x5 `seq` ()
         rnf (PRewrite x1 x2 x3 x4)

--- a/src/Idris/DeepSeq.hs
+++ b/src/Idris/DeepSeq.hs
@@ -220,7 +220,6 @@ instance NFData PTerm where
         rnf (PIfThenElse x1 x2 x3 x4) = rnf x1 `seq` rnf x2 `seq` rnf x3 `seq` rnf x4 `seq` ()
         rnf (PTrue x1 x2) = rnf x1 `seq` rnf x2 `seq` ()
         rnf (PResolveTC x1) = rnf x1 `seq` ()
-        rnf (PEq x1 x2 x3 x4 x5) = rnf x1 `seq` rnf x2 `seq` rnf x3 `seq` rnf x4 `seq` rnf x5 `seq` ()
         rnf (PRewrite x1 x2 x3 x4)
           = rnf x1 `seq` rnf x2 `seq` rnf x3 `seq` rnf x4 `seq` ()
         rnf (PPair x1 x2 x3 x4) = rnf x1 `seq` rnf x2 `seq` rnf x3 `seq` rnf x4 `seq` ()

--- a/src/Idris/Delaborate.hs
+++ b/src/Idris/Delaborate.hs
@@ -114,8 +114,6 @@ delabTy' ist imps tm fullname mvs = de [] imps tm
                            (de ((x,x):env) [] (instantiate (P Bound x ty) r))
     deFn env (P _ n _) [lt,rt,l,r]
          | n == pairCon = PPair un IsTerm (de env [] l) (de env [] r)
-         | n == eqTy    = PEq un (de env [] lt) (de env [] rt)
-                                 (de env [] l) (de env [] r)
          | n == sigmaCon = PDPair un IsTerm (de env [] l) Placeholder
                                              (de env [] r)
     deFn env f@(P _ n _) args
@@ -484,30 +482,6 @@ addImplicitDiffs x y
          = let (a', c') = addI a c
                (b', d') = addI b d in
                (PPi p n a' b', PPi p' n' c' d')
-    addI (PEq fc at bt a b) (PEq fc' ct dt c d)
-         | trace (show (at,bt)) False = undefined
-         | at `expLike` ct && bt `expLike` dt
-         = let (a', c') = addI a c
-               (b', d') = addI b d in
-               (PEq fc at bt a' b', PEq fc' ct dt c' d')
-         | otherwise
-         = let (at', ct') = addI at ct
-               (bt', dt') = addI bt dt
-               (a', c') = addI a c
-               (b', d') = addI b d
-               showa = if at `expLike` ct then [] else [AlwaysShow]
-               showb = if bt `expLike` dt then [] else [AlwaysShow] in
-               (PApp fc (PRef fc eqTy) [(pimp (sUN "A") at' True)
-                                               { argopts = showa },
-                                        (pimp (sUN "B") bt' True)
-                                               { argopts = showb },
-                                        pexp a', pexp b'],
-                PApp fc (PRef fc eqTy) [(pimp (sUN "A") ct' True)
-                                               { argopts = showa },
-                                        (pimp (sUN "B") dt' True)
-                                               { argopts = showb },
-                                        pexp c', pexp d'])
-
     addI (PPair fc pi a b) (PPair fc' pi' c d)
          = let (a', c') = addI a c
                (b', d') = addI b d in
@@ -530,8 +504,6 @@ addImplicitDiffs x y
         = n == n' && expLike s s' && expLike t t'
     expLike (PPair _ _ x y) (PPair _ _ x' y') = expLike x x' && expLike y y'
     expLike (PDPair _ _ x _ y) (PDPair _ _ x' _ y') = expLike x x' && expLike y y'
-    expLike (PEq _ xt yt x y) (PEq _ xt' yt' x' y')
-         = expLike x x' && expLike y y'
     expLike x y = x == y
 
 -- Issue #1589 on the issue tracker

--- a/src/Idris/Delaborate.hs
+++ b/src/Idris/Delaborate.hs
@@ -107,7 +107,6 @@ delabTy' ist imps tm fullname mvs = de [] imps tm
     deFn env (App _ f a) args = deFn env f (a:args)
     deFn env (P _ n _) [l,r]
          | n == pairTy    = PPair un IsType (de env [] l) (de env [] r)
-         | n == eqCon     = PRefl un (de env [] r)
          | n == sUN "lazy" = de env [] r -- TODO: Fix string based matching
     deFn env (P _ n _) [ty, Bind x (Lam _) r]
          | n == sigmaTy
@@ -485,9 +484,6 @@ addImplicitDiffs x y
          = let (a', c') = addI a c
                (b', d') = addI b d in
                (PPi p n a' b', PPi p' n' c' d')
-    addI (PRefl fc a) (PRefl fc' b)
-         = let (a', b') = addI a b in
-               (PRefl fc a', PRefl fc' b')
     addI (PEq fc at bt a b) (PEq fc' ct dt c d)
          | trace (show (at,bt)) False = undefined
          | at `expLike` ct && bt `expLike` dt
@@ -536,7 +532,6 @@ addImplicitDiffs x y
     expLike (PDPair _ _ x _ y) (PDPair _ _ x' _ y') = expLike x x' && expLike y y'
     expLike (PEq _ xt yt x y) (PEq _ xt' yt' x' y')
          = expLike x x' && expLike y y'
-    expLike (PRefl _ x) (PRefl _ x') = expLike x x'
     expLike x y = x == y
 
 -- Issue #1589 on the issue tracker

--- a/src/Idris/Elab/Clause.hs
+++ b/src/Idris/Elab/Clause.hs
@@ -885,7 +885,7 @@ elabClause info opts (_, PWith fc fname lhs_in withs wval_in pn_in withblock)
                     (map (pexp . (PRef fc) . fst) bargs_post) ++
                     case mpn of
                          Nothing -> []
-                         Just _ -> [pexp (PRefl fc Placeholder)])
+                         Just _ -> [pexp (PRef fc eqCon)])
         logLvl 5 ("New RHS " ++ showTmImpls rhs)
         ctxt <- getContext -- New context with block added
         i <- getIState

--- a/src/Idris/Elab/Term.hs
+++ b/src/Idris/Elab/Term.hs
@@ -343,7 +343,7 @@ elab ist info emode opts fn tm
     elab' ina fc (PResolveTC fc')
         = do c <- getNameFrom (sMN 0 "class")
              instanceArg c
-    elab' ina _ (PEq fc Placeholder Placeholder l r)
+    elab' ina _ (PApp fc (PRef _ n) args) | n == eqTy, [Placeholder, Placeholder, l, r] <- map getTm args
        = try (do tyn <- getNameFrom (sMN 0 "aqty")
                  claim tyn RType
                  movelast tyn
@@ -362,10 +362,6 @@ elab ist info emode opts fn tm
                     pimp (sUN "B") (PRef fc btyn) False,
                     pexp l, pexp r]))
 
-    elab' ina _ (PEq fc lt rt l r) = elab' ina (Just fc) (PApp fc (PRef fc eqTy)
-                                       [pimp (sUN "A") lt True,
-                                        pimp (sUN "B") rt False,
-                                        pexp l, pexp r])
     elab' ina _ (PPair fc _ l r)
         = do hnf_compute
              g <- goal

--- a/src/Idris/Elab/Term.hs
+++ b/src/Idris/Elab/Term.hs
@@ -343,9 +343,6 @@ elab ist info emode opts fn tm
     elab' ina fc (PResolveTC fc')
         = do c <- getNameFrom (sMN 0 "class")
              instanceArg c
-    elab' ina _ (PRefl fc t)
-        = elab' ina (Just fc) (PApp fc (PRef fc eqCon) [pimp (sMN 0 "A") Placeholder True,
-                                                   pimp (sMN 0 "x") t False])
     elab' ina _ (PEq fc Placeholder Placeholder l r)
        = try (do tyn <- getNameFrom (sMN 0 "aqty")
                  claim tyn RType

--- a/src/Idris/ElabQuasiquote.hs
+++ b/src/Idris/ElabQuasiquote.hs
@@ -109,9 +109,6 @@ extractUnquotes n (PIfThenElse fc c t f)
        (t', ex2) <- extractUnquotes n t
        (f', ex3) <- extractUnquotes n f
        return (PIfThenElse fc c' t' f', ex1 ++ ex2 ++ ex3)
-extractUnquotes n (PRefl fc x)
-  = do (x', ex) <- extractUnquotes n x
-       return (PRefl fc x', ex)
 extractUnquotes n (PEq fc at bt a b)
   = do (at', ex1) <- extractUnquotes n at
        (bt', ex2) <- extractUnquotes n bt

--- a/src/Idris/ElabQuasiquote.hs
+++ b/src/Idris/ElabQuasiquote.hs
@@ -109,12 +109,6 @@ extractUnquotes n (PIfThenElse fc c t f)
        (t', ex2) <- extractUnquotes n t
        (f', ex3) <- extractUnquotes n f
        return (PIfThenElse fc c' t' f', ex1 ++ ex2 ++ ex3)
-extractUnquotes n (PEq fc at bt a b)
-  = do (at', ex1) <- extractUnquotes n at
-       (bt', ex2) <- extractUnquotes n bt
-       (a', ex1) <- extractUnquotes n a
-       (b', ex2) <- extractUnquotes n b
-       return (PEq fc at' bt' a' b', ex1 ++ ex2)
 extractUnquotes n (PRewrite fc x y z)
   = do (x', ex1) <- extractUnquotes n x
        (y', ex2) <- extractUnquotes n y

--- a/src/Idris/Error.hs
+++ b/src/Idris/Error.hs
@@ -104,7 +104,6 @@ warnDisamb ist (PCase _ tm cases) = warnDisamb ist tm >>
                                     mapM_ (\(x,y)-> warnDisamb ist x >> warnDisamb ist y) cases
 warnDisamb ist (PIfThenElse _ c t f) = mapM_ (warnDisamb ist) [c, t, f]
 warnDisamb ist (PTrue _ _) = return ()
-warnDisamb ist (PRefl _ tm) = warnDisamb ist tm
 warnDisamb ist (PResolveTC _) = return ()
 warnDisamb ist (PEq _ a b x y) = warnDisamb ist a >> warnDisamb ist b >>
                                  warnDisamb ist x >> warnDisamb ist y

--- a/src/Idris/Error.hs
+++ b/src/Idris/Error.hs
@@ -105,8 +105,6 @@ warnDisamb ist (PCase _ tm cases) = warnDisamb ist tm >>
 warnDisamb ist (PIfThenElse _ c t f) = mapM_ (warnDisamb ist) [c, t, f]
 warnDisamb ist (PTrue _ _) = return ()
 warnDisamb ist (PResolveTC _) = return ()
-warnDisamb ist (PEq _ a b x y) = warnDisamb ist a >> warnDisamb ist b >>
-                                 warnDisamb ist x >> warnDisamb ist y
 warnDisamb ist (PRewrite _ x y z) = warnDisamb ist x >> warnDisamb ist y >>
                                     Foldable.mapM_ (warnDisamb ist) z
 warnDisamb ist (PPair _ _ x y) = warnDisamb ist x >> warnDisamb ist y

--- a/src/Idris/IBC.hs
+++ b/src/Idris/IBC.hs
@@ -1542,9 +1542,6 @@ instance Binary PTerm where
                 PTrue x1 x2 -> do putWord8 12
                                   put x1
                                   put x2
-                PRefl x1 x2 -> do putWord8 14
-                                  put x1
-                                  put x2
                 PResolveTC x1 -> do putWord8 15
                                     put x1
                 PEq x1 x2 x3 x4 x5 -> do putWord8 16
@@ -1681,9 +1678,6 @@ instance Binary PTerm where
                    12 -> do x1 <- get
                             x2 <- get
                             return (PTrue x1 x2)
-                   14 -> do x1 <- get
-                            x2 <- get
-                            return (PRefl x1 x2)
                    15 -> do x1 <- get
                             return (PResolveTC x1)
                    16 -> do x1 <- get

--- a/src/Idris/IBC.hs
+++ b/src/Idris/IBC.hs
@@ -1544,12 +1544,6 @@ instance Binary PTerm where
                                   put x2
                 PResolveTC x1 -> do putWord8 15
                                     put x1
-                PEq x1 x2 x3 x4 x5 -> do putWord8 16
-                                         put x1
-                                         put x2
-                                         put x3
-                                         put x4
-                                         put x5
                 PRewrite x1 x2 x3 x4 -> do putWord8 17
                                            put x1
                                            put x2
@@ -1680,12 +1674,6 @@ instance Binary PTerm where
                             return (PTrue x1 x2)
                    15 -> do x1 <- get
                             return (PResolveTC x1)
-                   16 -> do x1 <- get
-                            x2 <- get
-                            x3 <- get
-                            x4 <- get
-                            x5 <- get
-                            return (PEq x1 x2 x3 x4 x5)
                    17 -> do x1 <- get
                             x2 <- get
                             x3 <- get

--- a/src/Idris/IdrisDoc.hs
+++ b/src/Idris/IdrisDoc.hs
@@ -303,7 +303,6 @@ extractPTermNames (PMatchApp _ n)    = [n]
 extractPTermNames (PCase _ p ps)     = let (ps1, ps2) = unzip ps
                                        in  concatMap extract (p:(ps1 ++ ps2))
 extractPTermNames (PIfThenElse _ c t f) = concatMap extract [c, t, f]
-extractPTermNames (PEq _ _ _ p1 p2)  = concatMap extract [p1, p2]
 extractPTermNames (PRewrite _ a b m) | Just c <- m =
                                        concatMap extract [a, b, c]
 extractPTermNames (PRewrite _ a b _) = concatMap extract [a, b]

--- a/src/Idris/IdrisDoc.hs
+++ b/src/Idris/IdrisDoc.hs
@@ -303,7 +303,6 @@ extractPTermNames (PMatchApp _ n)    = [n]
 extractPTermNames (PCase _ p ps)     = let (ps1, ps2) = unzip ps
                                        in  concatMap extract (p:(ps1 ++ ps2))
 extractPTermNames (PIfThenElse _ c t f) = concatMap extract [c, t, f]
-extractPTermNames (PRefl _ p)        = extract p
 extractPTermNames (PEq _ _ _ p1 p2)  = concatMap extract [p1, p2]
 extractPTermNames (PRewrite _ a b m) | Just c <- m =
                                        concatMap extract [a, b, c]

--- a/src/Idris/ParseExpr.hs
+++ b/src/Idris/ParseExpr.hs
@@ -326,10 +326,6 @@ simpleExpr syn =
             try (simpleExternalExpr syn)
         <|> do x <- try (lchar '?' *> name); return (PMetavar x)
         <|> do lchar '%'; fc <- getFC; reserved "instance"; return (PResolveTC fc)
-        <|> do reserved "Refl"; fc <- getFC;
-               tm <- option Placeholder (do lchar '{'; t <- expr syn; lchar '}';
-                                            return t)
-               return (PRefl fc tm)
         <|> do reserved "elim_for"; fc <- getFC; t <- fnName; return (PRef fc (SN $ ElimN t))
         <|> proofExpr syn
         <|> tacticsExpr syn

--- a/src/Idris/ParseOps.hs
+++ b/src/Idris/ParseOps.hs
@@ -37,7 +37,7 @@ table fixes
      toTable (reverse fixes) ++
      [[backtick],
       [binary "$" (\fc x y -> flatten $ PApp fc x [pexp y]) AssocRight],
-      [binary "="  (\fc x y -> PEq fc Placeholder Placeholder x y) AssocLeft],
+      [binary "="  (\fc x y -> PApp fc (PRef fc eqTy) [pexp x, pexp y]) AssocLeft],
       [nofixityoperator]]
   where
     flatten :: PTerm -> PTerm -- flatten application

--- a/src/Idris/ProofSearch.hs
+++ b/src/Idris/ProofSearch.hs
@@ -22,7 +22,7 @@ import Debug.Trace
 -- Pass in a term elaborator to avoid a cyclic dependency with ElabTerm
 
 trivial :: (PTerm -> ElabD ()) -> IState -> ElabD ()
-trivial elab ist = try' (do elab (PRefl (fileFC "prf") Placeholder)
+trivial elab ist = try' (do elab (PApp (fileFC "prf") (PRef (fileFC "prf") eqCon) [pimp (sUN "A") Placeholder False, pimp (sUN "x") Placeholder False])
                             return ())
                         (do env <- get_env
                             g <- goal

--- a/test/reg037/reg037.idr
+++ b/test/reg037/reg037.idr
@@ -4,6 +4,6 @@
 class Foo (t : a -> b -> Type) where
   foo : (x : _) -> (y : _) -> t x y -> t x y
 
-instance Foo (=) where
+instance Foo ((=) {A=a} {B=b}) where
   foo x y prf = prf
 

--- a/test/reg047/reg047.idr
+++ b/test/reg047/reg047.idr
@@ -9,7 +9,7 @@ Id : (A : Type) -> A -> A -> Type
 Id A = (=) {A = A} {B = A}
 
 IdRefl : (A : Type) -> (a : A) -> Id A a a
-IdRefl A a = Refl {a}
+IdRefl A a = Refl {x = a}
 
 zzz : Id Nat zero zero
 zzz = IdRefl Nat zero

--- a/test/reg047/reg047a.idr
+++ b/test/reg047/reg047a.idr
@@ -9,7 +9,7 @@ Id : (A : Type) -> A -> A -> Type
 Id = \A,x,y => x = y --  {a = A} {b = A}
 
 IdRefl : (A : Type) -> (a : A) -> Id A a a
-IdRefl A a = Refl {a}
+IdRefl A a = Refl {x = a}
 
 zzzz : Id MNat zero zero
 zzzz = IdRefl MNat zero

--- a/test/reg056/reg056.idr
+++ b/test/reg056/reg056.idr
@@ -6,7 +6,7 @@ postulate trap : Z = Z
 dodgy : (a, b : ()) -> a = b -> Void
 dodgy n m Refl impossible
 
-nonk : (trap = Refl {Z}) -> Void
+nonk : (trap = Refl {x = Z}) -> Void
 nonk Refl impossible
 
 false : Void


### PR DESCRIPTION
This reduces the special treatment of equality in `PTerm`, decluttering some parts of the code a bit.