### PR TITLE
Upgrade to new Travis infrastructure

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -21,21 +21,28 @@ env:
   - CABAL="1.20" GHC="7.6.3"  TESTS="lib_doc"
   - CABAL="1.20" GHC="7.6.3"  TESTS="test_c"
   - CABAL="1.20" GHC="7.6.3"  TESTS="test_js"
+  - CABAL="1.20" GHC="7.6.3"  TESTS="test_llvm"
   - CABAL="1.20" GHC="7.8.4"  TESTS="doc"
   - CABAL="1.20" GHC="7.8.4"  TESTS="lib_doc"
   - CABAL="1.20" GHC="7.8.4"  TESTS="test_c"
   - CABAL="1.20" GHC="7.8.4"  TESTS="test_js"
+  - CABAL="1.20" GHC="7.8.4"  TESTS="test_llvm"
   - CABAL="head" GHC="7.10.1" TESTS="doc"
   - CABAL="head" GHC="7.10.1" TESTS="lib_doc"
   - CABAL="head" GHC="7.10.1" TESTS="test_c"
   - CABAL="head" GHC="7.10.1" TESTS="test_js"
+  - CABAL="head" GHC="7.10.1" TESTS="test_llvm"
 
 matrix:
+  fast_finish: true
   allow_failures:
+    - env: CABAL="1.20" GHC="7.8.4"  TESTS="test_llvm"
+    - env: CABAL="1.20" GHC="7.6.3"  TESTS="test_llvm"
     - env: CABAL="head" GHC="7.10.1" TESTS="doc"
     - env: CABAL="head" GHC="7.10.1" TESTS="lib_doc"
     - env: CABAL="head" GHC="7.10.1" TESTS="test_c"
     - env: CABAL="head" GHC="7.10.1" TESTS="test_js"
+    - env: CABAL="head" GHC="7.10.1" TESTS="test_llvm"
 
 cache:
   directories:
@@ -60,12 +67,21 @@ before_script:
   - tar -xf Idris-dev/dist/idris*.tar.gz
   - cd idris*
   - cp -r $SANDBOX .cabal-sandbox
+  - export PATH=$(pwd)/.cabal-sandbox/bin:$PATH
   - cabal sandbox init
 script:
   - cabal configure -f FFI -f CI
   - if [[ "$TESTS" != "doc" ]]; then cabal build; fi
   - if [[ "$TESTS" != "doc" ]]; then cabal copy; fi
   - if [[ "$TESTS" != "doc" ]]; then cabal register; fi
-  - if [[ "$TESTS" == "test_c" ]]; then cppcheck -j 2 --error-exitcode=1 ./rts/idris_bitstring.c ./rts/idris_bitstring.h ./rts/idris_gc.h ./rts/idris_gc.c ./rts/idris_gmp.h ./rts/idris_gmp.c ./rts/idris_heap.h ./rts/idris_heap.c ./rts/idris_main.c ./rts/idris_net.h ./rts/idris_net.c ./rts/idris_opts.h ./rts/idris_opts.c ./rts/idris_rts.h ./rts/idris_rts.c ./rts/idris_stats.h ./rts/idris_stats.c ./rts/idris_stdfgn.h ./rts/idris_stdfgn.c ./rts/libtest.c ; fi
-  - if [[ "$TESTS" == "test_llvm" ]]; then git clone --depth 1 https://github.com/idris-hackers/idris-llvm.git ; cd idris-llvm ; cabal install ; cd .. ; fi
+  - if [[ "$TESTS" == "test_c" ]]; then
+      cppcheck -j 2 --error-exitcode=1 ./rts/idris_bitstring.c ./rts/idris_bitstring.h ./rts/idris_gc.h ./rts/idris_gc.c ./rts/idris_gmp.h ./rts/idris_gmp.c ./rts/idris_heap.h ./rts/idris_heap.c ./rts/idris_main.c ./rts/idris_net.h ./rts/idris_net.c ./rts/idris_opts.h ./rts/idris_opts.c ./rts/idris_rts.h ./rts/idris_rts.c ./rts/idris_stats.h ./rts/idris_stats.c ./rts/idris_stdfgn.h ./rts/idris_stdfgn.c ./rts/libtest.c ;
+    fi
+  - if [[ "$TESTS" == "test_llvm" ]]; then
+      git clone --depth 1 https://github.com/idris-hackers/idris-llvm.git &&
+      cd idris-llvm &&
+      cabal sandbox --sandbox=../.cabal-sandbox init &&
+      cabal install &&
+      cd .. ;
+    fi
   - make -j2 $TESTS

