### PR TITLE
Hvect get implicit

### DIFF
--- a/libs/base/Data/HVect.idr
+++ b/libs/base/Data/HVect.idr
@@ -56,17 +56,17 @@ instance (Shows k ts) => Show (HVect ts) where
 
 ||| Extract an arbitrary element of the correct type.
 ||| @ t the goal type
-get : {default tactics { search 100; } p : Elem t ts} -> HVect ts -> t
+get : {auto p : Elem t ts} -> HVect ts -> t
 get {p = Here} (x::xs) = x
 get {p = There p'} (x::xs) = get {p = p'} xs
 
 ||| Replace an element with the correct type.
-put : {default tactics { search 100; } p : Elem t ts} -> t -> HVect ts -> HVect ts
+put : {auto p : Elem t ts} -> t -> HVect ts -> HVect ts
 put {p = Here} y (x::xs) = y :: xs
 put {p = There p'} y (x::xs) = x :: put {p = p'} y xs
 
 ||| Update an element with the correct type.
-update : {default tactics { search 100; } p : Elem t ts} -> (t -> u) -> HVect ts -> HVect (replaceByElem ts p u)
+update : {auto p : Elem t ts} -> (t -> u) -> HVect ts -> HVect (replaceByElem ts p u)
 update {p = Here} f (x::xs) = f x :: xs
 update {p = There p'} f (x::xs) = x :: update {p = p'} f xs
 

--- a/libs/base/Data/HVect.idr
+++ b/libs/base/Data/HVect.idr
@@ -1,7 +1,7 @@
 module Data.HVect
 
 import Data.Fin
-import Data.Vect
+import public Data.Vect
 
 %access public
 %default total

--- a/libs/effects/Effects.idr
+++ b/libs/effects/Effects.idr
@@ -293,15 +293,13 @@ syntax MkDefaultEnv = with Env
 
 call : {a, b: _} -> {e : Effect} ->
        (eff : e t a b) ->
-       {default tactics { search 100; }
-          prf : EffElem e a xs} ->
+       {auto prf : EffElem e a xs} ->
       EffM m t xs (\v => updateResTy v xs prf eff)
 call e {prf} = callP prf e
 
 implicit
 lift : EffM m t ys ys' ->
-       {default tactics { search 100; }
-          prf : SubList ys xs} ->
+       {auto prf : SubList ys xs} ->
        EffM m t xs (\v => updateWith (ys' v) xs prf)
 lift e {prf} = liftP prf e
 


### PR DESCRIPTION
`get` has an implicit `auto Elem` param; when attempting to use `get`
without the Vect module imported first you get `No such variable
Data.Vect.Elem`. This fixes that.