### PR TITLE
Don't include the executable in the output.

### DIFF
--- a/test/disambig001/disambig001.idr
+++ b/test/disambig001/disambig001.idr
@@ -8,5 +8,5 @@ import Effect.System
 main : IO ()
 main = do 
     args <- System.getArgs
-    putStrLn (concat args)
+    putStrLn (concat (drop 1 args))
 

--- a/test/disambig001/expected
+++ b/test/disambig001/expected
@@ -1,1 +1,1 @@
-./disambig001foobar
+foobar


### PR DESCRIPTION
It is different on Windows (not only .exe, it's the whole path
so it's impossible to predict).