--- a/.travis.yml
+++ b/.travis.yml
@@ -38,10 +38,6 @@ matrix:
   allow_failures:
     - env: CABAL="1.20" GHC="7.8.4"  TESTS="test_llvm"
     - env: CABAL="1.20" GHC="7.6.3"  TESTS="test_llvm"
-    - env: CABAL="head" GHC="7.10.1" TESTS="doc"
-    - env: CABAL="head" GHC="7.10.1" TESTS="lib_doc"
-    - env: CABAL="head" GHC="7.10.1" TESTS="test_c"
-    - env: CABAL="head" GHC="7.10.1" TESTS="test_js"
     - env: CABAL="head" GHC="7.10.1" TESTS="test_llvm"
 
 cache:

--- a/.travis.yml
+++ b/.travis.yml
@@ -17,9 +17,6 @@ addons:
 
 env:
   - CABAL="1.20" GHC="7.6.3"  TESTS="test_c"
-  - CABAL="1.20" GHC="7.6.3"  TESTS="test_js"
-  - CABAL="1.20" GHC="7.6.3"  TESTS="lib_doc"
-  - CABAL="1.20" GHC="7.6.3"  TESTS="doc"
   - CABAL="1.20" GHC="7.8.4"  TESTS="test_c"
   - CABAL="1.20" GHC="7.8.4"  TESTS="test_js"
   - CABAL="1.20" GHC="7.8.4"  TESTS="lib_doc"

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,21 +1,30 @@
+sudo: false
+
+addons:
+  apt:
+    packages:
+      # test dependencies
+      - expect
+      - cppcheck
+
+env:
+  - TESTS="doc"
+  - TESTS="lib_doc"
+  - TESTS="test_c"
+  #- TESTS="test_llvm"
+  - TESTS="test_js"
+
 language: haskell
+
 ghc:
   # Idris won't build on 7.4 and earlier due to dependency
   # problems. 7.10 isn't yet supported on Travis.
   - 7.6
   - 7.8
 
-before_install:
-  - sudo apt-get update -qq
-  - sudo apt-get install -qq libghc-unordered-containers-dev libghc-mtl-dev libghc-network-dev libghc-transformers-dev libghc-text-dev libghc-utf8-string-dev libghc-vector-dev libghc-split-dev libghc-ansi-terminal-dev libghc-ansi-wl-pprint-dev
-  # trifecta dependencies
-  - sudo apt-get install -qq libghc-blaze-builder-dev libghc-blaze-html-dev libghc-bifunctors-dev libghc-hashable-dev libghc-semigroups-dev libghc-semigroupoids-dev libghc-parallel-dev libghc-comonad-dev libghc-terminfo-dev libghc-keys-dev
-  # Haddock dependencies
-  - sudo apt-get install hscolour
-  # test dependency
-  - sudo apt-get install -qq expect
-  - sudo apt-get install -qq cppcheck
 install:
+  # haddock dependencies
+  - cabal install hscolour
   - cabal install -f FFI --enable-tests --dependencies-only --max-backjumps=-1
   - ghc-pkg list
 before_script:
