### PR TITLE
Fix dictionary arguments in dependent type class methods

### DIFF
--- a/idris.cabal
+++ b/idris.cabal
@@ -314,6 +314,9 @@ Extra-source-files:
                        test/reg064/run
                        test/reg064/*.idr
                        test/reg064/expected
+                       test/reg065/run
+                       test/reg065/*.idr
+                       test/reg065/expected
 
                        test/basic001/run
                        test/basic001/*.idr

--- a/src/Idris/AbsSyntax.hs
+++ b/src/Idris/AbsSyntax.hs
@@ -1623,12 +1623,12 @@ addImpl' inpat env infns imp_meths ist ptm
 -- names with zero explicit arguments, don't add implicits.
 
 aiFn :: Bool -> Bool -> Bool
-        -> [Name]
-        -> IState -> FC
-        -> Name -- ^ function being applied
-        -> FC -> [[T.Text]]
-        -> [PArg] -> -- ^ initial arguments
-        Either Err PTerm
+     -> [Name]
+     -> IState -> FC
+     -> Name -- ^ function being applied
+     -> FC -> [[T.Text]]
+     -> [PArg] -- ^ initial arguments
+     -> Either Err PTerm
 aiFn inpat True qq imp_meths ist fc f ffc ds []
   = case lookupDef f (tt_ctxt ist) of
         [] -> Right $ PPatvar ffc f

--- a/test/reg065/reg065.idr
+++ b/test/reg065/reg065.idr
@@ -1,0 +1,26 @@
+||| Test that dependent type class definitions work.
+|||
+||| Fixes a regression where previous methods used in a later method's
+||| type would lead to "can't resolve type class" errors
+module TypeClassDep
+
+import Data.Vect
+
+
+class Foo a where
+  getLen : Nat
+  item : a -> Vect getLen a
+
+instance Foo () where
+  getLen  = 3
+  item () = [(), (), ()]
+
+instance Foo String where
+  getLen = 1
+  item str = [str]
+
+check1 : item () = with Vect [(),(),()]
+check1 = Refl
+
+check2 : item "halløjsa" = with Vect ["halløjsa"]
+check2 = Refl

--- a/test/reg065/run
+++ b/test/reg065/run
@@ -1,0 +1,3 @@
+#!/usr/bin/env bash
+idris $@ reg065.idr --check
+rm -f *.ibc


### PR DESCRIPTION
Type class methods references were previously elaborated using the
ordinary function call elaboration, but their class isn't yet available
when the method lookup function is elaborated. This leads to a "can't
resolve type class" error on the type class definition.

Now, they have an explicit dictionary argument inserted, pointing at the
dictionary that's used for the type of the method whose signature they
appear in.

Fixes #2302.