### PR TITLE
Logging levels must be explicitly mentioned.

### DIFF
--- a/src/IRTS/Compiler.hs
+++ b/src/IRTS/Compiler.hs
@@ -60,7 +60,7 @@ compile codegen f mtm
         maindef <- case mtm of
                         Nothing -> return []
                         Just tm -> do md <- irMain tm
-                                      iLOG $ "MAIN: " ++ show md
+                                      logLvl 1 $ "MAIN: " ++ show md
                                       return [(sMN 0 "runMain", md)]
         objs <- getObjectFiles codegen
         libs <- getLibs codegen
@@ -83,13 +83,13 @@ compile codegen f mtm
         let (nexttag, tagged) = addTags 65536 (liftAll defsUniq)
         let ctxtIn = addAlist tagged emptyContext
 
-        iLOG "Defunctionalising"
+        logLvl 1 "Defunctionalising"
         let defuns_in = defunctionalise nexttag ctxtIn
         logLvl 5 $ show defuns_in
-        iLOG "Inlining"
+        logLvl 1 "Inlining"
         let defuns = inline defuns_in
         logLvl 5 $ show defuns
-        iLOG "Resolving variables for CG"
+        logLvl 1 "Resolving variables for CG"
         -- iputStrLn $ showSep "\n" (map show (toAlist defuns))
         let checked = simplifyDefs defuns (toAlist defuns)
         outty <- outputTy
@@ -103,7 +103,7 @@ compile codegen f mtm
             Just f -> runIO $ writeFile f (dumpDefuns defuns)
         triple <- Idris.AbsSyntax.targetTriple
         cpu <- Idris.AbsSyntax.targetCPU
-        iLOG "Building output"
+        logLvl 1 "Building output"
         case checked of
             OK c -> do return $ CodegenInfo f outty triple cpu
                                             hdrs impdirs objs libs flags

--- a/src/Idris/AbsSyntax.hs
+++ b/src/Idris/AbsSyntax.hs
@@ -345,7 +345,7 @@ addToCalledG :: Name -> [Name] -> Idris ()
 addToCalledG n ns = return () -- TODO
 
 push_estack :: Name -> Bool -> Idris ()
-push_estack n inst 
+push_estack n inst
     = do i <- getIState
          putIState (i { elab_stack = (n, inst) : elab_stack i })
 
@@ -401,10 +401,10 @@ addAutoHint :: Name -> Name -> Idris ()
 addAutoHint n hint =
     do ist <- getIState
        case lookupCtxtExact n (idris_autohints ist) of
-            Nothing -> 
+            Nothing ->
                  do let hs = addDef n [hint] (idris_autohints ist)
                     putIState $ ist { idris_autohints = hs }
-            Just nhints -> 
+            Just nhints ->
                  do let hs = addDef n (hint : nhints) (idris_autohints ist)
                     putIState $ ist { idris_autohints = hs }
 
