### PR TITLE
Fix implicit arg / function highlights

### DIFF
--- a/src/Idris/AbsSyntax.hs
+++ b/src/Idris/AbsSyntax.hs
@@ -1058,13 +1058,13 @@ expandParamsD rhsonly ist dec ps ns (PTy doc argdocs syn fc o n nfc ty)
               PTy doc argdocs syn fc o (dec n) nfc (piBindp expl_param ps (expandParams dec ps ns [] ty))
          else --trace (show (n, expandParams dec ps ns ty)) $
               PTy doc argdocs syn fc o n nfc (expandParams dec ps ns [] ty)
-expandParamsD rhsonly ist dec ps ns (PPostulate e doc syn fc o n ty)
+expandParamsD rhsonly ist dec ps ns (PPostulate e doc syn fc nfc o n ty)
     = if n `elem` ns && (not rhsonly)
          then -- trace (show (n, expandParams dec ps ns ty)) $
-              PPostulate e doc syn fc o (dec n) (piBind ps
-                            (expandParams dec ps ns [] ty))
+              PPostulate e doc syn fc nfc o (dec n)
+                         (piBind ps (expandParams dec ps ns [] ty))
          else --trace (show (n, expandParams dec ps ns ty)) $
-              PPostulate e doc syn fc o n (expandParams dec ps ns [] ty)
+              PPostulate e doc syn fc nfc o n (expandParams dec ps ns [] ty)
 expandParamsD rhsonly ist dec ps ns (PClauses fc opts n cs)
     = let n' = if n `elem` ns then dec n else n in
           PClauses fc opts n' (map expandParamsC cs)

--- a/src/Idris/AbsSyntaxTree.hs
+++ b/src/Idris/AbsSyntaxTree.hs
@@ -607,7 +607,7 @@ data PDecl' t
    = PFix     FC Fixity [String] -- ^ Fixity declaration
    | PTy      (Docstring (Either Err PTerm)) [(Name, Docstring (Either Err PTerm))] SyntaxInfo FC FnOpts Name FC t   -- ^ Type declaration (last FC is precise name location)
    | PPostulate Bool -- external def if true
