### PR TITLE
Add Show instance for Data.Fin

### DIFF
--- a/libs/base/Data/Fin.idr
+++ b/libs/base/Data/Fin.idr
@@ -200,6 +200,9 @@ instance Enum (Fin (S n)) where
   fromNat {n=n} m = case natToFin m (S n) of
     Just k => k
     Nothing => last
+    
+instance Show (Fin n) where
+  show = show . finToNat
 
 --------------------------------------------------------------------------------
 -- DecEq


### PR DESCRIPTION
`Data.Fin` was missing a `Show` instance, which I thought was a bit silly considering it's such a simple definition.