### PR TITLE
Fix typos in docs/reference/ide-protocol.rst

### DIFF
--- a/docs/reference/ide-protocol.rst
+++ b/docs/reference/ide-protocol.rst
@@ -188,4 +188,4 @@ They have the format:::
 
   (:output (:ok (:highlight-source POSNS)))
 
-where ``POSNS``is a list of positions to highlight. Each of these is a two-element list whose first element is a position (encoded as for the ``source-loc`` property above) and whose second element is highlighting metadata in the same format used for output.
+where ``POSNS`` is a list of positions to highlight. Each of these is a two-element list whose first element is a position (encoded as for the ``source-loc`` property above) and whose second element is highlighting metadata in the same format used for output.

--- a/docs/reference/ide-protocol.rst
+++ b/docs/reference/ide-protocol.rst
@@ -27,7 +27,7 @@ An example interaction from loading the file ``/home/hannes/empty.idr`` looks as
 
 The first message is the request from idris-mode to load the specific file, which length is hex 2a, decimal 42 (including the newline at the end).
 The request identifier is set to 1.
-The first message from Idris is to write the string ``Type checking /home/hannes/empty.idr'', another is to set the prompt to ``*/home/hannes/empty''.
+The first message from Idris is to write the string ``Type checking /home/hannes/empty.idr``, another is to set the prompt to ``*/home/hannes/empty``.
 The answer, starting with ``:return`` is ``ok``, and additional information is that the file was loaded.
 
 There are three atoms in the wire language: numbers, strings, and symbols.


### PR DESCRIPTION
fixes ![image](https://cloud.githubusercontent.com/assets/89889/7908824/7b82f626-0850-11e5-888d-f585e82d63b4.png) and 
![image](https://cloud.githubusercontent.com/assets/89889/7908831/8dde6c9c-0850-11e5-9505-31d76060cc9a.png)
