### PR TITLE
Parser highlights

### DIFF
--- a/docs/reference/ide-protocol.rst
+++ b/docs/reference/ide-protocol.rst
@@ -177,6 +177,12 @@ The following keys are available:
   ``link-href``
     provides a URL that the corresponding text is a link to. 
 
+  ``quasiquotation``
+    states that the region is quasiquoted.
+
+  ``antiquotation``
+    states that the region is antiquoted.
+
   ``tt-term``
     A serialized representation of the Idris core term corresponding to the region of text.
 

--- a/src/Idris/AbsSyntaxTree.hs
+++ b/src/Idris/AbsSyntaxTree.hs
@@ -242,7 +242,8 @@ data IState = IState {
                                   -- (instances appear twice; also as a funtion name)
     idris_symbols :: M.Map Name Name, -- ^ Symbol table (preserves sharing of names)
     idris_exports :: [Name], -- ^ Functions with ExportList
-    idris_highlightedRegions :: [(FC, OutputAnnotation)] -- ^ Highlighting information to output
+    idris_highlightedRegions :: [(FC, OutputAnnotation)], -- ^ Highlighting information to output
+    idris_parserHighlights :: [(FC, OutputAnnotation)] -- ^ Highlighting information from the parser
    }
 
 -- Required for parsers library, and therefore trifecta
@@ -330,7 +331,7 @@ idrisInit = IState initContext S.empty []
                    [] [] [] defaultOpts 6 [] [] [] [] emptySyntaxRules [] [] [] [] [] [] []
                    [] [] Nothing [] Nothing [] [] Nothing Nothing [] Hidden False [] Nothing [] []
                    (RawOutput stdout) True defaultTheme [] (0, emptyContext) emptyContext M.empty
-                   AutomaticWidth S.empty S.empty [] Nothing Nothing [] [] M.empty [] []
+                   AutomaticWidth S.empty S.empty [] Nothing Nothing [] [] M.empty [] [] []
 
 -- | The monad for the main REPL - reading and processing files and updating
 -- global state (hence the IO inner monad).

