### PR TITLE
Detect outdated IBC files in 'buildTree' function in Chaser.hs. Fixes #1163.

### DIFF
--- a/src/Idris/IBC.hs
+++ b/src/Idris/IBC.hs
@@ -2,7 +2,8 @@
 {-# OPTIONS_GHC -fwarn-incomplete-patterns #-}
 
 module Idris.IBC (loadIBC, loadPkgIndex,
-                  writeIBC, writePkgIndex) where
+                  writeIBC, writePkgIndex,
+                  hasValidIBCVersion) where
 
 import Idris.Core.Evaluate
 import Idris.Core.TT
@@ -93,6 +94,14 @@ deriving instance Binary IBCFile
 
 initIBC :: IBCFile
 initIBC = IBCFile ibcVersion "" [] [] [] [] [] [] [] [] [] [] [] [] [] [] [] [] [] [] [] [] [] [] [] [] [] [] [] [] [] [] [] [] [] [] [] [] [] [] Nothing [] [] []
+
+hasValidIBCVersion :: FilePath -> Idris Bool
+hasValidIBCVersion fp = do
+  archiveFile <- runIO $ B.readFile fp
+  case toArchiveOrFail archiveFile of
+    Left _ -> return False
+    Right archive -> do ver <- getEntry 0 "ver" archive
+                        return (ver == ibcVersion)
 
 loadIBC :: Bool -- ^ True = reexport, False = make everything private
         -> FilePath -> Idris ()


### PR DESCRIPTION
In addition to testing whether an IBC function is outdated we now also check if it is for an old version and set 'needsRecheck' to true in both cases.

IBC files with old versions are still found sometimes, my guess is that this happens because the dependency tracking of the IBC files is not 100% correct (in this case the respective code in 'buildTree' is not triggered). In most cases the IBC files with old versions are found and replaced.