@@ -31,9 +40,3 @@ script:
   - if [[ "$TESTS" == "test_c" ]]; then cppcheck -j 2 --error-exitcode=1 ./rts/idris_bitstring.c ./rts/idris_bitstring.h ./rts/idris_gc.h ./rts/idris_gc.c ./rts/idris_gmp.h ./rts/idris_gmp.c ./rts/idris_heap.h ./rts/idris_heap.c ./rts/idris_main.c ./rts/idris_net.h ./rts/idris_net.c ./rts/idris_opts.h ./rts/idris_opts.c ./rts/idris_rts.h ./rts/idris_rts.c ./rts/idris_stats.h ./rts/idris_stats.c ./rts/idris_stdfgn.h ./rts/idris_stdfgn.c ./rts/libtest.c ; fi
   - if [[ "$TESTS" == "test_llvm" ]]; then git clone --depth 1 https://github.com/idris-hackers/idris-llvm.git ; cd idris-llvm ; cabal install ; cd .. ; fi
   - make -j2 $TESTS
-env:
-  - TESTS="doc"
-  - TESTS="lib_doc"
-  - TESTS="test_c"
-  #- TESTS="test_llvm"
-  - TESTS="test_js"

--- a/.travis.yml
+++ b/.travis.yml
@@ -10,48 +10,57 @@ addons:
       - ghc-7.6.3
       - ghc-7.8.4
       - ghc-7.10.1
-      - cabal-install-1.22
+      - cabal-install-1.20
+      - cabal-install-head
       # test dependencies
       - expect
       - cppcheck
 
 env:
-  - GHC="7.6.3"  TESTS="doc"
-  - GHC="7.6.3"  TESTS="lib_doc"
-  - GHC="7.6.3"  TESTS="test_c"
-  - GHC="7.6.3"  TESTS="test_js"
-  - GHC="7.8.4"  TESTS="doc"
-  - GHC="7.8.4"  TESTS="lib_doc"
-  - GHC="7.8.4"  TESTS="test_c"
-  - GHC="7.8.4"  TESTS="test_js"
-  - GHC="7.10.1" TESTS="doc"
-  - GHC="7.10.1" TESTS="lib_doc"
-  - GHC="7.10.1" TESTS="test_c"
-  - GHC="7.10.1" TESTS="test_js"
+  - CABAL="1.20" GHC="7.6.3"  TESTS="doc"
+  - CABAL="1.20" GHC="7.6.3"  TESTS="lib_doc"
+  - CABAL="1.20" GHC="7.6.3"  TESTS="test_c"
+  - CABAL="1.20" GHC="7.6.3"  TESTS="test_js"
+  - CABAL="1.20" GHC="7.8.4"  TESTS="doc"
+  - CABAL="1.20" GHC="7.8.4"  TESTS="lib_doc"
+  - CABAL="1.20" GHC="7.8.4"  TESTS="test_c"
+  - CABAL="1.20" GHC="7.8.4"  TESTS="test_js"
+  - CABAL="head" GHC="7.10.1" TESTS="doc"
+  - CABAL="head" GHC="7.10.1" TESTS="lib_doc"
+  - CABAL="head" GHC="7.10.1" TESTS="test_c"
+  - CABAL="head" GHC="7.10.1" TESTS="test_js"
 
 matrix:
   allow_failures:
-    - env: GHC="7.10.1" TESTS="doc"
-    - env: GHC="7.10.1" TESTS="lib_doc"
-    - env: GHC="7.10.1" TESTS="test_c"
-    - env: GHC="7.10.1" TESTS="test_js"
+    - env: CABAL="head" GHC="7.10.1" TESTS="doc"
+    - env: CABAL="head" GHC="7.10.1" TESTS="lib_doc"
+    - env: CABAL="head" GHC="7.10.1" TESTS="test_c"
+    - env: CABAL="head" GHC="7.10.1" TESTS="test_js"
+
+cache:
+  directories:
+    - $HOME/.cabal-sandbox
 
 before_install:
-  - export CABAL="1.22"
-  - export PATH=/opt/ghc/$GHC/bin:/opt/cabal/$CABAL/bin:$PATH
+  - export SANDBOX=$HOME/.cabal-sandbox
+  - export PATH=/opt/ghc/$GHC/bin:/opt/cabal/$CABAL/bin:$SANDBOX/bin:$PATH
+  - ls -lh $SANDBOX
+  - env
   - cabal --version
   - ghc --version
   - cabal update
 install:
