### PR TITLE
Interactive fix

### DIFF
--- a/src/Idris/REPL.hs
+++ b/src/Idris/REPL.hs
@@ -573,8 +573,10 @@ splitName s = case reverse $ splitOn "." s of
 idemodeProcess :: FilePath -> Command -> Idris ()
 idemodeProcess fn Warranty = process fn Warranty
 idemodeProcess fn Help = process fn Help
-idemodeProcess fn (ChangeDirectory f) = do process fn (ChangeDirectory f)
-                                           iPrintResult "changed directory to"
+idemodeProcess fn (ChangeDirectory f) =
+  do process fn (ChangeDirectory f)
+     dir <- runIO $ getCurrentDirectory
+     iPrintResult $ "changed directory to " ++ dir
 idemodeProcess fn (ModImport f) = process fn (ModImport f)
 idemodeProcess fn (Eval t) = process fn (Eval t)
 idemodeProcess fn (NewDefn decls) = do process fn (NewDefn decls)


### PR DESCRIPTION
Fix interactive editing by canonicalizing Idris's internal ideas of paths.

Otherwise, equal pathnames would not show up as equal, leading to
problems in interactive editing if Idris's notion of a relative path
didn't agree with the user's notion. For example, loading a file as
"Foo/Bar.idr" would break interactive editing, because Idris would
remember the name as "./Foo/Bar.idr".