### PR TITLE
Turn off newline translation in IDE mode

### DIFF
--- a/src/Idris/REPL.hs
+++ b/src/Idris/REPL.hs
@@ -249,6 +249,9 @@ idemodeStart :: Bool -> IState -> [FilePath] -> Idris ()
 idemodeStart s orig mods
   = do h <- runIO $ if s then initIdemodeSocket else return stdout
        setIdeMode True h
+       -- Turn off newline translation to prevent the message lengths
+       -- from being incorrect on Windows
+       runIO $ hSetNewlineMode h noNewlineTranslation
        i <- getIState
        case idris_outputmode i of
          IdeMode n h ->


### PR DESCRIPTION
This is to prevent \r\n from making the character count incorrect on Windows.

Please don't merge until it's confirmed that this fixes it.

@archaeron: please let me know how it works for you!