### PR TITLE
Fixed REPL for `:doc Type` to display documentation rather than giving an error

### DIFF
--- a/src/Idris/AbsSyntax.hs
+++ b/src/Idris/AbsSyntax.hs
@@ -637,8 +637,8 @@ setWidth :: ConsoleWidth -> Idris ()
 setWidth w = do ist <- getIState
                 put ist { idris_consolewidth = w }
 
-
-
+typeDescription :: String
+typeDescription = "The type of types"
 
 type1Doc :: Doc OutputAnnotation
 type1Doc = (annotate (AnnType "Type" "The type of types, one level up") $ text "Type 1")

--- a/src/Idris/Docs.hs
+++ b/src/Idris/Docs.hs
@@ -1,6 +1,6 @@
 {-# LANGUAGE DeriveFunctor, PatternGuards, MultiWayIf #-}
 {-# OPTIONS_GHC -fwarn-incomplete-patterns #-}
-module Idris.Docs (pprintDocs, getDocs, pprintConstDocs, pprintType1Doc, FunDoc, FunDoc'(..), Docs, Docs'(..)) where
+module Idris.Docs (pprintDocs, getDocs, pprintConstDocs, pprintTypeDoc, FunDoc, FunDoc'(..), Docs, Docs'(..)) where
 
 import Idris.AbsSyntax
 import Idris.AbsSyntaxTree
@@ -319,6 +319,6 @@ pprintConstDocs ist c str = text "Primitive" <+> text (if constIsType c then "ty
         t _       = PType NoFC
 
 
-pprintType1Doc :: IState -> Doc OutputAnnotation
-pprintType1Doc ist = prettyIst ist (PType emptyFC) <+> colon <+> type1Doc <+>
+pprintTypeDoc :: IState -> Doc OutputAnnotation
+pprintTypeDoc ist = prettyIst ist (PType emptyFC) <+> colon <+> type1Doc <+>
                      nest 4 (line <> text typeDescription) 

--- a/src/Idris/Docs.hs
+++ b/src/Idris/Docs.hs
@@ -1,6 +1,6 @@
 {-# LANGUAGE DeriveFunctor, PatternGuards, MultiWayIf #-}
 {-# OPTIONS_GHC -fwarn-incomplete-patterns #-}
-module Idris.Docs (pprintDocs, getDocs, pprintConstDocs, FunDoc, FunDoc'(..), Docs, Docs'(..)) where
+module Idris.Docs (pprintDocs, getDocs, pprintConstDocs, pprintType1Doc, FunDoc, FunDoc'(..), Docs, Docs'(..)) where
 
 import Idris.AbsSyntax
 import Idris.AbsSyntaxTree
@@ -317,3 +317,8 @@ pprintConstDocs ist c str = text "Primitive" <+> text (if constIsType c then "ty
         t (Str _) = PConstant NoFC StrType
         t (Ch c)  = PConstant NoFC $ AType (ATInt ITChar)
         t _       = PType NoFC
+
+
+pprintType1Doc :: IState -> Doc OutputAnnotation
+pprintType1Doc ist = prettyIst ist (PType emptyFC) <+> colon <+> type1Doc <+>
+                     nest 4 (line <> text typeDescription) 

--- a/src/Idris/REPL.hs
+++ b/src/Idris/REPL.hs
@@ -941,23 +941,22 @@ process fn (Core t)
         iPrintTermWithType (pprintTT [] tm) (pprintTT [] ty)
 
 process fn (DocStr (Left n) w)
-   = do ist <- getIState
-        let txtType = txt "Type" 
-        case n of
-          (UN txtType) -> iRenderResult $ pprintTypeDoc ist
-          _ -> do let docs = lookupCtxtName n (idris_docstrings ist) ++
-                             map (\(n,d)-> (n, (d, [])))
-                                 (lookupCtxtName (modDocN n) (idris_moduledocs ist))
-                  case docs of
-                    [] -> iPrintError $ "No documentation for " ++ show n
-                    ns -> do toShow <- mapM (showDoc ist) ns
-                             iRenderResult (vsep toShow)
-                where showDoc ist (n, d) = do doc <- getDocs n w
-                                              return $ pprintDocs ist doc
+  | UN ty <- n, ty == T.pack "Type" = getIState >>= iRenderResult . pprintTypeDoc  
+  | otherwise = do    
+        ist <- getIState
+        let docs = lookupCtxtName n (idris_docstrings ist) ++
+                   map (\(n,d)-> (n, (d, [])))
+                       (lookupCtxtName (modDocN n) (idris_moduledocs ist))
+        case docs of
+          [] -> iPrintError $ "No documentation for " ++ show n
+          ns -> do toShow <- mapM (showDoc ist) ns
+                   iRenderResult (vsep toShow)
+    where showDoc ist (n, d) = do doc <- getDocs n w
+                                  return $ pprintDocs ist doc
 
-                      modDocN (NS (UN n) ns) = NS modDocName (n:ns)
-                      modDocN (UN n)         = NS modDocName [n]
-                      modDocN _              = sMN 1 "NotFoundForSure"
+          modDocN (NS (UN n) ns) = NS modDocName (n:ns)
+          modDocN (UN n)         = NS modDocName [n]
+          modDocN _              = sMN 1 "NotFoundForSure"
 
 process fn (DocStr (Right c) _) -- constants only have overviews
    = do ist <- getIState

--- a/src/Idris/REPL.hs
+++ b/src/Idris/REPL.hs
@@ -942,19 +942,21 @@ process fn (Core t)
 
 process fn (DocStr (Left n) w)
    = do ist <- getIState
-        let docs = lookupCtxtName n (idris_docstrings ist) ++
-                   map (\(n,d)-> (n, (d, [])))
-                       (lookupCtxtName (modDocN n) (idris_moduledocs ist))
-        case docs of
-          [] -> iPrintError $ "No documentation for " ++ show n
-          ns -> do toShow <- mapM (showDoc ist) ns
-                   iRenderResult (vsep toShow)
-    where showDoc ist (n, d) = do doc <- getDocs n w
-                                  return $ pprintDocs ist doc
+        case show n of
+          "Type" -> iRenderResult $ pprintType1Doc ist
+          _ -> do let docs = lookupCtxtName n (idris_docstrings ist) ++
+                             map (\(n,d)-> (n, (d, [])))
+                                 (lookupCtxtName (modDocN n) (idris_moduledocs ist))
+                  case docs of
+                    [] -> iPrintError $ "No documentation for " ++ show n
+                    ns -> do toShow <- mapM (showDoc ist) ns
+                             iRenderResult (vsep toShow)
+                where showDoc ist (n, d) = do doc <- getDocs n w
+                                              return $ pprintDocs ist doc
 
-          modDocN (NS (UN n) ns) = NS modDocName (n:ns)
-          modDocN (UN n)         = NS modDocName [n]
-          modDocN _              = sMN 1 "NotFoundForSure"
+                      modDocN (NS (UN n) ns) = NS modDocName (n:ns)
+                      modDocN (UN n)         = NS modDocName [n]
+                      modDocN _              = sMN 1 "NotFoundForSure"
 
 process fn (DocStr (Right c) _) -- constants only have overviews
    = do ist <- getIState

--- a/src/Idris/REPL.hs
+++ b/src/Idris/REPL.hs
@@ -942,8 +942,9 @@ process fn (Core t)
 
 process fn (DocStr (Left n) w)
    = do ist <- getIState
-        case show n of
-          "Type" -> iRenderResult $ pprintType1Doc ist
+        let txtType = txt "Type" 
+        case n of
+          (UN txtType) -> iRenderResult $ pprintTypeDoc ist
           _ -> do let docs = lookupCtxtName n (idris_docstrings ist) ++
                              map (\(n,d)-> (n, (d, [])))
                                  (lookupCtxtName (modDocN n) (idris_moduledocs ist))

--- a/src/Idris/REPLParser.hs
+++ b/src/Idris/REPLParser.hs
@@ -268,10 +268,15 @@ cmd_doc name = do
         c <- fmap fst P.constant
         eof
         return $ Right (DocStr (Right c) FullDocs)
+    
+    let pType = do
+        P.reserved "Type"
+        eof
+        return $ Right (DocStr (Left $ P.mkName ("Type", "")) FullDocs)
 
     let fnName = fnNameArg (\n -> DocStr (Left n) FullDocs) name
 
-    try constant <|> fnName
+    try constant <|> pType <|> fnName
 
 cmd_consolewidth :: String -> P.IdrisParser (Either String Command)
 cmd_consolewidth name = do


### PR DESCRIPTION
Fix for #2273 

REPL now displays
```
Idris> :doc Type
Type : Type 1
    The type of types
```

rather than
```
Idris> :doc Type
Usage is :doc <functionname>
```