### PR TITLE
Detect outdated IBC files in 'buildTree' function in Chaser.hs. Fixes #1163.

### DIFF
--- a/src/Idris/Chaser.hs
+++ b/src/Idris/Chaser.hs
@@ -116,29 +116,26 @@ buildTree built fp = btree [] fp
                              else return []
                    mt <- idrisCatch (runIO $ getModificationTime fn)
                                     (\c -> runIO $ getIModTime src)
-                   ok <- checkIBCUpToDate fn src
-                   return [MTree (IBC fn src) ok mt ms]
+                   -- FIXME: It's also not up to date if anything it imports has
+                   -- been modified since its own ibc has.
+                   --
+                   -- Issue #1592 on the issue tracker.
+                   --
+                   -- https://github.com/idris-lang/Idris-dev/issues/1592
+                   ibcOutdated <- fn `younger` (getSrcFile src)
+                   ibcInvalid <- not <$> hasValidIBCVersion fn
+                   return [MTree (IBC fn src) (ibcOutdated || ibcInvalid) mt ms]
 
           getSrcFile (IBC _ src) = getSrcFile src
           getSrcFile (LIDR src) = src
           getSrcFile (IDR src) = src
 
-          -- FIXME: It's also not up to date if anything it imports has
-          -- been modified since its own ibc has.
-          --
-          -- Issue #1592 on the issue tracker.
-          --
-          -- https://github.com/idris-lang/Idris-dev/issues/1592
-
-          checkIBCUpToDate fn (LIDR src) = older fn src
-          checkIBCUpToDate fn (IDR src) = older fn src
-
-          older ibc src = do exist <- runIO $ doesFileExist src
-                             if exist then do
-                                 ibct <- runIO $ getModificationTime ibc
-                                 srct <- runIO $ getModificationTime src
-                                 return (srct >= ibct)
-                               else return False
+          younger ibc src = do exist <- runIO $ doesFileExist src
+                               if exist then do
+                                   ibct <- runIO $ getModificationTime ibc
+                                   srct <- runIO $ getModificationTime src
+                                   return (srct > ibct)
+                                 else return False
 
   children :: Bool -> FilePath -> [FilePath] -> Idris [ModuleTree]
   children lit f done = -- idrisCatch

--- a/src/Idris/IBC.hs
+++ b/src/Idris/IBC.hs
@@ -2,7 +2,8 @@
 {-# OPTIONS_GHC -fwarn-incomplete-patterns #-}
 
 module Idris.IBC (loadIBC, loadPkgIndex,
-                  writeIBC, writePkgIndex) where
+                  writeIBC, writePkgIndex,
+                  hasValidIBCVersion) where
 
 import Idris.Core.Evaluate
 import Idris.Core.TT
@@ -93,6 +94,14 @@ deriving instance Binary IBCFile
 
 initIBC :: IBCFile
 initIBC = IBCFile ibcVersion "" [] [] [] [] [] [] [] [] [] [] [] [] [] [] [] [] [] [] [] [] [] [] [] [] [] [] [] [] [] [] [] [] [] [] [] [] [] [] Nothing [] [] []
+
+hasValidIBCVersion :: FilePath -> Idris Bool
+hasValidIBCVersion fp = do
+  archiveFile <- runIO $ B.readFile fp
+  case toArchiveOrFail archiveFile of
+    Left _ -> return False
+    Right archive -> do ver <- getEntry 0 "ver" archive
+                        return (ver == ibcVersion)
 
 loadIBC :: Bool -- ^ True = reexport, False = make everything private
         -> FilePath -> Idris ()


### PR DESCRIPTION
In addition to testing whether an IBC function is outdated we now also check if it is for an old version and set 'needsRecheck' to true in both cases.
    
IBC files with old versions are still found sometimes, my guess is that this happens because the dependency tracking of the IBC files is not 100% correct (in this case the respective code in 'buildTree' is not triggered). In most cases the IBC files with old versions are found and replaced.