-          (Docstring (Either Err PTerm)) SyntaxInfo FC FnOpts Name t -- ^ Postulate
+          (Docstring (Either Err PTerm)) SyntaxInfo FC FC FnOpts Name t -- ^ Postulate, second FC is precise name location
    | PClauses FC FnOpts Name [PClause' t]   -- ^ Pattern clause
    | PCAF     FC Name t -- ^ Top level constant
    | PData    (Docstring (Either Err PTerm)) [(Name, Docstring (Either Err PTerm))] SyntaxInfo FC DataOpts (PData' t)  -- ^ Data declaration.
@@ -655,7 +655,7 @@ data PDecl' t
    | PSyntax  FC Syntax -- ^ Syntax definition
    | PMutual  FC [PDecl' t] -- ^ Mutual block
    | PDirective Directive -- ^ Compiler directive.
-   | PProvider (Docstring (Either Err PTerm)) SyntaxInfo FC (ProvideWhat' t) Name -- ^ Type provider. The first t is the type, the second is the term
+   | PProvider (Docstring (Either Err PTerm)) SyntaxInfo FC FC (ProvideWhat' t) Name -- ^ Type provider. The first t is the type, the second is the term. The second FC is precise highlighting location.
    | PTransform FC Bool t t -- ^ Source-to-source transformation rule. If
                             -- bool is True, lhs and rhs must be convertible
  deriving Functor
@@ -750,7 +750,7 @@ type PClause = PClause' PTerm
 declared :: PDecl -> [Name]
 declared (PFix _ _ _) = []
 declared (PTy _ _ _ _ _ n fc t) = [n]
-declared (PPostulate _ _ _ _ _ n t) = [n]
+declared (PPostulate _ _ _ _ _ _ n t) = [n]
 declared (PClauses _ _ n _) = [] -- not a declaration
 declared (PCAF _ n _) = [n]
 declared (PData _ _ _ _ _ (PDatadecl n _ _ ts)) = n : map fstt ts
@@ -771,7 +771,7 @@ declared _ = []
 tldeclared :: PDecl -> [Name]
 tldeclared (PFix _ _ _) = []
 tldeclared (PTy _ _ _ _ _ n _ t) = [n]
-tldeclared (PPostulate _ _ _ _ _ n t) = [n]
+tldeclared (PPostulate _ _ _ _ _ _ n t) = [n]
 tldeclared (PClauses _ _ n _) = [] -- not a declaration
 tldeclared (PRecord _ _ _ _ n _ _ _ _ cn _ _) = n : map fst (maybeToList cn)
 tldeclared (PData _ _ _ _ _ (PDatadecl n _ _ ts)) = n : map fstt ts
@@ -786,7 +786,7 @@ tldeclared _ = []
 defined :: PDecl -> [Name]
 defined (PFix _ _ _) = []
 defined (PTy _ _ _ _ _ n _ t) = []
-defined (PPostulate _ _ _ _ _ n t) = []
+defined (PPostulate _ _ _ _ _ _ n t) = []
 defined (PClauses _ _ n _) = [n] -- not a declaration
 defined (PCAF _ n _) = [n]
 defined (PData _ _ _ _ _ (PDatadecl n _ _ ts)) = n : map fstt ts

--- a/src/Idris/DeepSeq.hs
+++ b/src/Idris/DeepSeq.hs
@@ -136,9 +136,12 @@ instance (NFData t) => NFData (PDecl' t) where
                 rnf x3 `seq`
                   rnf x4 `seq`
                     rnf x5 `seq` rnf x6 `seq` rnf x7 `seq` rnf x8 `seq` ()
-        rnf (PPostulate x1 x2 x3 x4 x5 x6 x7)
+        rnf (PPostulate x1 x2 x3 x4 x5 x6 x7 x8)
           = rnf x1 `seq`
-              rnf x2 `seq` rnf x3 `seq` rnf x4 `seq` rnf x5 `seq` rnf x6 `seq` rnf x7 `seq` ()
+              rnf x2 `seq`
+                rnf x3 `seq`
+                  rnf x4 `seq`
+                    rnf x5 `seq` rnf x6 `seq` rnf x7 `seq` rnf x8 `seq` ()
         rnf (PClauses x1 x2 x3 x4)
           = rnf x1 `seq` rnf x2 `seq` rnf x3 `seq` rnf x4 `seq` ()
         rnf (PCAF x1 x2 x3) = rnf x1 `seq` rnf x2 `seq` rnf x3 `seq` ()
@@ -185,8 +188,12 @@ instance (NFData t) => NFData (PDecl' t) where
         rnf (PSyntax x1 x2) = rnf x1 `seq` rnf x2 `seq` ()
         rnf (PMutual x1 x2) = rnf x1 `seq` rnf x2 `seq` ()
         rnf (PDirective x1) = ()
-        rnf (PProvider x1 x2 x3 x4 x5)
-          = rnf x1 `seq` rnf x2 `seq` rnf x3 `seq` rnf x4 `seq` rnf x5 `seq` ()
+        rnf (PProvider x1 x2 x3 x4 x5 x6)
+          = rnf x1 `seq`
+              rnf x2 `seq`
+                rnf x3 `seq`
+                  rnf x4 `seq`
+                    rnf x5 `seq` rnf x6 `seq` ()
         rnf (PTransform x1 x2 x3 x4)
           = rnf x1 `seq` rnf x2 `seq` rnf x3 `seq` rnf x4 `seq` ()
 

--- a/src/Idris/Elab/Class.hs
+++ b/src/Idris/Elab/Class.hs
@@ -290,7 +290,7 @@ mdec x = x
 -- | Get the docstring corresponding to a member, if one exists
 memberDocs :: PDecl -> Maybe (Name, Docstring (Either Err PTerm))
 memberDocs (PTy d _ _ _ _ n _ _) = Just (basename n, d)
-memberDocs (PPostulate _ d _ _ _ n _) = Just (basename n, d)
+memberDocs (PPostulate _ d _ _ _ _ n _) = Just (basename n, d)
 memberDocs (PData d _ _ _ _ pdata) = Just (basename $ d_name pdata, d)
 memberDocs (PRecord d _ _ _ n _ _ _ _ _ _ _ ) = Just (basename n, d)
 memberDocs (PClass d _ _ _ n _ _ _ _ _ _ _) = Just (basename n, d)

--- a/src/Idris/Elab/Clause.hs
+++ b/src/Idris/Elab/Clause.hs
@@ -483,7 +483,7 @@ propagateParams i ps t tm@(PApp _ (PRef fc n) args)
               | Placeholder <- getTm t,
                 n `elem` ps,
                 not (n `elem` allNamesIn tm)
-                    = t { getTm = PRef fc n } : addP sc ts
+                    = t { getTm = PRef NoFC n } : addP sc ts
          addP (Bind n _ sc) (t : ts) = t : addP sc ts
          addP _ ts = ts
 propagateParams i ps t (PRef fc n)

--- a/src/Idris/Elab/Provider.hs
+++ b/src/Idris/Elab/Provider.hs
@@ -52,8 +52,8 @@ import Data.List.Split (splitOn)
 import Util.Pretty(pretty, text)
 
 -- | Elaborate a type provider
-elabProvider :: Docstring (Either Err PTerm) -> ElabInfo -> SyntaxInfo -> FC -> ProvideWhat -> Name -> Idris ()
-elabProvider doc info syn fc what n
+elabProvider :: Docstring (Either Err PTerm) -> ElabInfo -> SyntaxInfo -> FC -> FC -> ProvideWhat -> Name -> Idris ()
+elabProvider doc info syn fc nfc what n
     = do i <- getIState
          -- Ensure that the experimental extension is enabled
          unless (TypeProviders `elem` idris_language_extensions i) $
@@ -98,7 +98,7 @@ elabProvider doc info syn fc what n
                   logLvl 3 $ "Elaborated provider " ++ show n ++ " as: " ++ show tm
              | ProvPostulate _ <- what ->
                do -- Add the postulate
-                  elabPostulate info syn doc fc [] n (delab i tm)
+                  elabPostulate info syn doc fc nfc [] n (delab i tm)
                   logLvl 3 $ "Elaborated provided postulate " ++ show n
              | otherwise ->
                ierror . Msg $ "Attempted to provide a postulate where a term was expected."

--- a/src/Idris/Elab/Term.hs
+++ b/src/Idris/Elab/Term.hs
@@ -1191,7 +1191,7 @@ elab ist info emode opts fn tm
              -- old ones with an _
              mkClause args (l, r)
                    = let args' = map (shadowed (allNamesIn l)) args
-                         lhs = PApp (getFC fc l) (PRef (getFC fc l) n)
+                         lhs = PApp (getFC fc l) (PRef NoFC n)
                                  (map (mkLHSarg l) args') in
                             PClause (getFC fc l) n lhs [] r []
 

--- a/src/Idris/Elab/Type.hs
+++ b/src/Idris/Elab/Type.hs
@@ -232,18 +232,19 @@ elabType' norm info syn doc argDocs fc opts n nfc ty' = {- let ty' = piBind (par
     tyIsHandler _                                           = False
 
 elabPostulate :: ElabInfo -> SyntaxInfo -> Docstring (Either Err PTerm) ->
-                 FC -> FnOpts -> Name -> PTerm -> Idris ()
-elabPostulate info syn doc fc opts n ty = do
+                 FC -> FC -> FnOpts -> Name -> PTerm -> Idris ()
+elabPostulate info syn doc fc nfc opts n ty = do
     elabType info syn doc [] fc opts n NoFC ty
     putIState . (\ist -> ist{ idris_postulates = S.insert n (idris_postulates ist) }) =<< getIState
     addIBC (IBCPostulate n)
+    sendHighlighting [(nfc, AnnName n (Just PostulateOutput) Nothing Nothing)]
 
     -- remove it from the deferred definitions list
     solveDeferred n
 
 elabExtern :: ElabInfo -> SyntaxInfo -> Docstring (Either Err PTerm) ->
-                 FC -> FnOpts -> Name -> PTerm -> Idris ()
-elabExtern info syn doc fc opts n ty = do
+                 FC -> FC -> FnOpts -> Name -> PTerm -> Idris ()
+elabExtern info syn doc fc nfc opts n ty = do
     cty <- elabType info syn doc [] fc opts n NoFC ty
     ist <- getIState
     let arity = length (getArgTys (normalise (tt_ctxt ist) [] cty))

--- a/src/Idris/ElabDecls.hs
+++ b/src/Idris/ElabDecls.hs
@@ -161,12 +161,12 @@ elabDecl' what info (PTy doc argdocs s f o n nfc ty)
     = do logLvl 1 $ "Elaborating type decl " ++ show n ++ show o
          elabType info s doc argdocs f o n nfc ty
          return ()
-elabDecl' what info (PPostulate b doc s f o n ty)
+elabDecl' what info (PPostulate b doc s f nfc o n ty)
   | what /= EDefns
     = do logLvl 1 $ "Elaborating postulate " ++ show n ++ show o
          if b 
-            then elabExtern info s doc f o n ty
-            else elabPostulate info s doc f o n ty
+            then elabExtern info s doc f nfc o n ty
+            else elabPostulate info s doc f nfc o n ty
 elabDecl' what info (PData doc argDocs s f co d)
   | what /= ETypes
     = do logLvl 1 $ "Elaborating " ++ show (d_name d)
@@ -259,10 +259,10 @@ elabDecl' _ info (PDSL n dsl)
          addIBC (IBCDSL n)
 elabDecl' what info (PDirective i)
   | what /= EDefns = directiveAction i
-elabDecl' what info (PProvider doc syn fc provWhat n)
+elabDecl' what info (PProvider doc syn fc nfc provWhat n)
   | what /= EDefns
     = do logLvl 1 $ "Elaborating type provider " ++ show n
-         elabProvider doc info syn fc provWhat n
+         elabProvider doc info syn fc nfc provWhat n
 elabDecl' what info (PTransform fc safety old new)
     = do elabTransform info fc safety old new
          return ()

--- a/src/Idris/IBC.hs
+++ b/src/Idris/IBC.hs
@@ -1232,7 +1232,7 @@ instance (Binary t) => Binary (PDecl' t) where
                 PMutual x1 x2  -> do putWord8 11
                                      put x1
                                      put x2
-                PPostulate x1 x2 x3 x4 x5 x6 x7
+                PPostulate x1 x2 x3 x4 x5 x6 x7 x8
                                    -> do putWord8 12
                                          put x1
                                          put x2
@@ -1241,17 +1241,19 @@ instance (Binary t) => Binary (PDecl' t) where
                                          put x5
                                          put x6
                                          put x7
+                                         put x8
                 PSyntax x1 x2 -> do putWord8 13
                                     put x1
                                     put x2
                 PDirective x1 -> error "Cannot serialize PDirective"
-                PProvider x1 x2 x3 x4 x5 ->
+                PProvider x1 x2 x3 x4 x5 x6 ->
                   do putWord8 15
                      put x1
                      put x2
                      put x3
                      put x4
                      put x5
+                     put x6
                 PTransform x1 x2 x3 x4 -> do putWord8 16
                                              put x1
                                              put x2
@@ -1348,7 +1350,8 @@ instance (Binary t) => Binary (PDecl' t) where
                             x5 <- get
                             x6 <- get
                             x7 <- get
-                            return (PPostulate x1 x2 x3 x4 x5 x6 x7)
+                            x8 <- get
+                            return (PPostulate x1 x2 x3 x4 x5 x6 x7 x8)
                    13 -> do x1 <- get
                             x2 <- get
                             return (PSyntax x1 x2)
@@ -1358,7 +1361,8 @@ instance (Binary t) => Binary (PDecl' t) where
                             x3 <- get
                             x4 <- get
                             x5 <- get
-                            return (PProvider x1 x2 x3 x4 x5)
+                            x6 <- get
+                            return (PProvider x1 x2 x3 x4 x5 x6)
                    16 -> do x1 <- get
                             x2 <- get
                             x3 <- get

--- a/src/Idris/Parser.hs
+++ b/src/Idris/Parser.hs
@@ -533,14 +533,14 @@ postulate syn = do (doc, ext)
                    opts <- fnOpts initOpts
                    acc <- optional accessibility
                    opts' <- fnOpts opts
-                   n_in <- fst <$> fnName
+                   (n_in, nfc) <- fnName
                    let n = expandNS syn n_in
                    lchar ':'
                    ty <- typeExpr (allowImp syn)
                    fc <- getFC
                    terminator
                    addAcc n acc
-                   return (PPostulate ext doc syn fc opts' n ty)
+                   return (PPostulate ext doc syn fc nfc opts' n ty)
                  <?> "postulate"
    where ppostDecl = do reserved "postulate"; return False
                  <|> do lchar '%'; reserved "extern"; return True
@@ -1193,18 +1193,18 @@ provider syn = do doc <- try (do (doc, _) <- docstring syn
                   provideTerm doc <|> providePostulate doc
                <?> "type provider"
   where provideTerm doc =
-          do lchar '('; n <- fst <$> fnName; lchar ':'; t <- typeExpr syn; lchar ')'
+          do lchar '('; (n, nfc) <- fnName; lchar ':'; t <- typeExpr syn; lchar ')'
              fc <- getFC
              reserved "with"
              e <- expr syn <?> "provider expression"
-             return  [PProvider doc syn fc (ProvTerm t e) n]
+             return  [PProvider doc syn fc nfc (ProvTerm t e) n]
         providePostulate doc =
           do reserved "postulate"
-             n <- fst <$> fnName
+             (n, nfc) <- fnName
              fc <- getFC
              reserved "with"
              e <- expr syn <?> "provider expression"
-             return [PProvider doc syn fc (ProvPostulate e) n]
+             return [PProvider doc syn fc nfc (ProvPostulate e) n]
 
 {- | Parses a transform
 


### PR DESCRIPTION
Before, sometimes implicit args were given the FC of their function
application. This caused them to sometimes overwrite the highlighting
information from their function when in a pattern position.

Additionally, postulate definition and case block highlighting is fixed.