### PR TITLE
Highlight all keywords with the parser

### DIFF
--- a/src/Idris/ParseHelpers.hs
+++ b/src/Idris/ParseHelpers.hs
@@ -286,6 +286,10 @@ reservedFC str = do (FC file (l, c) _) <- getFC
                     Tok.reserve idrisStyle str
                     return $ FC file (l, c) (l, c + length str)
 
+-- | Parse a reserved identfier, highlighting its span as a keyword
+reservedHL :: String -> IdrisParser ()
+reservedHL str = reservedFC str >>= flip highlightP AnnKeyword
+
 -- Taken from Parsec (c) Daan Leijen 1999-2001, (c) Paolo Martini 2007
 -- | Parses a reserved operator
 reservedOp :: MonadicParsing m => String -> m ()


### PR DESCRIPTION
Now, editors do not need to implement their own regexp-based highlighting, as all keywords are highlighted by Idris's parser (though they still may want to, as a fallback to when parsing and type checking is too slow). This also means that the data exported by `--highlight` can be used to fully annotate a source file, either for HTML data or for LaTeX.