### PR TITLE
Dump highlighting info

### DIFF
--- a/CHANGELOG
+++ b/CHANGELOG
@@ -14,6 +14,10 @@ New in 0.9.19:
   compiler output
 * An interactive shell, similar to the prover, for running reflected elaborator
   actions. Access it with :elab from the REPL.
+* New command-line option --highlight that causes Idris to save highlighting
+  information when successfully type checking. The information is in the same
+  format sent by the IDE mode, and is saved in a file with the extension ".idh".
+
 
 New in 0.9.18:
 --------------

--- a/src/Idris/AbsSyntax.hs
+++ b/src/Idris/AbsSyntax.hs
@@ -694,6 +694,11 @@ getCmdLine :: Idris [Opt]
 getCmdLine = do i <- getIState
                 return (opt_cmdline (idris_options i))
 
+getDumpHighlighting :: Idris Bool
+getDumpHighlighting = do ist <- getIState
+                         return (findC (opt_cmdline (idris_options ist)))
+  where findC = elem DumpHighlights
+
 getDumpDefun :: Idris (Maybe FilePath)
 getDumpDefun = do i <- getIState
                   return $ findC (opt_cmdline (idris_options i))

--- a/src/Idris/AbsSyntaxTree.hs
+++ b/src/Idris/AbsSyntaxTree.hs
@@ -241,7 +241,8 @@ data IState = IState {
     elab_stack :: [(Name, Bool)], -- ^ Stack of names currently being elaborated, Bool set if it's an instance
                                   -- (instances appear twice; also as a funtion name)
     idris_symbols :: M.Map Name Name, -- ^ Symbol table (preserves sharing of names)
-    idris_exports :: [Name] -- ^ Functions with ExportList
+    idris_exports :: [Name], -- ^ Functions with ExportList
+    idris_highlightedRegions :: [(FC, OutputAnnotation)] -- ^ Highlighting information to output
    }
 
 -- Required for parsers library, and therefore trifecta
@@ -329,7 +330,7 @@ idrisInit = IState initContext S.empty []
                    [] [] [] defaultOpts 6 [] [] [] [] emptySyntaxRules [] [] [] [] [] [] []
                    [] [] Nothing [] Nothing [] [] Nothing Nothing [] Hidden False [] Nothing [] []
                    (RawOutput stdout) True defaultTheme [] (0, emptyContext) emptyContext M.empty
-                   AutomaticWidth S.empty S.empty [] Nothing Nothing [] [] M.empty []
+                   AutomaticWidth S.empty S.empty [] Nothing Nothing [] [] M.empty [] []
 
 -- | The monad for the main REPL - reading and processing files and updating
 -- global state (hence the IO inner monad).
@@ -484,6 +485,7 @@ data Opt = Filename String
          | AutoWidth -- ^ Automatically adjust terminal width
          | AutoSolve -- ^ Automatically issue "solve" tactic in interactive prover
          | UseConsoleWidth ConsoleWidth
+         | DumpHighlights
     deriving (Show, Eq)
 
 data ElabShellCmd = EQED | EAbandon | EUndo | EProofState | EProofTerm

--- a/src/Idris/CmdOptions.hs
+++ b/src/Idris/CmdOptions.hs
@@ -141,7 +141,7 @@ parseFlags = many $
   <|> flag' (ColourREPL False) (long "nocolour" <> long "nocolor" <> help "Disable coloured output")
 
   <|> (UseConsoleWidth <$> option (str >>= parseConsoleWidth) (long "consolewidth" <> metavar "WIDTH" <> help "Select console width: auto, infinite, nat"))
-
+  <|> flag' DumpHighlights (long "highlight" <> help "Emit source code highlighting")
 
   where
     getExt s = case maybeRead s of

--- a/src/Idris/IdeMode.hs
+++ b/src/Idris/IdeMode.hs
@@ -2,7 +2,7 @@
 
 {-# LANGUAGE FlexibleInstances, IncoherentInstances, PatternGuards #-}
 
-module Idris.IdeMode(parseMessage, convSExp, WhatDocs(..), IdeModeCommand(..), sexpToCommand, toSExp, SExp(..), SExpable, Opt(..), ideModeEpoch, getLen, getNChar) where
+module Idris.IdeMode(parseMessage, convSExp, WhatDocs(..), IdeModeCommand(..), sexpToCommand, toSExp, SExp(..), SExpable, Opt(..), ideModeEpoch, getLen, getNChar, sExpToString) where
 
 import Text.Printf
 import Numeric

--- a/src/Idris/Parser.hs
+++ b/src/Idris/Parser.hs
@@ -1535,11 +1535,16 @@ loadSource lidr f toline
                     Just docs -> addModDoc syntax mname docs
 
 
-                  -- Finally, write an ibc if checking was successful
+                  -- Finally, write an ibc and highlights if checking was successful
                   ok <- noErrors
                   when ok $
-                    idrisCatch (do writeIBC f ibc; clearIBC)
-                               (\c -> return ()) -- failure is harmless
+                    do idrisCatch (do writeIBC f ibc; clearIBC)
+                                  (\c -> return ()) -- failure is harmless
+                       hl <- getDumpHighlighting
+                       when hl $
+                         idrisCatch (writeHighlights f)
+                                    (const $ return ()) -- failure is harmless
+                  clearHighlights
                   i <- getIState
                   putIState (i { default_total = def_total,
                                  hide_list = [] })

--- a/src/Idris/REPL.hs
+++ b/src/Idris/REPL.hs
@@ -1615,7 +1615,7 @@ idrisMain opts =
        when (DefaultTotal `elem` opts) $ do i <- getIState
                                             putIState (i { default_total = True })
        setColourise $ not quiet && last ((not isWindows) : opt getColour opts)
-
+       
 
 
        mapM_ addLangExt (opt getLanguageExt opts)


### PR DESCRIPTION
Now, the highlighting info that's sent to IDE clients is saved next to
files that are type checked if the user provides the --highlight
command-line option.

RE #2393, this provides enough information to write an Idris -> HTML or Idris -> LaTeX converter, either in Idris itself or in some other language.