### PR TITLE
Sync the documentation with opChars in ParseHelpers.hs

### DIFF
--- a/docs/tutorial/typesfuns.rst
+++ b/docs/tutorial/typesfuns.rst
@@ -103,7 +103,7 @@ symbols:
 
 ::
 
-    :+-*/=_.?|&><!@$%^~.
+    :+-*\/=.?|&><!@$%^~#
 
 Some operators built from these symbols can't be user defined. These are
 ``:``,  ``=>``,  ``->``,  ``<-``,  ``=``,  ``?=``,  ``|``,  ``**``,


### PR DESCRIPTION
hash and backslash was missing, and underscore isn't an operator char