### PR TITLE
Fix quasiquotes of Raw bindings

### DIFF
--- a/idris.cabal
+++ b/idris.cabal
@@ -317,6 +317,9 @@ Extra-source-files:
                        test/reg065/run
                        test/reg065/*.idr
                        test/reg065/expected
+                       test/reg066/run
+                       test/reg066/*.idr
+                       test/reg066/expected
 
                        test/basic001/run
                        test/basic001/*.idr

--- a/test/reg066/reg066.idr
+++ b/test/reg066/reg066.idr
@@ -1,0 +1,7 @@
+foo : Reflection.Raw -> Bool
+foo `(~_ -> ~_) = True
+foo _ = False
+
+foo' : TT -> Bool
+foo' `(~_ -> ~_) = True
+foo' _ = False

--- a/test/reg066/run
+++ b/test/reg066/run
@@ -1,0 +1,3 @@
+#!/usr/bin/env bash
+idris $@ reg066.idr --check --nocolor
+rm -f *.ibc


### PR DESCRIPTION
Some old hard-codings of TT survived when they shouldn't have. This makes the system more polymorphic, instantiating with the correct arguments.

Fixes #2425.