### PR TITLE
Fix a few user-visible leftover uses of “Float”

### DIFF
--- a/src/Idris/Core/TT.hs
+++ b/src/Idris/Core/TT.hs
@@ -1388,7 +1388,7 @@ instance Show Const where
     show (B16 x) = show x
     show (B32 x) = show x
     show (B64 x) = show x
-    show (AType ATFloat) = "Float"
+    show (AType ATFloat) = "Double"
     show (AType (ATInt ITBig)) = "Integer"
     show (AType (ATInt ITNative)) = "Int"
     show (AType (ATInt ITChar)) = "Char"

--- a/src/Idris/IdeMode.hs
+++ b/src/Idris/IdeMode.hs
@@ -107,7 +107,7 @@ maybeProps ((n, Nothing):ps) = maybeProps ps
 constTy :: Const -> String
 constTy (I _) = "Int"
 constTy (BI _) = "Integer"
-constTy (Fl _) = "Float"
+constTy (Fl _) = "Double"
 constTy (Ch _) = "Char"
 constTy (Str _) = "String"
 constTy (B8 _) = "Bits8"

--- a/src/Idris/ParseExpr.hs
+++ b/src/Idris/ParseExpr.hs
@@ -1200,18 +1200,12 @@ Constant ::=
     'Integer'
   | 'Int'
   | 'Char'
-  | 'Float'
+  | 'Double'
   | 'String'
-  | 'Ptr'
-  | 'ManagedPtr'
   | 'Bits8'
   | 'Bits16'
   | 'Bits32'
   | 'Bits64'
-  | 'Bits8x16'
-  | 'Bits16x8'
-  | 'Bits32x4'
-  | 'Bits64x2'
   | Float_t
   | Natural_t
   | VerbatimString_t


### PR DESCRIPTION
`Double` was still getting printed as `Float` in places.