@@ -589,7 +589,7 @@ addConstraints fc (v, cs)
          putIState $ i { tt_ctxt = ctxt', idris_constraints = ics }
   where
     insertAll [] c = c
-    insertAll ((c, fc) : cs) ics 
+    insertAll ((c, fc) : cs) ics
        = insertAll cs $ S.insert (ConstraintFC c fc) ics
 
 addDeferred = addDeferred' Ref
@@ -945,9 +945,6 @@ logLvl l str = do i <- getIState
 cmdOptType :: Opt -> Idris Bool
 cmdOptType x = do i <- getIState
                   return $ x `elem` opt_cmdline (idris_options i)
-
-iLOG :: String -> Idris ()
-iLOG = logLvl 1
 
 noErrors :: Idris Bool
 noErrors = do i <- getIState
@@ -1714,9 +1711,9 @@ aiFn inpat expat qq imp_meths ist fc f ffc ds as
     insertImpl :: [PArg] -- ^ expected argument types (from idris_implicits)
                -> [PArg] -- ^ given arguments
                -> [PArg]
-    insertImpl ps as 
+    insertImpl ps as
         = let (as', badimpls) = partition (impIn ps) as in
-              map addUnknownImp badimpls ++ 
+              map addUnknownImp badimpls ++
               insImpAcc M.empty ps (filter expArg as') (filter (not . expArg) as')
 
     insImpAcc :: M.Map Name PTerm -- accumulated param names & arg terms
@@ -1761,7 +1758,7 @@ aiFn inpat expat qq imp_meths ist fc f ffc ds as
     find n (PTacImplicit _ _ n' _ t : gs) acc
          | n == n' = Just (t, reverse acc ++ gs)
     find n (g : gs) acc = find n gs (g : acc)
-    
+
 -- return True if the second argument is an implicit argument which is
 -- expected in the implicits, or if it's not an implicit
 impIn :: [PArg] -> PArg -> Bool

--- a/src/Idris/CaseSplit.hs
+++ b/src/Idris/CaseSplit.hs
@@ -72,7 +72,7 @@ split n t'
              Nothing -> ifail $ show n ++ " is not a pattern variable"
              Just ty ->
                 do let splits = findPats ist ty
-                   iLOG ("New patterns " ++ showSep ", "  
+                   logLvl 1 ("New patterns " ++ showSep ", "  
                          (map showTmImpls splits))
                    let newPats_in = zipWith (replaceVar ctxt n) splits (repeat t)
                    logLvl 4 ("Working from " ++ show t)
@@ -84,7 +84,7 @@ split n t'
                               (showSep "\n" (map show (mapMaybe id newPats))))
                    logLvl 3 "----"
                    let newPats' = mergeAllPats ist n t (mapMaybe id newPats)
-                   iLOG ("Name updates " ++ showSep "\n"
+                   logLvl 1 ("Name updates " ++ showSep "\n"
                          (map (\ (p, u) -> show u ++ " " ++ show p) newPats'))
                    return (map snd newPats')
 

--- a/src/Idris/Chaser.hs
+++ b/src/Idris/Chaser.hs
@@ -90,11 +90,11 @@ buildTree built fp = btree [] fp
   btree done f =
     do i <- getIState
        let file = extractFileName f
-       iLOG $ "CHASING " ++ show file
+       logLvl 1 $ "CHASING " ++ show file
        ibcsd <- valIBCSubDir i
        ids <- allImportDirs
        fp <- findImport ids ibcsd file
-       iLOG $ "Found " ++ show fp
+       logLvl 1 $ "Found " ++ show fp
        mt <- runIO $ getIModTime fp
        if (file `elem` built)
           then return [MTree fp False mt []]

--- a/src/Idris/Elab/Class.hs
+++ b/src/Idris/Elab/Class.hs
@@ -174,7 +174,7 @@ elabClass info syn_in doc fc constraints tn tnfc ps pDocs fds ds mcn cd
                  let ds = map (decorateid defaultdec)
                               [PTy emptyDocstring [] syn fc [] n nfc ty',
                                PClauses fc (o ++ opts) n cs]
-                 iLOG (show ds)
+                 logLvl 1 (show ds)
                  return (n, ((defaultdec n, ds!!1), ds))
             _ -> ifail $ show n ++ " is not a method"
     defdecl _ _ _ = ifail "Can't happen (defdecl)"
@@ -231,7 +231,7 @@ elabClass info syn_in doc fc constraints tn tnfc ps pDocs fds ds mcn cd
              let lhs = PApp fc (PRef fc m) (pconst capp : lhsArgs margs anames)
              let rhs = PApp fc (getMeth mnames all m) (rhsArgs margs anames)
              logLvl 2 ("Top level type: " ++ showTmImpls ty')
-             iLOG (show (m, ty', capp, margs))
+             logLvl 1 (show (m, ty', capp, margs))
              logLvl 2 ("Definition: " ++ showTmImpls lhs ++ " = " ++ showTmImpls rhs)
              return [PTy doc [] syn fc o m mfc ty',
                      PClauses fc [Inlinable] m [PClause fc m lhs [] rhs []]]

--- a/src/Idris/Elab/Clause.hs
+++ b/src/Idris/Elab/Clause.hs
@@ -650,7 +650,7 @@ elabClause info opts (cnum, PClause fc fname lhs_in_as withs rhs_in_as wherebloc
 
         logLvl 5 "DONE CHECK"
         logLvl 4 $ "---> " ++ show rhs'
-        when (not (null defer)) $ iLOG $ "DEFERRED " ++
+        when (not (null defer)) $ logLvl 1 $ "DEFERRED " ++
                     show (map (\ (n, (_,_,t)) -> (n, t)) defer)
         def' <- checkDef fc (Elaborating "deferred type of ") defer
         let def'' = map (\(n, (i, top, t)) -> (n, (i, top, t, False))) def'

--- a/src/Idris/Elab/Data.hs
+++ b/src/Idris/Elab/Data.hs
@@ -53,7 +53,7 @@ import Util.Pretty(pretty, text)
 elabData :: ElabInfo -> SyntaxInfo -> Docstring (Either Err PTerm)-> [(Name, Docstring (Either Err PTerm))] -> FC -> DataOpts -> PData -> Idris ()
 elabData info syn doc argDocs fc opts (PLaterdecl n nfc t_in)
     = do let codata = Codata `elem` opts
-         iLOG (show (fc, doc))
+         logLvl 1 (show (fc, doc))
          checkUndefined fc n
          (cty, _, t, inacc) <- buildType info syn fc [] n t_in
 
@@ -63,7 +63,7 @@ elabData info syn doc argDocs fc opts (PLaterdecl n nfc t_in)
 
 elabData info syn doc argDocs fc opts (PDatadecl n nfc t_in dcons)
     = do let codata = Codata `elem` opts
-         iLOG (show fc)
+         logLvl 1 (show fc)
          undef <- isUndefined fc n
          (cty, ckind, t, inacc) <- buildType info syn fc [] n t_in
          -- if n is defined already, make sure it is just a type declaration

--- a/src/Idris/Elab/Instance.hs
+++ b/src/Idris/Elab/Instance.hs
@@ -111,7 +111,7 @@ elabInstance info syn doc argDocs what fc cs n nfc ps t expn ds = do
          let ds_defs = insertDefaults i iname (class_defaults ci) ns ds
          logLvl 3 ("After defaults: " ++ show ds_defs ++ "\n")
          let ds' = reorderDefs (map fst (class_methods ci)) $ ds_defs
-         iLOG ("Reordered: " ++ show ds' ++ "\n")
+         logLvl 1 ("Reordered: " ++ show ds' ++ "\n")
          mapM_ (warnMissing ds' ns iname) (map fst (class_methods ci))
          mapM_ (checkInClass (map fst (class_methods ci))) (concatMap defined ds')
          let wbTys = map mkTyDecl mtys
@@ -139,7 +139,7 @@ elabInstance info syn doc argDocs what fc cs n nfc ps t expn ds = do
 
          let idecls = [PClauses fc [Dictionary] iname
                                  [PClause fc iname lhs [] rhs wb]]
-         iLOG (show idecls)
+         logLvl 1 (show idecls)
          push_estack iname True
          mapM_ (rec_elabDecl info EAll info) idecls
          pop_estack

--- a/src/Idris/Elab/Record.hs
+++ b/src/Idris/Elab/Record.hs
@@ -57,12 +57,12 @@ elabRecord info doc rsyn fc opts tyn nfc params paramDocs fields cname cdoc csyn
        logLvl 1 $ "Data constructor: " ++ showTmImpls dconTy
 
        -- Build data declaration for elaboration
-       iLOG $ foldr (++) "" $ intersperse "\n" (map show dconsArgDocs)
+       logLvl 1 $ foldr (++) "" $ intersperse "\n" (map show dconsArgDocs)
        let datadecl = PDatadecl tyn NoFC tycon [(cdoc, dconsArgDocs, dconName, NoFC, dconTy, fc, [])]
        elabData info rsyn doc paramDocs fc opts datadecl
 
-       iLOG $ "fieldsWithName " ++ show fieldsWithName
-       iLOG $ "fieldsWIthNameAndDoc " ++ show fieldsWithNameAndDoc
+       logLvl 1 $ "fieldsWithName " ++ show fieldsWithName
+       logLvl 1 $ "fieldsWIthNameAndDoc " ++ show fieldsWithNameAndDoc
        elabRecordFunctions info rsyn fc tyn paramsAndDoc fieldsWithNameAndDoc dconName target
 
        sendHighlighting $
@@ -154,8 +154,8 @@ elabRecordFunctions :: ElabInfo -> SyntaxInfo -> FC
 elabRecordFunctions info rsyn fc tyn params fields dconName target
   = do logLvl 1 $ "Elaborating helper functions for record " ++ show tyn
 
-       iLOG $ "Fields: " ++ show fieldNames
-       iLOG $ "Params: " ++ show paramNames
+       logLvl 1 $ "Fields: " ++ show fieldNames
+       logLvl 1 $ "Params: " ++ show paramNames
        -- The elaborated constructor type for the data declaration
        i <- getIState
        ttConsTy <-
@@ -165,8 +165,8 @@ elabRecordFunctions info rsyn fc tyn params fields dconName target
 
        -- The arguments to the constructor
        let constructorArgs = getArgTys ttConsTy
-       iLOG $ "Cons args: " ++ show constructorArgs
-       iLOG $ "Free fields: " ++ show (filter (not . isFieldOrParam') constructorArgs)
+       logLvl 1 $ "Cons args: " ++ show constructorArgs
+       logLvl 1 $ "Free fields: " ++ show (filter (not . isFieldOrParam') constructorArgs)
        -- If elaborating the constructor has resulted in some new implicit fields we make projection functions for them.
        let freeFieldsForElab = map (freeField i) (filter (not . isFieldOrParam') constructorArgs)
            

--- a/src/Idris/ElabDecls.hs
+++ b/src/Idris/ElabDecls.hs
@@ -158,25 +158,25 @@ elabDecl' _ info (PSyntax _ p)
      = return () -- nothing to elaborate
 elabDecl' what info (PTy doc argdocs s f o n nfc ty)
   | what /= EDefns
-    = do iLOG $ "Elaborating type decl " ++ show n ++ show o
+    = do logLvl 1 $ "Elaborating type decl " ++ show n ++ show o
          elabType info s doc argdocs f o n nfc ty
          return ()
 elabDecl' what info (PPostulate b doc s f o n ty)
   | what /= EDefns
-    = do iLOG $ "Elaborating postulate " ++ show n ++ show o
+    = do logLvl 1 $ "Elaborating postulate " ++ show n ++ show o
          if b 
             then elabExtern info s doc f o n ty
             else elabPostulate info s doc f o n ty
 elabDecl' what info (PData doc argDocs s f co d)
   | what /= ETypes
-    = do iLOG $ "Elaborating " ++ show (d_name d)
+    = do logLvl 1 $ "Elaborating " ++ show (d_name d)
          elabData info s doc argDocs f co d
   | otherwise
-    = do iLOG $ "Elaborating [type of] " ++ show (d_name d)
+    = do logLvl 1 $ "Elaborating [type of] " ++ show (d_name d)
          elabData info s doc argDocs f co (PLaterdecl (d_name d) (d_name_fc d) (d_tcon d))
 elabDecl' what info d@(PClauses f o n ps)
   | what /= ETypes
-    = do iLOG $ "Elaborating clause " ++ show n
+    = do logLvl 1 $ "Elaborating clause " ++ show n
          i <- getIState -- get the type options too
          let o' = case lookupCtxt n (idris_flags i) of
                     [fs] -> fs
@@ -190,7 +190,7 @@ elabDecl' what info (PMutual f ps)
          -- record mutually defined data definitions
          let datans = concatMap declared (filter isDataDecl ps)
          mapM_ (setMutData datans) datans
-         iLOG $ "Rechecking for positivity " ++ show datans
+         logLvl 1 $ "Rechecking for positivity " ++ show datans
          mapM_ (\x -> do setTotality x Unchecked) datans
          -- Do totality checking after entire mutual block
          i <- get
@@ -215,7 +215,7 @@ elabDecl' what info (PMutual f ps)
 
 elabDecl' what info (PParams f ns ps)
     = do i <- getIState
-         iLOG $ "Expanding params block with " ++ show ns ++ " decls " ++
+         logLvl 1 $ "Expanding params block with " ++ show ns ++ " decls " ++
                 show (concatMap tldeclared ps)
          let nblock = pblock i
          mapM_ (elabDecl' what info) nblock
@@ -239,18 +239,18 @@ elabDecl' what info (PNamespace n nfc ps) =
 
 elabDecl' what info (PClass doc s f cs n nfc ps pdocs fds ds cn cd)
   | what /= EDefns
-    = do iLOG $ "Elaborating class " ++ show n
+    = do logLvl 1 $ "Elaborating class " ++ show n
          elabClass info (s { syn_params = [] }) doc f cs n nfc ps pdocs fds ds cn cd
 elabDecl' what info (PInstance doc argDocs s f cs n nfc ps t expn ds)
-    = do iLOG $ "Elaborating instance " ++ show n
+    = do logLvl 1 $ "Elaborating instance " ++ show n
          elabInstance info s doc argDocs what f cs n nfc ps t expn ds
 elabDecl' what info (PRecord doc rsyn fc opts name nfc ps pdocs fs cname cdoc csyn)
   | what /= ETypes
-    = do iLOG $ "Elaborating record " ++ show name
+    = do logLvl 1 $ "Elaborating record " ++ show name
          elabRecord info doc rsyn fc opts name nfc ps pdocs fs cname cdoc csyn
 {-
   | otherwise
-    = do iLOG $ "Elaborating [type of] " ++ show tyn
+    = do logLvl 1 $ "Elaborating [type of] " ++ show tyn
          elabData info s doc [] f [] (PLaterdecl tyn ty)
 -}
 elabDecl' _ info (PDSL n dsl)
@@ -261,7 +261,7 @@ elabDecl' what info (PDirective i)
   | what /= EDefns = directiveAction i
 elabDecl' what info (PProvider doc syn fc provWhat n)
   | what /= EDefns
-    = do iLOG $ "Elaborating type provider " ++ show n
+    = do logLvl 1 $ "Elaborating type provider " ++ show n
          elabProvider doc info syn fc provWhat n
 elabDecl' what info (PTransform fc safety old new)
     = do elabTransform info fc safety old new

--- a/src/Idris/IBC.hs
+++ b/src/Idris/IBC.hs
@@ -105,7 +105,7 @@ loadIBC reexport fp
                                 Nothing -> True
                                 Just p -> not p && reexport
                 when redo $
-                  do iLOG $ "Loading ibc " ++ fp ++ " " ++ show reexport
+                  do logLvl 1 $ "Loading ibc " ++ fp ++ " " ++ show reexport
                      archiveFile <- runIO $ B.readFile fp
                      case toArchiveOrFail archiveFile of
                         Left _ -> ifail $ fp ++ " isn't loadable, it may have an old ibc format.\n"
@@ -180,7 +180,7 @@ writeArchive fp i = do let a = L.foldl (\x y -> addEntryToArchive y x) emptyArch
 
 writeIBC :: FilePath -> FilePath -> Idris ()
 writeIBC src f
-    = do iLOG $ "Writing ibc " ++ show f
+    = do logLvl 1 $ "Writing ibc " ++ show f
          i <- getIState
 --          case (Data.List.map fst (idris_metavars i)) \\ primDefs of
 --                 (_:_) -> ifail "Can't write ibc when there are unsolved metavariables"
@@ -189,8 +189,8 @@ writeIBC src f
          ibcf <- mkIBC (ibc_write i) (initIBC { sourcefile = src })
          idrisCatch (do runIO $ createDirectoryIfMissing True (dropFileName f)
                         writeArchive f ibcf
-                        iLOG "Written")
-            (\c -> do iLOG $ "Failed " ++ pshow i c)
+                        logLvl 1 "Written")
+            (\c -> do logLvl 1 $ "Failed " ++ pshow i c)
          return ()
 
 -- Write a package index containing all the imports in the current IState
@@ -199,14 +199,14 @@ writePkgIndex :: FilePath -> Idris ()
 writePkgIndex f
     = do i <- getIState
          let imps = map (\ (x, y) -> (True, x)) $ idris_imported i
-         iLOG $ "Writing package index " ++ show f ++ " including\n" ++
+         logLvl 1 $ "Writing package index " ++ show f ++ " including\n" ++
                 show (map snd imps)
          resetNameIdx
          let ibcf = initIBC { ibc_imports = imps }
          idrisCatch (do runIO $ createDirectoryIfMissing True (dropFileName f)
                         writeArchive f ibcf
-                        iLOG "Written")
-            (\c -> do iLOG $ "Failed " ++ pshow i c)
+                        logLvl 1 "Written")
+            (\c -> do logLvl 1 $ "Failed " ++ pshow i c)
          return ()
 
 mkIBC :: [IBCWrite] -> IBCFile -> Idris IBCFile
@@ -305,7 +305,7 @@ process :: Bool -- ^ Reexporting
 process reexp i fn = do
                 ver <- getEntry 0 "ver" i
                 when (ver /= ibcVersion) $ do
-                                    iLOG "ibc out of date"
+                                    logLvl 1 "ibc out of date"
                                     let e = if ver < ibcVersion
                                             then " an earlier " else " a later "
                                     ifail $ "Incompatible ibc version.\nThis library was built with"
@@ -395,12 +395,12 @@ pImports fs
                        ids <- allImportDirs
                        fp <- findImport ids ibcsd f
 --                        if (f `elem` imported i)
---                         then iLOG $ "Already read " ++ f
+--                         then logLvl 1 $ "Already read " ++ f
                        putIState (i { imported = f : imported i })
                        case fp of
-                            LIDR fn -> do iLOG $ "Failed at " ++ fn
+                            LIDR fn -> do logLvl 1 $ "Failed at " ++ fn
                                           ifail "Must be an ibc"
-                            IDR fn -> do iLOG $ "Failed at " ++ fn
+                            IDR fn -> do logLvl 1 $ "Failed at " ++ fn
                                          ifail "Must be an ibc"
                             IBC fn src -> loadIBC re fn)
              fs
@@ -491,13 +491,13 @@ pDefs reexp syms ds
                do d' <- updateDef d
                   case d' of
                        TyDecl _ _ -> return ()
-                       _ -> do iLOG $ "SOLVING " ++ show n
+                       _ -> do logLvl 1 $ "SOLVING " ++ show n
                                solveDeferred n
                   updateIState (\i -> i { tt_ctxt = addCtxtDef n d' (tt_ctxt i) })
 --                   logLvl 1 $ "Added " ++ show (n, d')
-                  if (not reexp) then do iLOG $ "Not exporting " ++ show n
+                  if (not reexp) then do logLvl 1 $ "Not exporting " ++ show n
                                          setAccessibility n Hidden
-                                 else iLOG $ "Exporting " ++ show n) ds
+                                 else logLvl 1 $ "Exporting " ++ show n) ds
   where
     updateDef (CaseOp c t args o s cd)
       = do o' <- mapM updateOrig o

--- a/src/Idris/Interactive.hs
+++ b/src/Idris/Interactive.hs
@@ -35,7 +35,7 @@ caseSplitAt :: FilePath -> Bool -> Int -> Name -> Idris ()
 caseSplitAt fn updatefile l n
    = do src <- runIO $ readSource fn
         res <- splitOnLine l n fn
-        iLOG (showSep "\n" (map show res))
+        logLvl 1 (showSep "\n" (map show res))
         let (before, (ap : later)) = splitAt (l-1) (lines src)
         res' <- replaceSplits ap res
         let new = concat res'

--- a/src/Idris/Parser.hs
+++ b/src/Idris/Parser.hs
@@ -1362,7 +1362,7 @@ loadModule' f
         ids <- allImportDirs
         fp <- findImport ids ibcsd file
         if file `elem` imported i
-          then do iLOG $ "Already read " ++ file
+          then do logLvl 1 $ "Already read " ++ file
                   return Nothing
           else do putIState (i { imported = file : imported i })
                   case fp of
@@ -1370,7 +1370,7 @@ loadModule' f
                     LIDR fn -> loadSource True  fn Nothing
                     IBC fn src ->
                       idrisCatch (loadIBC True fn)
-                                 (\c -> do iLOG $ fn ++ " failed " ++ pshow i c
+                                 (\c -> do logLvl 1 $ fn ++ " failed " ++ pshow i c
                                            case src of
                                              IDR sfn -> loadSource False sfn Nothing
                                              LIDR sfn -> loadSource True sfn Nothing)
@@ -1379,7 +1379,7 @@ loadModule' f
 {- | Load idris code from file -}
 loadFromIFile :: Bool -> IFileType -> Maybe Int -> Idris ()
 loadFromIFile reexp i@(IBC fn src) maxline
-   = do iLOG $ "Skipping " ++ getSrcFile i
+   = do logLvl 1 $ "Skipping " ++ getSrcFile i
         idrisCatch (loadIBC reexp fn)
                 (\err -> ierror $ LoadingFailed fn err)
   where
@@ -1403,7 +1403,7 @@ loadSource' lidr r maxline
 {- | Load Idris source code-}
 loadSource :: Bool -> FilePath -> Maybe Int -> Idris ()
 loadSource lidr f toline
-             = do iLOG ("Reading " ++ f)
+             = do logLvl 1 ("Reading " ++ f)
                   i <- getIState
                   let def_total = default_total i
                   file_in <- runIO $ readSource f
@@ -1505,14 +1505,14 @@ loadSource lidr f toline
                                   setContext ctxt')
                            (map snd (idris_totcheck i))
                   -- build size change graph from simplified definitions
-                  iLOG "Totality checking"
+                  logLvl 1 "Totality checking"
                   i <- getIState
                   mapM_ buildSCG (idris_totcheck i)
                   mapM_ checkDeclTotality (idris_totcheck i)
 
                   -- Redo totality check for deferred names
                   let deftots = idris_defertotcheck i
-                  iLOG $ "Totality checking " ++ show deftots
+                  logLvl 1 $ "Totality checking " ++ show deftots
                   mapM_ (\x -> do tot <- getTotality x
                                   case tot of
                                        Total _ -> setTotality x Unchecked
@@ -1520,9 +1520,9 @@ loadSource lidr f toline
                   mapM_ buildSCG deftots
                   mapM_ checkDeclTotality deftots
 
-                  iLOG ("Finished " ++ f)
+                  logLvl 1 ("Finished " ++ f)
                   ibcsd <- valIBCSubDir i
-                  iLOG "Universe checking"
+                  logLvl 1 "Universe checking"
                   iucheck
                   let ibc = ibcPathNoFallback ibcsd f
                   i <- getIState

--- a/src/Idris/Prover.hs
+++ b/src/Idris/Prover.hs
@@ -90,7 +90,7 @@ prove mode opt ctxt lit n ty
             if mode
               then elabloop n True ("-" ++ show n) [] (ES (ps, initEState) "" Nothing) [] Nothing []
               else ploop n True ("-" ++ show n) [] (ES (ps, initEState) "" Nothing) Nothing
-         iLOG $ "Adding " ++ show tm
+         logLvl 1 $ "Adding " ++ show tm
          i <- getIState
          let shower = if mode
                          then showRunElab

--- a/src/Idris/REPL.hs
+++ b/src/Idris/REPL.hs
@@ -1205,7 +1205,7 @@ process fn (DynamicLink l)
                                   Nothing -> iPrintError $ "Could not load dynamic lib \"" ++ l ++ "\""
                                   Just x -> do let libs = idris_dynamic_libs i
                                                if x `elem` libs
-                                                  then do iLOG ("Tried to load duplicate library " ++ lib_name x)
+                                                  then do logLvl 1 ("Tried to load duplicate library " ++ lib_name x)
                                                           return ()
                                                   else putIState $ i { idris_dynamic_libs = x:libs }
     where trim = reverse . dropWhile isSpace . reverse . dropWhile isSpace
@@ -1476,8 +1476,8 @@ loadInputs inputs toline -- furthest line to read in input source files
                                    (map snd (take (num-1) ninputs))
                                    input
                    let ifiles = getModuleFiles modTree
-                   iLOG ("MODULE TREE : " ++ show modTree)
-                   iLOG ("RELOAD: " ++ show ifiles)
+                   logLvl 1 ("MODULE TREE : " ++ show modTree)
+                   logLvl 1 ("RELOAD: " ++ show ifiles)
                    when (not (all ibc ifiles) || loadCode) $
                         tryLoad False (filter (not . ibc) ifiles)
                    -- return the files that need rechecking
@@ -1696,7 +1696,7 @@ idrisMain opts =
        -- Create Idris data dir + repl history and config dir
        idrisCatch (do dir <- getIdrisUserDataDir
                       exists <- runIO $ doesDirectoryExist dir
-                      unless exists $ iLOG ("Creating " ++ dir)
+                      unless exists $ logLvl 1 ("Creating " ++ dir)
                       runIO $ createDirectoryIfMissing True (dir </> "repl"))
          (\e -> return ())
 


### PR DESCRIPTION
Removed `iLOG`, all logging levels must be now explicitly declared when logging.

This is a precursor to more drastic changes I plan to make to the logging infrastructure in the near/distant future that benefits both developers of Idris and programmers that use Idris.