### PR TITLE
Add compiler highlighting for quoted names in source

### DIFF
--- a/src/Idris/DeepSeq.hs
+++ b/src/Idris/DeepSeq.hs
@@ -268,7 +268,7 @@ instance NFData PTerm where
         rnf (PNoImplicits x1) = rnf x1 `seq` ()
         rnf (PQuasiquote x1 x2) = rnf x1 `seq` rnf x2 `seq` ()
         rnf (PUnquote x1) = rnf x1 `seq` ()
-        rnf (PQuoteName x1) = rnf x1 `seq` ()
+        rnf (PQuoteName x1 x2) = rnf x1 `seq` rnf x2 `seq` ()
         rnf (PRunElab x1 x2 x3) = rnf x1 `seq` rnf x2 `seq` rnf x3 `seq` ()
 
 instance NFData PAltType where

--- a/src/Idris/Elab/Term.hs
+++ b/src/Idris/Elab/Term.hs
@@ -1106,15 +1106,18 @@ elab ist info emode opts fn tm
 
 
     elab' ina fc (PUnquote t) = fail "Found unquote outside of quasiquote"
-    elab' ina fc (PQuoteName n) =
+    elab' ina fc (PQuoteName n nfc) =
       do ctxt <- get_context
          env <- get_env
          case lookup n env of
-           Just _ -> do fill $ reflectName n ; solve
+           Just _ -> do fill $ reflectName n
+                        solve
+                        highlightSource nfc (AnnBoundName n False)
            Nothing ->
              case lookupNameDef n ctxt of
                [(n', _)] -> do fill $ reflectName n'
                                solve
+                               highlightSource nfc (AnnName n' Nothing Nothing Nothing)
                [] -> lift . tfail . NoSuchVariable $ n
                more -> lift . tfail . CantResolveAlts $ map fst more
     elab' ina fc (PAs _ n t) = lift . tfail . Msg $ "@-pattern not allowed here"

--- a/src/Idris/Error.hs
+++ b/src/Idris/Error.hs
@@ -147,7 +147,7 @@ warnDisamb ist (PNoImplicits tm) = warnDisamb ist tm
 warnDisamb ist (PQuasiquote tm goal) = warnDisamb ist tm >>
                                        Foldable.mapM_ (warnDisamb ist) goal
 warnDisamb ist (PUnquote tm) = warnDisamb ist tm
-warnDisamb ist (PQuoteName _) = return ()
+warnDisamb ist (PQuoteName _ _) = return ()
 warnDisamb ist (PAs _ _ tm) = warnDisamb ist tm
 warnDisamb ist (PAppImpl tm _) = warnDisamb ist tm
 warnDisamb ist (PRunElab _ tm _) = warnDisamb ist tm

--- a/src/Idris/IBC.hs
+++ b/src/Idris/IBC.hs
@@ -41,7 +41,7 @@ import Codec.Archive.Zip
 import Util.Zlib (decompressEither)
 
 ibcVersion :: Word16
-ibcVersion = 113
+ibcVersion = 114
 
 data IBCFile = IBCFile { ver :: Word16,
                          sourcefile :: FilePath,
@@ -1640,8 +1640,9 @@ instance Binary PTerm where
                                         put x2
                 PUnquote x1 -> do putWord8 43
                                   put x1
-                PQuoteName x1 -> do putWord8 44
-                                    put x1
+                PQuoteName x1 x2 -> do putWord8 44
+                                       put x1
+                                       put x2
                 PIfThenElse x1 x2 x3 x4 -> do putWord8 45
                                               put x1
                                               put x2
@@ -1778,7 +1779,8 @@ instance Binary PTerm where
                    43 -> do x1 <- get
                             return (PUnquote x1)
                    44 -> do x1 <- get
-                            return (PQuoteName x1)
+                            x2 <- get
+                            return (PQuoteName x1 x2)
                    45 -> do x1 <- get
                             x2 <- get
                             x3 <- get

--- a/src/Idris/ParseExpr.hs
+++ b/src/Idris/ParseExpr.hs
@@ -684,10 +684,15 @@ unquote syn = do guard (syn_in_quasiquote syn > 0)
 
 -}
 namequote :: SyntaxInfo -> IdrisParser PTerm
-namequote syn = do symbol "`{"
-                   n <- fst <$> fnName
-                   symbol "}"
-                   return $ PQuoteName n
+namequote syn = do startFC <- symbolFC "`{"
+                   (n, nfc) <- fnName
+                   endFC <- symbolFC "}"
+                   mapM_ (uncurry highlightP)
+                         [ (startFC, AnnKeyword)
+                         , (endFC, AnnKeyword)
+                         , (spanFC startFC endFC, AnnQuasiquote)
+                         ]
+                   return $ PQuoteName n nfc
                 <?> "quoted name"
 
 


### PR DESCRIPTION
Name quotations are now highlighted with the actual name, and the
surrounding brackets are highlighted as a quotation. This can make it
easier to follow reflection code.