### PR TITLE
Trim trailing whitespace in parseCmd

### DIFF
--- a/src/Idris/REPLParser.hs
+++ b/src/Idris/REPLParser.hs
@@ -26,11 +26,8 @@ import qualified Data.ByteString.UTF8 as UTF8
 
 parseCmd :: IState -> String -> String -> Result (Either String Command)
 parseCmd i inputname = P.runparser pCmd i inputname . trim
-    where trim = fst . foldr f ("", True) . dropWhile isSpace
-              where f e (xs, False) = (e : xs, False)
-                    f e (xs, True)
-                      | isSpace e = (xs, True)
-                      | otherwise = (e : xs, False)
+    where trim = f . f
+              where f = reverse . dropWhile isSpace
 
 type CommandTable = [ ( [String], CmdArg, String
                     , String -> P.IdrisParser (Either String Command) ) ]

--- a/src/Idris/REPLParser.hs
+++ b/src/Idris/REPLParser.hs
@@ -25,7 +25,12 @@ import Data.Char(isSpace, toLower)
 import qualified Data.ByteString.UTF8 as UTF8
 
 parseCmd :: IState -> String -> String -> Result (Either String Command)
-parseCmd i inputname = P.runparser pCmd i inputname . dropWhile isSpace
+parseCmd i inputname = P.runparser pCmd i inputname . trim
+    where trim = fst . foldr f ("", True) . dropWhile isSpace
+              where f e (xs, False) = (e : xs, False)
+                    f e (xs, True)
+                      | isSpace e = (xs, True)
+                      | otherwise = (e : xs, False)
 
 type CommandTable = [ ( [String], CmdArg, String
                     , String -> P.IdrisParser (Either String Command) ) ]


### PR DESCRIPTION
When auto-completing a filename to `:load` from the REPL, the trailing
space added by the auto-completion will be ignored for actually loading
the file, but a subsequent invocation of `:edit` will use the path
including the space, leading to the creation of a new file
"\<module\>.idr .idr".

This problem is easily fixed by trimming not just leading, but also
trailing whitespace in `parseCmd`.