### PR TITLE
Replace absurd syntax rule FCs

### DIFF
--- a/idris.cabal
+++ b/idris.cabal
@@ -641,6 +641,10 @@ Extra-source-files:
                        test/sugar005/*.idr
                        test/sugar005/expected
 
+                       test/syntax001/run
+                       test/syntax001/*.idr
+                       test/syntax001/expected
+
                        test/tactics001/run
                        test/tactics001/*.idr
                        test/tactics001/expected

--- a/src/Idris/Core/TT.hs
+++ b/src/Idris/Core/TT.hs
@@ -107,6 +107,16 @@ spanFC (FileFC f) (FileFC f') | f == f' = FileFC f
 spanFC NoFC fc = fc
 spanFC fc NoFC = fc
 
+-- | Determine whether the first argument is completely contained in the second
+fcIn :: FC -> FC -> Bool
+fcIn NoFC   _ = False
+fcIn (FileFC _) _ = False
+fcIn (FC {}) NoFC = False
+fcIn (FC {}) (FileFC _) = False
+fcIn (FC fn1 (sl1, sc1) (el1, ec1)) (FC fn2 (sl2, sc2) (el2, ec2)) =
+  fn1 == fn2 &&
+  (sl1 == sl2 && sc1 > sc2 || sl1 > sl2) &&
+  (el1 == el2 && ec1 < ec2 || el1 < el2)
 
 -- | Ignore source location equality (so deriving classes do not compare FCs)
 instance Eq FC where

--- a/src/Idris/ParseExpr.hs
+++ b/src/Idris/ParseExpr.hs
@@ -91,8 +91,13 @@ expr' syn = try (externalExpr syn)
 {- | Parses a user-defined expression -}
 externalExpr :: SyntaxInfo -> IdrisParser PTerm
 externalExpr syn = do i <- get
-                      extensions syn (syntaxRulesList $ syntax_rules i)
+                      (FC fn start _) <- getFC
+                      expr <- extensions syn (syntaxRulesList $ syntax_rules i)
+                      (FC _ _ end) <- getFC
+                      return (mapPTermFC (fixFC fn (FC fn start end)) expr)
                    <?> "user-defined expression"
+  where fixFC fn outer inner | inner `fcIn` outer = inner
+                             | otherwise          = FileFC fn
 
 {- | Parses a simple user-defined expression -}
 simpleExternalExpr :: SyntaxInfo -> IdrisParser PTerm

--- a/src/Idris/ParseExpr.hs
+++ b/src/Idris/ParseExpr.hs
@@ -94,10 +94,15 @@ externalExpr syn = do i <- get
                       (FC fn start _) <- getFC
                       expr <- extensions syn (syntaxRulesList $ syntax_rules i)
                       (FC _ _ end) <- getFC
-                      return (mapPTermFC (fixFC fn (FC fn start end)) expr)
+                      let outerFC = FC fn start end
+                      return (mapPTermFC (fixFC outerFC) (fixFCH fn outerFC) expr)
                    <?> "user-defined expression"
-  where fixFC fn outer inner | inner `fcIn` outer = inner
-                             | otherwise          = FileFC fn
+  where -- Fix non-highlighting FCs by approximating with the span of the syntax application
+        fixFC outer inner | inner `fcIn` outer = inner
+                          | otherwise          = outer
+        -- Fix highlighting FCs by making them useless, to avoid spurious highlights
+        fixFCH fn outer inner | inner `fcIn` outer = inner
+                              | otherwise          = FileFC fn
 
 {- | Parses a simple user-defined expression -}
 simpleExternalExpr :: SyntaxInfo -> IdrisParser PTerm

--- a/test/proof002/expected
+++ b/test/proof002/expected
@@ -1,4 +1,4 @@
-Reflect.idr:208:38:
+test030a.idr:12:26-14:1:
 When checking right hand side of testReflect1:
 When checking an application of function Reflect.getJust:
         Type mismatch between

--- a/test/syntax001/Syntax.idr
+++ b/test/syntax001/Syntax.idr
@@ -1,4 +1,4 @@
- module Syntax
+module Syntax
 
 syntax "fnord" [y] = y + y + y
 

--- a/test/syntax001/Syntax.idr
+++ b/test/syntax001/Syntax.idr
@@ -1,0 +1,8 @@
+ module Syntax
+
+syntax "fnord" [y] = y + y + y
+
+foo : Nat
+foo = fnord "argh"
+
+

--- a/test/syntax001/SyntaxOk.idr
+++ b/test/syntax001/SyntaxOk.idr
@@ -1,0 +1,8 @@
+module SyntaxOk
+
+syntax "fnord" [y] = y + y + y
+
+foo : Nat
+foo = fnord "argh"
+
+

--- a/test/syntax001/SyntaxOk.idr
+++ b/test/syntax001/SyntaxOk.idr
@@ -2,7 +2,5 @@ module SyntaxOk
 
 syntax "fnord" [y] = y + y + y
 
-foo : Nat
-foo = fnord "argh"
 
 

--- a/test/syntax001/SyntaxTest.idr
+++ b/test/syntax001/SyntaxTest.idr
@@ -1,0 +1,5 @@
+module SyntaxTest
+import SyntaxOk
+
+foo : Nat
+foo = fnord "argh"

--- a/test/syntax001/expected
+++ b/test/syntax001/expected
@@ -1,10 +1,10 @@
-When checking right hand side of foo:
+Syntax.idr:6:7-9:1:When checking right hand side of foo:
 When checking an application of function Prelude.Classes.+:
         Type mismatch between
                 String (Type of "argh")
         and
                 Nat (Expected type)
-When checking right hand side of foo:
+SyntaxTest.idr:5:7-6:1:When checking right hand side of foo:
 When checking an application of function Prelude.Classes.+:
         Type mismatch between
                 String (Type of "argh")

--- a/test/syntax001/expected
+++ b/test/syntax001/expected
@@ -1,0 +1,12 @@
+When checking right hand side of foo:
+When checking an application of function Prelude.Classes.+:
+        Type mismatch between
+                String (Type of "argh")
+        and
+                Nat (Expected type)
+When checking right hand side of foo:
+When checking an application of function Prelude.Classes.+:
+        Type mismatch between
+                String (Type of "argh")
+        and
+                Nat (Expected type)

--- a/test/syntax001/run
+++ b/test/syntax001/run
@@ -1,0 +1,4 @@
+#!/usr/bin/env bash
+idris $@ Syntax.idr --nocolour --consolewidth 80 --check
+idris $@ SyntaxTest.idr --nocolour --consolewidth 80 --check
+rm -f *.ibc


### PR DESCRIPTION
Previously, FCs coming from syntax rules would keep the FCs of their
definition context. Now, after expanding a syntax rule, the FCs that
aren't contained in the region in which the syntax was expanded are
replaced by a reference to the present file.

This does not give a precise source location - that runs the risk of
generating false highlighting information - but this solution at least
places the error in the right file, and the "While elaborating ..." bit
can be used to find the error. We should probably get better at
separating the highlighting-relevant FCs from the
highlighting-irrelevant FCs in the future.