### PR TITLE
Semantic highlighting of implicit fromInteger

### DIFF
--- a/src/Idris/DSL.hs
+++ b/src/Idris/DSL.hs
@@ -113,6 +113,7 @@ expandSugar dsl (PDoBlock ds)
 
 expandSugar dsl (PIdiom fc e) = expandSugar dsl $ unIdiom (dsl_apply dsl) (dsl_pure dsl) fc e
 expandSugar dsl (PRunElab fc tm ns) = PRunElab fc (expandSugar dsl tm) ns
+expandSugar dsl (PConstSugar fc tm) = PConstSugar fc (expandSugar dsl tm)
 expandSugar dsl t = t
 
 -- | Replace DSL-bound variable in a term
@@ -199,6 +200,7 @@ debind b tm = let (tm', (bs, _)) = runState (db' tm) ([], 0) in
                                      r' <- db' r
                                      return (PDPair fc hls p l' t r')
     db' (PRunElab fc t ns) = fmap (\tm -> PRunElab fc tm ns) (db' t)
+    db' (PConstSugar fc tm) = liftM (PConstSugar fc) (db' tm)
     db' t = return t
 
     dbArg a = do t' <- db' (getTm a)

--- a/src/Idris/DeepSeq.hs
+++ b/src/Idris/DeepSeq.hs
@@ -270,6 +270,7 @@ instance NFData PTerm where
         rnf (PUnquote x1) = rnf x1 `seq` ()
         rnf (PQuoteName x1 x2) = rnf x1 `seq` rnf x2 `seq` ()
         rnf (PRunElab x1 x2 x3) = rnf x1 `seq` rnf x2 `seq` rnf x3 `seq` ()
+        rnf (PConstSugar x1 x2) = rnf x1 `seq` rnf x2 `seq` ()
 
 instance NFData PAltType where
         rnf (ExactlyOne x1) = rnf x1 `seq` ()

--- a/src/Idris/Elab/Term.hs
+++ b/src/Idris/Elab/Term.hs
@@ -1226,6 +1226,42 @@ elab ist info emode opts fn tm
          env <- get_env
          runElabAction ist (maybe fc' id fc) env (P Bound n' Erased) ns
          solve
