### PR TITLE
Use Text's own Binary instance

### DIFF
--- a/idris.cabal
+++ b/idris.cabal
@@ -888,7 +888,7 @@ Library
                 , pretty < 1.2
                 , process < 1.3
                 , split < 0.3
-                , text < 1.3
+                , text >=1.2.1.0 && < 1.3
                 , time >= 1.4 && < 1.6
                 , transformers < 0.5
                 , transformers-compat >= 0.3

--- a/src/Idris/Core/Binary.hs
+++ b/src/Idris/Core/Binary.hs
@@ -311,12 +311,6 @@ instance Binary Name where
                            return (SymRef x1)
                    _ -> error "Corrupted binary data for Name"
 
-instance Binary T.Text where
-        put x = put (E.encodeUtf8 x)
-        get = do x <- get
-                 return $!! (E.decodeUtf8 x)
-
-
 instance Binary SpecialName where
         put x
           = case x of


### PR DESCRIPTION
Text has added a Binary instance upstream, so we can't define our own anymore.