### PR TITLE
Add Stackage Configuration for easy building

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -28,3 +28,4 @@ test/*[0-9][0-9][0-9]/*.exe
 tags
 TAGS
 src/Version_idris.hs
+.stack-work

--- a/stack.yaml
+++ b/stack.yaml
@@ -1,0 +1,6 @@
+flags: {}
+packages:
+- '.'
+extra-deps: 
+- cheapskate-0.1.0.4
+resolver: nightly-2015-07-24


### PR DESCRIPTION
Using a nightly stackage config to build on GHC 7.10, and there are some
dependencies that are more advanced than the most recent LTS stackage
config. This should just build using `stack build` in the Idris-dev root.

I had to add cheapskate as an "extra dependency" because it's not in any 
stackage configurations. This may be worth revisiting later.