### PR TITLE
Latest Elab reflection updates

### DIFF
--- a/libs/prelude/Language/Reflection/Elab.idr
+++ b/libs/prelude/Language/Reflection/Elab.idr
@@ -7,6 +7,7 @@ module Language.Reflection.Elab
 
 import Builtins
 import Prelude.Applicative
+import Prelude.Bool
 import Prelude.Functor
 import Prelude.List
 import Prelude.Maybe
@@ -99,7 +100,8 @@ data Elab : Type -> Type where
 
   prim__Solve : Elab ()
   prim__Fill : Raw -> Elab ()
-  prim__Apply : Raw -> Elab ()
+  prim__Apply : Raw -> List (Bool, Int) -> Elab (List (TTName, TTName))
+  prim__MatchApply : Raw -> List (Bool, Int) -> Elab (List (TTName, TTName))
   prim__Focus : TTName -> Elab ()
   prim__Unfocus : TTName -> Elab ()
   prim__Attack : Elab ()
@@ -217,9 +219,49 @@ namespace Tactics
   fill : Raw -> Elab ()
   fill tm = prim__Fill tm
 
-  ||| Fill with unification
-  apply : Raw -> Elab ()
-  apply tm = prim__Apply tm
+  ||| Attempt to apply an operator to fill the current hole,
+  ||| potentially solving arugments by unification.
+  |||
+  ||| The return value is a list of pairs of names, one for each input
+  ||| argument. The first projection of these pairs is the original
+  ||| name of the argument, from the type declaration, and the second
+  ||| projection is the hole into which it is placed.
+  |||
+  ||| Note that not all of the returned hole names still exist, as
+  ||| they may have been solved.
+  |||
+  ||| @ op the term to apply
+  |||
+  ||| @ argSpec instructions for finding the arguments to the term,
+  |||     where the Boolean states whether or not to attempt to solve
+  |||     the argument and the Int gives the priority in which to do
+  |||     so
+  apply : (op : Raw) ->
+          (argSpec : List (Bool, Int)) ->
+          Elab (List (TTName, TTName))
+  apply tm argSpec = prim__Apply tm argSpec
+
+  ||| Attempt to apply an operator to fill the current hole,
+  ||| potentially solving arugments by matching.
+  |||
+  ||| The return value is a list of pairs of names, one for each input
+  ||| argument. The first projection of these pairs is the original
+  ||| name of the argument, from the type declaration, and the second
+  ||| projection is the hole into which it is placed.
+  |||
+  ||| Note that not all of the returned hole names still exist, as
+  ||| they may have been solved.
+  |||
+  ||| @ op the term to apply
+  |||
+  ||| @ argSpec instructions for finding the arguments to the term,
+  |||     where the Boolean states whether or not to attempt to solve
+  |||     the argument and the Int gives the priority in which to do
+  |||     so
+  matchApply : (op : Raw) ->
+               (argSpec : List (Bool, Int)) ->
+               Elab (List (TTName, TTName))
+  matchApply tm argSpec = prim__Apply tm argSpec
 
   ||| Move the focus to the specified hole
   |||

--- a/src/Idris/Core/Elaborate.hs
+++ b/src/Idris/Core/Elaborate.hs
@@ -563,7 +563,12 @@ prepare_apply fn imps =
     rebind hs (App s f a) = App s (rebind hs f) (rebind hs a)
     rebind hs t = t
 
-apply, match_apply :: Raw -> [(Bool, Int)] -> Elab' aux [(Name, Name)]
+-- | Apply an operator, solving some arguments by unification or matching.
+apply, match_apply :: Raw -- ^ The operator to apply
+                   -> [(Bool, Int)] -- ^ For each argument, whether to
+                                    -- attempt to solve it and the
+                                    -- priority in which to do so
+                   -> Elab' aux [(Name, Name)]
 apply = apply' fill
 match_apply = apply' match_fill
 
