### PR TITLE
Fix callstack use in ffiWrap.

### DIFF
--- a/jsrts/Runtime-common.js
+++ b/jsrts/Runtime-common.js
@@ -63,6 +63,7 @@ var i$CALL = function(fun,args) {
 
 var i$ffiWrap = function(fid,oldbase,myoldbase) {
   return function() {
+    var oldstack = i$callstack;
     i$callstack = [];
 
     var res = fid;
@@ -82,7 +83,7 @@ var i$ffiWrap = function(fid,oldbase,myoldbase) {
       res = i$ret;
     }
 
-    i$callstack = i$vm.callstack;
+    i$callstack = oldstack;
 
     return i$ret;
   }


### PR DESCRIPTION
Getting the old stack from the vm can't work as it's not
written back there.