### PR TITLE
Fix #2176 by adding totality status to the REPL :doc command output

### DIFF
--- a/src/Idris/Docs.hs
+++ b/src/Idris/Docs.hs
@@ -53,17 +53,26 @@ showDoc ist d
   | otherwise = text "  -- " <>
                 renderDocstring (renderDocTerm (pprintDelab ist) (normaliseAll (tt_ctxt ist) [])) d
 
-pprintFD :: IState -> FunDoc -> Doc OutputAnnotation
-pprintFD ist (FD n doc args ty f)
+pprintFD :: IState -> Bool -> FunDoc -> Doc OutputAnnotation
+pprintFD ist totalityFlag (FD n doc args ty f)
     = nest 4 (prettyName True (ppopt_impl ppo) [] n <+> colon <+>
               pprintPTerm ppo [] [ n | (n@(UN n'),_,_,_) <- args
                                      , not (T.isPrefixOf (T.pack "__") n') ] infixes ty <$>
+              -- show doc
               renderDocstring (renderDocTerm (pprintDelab ist) (normaliseAll (tt_ctxt ist) [])) doc <$>
+              -- show fixity
               maybe empty (\f -> text (show f) <> line) f <>
+              -- show arguments doc
               let argshow = showArgs args [] in
-              if not (null argshow)
+              (if not (null argshow)
                 then nest 4 $ text "Arguments:" <$> vsep argshow
-                else empty)
+                else empty) <>
+              -- show totality status
+              let totality = getTotality in
+              (if totalityFlag && not (null totality) then
+                line <> (vsep . map (\t -> text "The function is" <+> t) $ totality)
+               else
+                empty))
 
     where ppo = ppOptionIst ist
           infixes = idris_infixes ist
@@ -87,15 +96,21 @@ pprintFD ist (FD n doc args ty f)
                showArgs args ((n, True):bnd)
           showArgs ((n, _, _, _):args) bnd = showArgs args ((n, True):bnd)
           showArgs []                  _ = []
+          getTotality = map (text . show) $ lookupTotal n (tt_ctxt ist)
 
+pprintFDWithTotality :: IState -> FunDoc -> Doc OutputAnnotation
+pprintFDWithTotality ist = pprintFD ist True
+
+pprintFDWithoutTotality :: IState -> FunDoc -> Doc OutputAnnotation
+pprintFDWithoutTotality ist = pprintFD ist False
 
 pprintDocs :: IState -> Docs -> Doc OutputAnnotation
-pprintDocs ist (FunDoc d) = pprintFD ist d
+pprintDocs ist (FunDoc d) = pprintFDWithTotality ist d
 pprintDocs ist (DataDoc t args)
-           = text "Data type" <+> pprintFD ist t <$>
+           = text "Data type" <+> pprintFDWithoutTotality ist t <$>
              if null args then text "No constructors."
              else nest 4 (text "Constructors:" <> line <>
-                          vsep (map (pprintFD ist) args))
+                          vsep (map (pprintFDWithoutTotality ist) args))
 pprintDocs ist (ClassDoc n doc meths params instances subclasses superclasses ctor)
            = nest 4 (text "Type class" <+> prettyName True (ppopt_impl ppo) [] n <>
                      if nullDocstring doc
@@ -105,12 +120,12 @@ pprintDocs ist (ClassDoc n doc meths params instances subclasses superclasses ct
              nest 4 (text "Parameters:" <$> prettyParameters)
              <> line <$>
              nest 4 (text "Methods:" <$>
-                      vsep (map (pprintFD ist) meths))
+                      vsep (map (pprintFDWithTotality ist) meths))
              <$>
              maybe empty
                    ((<> line) . nest 4 .
                     (text "Instance constructor:" <$>) .
-                    pprintFD ist)
+                    pprintFDWithoutTotality ist)
                    ctor
              <>
              nest 4 (text "Instances:" <$>
@@ -195,7 +210,7 @@ pprintDocs ist (ClassDoc n doc meths params instances subclasses superclasses ct
          else hsep (punctuate comma (map (prettyName True False params' . fst) params))
 
 pprintDocs ist (NamedInstanceDoc _cls doc)
-   = nest 4 (text "Named instance:" <$> pprintFD ist doc)
+   = nest 4 (text "Named instance:" <$> pprintFDWithoutTotality ist doc)
 
 pprintDocs ist (ModDoc mod docs)
    = nest 4 $ text "Module" <+> text (concat (intersperse "." mod)) <> colon <$>

--- a/test/classes001/expected
+++ b/test/classes001/expected
@@ -8,6 +8,7 @@ Methods:
     myShow : MyShow a => (x : a) -> String
         The shower
         
+        The function is Total
 Instance constructor:
     MkMyShow : (myShow : a -> String) -> MyShow a
         Build a MyShow
@@ -25,3 +26,4 @@ MkMyShow : (myShow : a -> String) -> MyShow a
         
         myShow : a -> String  -- The shower
         
+    The function is Total

--- a/test/docs001/expected
+++ b/test/docs001/expected
@@ -8,6 +8,7 @@ Methods:
     m : C t => t
         member of class
         
+        The function is Total
 Instances:
     C A
         instance of class

--- a/test/docs002/expected
+++ b/test/docs002/expected
@@ -1,9 +1,12 @@
 T1 : Type
     Some documentation
     
+    The function is Total
 T2 : Type
     Some other documentation
     
+    The function is Total
 T3 : Int
     Some provided postulate
     
+    The function is not yet checked for totality

--- a/test/docs003/expected
+++ b/test/docs003/expected
@@ -8,6 +8,7 @@ Methods:
     map : Functor f => (m : a -> b) -> f a -> f b
         The action of the functor on morphisms
         
+        The function is Total
 Instances:
     Functor List
     Functor Stream

--- a/test/docs004/expected
+++ b/test/docs004/expected
@@ -7,9 +7,12 @@ MkFoo : (bar : Nat) -> (baz : Bool) -> Foo a
         
         baz : Bool  -- A field baz
         
+    The function is Total
 bar : (rec : Foo a) -> Nat
     A field bar
     
+    The function is Total
 baz : (rec : Foo a) -> Bool
     A field baz
     
+    The function is Total

--- a/test/interactive005/expected
+++ b/test/interactive005/expected
@@ -3,6 +3,7 @@ Hello, World
 main : IO ()
     This is a docstring
     
+    The function is Total
 Main.main is Total
 Hello, World
 Prelude.Basics.id : a -> a
@@ -26,8 +27,10 @@ main : IO ()
     is a
     docstring
     
+    The function is Total
 main : IO ()
     This is a docstring
     
+    The function is Total
 Nat2 : Type
 Invalid filename for compiler output "Test.idr"


### PR DESCRIPTION
Fix #2176

The totality status is now reported at the end of the REPL :doc command output for all the functions except:
* data types and their related constructors
* type classes and their instance constructors and named instances

Output examples:
```
map : Functor f => (m : a -> b) -> f a -> f b
    The action of the functor on morphisms
    
    The function is Total
Idris> :doc filter
filter : (a -> Bool) -> List a -> List a
    filter, applied to a predicate and a list, returns the list of
    those elements that satisfy the predicate; e.g.,
    
        > filter (\ARG => ARG < 3) [0, 1, 2, 3, 4]
        [0, 1, 2]
    
    The function is Total
Idris> :doc Stream.foldr
foldr : (f : a -> Inf b -> b) -> (xs : Stream a) -> b
    Fold a Stream corecursively. Since there is no Nil, no initial
    value is used.
    Arguments:
        f : a -> Inf b -> b  -- the combining function
        
        xs : Stream a  -- the Stream to fold up
        
    The function is possibly not total due to recursive path Prelude.Stream.foldr --> Prelude.Stream.foldr
```