@@ -574,7 +579,7 @@ apply' fillt fn imps =
        -- (remove from unified list before calling end_unify)
        hs <- get_holes
        ES (p, a) s prev <- get
-       let dont = if null imps 
+       let dont = if null imps
                      then head hs : dontunify p
                      else getNonUnify (head hs : dontunify p) imps args
        let (n, hunis) = -- trace ("AVOID UNIFY: " ++ show (fn, dont)) $

--- a/src/Idris/Elab/Utils.hs
+++ b/src/Idris/Elab/Utils.hs
@@ -66,8 +66,6 @@ inaccessibleImps _ _ _ = []
 
 -- | Get the list of (index, name) of inaccessible arguments from the type.
 inaccessibleArgs :: Int -> PTerm -> [(Int, Name)]
-inaccessibleArgs i (PPi (Imp _ _ _ _) n _ Placeholder t)
-        = (i,n) : inaccessibleArgs (i+1) t  -- unbound implicit
 inaccessibleArgs i (PPi plicity n _ ty t)
     | InaccessibleArg `elem` pargopts plicity
         = (i,n) : inaccessibleArgs (i+1) t  -- an .{erased : Implicit}

--- a/test/meta002/Tacs.idr
+++ b/test/meta002/Tacs.idr
@@ -181,7 +181,7 @@ namespace STLC
               mkIx : Fin n -> Elab ()
               mkIx FZ = do envH <- mkEnvH
                            tH <- mkTyH
-                           apply `(Z {t=~(Var tH)} {env=~(Var envH)})
+                           apply `(Z {t=~(Var tH)} {env=~(Var envH)}) []
                            solve
               mkIx (FS i) = do envH <- mkEnvH
                                tH <- mkTyH
@@ -189,7 +189,7 @@ namespace STLC
                                argH <- gensym "arg"
                                claim argH `(Ix ~(Var envH) ~(Var tH))
                                unfocus argH
-                               apply `(S {env=~(Var envH)} {t=~(Var tH)} {t'=~(Var vH)} ~(Var argH))
+                               apply `(S {env=~(Var envH)} {t=~(Var tH)} {t'=~(Var vH)} ~(Var argH)) []
                                solve
                                focus argH
                                mkIx i
@@ -203,6 +203,7 @@ namespace STLC
                                         apply `(Lam {env=~(Var envH)}
                                                     {t=~(Var tH)} {t'=~(Var tH')}
                                                     ~(Var bodyH))
+                                              []
 
                                         solve
                                         focus bodyH
@@ -219,6 +220,7 @@ namespace STLC
                                           apply `(App {env=~(Var envH)}
                                                       {t=~(Var tH)} {t'=~(Var tH')}
                                                       ~(Var fH) ~(Var argH))
+                                                []
                                           solve
                                           focus fH
                                           mkTerm xs tm
@@ -230,11 +232,13 @@ namespace STLC
                                      claim ixH `(Ix ~(Var envH) ~(Var tH))
                                      unfocus ixH
                                      apply `(Var {env=~(Var envH)} {t=~(Var tH)} ~(Var ixH))
+                                           []
                                      solve
                                      focus ixH
                                      mkIx i
               mkTerm xs UnitCon = do envH <- mkEnvH
                                      apply `(UnitCon {env=~(Var envH)})
+                                           []
                                      solve
     testElab : Sigma Ty (Tm [])
     testElab = %runElab (elaborateSTLC (App (Lam "x" UnitCon) UnitCon))

--- a/test/meta002/expected
+++ b/test/meta002/expected
@@ -1,3 +1,3 @@
-Tacs.idr:247:15:
+Tacs.idr:251:15:
 When checking right hand side of testElab3:
 Unifying ty and ARR ty t would lead to infinite value


### PR DESCRIPTION
1. The erasure check, previously updated so that arguments are decorated, now relies only on those decorations. This makes it more accurate.

2. The behavior of `apply` now matches the Idris internals, and it's become much more useful when applying highly dependent things.