### PR TITLE
Better support for links in doc output, and docstrings for FFI

### DIFF
--- a/docs/reference/ide-protocol.rst
+++ b/docs/reference/ide-protocol.rst
@@ -174,6 +174,9 @@ The following keys are available:
   ``text-formatting``
     provides an attribute of formatted text. This is for use with natural-language text, not code, and is presently emitted only from inline documentation. The potential values are ``bold``, ``italic``, and ``underline``.
 
+  ``link-href``
+    provides a URL that the corresponding text is a link to. 
+
   ``tt-term``
     A serialized representation of the Idris core term corresponding to the region of text.
 

--- a/src/Idris/AbsSyntaxTree.hs
+++ b/src/Idris/AbsSyntaxTree.hs
@@ -1494,6 +1494,8 @@ consoleDecorate ist (AnnTerm _ _) = id
 consoleDecorate ist (AnnSearchResult _) = id
 consoleDecorate ist (AnnErr _) = id
 consoleDecorate ist (AnnNamespace _ _) = id
+consoleDecorate ist (AnnLink url) =
+   \txt -> Idris.Colours.colourise (IdrisColour Nothing True True False False) txt ++ " (" ++ url ++ ")"
 
 isPostulateName :: Name -> IState -> Bool
 isPostulateName n ist = S.member n (idris_postulates ist)

--- a/src/Idris/Core/TT.hs
+++ b/src/Idris/Core/TT.hs
@@ -175,6 +175,7 @@ data OutputAnnotation = AnnName Name (Maybe NameOutput) (Maybe String) (Maybe St
                       | AnnKeyword
                       | AnnFC FC
                       | AnnTextFmt TextFormatting
+                      | AnnLink String -- ^ A link to this URL
                       | AnnTerm [(Name, Bool)] (TT Name) -- ^ pprint bound vars, original term
                       | AnnSearchResult Ordering -- ^ more general, isomorphic, or more specific
                       | AnnErr Err

--- a/src/Idris/Docstrings.hs
+++ b/src/Idris/Docstrings.hs
@@ -190,8 +190,7 @@ renderInline pp LineBreak = line
 renderInline pp (Emph txt) = annotate (AnnTextFmt ItalicText) $ renderInlines pp txt
 renderInline pp (Strong txt) = annotate (AnnTextFmt BoldText) $ renderInlines pp txt
 renderInline pp (Code txt tm) = pp tm $ T.unpack txt
-renderInline pp (Link body url title) = annotate (AnnTextFmt UnderlineText) (renderInlines pp body) <+>
-                                        parens (text $ T.unpack url)
+renderInline pp (Link body url title) = annotate (AnnLink (T.unpack url)) (renderInlines pp body)
 renderInline pp (Image body url title) = text "<image>" -- TODO
 renderInline pp (Entity a) = text $ "<entity " ++ T.unpack a ++ ">" -- TODO
 renderInline pp (RawHtml txt) = text "<html content>" --TODO

--- a/src/Idris/IdeMode.hs
+++ b/src/Idris/IdeMode.hs
@@ -148,6 +148,7 @@ instance SExpable OutputAnnotation where
                        BoldText      -> "bold"
                        ItalicText    -> "italic"
                        UnderlineText -> "underline"
+  toSExp (AnnLink url) = toSExp [(SymbolAtom "link-href", StringAtom url)]
   toSExp (AnnTerm bnd tm)
     | termSmallerThan 1000 tm = toSExp [(SymbolAtom "tt-term", StringAtom (encodeTerm bnd tm))]
     | otherwise = SexpList []

--- a/src/Idris/Output.hs
+++ b/src/Idris/Output.hs
@@ -256,6 +256,8 @@ renderExternal fmt width doc
     decorate HTMLOutput (AnnSearchResult _) = id
     decorate HTMLOutput (AnnErr _) = id
     decorate HTMLOutput (AnnNamespace _ _) = id
+    decorate HTMLOutput (AnnLink url) =
+      \txt -> "<a href=\"" ++ url ++ "\">" ++ txt ++ "</a>"
 
     decorate LaTeXOutput (AnnName _ (Just TypeOutput) _ _) =
       latex "IdrisType"
@@ -284,6 +286,7 @@ renderExternal fmt width doc
     decorate LaTeXOutput (AnnSearchResult _) = id
     decorate LaTeXOutput (AnnErr _) = id
     decorate LaTeXOutput (AnnNamespace _ _) = id
+    decorate LaTeXOutput (AnnLink url) = (++ "(\\url{" ++ url ++ "})")
 
     tag cls docs str = "<span class=\""++cls++"\""++title++">" ++ str ++ "</span>"
       where title = maybe "" (\d->" title=\"" ++ d ++ "\"") docs


### PR DESCRIPTION
When adding doc comments to the FFI to fix #2381 I realized that links to the online docs were completely hideous in `idris-mode`. So this changeset also fixes that, introducing a new semantic annotation for links.