### PR TITLE
bump lens dependency

### DIFF
--- a/idris.cabal
+++ b/idris.cabal
@@ -883,7 +883,7 @@ Library
                 , filepath < 1.5
                 , fingertree >= 0.1 && < 0.2
                 , haskeline >= 0.7 && < 0.8
-                , lens >= 4.1.1 && < 4.10
+                , lens >= 4.1.1 && < 4.12
                 , mtl >= 2.1 && < 2.3
                 , network < 2.7
                 , optparse-applicative >= 0.11 && < 0.12


### PR DESCRIPTION
works fine with 4.11