### PR TITLE
Bump some upper bounds on deps to build w/ stackage-nightly

### DIFF
--- a/idris.cabal
+++ b/idris.cabal
@@ -880,8 +880,8 @@ Library
                 , ansi-wl-pprint < 0.7
                 , base64-bytestring < 1.1
                 , binary >= 0.7 && < 0.8
-                , blaze-html >= 0.6.1.3 && < 0.8
-                , blaze-markup >= 0.5.2.1 && < 0.6.3.0
+                , blaze-html >= 0.6.1.3 && < 0.9
+                , blaze-markup >= 0.5.2.1 && < 0.8
                 , bytestring < 0.11
                 , cheapskate < 0.2
                 , containers >= 0.5 && < 0.6
@@ -905,10 +905,9 @@ Library
                 , trifecta >= 1.1 && < 1.6
                 , uniplate >=1.6 && < 1.7
                 , unordered-containers < 0.3
-                , utf8-string < 0.4
+                , utf8-string <= 1
                 , vector < 0.11
                 , vector-binary-instances < 0.3
-                , xml < 1.4
                 , zip-archive > 0.2.3.5 && < 0.2.4
                 , zlib < 0.6
                 , safe


### PR DESCRIPTION
I assume this should also build with previous versions of stackage,
given these constraints.
Also, xml was only used by the Java backend to make pom.xml files.

I think this should address #2135, #2235 (for the time being?), #2416

I've only tested it with a fresh GHC 7.10.1 install whose provided are:
```
/usr/lib/ghc-7.10.1/package.conf.d
   Cabal-1.22.2.0
   array-0.5.1.0
   base-4.8.0.0
   bin-package-db-0.0.0.0
   binary-0.7.3.0
   bytestring-0.10.6.0
   containers-0.5.6.2
   deepseq-1.4.1.1
   directory-1.2.2.0
   filepath-1.4.0.0
   ghc-7.10.1
   ghc-prim-0.4.0.0
   haskeline-0.7.2.1
   hoopl-3.10.0.2
   hpc-0.6.0.2
   integer-gmp-1.0.0.0
   pretty-1.1.2.0
   process-1.2.3.0
   rts-1.0
   template-haskell-2.10.0.0
   terminfo-0.4.0.1
   time-1.5.0.1
   transformers-0.4.2.0
   unix-2.7.1.0
   xhtml-3000.2.1
```
and a cabal.config from https://www.stackage.org/nightly-2015-07-07/cabal.config?download=true
