### PR TITLE
More parser-driven highlighting

### DIFF
--- a/CHANGELOG
+++ b/CHANGELOG
@@ -17,7 +17,9 @@ New in 0.9.19:
 * New command-line option --highlight that causes Idris to save highlighting
   information when successfully type checking. The information is in the same
   format sent by the IDE mode, and is saved in a file with the extension ".idh".
-* Use predicates instead of boolean equality proofs as preconditions 
+* Highlighting information is saved by the parser as well, allowing it to highlight
+  keywords like "case", "of", "let", and "do"
+* Use predicates instead of boolean equality proofs as preconditions
   on List functions
 * More flexible 'case' construct, allowing each branch to target different
   types, provided that the case analysis does not affect the form of any

--- a/src/Idris/AbsSyntaxTree.hs
+++ b/src/Idris/AbsSyntaxTree.hs
@@ -678,8 +678,8 @@ data Directive = DLib Codegen String |
                  DDefault Bool |
                  DLogging Integer |
                  DDynamicLibs [String] |
-                 DNameHint Name [Name] |
-                 DErrorHandlers Name Name [Name] |
+                 DNameHint Name FC [(Name, FC)] |
+                 DErrorHandlers Name FC Name FC [(Name, FC)] |
                  DLanguage LanguageExt |
                  DUsed FC Name Name
 

--- a/src/Idris/Parser.hs
+++ b/src/Idris/Parser.hs
@@ -1146,14 +1146,14 @@ directive syn = do try (lchar '%' *> reserved "lib")
                     libs <- sepBy1 (fmap fst stringLiteral) (lchar ',')
                     return [PDirective (DDynamicLibs libs)]
              <|> do try (lchar '%' *> reserved "name")
-                    ty <- fst <$> fnName
-                    ns <- sepBy1 (fst <$> name) (lchar ',')
-                    return [PDirective (DNameHint ty ns)]
+                    (ty, tyFC) <- fnName
+                    ns <- sepBy1 name (lchar ',')
+                    return [PDirective (DNameHint ty tyFC ns)]
              <|> do try (lchar '%' *> reserved "error_handlers")
-                    fn <- fst <$> fnName
-                    arg <- fst <$> fnName
-                    ns <- sepBy1 (fst <$> name) (lchar ',')
-                    return [PDirective (DErrorHandlers fn arg ns) ]
+                    (fn, nfc) <- fnName
+                    (arg, afc) <- fnName
+                    ns <- sepBy1 name (lchar ',')
+                    return [PDirective (DErrorHandlers fn nfc arg afc ns) ]
              <|> do try (lchar '%' *> reserved "language"); ext <- pLangExt;
                     return [PDirective (DLanguage ext)]
              <|> do fc <- getFC


### PR DESCRIPTION
Now, expression keywords like "case", "let", and "of" are highlighted by the parser. Additionally, names embedded in directives like "%name" are highlighted post-disambiguation, to make it easier to see how they were disambiguated.