### PR TITLE
Use HashMap in Ctxt

### DIFF
--- a/idris.cabal
+++ b/idris.cabal
@@ -890,6 +890,7 @@ Library
                 , filepath < 1.5
                 , fingertree >= 0.1 && < 0.2
                 , haskeline >= 0.7 && < 0.8
+                , hashable >= 1.2.0.0
                 , lens >= 4.1.1 && < 4.12
                 , mtl >= 2.1 && < 2.3
                 , network < 2.7

--- a/src/Idris/AbsSyntax.hs
+++ b/src/Idris/AbsSyntax.hs
@@ -27,6 +27,7 @@ import Data.Char
 import qualified Data.Text as T
 import Data.Either
 import qualified Data.Map as M
+import qualified Data.HashMap.Strict as H
 import Data.Maybe
 import qualified Data.Set as S
 import Data.Word (Word)
@@ -1391,7 +1392,7 @@ implicit' :: ElabInfo -> SyntaxInfo -> [Name] -> Name -> PTerm -> Idris PTerm
 implicit' info syn ignore n ptm
     = do i <- getIState
          let (tm', impdata) = implicitise syn ignore i ptm
-         defaultArgCheck (eInfoNames info ++ M.keys (idris_implicits i)) impdata
+         defaultArgCheck (eInfoNames info ++ H.keys (idris_implicits i)) impdata
 --          let (tm'', spos) = findStatics i tm'
          putIState $ i { idris_implicits = addDef n impdata (idris_implicits i) }
          addIBC (IBCImp n)

--- a/src/Idris/AbsSyntaxTree.hs
+++ b/src/Idris/AbsSyntaxTree.hs
@@ -32,6 +32,7 @@ import Data.Generics.Uniplate.Data (universe)
 import Data.List hiding (group)
 import Data.Char
 import qualified Data.Map.Strict as M
+import qualified Data.HashMap.Strict as H
 import qualified Data.Text as T
 import Data.Either
 import qualified Data.Set as S
@@ -66,7 +67,7 @@ toplevel :: ElabInfo
 toplevel = EInfo [] emptyContext id Nothing Nothing (\_ _ _ -> fail "Not implemented")
 
 eInfoNames :: ElabInfo -> [Name]
-eInfoNames info = map fst (params info) ++ M.keys (inblock info)
+eInfoNames info = map fst (params info) ++ H.keys (inblock info)
 
 data IOption = IOption { opt_logLevel     :: Int,
                          opt_typecase     :: Bool,

--- a/test/basic009/expected
+++ b/test/basic009/expected
@@ -1,4 +1,4 @@
 MAIN-PASS
 Faulty.idr:6:7:When checking type of Faulty.fault:
-Can't disambiguate name: A.num, B.C.num
+Can't disambiguate name: B.C.num, A.num
 Multiple.idr:3:1:import alias not unique: "X"

--- a/test/quasiquote006/expected
+++ b/test/quasiquote006/expected
@@ -8,6 +8,6 @@ No such variable alsdkjflkj
 quasiquote006.idr:15:3:
 When checking right hand side of d:
 Can't disambiguate name: ForeignEnv.::, 
-                         Prelude.List.::, 
-                         Prelude.Stream.::
+                         Prelude.Stream.::, 
+                         Prelude.List.::
 quasiquote006.idr:17:3:Main.d already defined


### PR DESCRIPTION
The ambition is to improve the performance, problem is that the
lookup actually doesn't use the second map, so do that in the exact
case.