### PR TITLE
Revert "Fix function wrapping bug in JavaScript RTS"

### DIFF
--- a/jsrts/Runtime-common.js
+++ b/jsrts/Runtime-common.js
@@ -68,18 +68,20 @@ var i$ffiWrap = function(fid,oldbase,myoldbase) {
     var res = fid;
 
     for(var i = 0; i < (arguments.length ? arguments.length : 1); ++i) {
-      i$valstack_top += 1;
-      i$valstack[i$valstack_top] = res;
-      i$valstack[i$valstack_top + 1] = arguments[i];
-      i$SLIDE(2);
-      i$valstack_top = i$valstack_base + 2;
-      i$CALL(_idris__123_APPLY0_125_,[oldbase])
-      while (i$callstack.length) {
-        var func = i$callstack.pop();
-        var args = i$callstack.pop();
-        func.apply(this,args);
+      while (res instanceof i$CON) {
+        i$valstack_top += 1;
+        i$valstack[i$valstack_top] = res;
+        i$valstack[i$valstack_top + 1] = arguments[i];
+        i$SLIDE(2);
+        i$valstack_top = i$valstack_base + 2;
+        i$CALL(_idris__123_APPLY0_125_,[oldbase])
+        while (i$callstack.length) {
+          var func = i$callstack.pop();
+          var args = i$callstack.pop();
+          func.apply(this,args);
+        }
+        res = i$ret;
       }
-      res = i$ret;
     }
 
     i$callstack = i$vm.callstack;


### PR DESCRIPTION
Fixes #2043, as originally reported.

This reverts commit 15590d71071a32757ea0b851d0d04f13cc2700f1.

Not ideal as the higher-order js problem remains, but it's more broken to only call the first thing on the idris call stack than to not be able to use higher order JS.  