-  # haddock dependencies
-  - cabal install hscolour
-  - cabal install -f FFI --enable-tests --dependencies-only --max-backjumps=-1
-  - ghc-pkg list
+  - cabal sandbox --sandbox=$SANDBOX init
+  - cabal install hscolour # haddock dependency
+  - cabal install -f FFI --enable-tests --dependencies-only --force-reinstalls
+  - cabal sandbox hc-pkg list
 before_script:
   - cabal sdist
   - cd ..
   - tar -xf Idris-dev/dist/idris*.tar.gz
   - cd idris*
+  - cp -r $SANDBOX .cabal-sandbox
+  - cabal sandbox init
 script:
   - cabal configure -f FFI -f CI
   - if [[ "$TESTS" != "doc" ]]; then cabal build; fi

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,27 +1,47 @@
 sudo: false
 
+language: haskell
+
 addons:
   apt:
+    sources:
+      - hvr-ghc
     packages:
+      - ghc-7.6.3
+      - ghc-7.8.4
+      - ghc-7.10.1
+      - cabal-install-1.22
       # test dependencies
       - expect
       - cppcheck
 
 env:
-  - TESTS="doc"
-  - TESTS="lib_doc"
-  - TESTS="test_c"
-  #- TESTS="test_llvm"
-  - TESTS="test_js"
+  - GHC="7.6.3"  TESTS="doc"
+  - GHC="7.6.3"  TESTS="lib_doc"
+  - GHC="7.6.3"  TESTS="test_c"
+  - GHC="7.6.3"  TESTS="test_js"
+  - GHC="7.8.4"  TESTS="doc"
+  - GHC="7.8.4"  TESTS="lib_doc"
+  - GHC="7.8.4"  TESTS="test_c"
+  - GHC="7.8.4"  TESTS="test_js"
+  - GHC="7.10.1" TESTS="doc"
+  - GHC="7.10.1" TESTS="lib_doc"
+  - GHC="7.10.1" TESTS="test_c"
+  - GHC="7.10.1" TESTS="test_js"
 
-language: haskell
+matrix:
+  allow_failures:
+    - env: GHC="7.10.1" TESTS="doc"
+    - env: GHC="7.10.1" TESTS="lib_doc"
+    - env: GHC="7.10.1" TESTS="test_c"
+    - env: GHC="7.10.1" TESTS="test_js"
 
-ghc:
-  # Idris won't build on 7.4 and earlier due to dependency
-  # problems. 7.10 isn't yet supported on Travis.
-  - 7.6
-  - 7.8
-
+before_install:
+  - export CABAL="1.22"
+  - export PATH=/opt/ghc/$GHC/bin:/opt/cabal/$CABAL/bin:$PATH
+  - cabal --version
+  - ghc --version
+  - cabal update
 install:
   # haddock dependencies
   - cabal install hscolour

--- a/.travis.yml
+++ b/.travis.yml
@@ -9,9 +9,8 @@ addons:
     packages:
       - ghc-7.6.3
       - ghc-7.8.4
-      - ghc-7.10.1
+      - ghc-7.10.2
       - cabal-install-1.20
-      - cabal-install-head
       # test dependencies
       - expect
       - cppcheck
@@ -27,18 +26,18 @@ env:
   - CABAL="1.20" GHC="7.8.4"  TESTS="test_c"
   - CABAL="1.20" GHC="7.8.4"  TESTS="test_js"
   - CABAL="1.20" GHC="7.8.4"  TESTS="test_llvm"
