### PR TITLE
need to import `Data.Vect` and `Data.Fin` for `interp.idr` to compile

### DIFF
--- a/samples/tutorial/interp.idr
+++ b/samples/tutorial/interp.idr
@@ -1,5 +1,8 @@
 module Main
 
+import Data.Vect
+import Data.Fin
+
 data Ty = TyInt | TyBool| TyFun Ty Ty
 
 interpTy : Ty -> Type


### PR DESCRIPTION
I had to add these lines to the `interp.idr` sample in order to compile it. It would also be good to mention that these imports are needed in the relevant section of the tutorial.