### PR TITLE
Bracket new directory operations in messages

### DIFF
--- a/test/totality007/expected
+++ b/test/totality007/expected
@@ -1,3 +1,5 @@
+Entering directory `./src'
 Totality.idr:4:1:
 Totality.foo is not total as there are missing cases
 Totality.idr:4:1:Could not build: Totality.foo is not total as there are missing cases
+Leaving directory `./src'


### PR DESCRIPTION
When changing directories while building an .ipkg file, track the
current directory with "Entering" and "Leaving" messages. This does the
same thing as recursive Makefile instantiations, and allows tools that
rely on that format to be able to parse Idris's output.