-  - CABAL="head" GHC="7.10.1" TESTS="doc"
-  - CABAL="head" GHC="7.10.1" TESTS="lib_doc"
-  - CABAL="head" GHC="7.10.1" TESTS="test_c"
-  - CABAL="head" GHC="7.10.1" TESTS="test_js"
-  - CABAL="head" GHC="7.10.1" TESTS="test_llvm"
+  - CABAL="1.20" GHC="7.10.2" TESTS="doc"
+  - CABAL="1.20" GHC="7.10.2" TESTS="lib_doc"
+  - CABAL="1.20" GHC="7.10.2" TESTS="test_c"
+  - CABAL="1.20" GHC="7.10.2" TESTS="test_js"
+  - CABAL="1.20" GHC="7.10.2" TESTS="test_llvm"
 
 matrix:
   fast_finish: true
   allow_failures:
     - env: CABAL="1.20" GHC="7.8.4"  TESTS="test_llvm"
     - env: CABAL="1.20" GHC="7.6.3"  TESTS="test_llvm"
-    - env: CABAL="head" GHC="7.10.1" TESTS="test_llvm"
+    - env: CABAL="1.20" GHC="7.10.2" TESTS="test_llvm"
 
 cache:
   directories:

--- a/.travis.yml
+++ b/.travis.yml
@@ -16,28 +16,18 @@ addons:
       - cppcheck
 
 env:
-  - CABAL="1.20" GHC="7.6.3"  TESTS="doc"
-  - CABAL="1.20" GHC="7.6.3"  TESTS="lib_doc"
   - CABAL="1.20" GHC="7.6.3"  TESTS="test_c"
   - CABAL="1.20" GHC="7.6.3"  TESTS="test_js"
-  - CABAL="1.20" GHC="7.6.3"  TESTS="test_llvm"
-  - CABAL="1.20" GHC="7.8.4"  TESTS="doc"
-  - CABAL="1.20" GHC="7.8.4"  TESTS="lib_doc"
+  - CABAL="1.20" GHC="7.6.3"  TESTS="lib_doc"
+  - CABAL="1.20" GHC="7.6.3"  TESTS="doc"
   - CABAL="1.20" GHC="7.8.4"  TESTS="test_c"
   - CABAL="1.20" GHC="7.8.4"  TESTS="test_js"
-  - CABAL="1.20" GHC="7.8.4"  TESTS="test_llvm"
-  - CABAL="1.20" GHC="7.10.2" TESTS="doc"
-  - CABAL="1.20" GHC="7.10.2" TESTS="lib_doc"
+  - CABAL="1.20" GHC="7.8.4"  TESTS="lib_doc"
+  - CABAL="1.20" GHC="7.8.4"  TESTS="doc"
   - CABAL="1.20" GHC="7.10.2" TESTS="test_c"
   - CABAL="1.20" GHC="7.10.2" TESTS="test_js"
-  - CABAL="1.20" GHC="7.10.2" TESTS="test_llvm"
-
-matrix:
-  fast_finish: true
-  allow_failures:
-    - env: CABAL="1.20" GHC="7.8.4"  TESTS="test_llvm"
-    - env: CABAL="1.20" GHC="7.6.3"  TESTS="test_llvm"
-    - env: CABAL="1.20" GHC="7.10.2" TESTS="test_llvm"
+  - CABAL="1.20" GHC="7.10.2" TESTS="lib_doc"
+  - CABAL="1.20" GHC="7.10.2" TESTS="doc"
 
 cache:
   directories:
@@ -71,12 +61,5 @@ script:
   - if [[ "$TESTS" != "doc" ]]; then cabal register; fi
   - if [[ "$TESTS" == "test_c" ]]; then
       cppcheck -j 2 --error-exitcode=1 ./rts/idris_bitstring.c ./rts/idris_bitstring.h ./rts/idris_gc.h ./rts/idris_gc.c ./rts/idris_gmp.h ./rts/idris_gmp.c ./rts/idris_heap.h ./rts/idris_heap.c ./rts/idris_main.c ./rts/idris_net.h ./rts/idris_net.c ./rts/idris_opts.h ./rts/idris_opts.c ./rts/idris_rts.h ./rts/idris_rts.c ./rts/idris_stats.h ./rts/idris_stats.c ./rts/idris_stdfgn.h ./rts/idris_stdfgn.c ./rts/libtest.c ;
