### PR TITLE
Remove unused imports

### DIFF
--- a/Setup.hs
+++ b/Setup.hs
@@ -19,8 +19,6 @@ import System.FilePath ((</>), splitDirectories,isAbsolute)
 import System.Directory
 import qualified System.FilePath.Posix as Px
 import System.Process
-import qualified Data.Text as T
-import qualified Data.Text.IO as TIO
 
 -- After Idris is built, we need to check and install the prelude and other libs
 


### PR DESCRIPTION
Currently, build-depends are not expected to be ready at the time Setup.hs is run.  This may change in a future version of Cabal; meanwhile, removing these unused imports fixes failures at `cabal copy` time on OS X.