### PR TITLE
Remove spurious Data.Fin imports (now reexported by Vect)

### DIFF
--- a/libs/base/Data/HVect.idr
+++ b/libs/base/Data/HVect.idr
@@ -1,6 +1,5 @@
 module Data.HVect
 
-import Data.Fin
 import public Data.Vect
 
 %access public

--- a/libs/contrib/Control/Algebra.idr
+++ b/libs/contrib/Control/Algebra.idr
@@ -116,7 +116,7 @@ class RingWithUnity a => Field a where
   inverseM : (x : a) -> Not (x = neutral) -> a
 
 sum' : (Foldable t, Monoid a) => t a -> a
-sum' = foldr (<+>) neutral
+sum' = concat
 
 product' : (Foldable t, RingWithUnity a) => t a -> a
 product' = foldr (<.>) unity

--- a/libs/effects/Effect/Random.idr
+++ b/libs/effects/Effect/Random.idr
@@ -2,7 +2,6 @@ module Effect.Random
 
 import Effects
 import Data.Vect
-import Data.Fin
 
 data Random : Effect where 
      getRandom : sig Random Integer Integer


### PR DESCRIPTION
Importing both `Data.Fin` and `Data.Vect` is unnecessary since the latter now reexports the former.