-    fi
-  - if [[ "$TESTS" == "test_llvm" ]]; then
-      git clone --depth 1 https://github.com/idris-hackers/idris-llvm.git &&
-      cd idris-llvm &&
-      cabal sandbox --sandbox=../.cabal-sandbox init &&
-      cabal install &&
-      cd .. ;
     fi
   - make -j2 $TESTS

--- a/src/Idris/Reflection.hs
+++ b/src/Idris/Reflection.hs
@@ -1,11 +1,13 @@
 {-| Code related to Idris's reflection system. This module contains
 quoters and unquoters along with some supporting datatypes.
 -}
-{-# LANGUAGE PatternGuards #-}
+{-# LANGUAGE PatternGuards, CPP #-}
 {-# OPTIONS_GHC -fwarn-incomplete-patterns -fwarn-unused-imports #-}
 module Idris.Reflection where
 
+#if __GLASGOW_HASKELL__ < 710
 import Control.Applicative ((<$>), (<*>), pure)
+#endif
 import Control.Monad (liftM, liftM2, liftM3)
 import Data.Maybe (catMaybes)
 import Data.List ((\\))
@@ -887,7 +889,7 @@ reflectErr (CantResolveAlts ss) =
   raw_apply (Var $ reflErrName "CantResolveAlts")
             [rawList (Var $ reflm "TTName") (map reflectName ss)]
 reflectErr (IncompleteTerm t) = raw_apply (Var $ reflErrName "IncompleteTerm") [reflect t]
-reflectErr (NoEliminator str t) 
+reflectErr (NoEliminator str t)
   = raw_apply (Var $ reflErrName "NoEliminator") [RConstant (Str str),
                                                   reflect t]
 reflectErr (UniverseError fc ue old new tys) =


### PR DESCRIPTION
# Travis build using new container-based infrastructure and caching

close #2443 Upgrade to new Travis infrastructure
close #2364 Idris doesn't compile on GHC 7.10 because of prelude exporting <$>
close #2321 Cabal constraint solving hits the backjump limit

## build process
A brief explanation of travis build steps:

+ `before_install`: setup build environment. Add current `ghc` and `cabal` executables on `PATH`. Print debug information
+ `install`: initialize shared SANDBOX (which is cached between builds). Install dependencies in the shared SANDBOX
+ `before_script`: generate idris distribution and unpack it to WORKDIR. Copy SANDBOX to WORKDIR (since cabal is not able to cleanup after the `copy` step and we want to cache only dependencies and not the results of each idris compilation)
+ `script`: build idris and run tests using the copy of sandbox

## build matrix
Idris is building via cabal `1.20` and ghc `7.6.3`, `7.8.4`, `7.10.2`. Since Travis doesn't support ghc `7.10` yet, build uses custom [hvr-ghc](https://launchpad.net/~hvr/+archive/ubuntu/ghc) PPA to install appropriate versions of cabal and ghc. All builds are defined explicitly in the `.travis.yml` as `env` list of environment variables `CABAL`, `GHC` and `TESTS`. Also d896abc fixes #2364 to be able to build with ghc `7.10` and `CI` (`-Werror`) flag

## cabal
Atm Idris can not be built with the latest cabal `1.22` due to #1836, this build uses cabal `1.20`

## cache
All builds share the same sandbox for dependencies which is cached between builds. This allows to speedup `install` step, since all dependencies are already installed in the sandbox.

## `install` options changes:
+ added `--force-reinstalls`. Since sandbox is shared between buids. We should be able to reinstall dependencies to proceed the build, if some deps changed.
+ removed `--max-backjumps=-1`. With the progress on #2135 Building Against LTS Haskell, seems that related #2321 is not an issue anymore.

## idris-llvm
llvm backend build was dropped. Currently it is outdated and failing to build against present Idris version. Since it was moved to separate repo at [idris-hackers/idris-llvm](https://github.com/idris-hackers/idris-llvm), I believe it should be tested separately.