--- a/src/Idris/Core/TT.hs
+++ b/src/Idris/Core/TT.hs
@@ -186,6 +186,8 @@ data OutputAnnotation = AnnName Name (Maybe NameOutput) (Maybe String) (Maybe St
                         -- resolved. If a file path is present, then
                         -- the namespace represents a module imported
                         -- from that file.
+                      | AnnQuasiquote
+                      | AnnAntiquote
   deriving (Show, Eq)
 
 -- | Used for error reflection

--- a/src/Idris/Core/TT.hs
+++ b/src/Idris/Core/TT.hs
@@ -159,10 +159,10 @@ instance Show FC where
     show (FileFC f) = f
 
 -- | Output annotation for pretty-printed name - decides colour
-data NameOutput = TypeOutput | FunOutput | DataOutput | MetavarOutput | PostulateOutput deriving Show
+data NameOutput = TypeOutput | FunOutput | DataOutput | MetavarOutput | PostulateOutput deriving (Show, Eq)
 
 -- | Text formatting output
-data TextFormatting = BoldText | ItalicText | UnderlineText deriving Show
+data TextFormatting = BoldText | ItalicText | UnderlineText deriving (Show, Eq)
 
 -- | Output annotations for pretty-printing
 data OutputAnnotation = AnnName Name (Maybe NameOutput) (Maybe String) (Maybe String)
@@ -186,7 +186,7 @@ data OutputAnnotation = AnnName Name (Maybe NameOutput) (Maybe String) (Maybe St
                         -- resolved. If a file path is present, then
                         -- the namespace represents a module imported
                         -- from that file.
-  deriving Show
+  deriving (Show, Eq)
 
 -- | Used for error reflection
 data ErrorReportPart = TextPart String

--- a/src/Idris/IdeMode.hs
+++ b/src/Idris/IdeMode.hs
@@ -163,6 +163,8 @@ instance SExpable OutputAnnotation where
     toSExp $ [(SymbolAtom "namespace", StringAtom (intercalate "." (map T.unpack ns)))] ++
              [(SymbolAtom "decor", SymbolAtom $ if isJust file then "module" else "namespace")] ++
              maybeProps [("source-file", file)]
+  toSExp AnnQuasiquote = toSExp [(SymbolAtom "quasiquotation", True)]
+  toSExp AnnAntiquote = toSExp [(SymbolAtom "antiquotation", True)]
 
 encodeTerm :: [(Name, Bool)] -> Term -> String
 encodeTerm bnd tm = UTF8.toString . Base64.encode . Lazy.toStrict . Binary.encode $

--- a/src/Idris/Output.hs
+++ b/src/Idris/Output.hs
@@ -199,9 +199,11 @@ prettyDocumentedIst ist (name, ty, docs) =
 sendParserHighlighting :: Idris ()
 sendParserHighlighting =
   do ist <- getIState
-     let hs = nub $ idris_parserHighlights ist
+     let hs = map unwrap . nub . map wrap $ idris_parserHighlights ist
      sendHighlighting hs
      putIState ist {idris_parserHighlights = []}
+  where wrap (fc, a) = (FC' fc, a)
+        unwrap (fc', a) = (unwrapFC fc', a)
 
 sendHighlighting :: [(FC, OutputAnnotation)] -> Idris ()
 sendHighlighting highlights =

--- a/src/Idris/Output.hs
+++ b/src/Idris/Output.hs
@@ -196,6 +196,13 @@ prettyDocumentedIst ist (name, ty, docs) =
   where ppTm = pprintDelab ist
         norm = normaliseAll (tt_ctxt ist) []
 
+sendParserHighlighting :: Idris ()
+sendParserHighlighting =
+  do ist <- getIState
+     let hs = nub $ idris_parserHighlights ist
+     sendHighlighting hs
+     putIState ist {idris_parserHighlights = []}
+
 sendHighlighting :: [(FC, OutputAnnotation)] -> Idris ()
 sendHighlighting highlights =
   do ist <- getIState

--- a/src/Idris/Output.hs
+++ b/src/Idris/Output.hs
@@ -285,6 +285,8 @@ renderExternal fmt width doc
     decorate HTMLOutput (AnnNamespace _ _) = id
     decorate HTMLOutput (AnnLink url) =
       \txt -> "<a href=\"" ++ url ++ "\">" ++ txt ++ "</a>"
+    decorate HTMLOutput AnnQuasiquote = id
+    decorate HTMLOutput AnnAntiquote = id
 
     decorate LaTeXOutput (AnnName _ (Just TypeOutput) _ _) =
       latex "IdrisType"
@@ -314,6 +316,8 @@ renderExternal fmt width doc
     decorate LaTeXOutput (AnnErr _) = id
     decorate LaTeXOutput (AnnNamespace _ _) = id
     decorate LaTeXOutput (AnnLink url) = (++ "(\\url{" ++ url ++ "})")
+    decorate LaTeXOutput AnnQuasiquote = id
+    decorate LaTeXOutput AnnAntiquote = id
 
     tag cls docs str = "<span class=\""++cls++"\""++title++">" ++ str ++ "</span>"
       where title = maybe "" (\d->" title=\"" ++ d ++ "\"") docs

--- a/src/Idris/ParseExpr.hs
+++ b/src/Idris/ParseExpr.hs
@@ -147,14 +147,17 @@ extension syn ns rules =
     ruleGroup _ _ = False
 
     extensionSymbol :: SSymbol -> IdrisParser (Maybe (Name, SynMatch))
-    extensionSymbol (Keyword n)    = do reserved (show n); return Nothing
+    extensionSymbol (Keyword n)    = do fc <- reservedFC (show n)
+                                        highlightP fc AnnKeyword
+                                        return Nothing
     extensionSymbol (Expr n)       = do tm <- expr syn
                                         return $ Just (n, SynTm tm)
     extensionSymbol (SimpleExpr n) = do tm <- simpleExpr syn
                                         return $ Just (n, SynTm tm)
     extensionSymbol (Binding n)    = do b <- fst <$> name
                                         return $ Just (n, SynBind b)
-    extensionSymbol (Symbol s)     = do symbol s
+    extensionSymbol (Symbol s)     = do fc <- symbolFC s
+                                        highlightP fc AnnKeyword
                                         return Nothing
     dropn :: Name -> [(Name, a)] -> [(Name, a)]
     dropn n [] = []

--- a/src/Idris/ParseExpr.hs
+++ b/src/Idris/ParseExpr.hs
@@ -656,7 +656,7 @@ quasiquote syn = do startFC <- symbolFC "`("
                               ty <- expr syn { inPattern = False } -- don't allow antiquotes
                               return (ty, fc)
                     endFC <- symbolFC ")"
-                    mapM_ (uncurry highlightP) [(startFC, AnnKeyword), (endFC, AnnKeyword)]
+                    mapM_ (uncurry highlightP) [(startFC, AnnKeyword), (endFC, AnnKeyword), (spanFC startFC endFC, AnnQuasiquote)]
                     case g of
                       Just (_, fc) -> highlightP fc AnnKeyword
                       _ -> return ()
@@ -672,7 +672,9 @@ unquote :: SyntaxInfo -> IdrisParser PTerm
 unquote syn = do guard (syn_in_quasiquote syn > 0)
                  startFC <- symbolFC "~"
                  e <- simpleExpr syn { syn_in_quasiquote = syn_in_quasiquote syn - 1 }
+                 endFC <- getFC
                  highlightP startFC AnnKeyword
+                 highlightP (spanFC startFC endFC) AnnAntiquote
                  return $ PUnquote e
               <?> "unquotation"
 

--- a/src/Idris/ParseHelpers.hs
+++ b/src/Idris/ParseHelpers.hs
@@ -79,6 +79,10 @@ runparser p i inputname =
   parseString (runInnerParser (evalStateT p i))
               (Directed (UTF8.fromString inputname) 0 0 0 0)
 
+highlightP :: FC -> OutputAnnotation -> IdrisParser ()
+highlightP fc annot = do ist <- get
+                         put ist { idris_parserHighlights = (fc, annot) : idris_parserHighlights ist}
+
 noDocCommentHere :: String -> IdrisParser ()
 noDocCommentHere msg =
   optional (do fc <- getFC
@@ -259,6 +263,11 @@ lchar = token . char
 -- | Parses string as a token
 symbol :: MonadicParsing m => String -> m String
 symbol = Tok.symbol
+
+symbolFC :: MonadicParsing m => String -> m FC
+symbolFC str = do (FC file (l, c) _) <- getFC
+                  Tok.symbol str
+                  return $ FC file (l, c) (l, c + length str)
 
 -- | Parses a reserved identifier
 reserved :: MonadicParsing m => String -> m ()

--- a/src/Idris/Parser.hs
+++ b/src/Idris/Parser.hs
@@ -98,7 +98,8 @@ import System.IO
 moduleHeader :: IdrisParser (Maybe (Docstring ()), [String], [(FC, OutputAnnotation)])
 moduleHeader =     try (do docs <- optional docComment
                            noArgs docs
-                           reserved "module"
+                           modFC <- reservedFC "module"
+                           highlightP modFC AnnKeyword
                            (i, ifc) <- identifier
                            option ';' (lchar ';')
                            let modName = moduleName i
@@ -1430,6 +1431,7 @@ loadSource lidr f toline
                                            sendHighlighting [(nfc, AnnNamespace ns srcFnAbs)])
                         [(re, fn, ns, nfc) | ImportInfo re fn _ ns _ nfc <- imports]
                   reportParserWarnings
+                  sendParserHighlighting
 
                   -- process and check module aliases
                   let modAliases = M.fromList
@@ -1480,6 +1482,7 @@ loadSource lidr f toline
                                                      ibc_write ist
                                        }
                     _ -> return ()
+                  sendParserHighlighting
 
                   -- Parsing done, now process declarations
 


### PR DESCRIPTION
This PR is the beginning of using Idris's parser to highlight syntax in editors. Presently, it supports syntax extensions and quasiquotations.