+    elab' ina fc (PConstSugar constFC tm) =
+      -- Here we elaborate the contained term, then calculate
+      -- highlighting for constFC.  The highlighting is the
+      -- highlighting for the outermost constructor of the result of
+      -- evaluating the elaborated term, if one exists (it always
+      -- should, but better to fail gracefully for something silly
+      -- like highlighting info). This is how implicit applications of
+      -- fromInteger get highlighted.
+      do saveState -- so we don't pollute the elaborated term
+         n <- getNameFrom (sMN 0 "cstI")
+         n' <- getNameFrom (sMN 0 "cstIhole")
+         g <- forget <$> goal
+         claim n' g
+         movelast n'
+         -- In order to intercept the elaborated value, we need to
+         -- let-bind it.
+         attack
+         letbind n g (Var n')
+         focus n'
+         elab' ina fc tm
+         env <- get_env
+         ctxt <- get_context
+         let v = fmap (normaliseAll ctxt env . finalise . binderVal)
+                      (lookup n env)
+         loadState -- we have the highlighting - re-elaborate the value
+         elab' ina fc tm
+         case v of
+           Just val -> highlightConst constFC val
+           Nothing -> return ()
+       where highlightConst fc (P _ n _) =
+               highlightSource fc (AnnName n Nothing Nothing Nothing)
+             highlightConst fc (App _ f _) =
+               highlightConst fc f
+             highlightConst fc (Constant c) =
+               highlightSource fc (AnnConst c)
+             highlightConst _ _ = return ()
     elab' ina fc x = fail $ "Unelaboratable syntactic form " ++ showTmImpls x
 
     -- delay elaboration of 't', with priority 'pri' until after everything

--- a/src/Idris/ElabQuasiquote.hs
+++ b/src/Idris/ElabQuasiquote.hs
@@ -168,6 +168,8 @@ extractUnquotes n (PUnquote tm)
                 extractUnquotes (n-1) tm
 extractUnquotes n (PRunElab fc tm ns)
   = fmap (\(tm', ex) -> (PRunElab fc tm' ns, ex)) $ extractUnquotes n tm
+extractUnquotes n (PConstSugar fc tm)
+  = extractUnquotes n tm
 extractUnquotes n x = return (x, []) -- no subterms!
 
 

--- a/src/Idris/Error.hs
+++ b/src/Idris/Error.hs
@@ -151,3 +151,4 @@ warnDisamb ist (PQuoteName _ _) = return ()
 warnDisamb ist (PAs _ _ tm) = warnDisamb ist tm
 warnDisamb ist (PAppImpl tm _) = warnDisamb ist tm
 warnDisamb ist (PRunElab _ tm _) = warnDisamb ist tm
+warnDisamb ist (PConstSugar _ tm) = warnDisamb ist tm

--- a/src/Idris/IBC.hs
+++ b/src/Idris/IBC.hs
@@ -1660,6 +1660,9 @@ instance Binary PTerm where
                                               put x2
                                               put x3
                                               put x4
+                PConstSugar x1 x2 -> do putWord8 46
+                                        put x1
+                                        put x2
 
         get
           = do i <- getWord8
@@ -1803,6 +1806,9 @@ instance Binary PTerm where
                             x3 <- get
                             x4 <- get
                             return (PIfThenElse x1 x2 x3 x4)
+                   46 -> do x1 <- get
+                            x2 <- get
+                            return (PConstSugar x1 x2)
                    _ -> error "Corrupted binary data for PTerm"
 
 instance Binary PAltType where

--- a/src/Idris/IdrisDoc.hs
+++ b/src/Idris/IdrisDoc.hs
@@ -321,6 +321,7 @@ extractPTermNames (PDisamb _ p)      = extract p
 extractPTermNames (PUnifyLog p)      = extract p
 extractPTermNames (PNoImplicits p)   = extract p
 extractPTermNames (PRunElab _ p _)   = extract p
+extractPTermNames (PConstSugar _ tm) = extract tm
 extractPTermNames _                  = []
 
 -- | Shorter name for extractPTermNames

--- a/src/Idris/ParseExpr.hs
+++ b/src/Idris/ParseExpr.hs
@@ -464,10 +464,12 @@ bracketedExpr syn openParenFC e =
 modifyConst :: SyntaxInfo -> FC -> PTerm -> PTerm
 modifyConst syn fc (PConstant inFC (BI x))
     | not (inPattern syn)
-        = PAlternative [] FirstSuccess
-             (PApp fc (PRef fc [] (sUN "fromInteger")) [pexp (PConstant NoFC (BI (fromInteger x)))]
-             : consts)
-    | otherwise = PAlternative [] FirstSuccess consts
+        = PConstSugar inFC $ -- wrap in original location for highlighting
+            PAlternative [] FirstSuccess
+              (PApp fc (PRef fc [] (sUN "fromInteger")) [pexp (PConstant NoFC (BI (fromInteger x)))]
+              : consts)
+    | otherwise = PConstSugar inFC $
+                    PAlternative [] FirstSuccess consts
     where
       consts = [ PConstant inFC (BI x)
                , PConstant inFC (I (fromInteger x))


### PR DESCRIPTION
Now, editors get highlighting information for integer literals according
to the following rules:

 1. If the constant elaborates to a constant (such as the fromInteger
    implementations for Integer, Int, Bits8, etc), then the constant
    itself is used for highlighting informating, as it would be in the
    pretty printer.

 2. If the constant elaborates to an inductive datatype, the outermost
    constructor is used for highlighting (e.g., the Nat 4 highlights as
    S, and the Nat 0 highlights as Z)

 3. Otherwise, no highlighting is performed.