### PR TITLE
Send absolute file names in annotations

### DIFF
--- a/idris.cabal
+++ b/idris.cabal
@@ -869,7 +869,7 @@ Library
                 , cheapskate < 0.2
                 , containers >= 0.5 && < 0.6
                 , deepseq < 1.5
-                , directory >= 1.2 && < 1.3
+                , directory >= 1.2.2.0 && < 1.3
                 , filepath < 1.5
                 , fingertree >= 0.1 && < 0.2
                 , haskeline >= 0.7 && < 0.8


### PR DESCRIPTION
This makes it much easier for clients of the IDE protocol to make use of
namespace information.