### PR TITLE
Highlight name in dependent pair type as binder

### DIFF
--- a/src/Idris/Elab/Term.hs
+++ b/src/Idris/Elab/Term.hs
@@ -409,7 +409,7 @@ elab ist info emode opts fn tm
 --                                                  pexp l, pexp r]))
 --                                   True
 
-    elab' ina _ (PDPair fc p l@(PRef _ n) t r)
+    elab' ina _ (PDPair fc p l@(PRef nfc n) t r)
             = case t of
                 Placeholder ->
                    do hnf_compute
@@ -418,13 +418,9 @@ elab ist info emode opts fn tm
                          TType _ -> asType
                          _ -> asValue
                 _ -> asType
-         where asType = elab' ina (Just fc) (PApp fc (PRef fc sigmaTy)
+         where asType = elab' ina (Just fc) (PApp fc (PRef NoFC sigmaTy)
                                         [pexp t,
-
-                                         -- TODO: save the FC from the dependent pair
-                                         -- syntax and put it on this lambda for interactive
-                                         -- semantic highlighting support. NoFC for now.
-                                         pexp (PLam fc n NoFC Placeholder r)])
+                                         pexp (PLam fc n nfc Placeholder r)])
                asValue = elab' ina (Just fc) (PApp fc (PRef fc sigmaCon)
                                          [pimp (sMN 0 "a") t False,
                                           pimp (sMN 0 "P") Placeholder True,

--- a/src/Idris/ParseExpr.hs
+++ b/src/Idris/ParseExpr.hs
@@ -403,13 +403,13 @@ bracketed' open syn =
             do (FC f start (l, c)) <- getFC
                lchar ')'
                return $ PTrue (spanFC open (FC f start (l, c+1))) TypeOrTerm
-        <|> try (do ln <- fst <$> name; lchar ':';
+        <|> try (do (ln, lnfc) <- name; lchar ':';
                     lty <- expr syn
                     reservedOp "**"
                     fc <- getFC
                     r <- expr syn
                     lchar ')'
-                    return (PDPair fc TypeOrTerm (PRef fc ln) lty r))
+                    return (PDPair fc TypeOrTerm (PRef lnfc ln) lty r))
         <|> try (do fc <- getFC; o <- operator; e <- expr syn; lchar ')'
                     -- No prefix operators! (bit of a hack here...)
                     if (o == "-" || o == "!")


### PR DESCRIPTION
This fixes missing source code highlighting for dependent pair types.