### PR TITLE
Add libFFI to extra-deps, and default flags to use gmp and ffi

### DIFF
--- a/stack.yaml
+++ b/stack.yaml
@@ -1,6 +1,10 @@
-flags: {}
+flags:
+  idris:
+    gmp: true
+    ffi: true
 packages:
 - '.'
-extra-deps: 
+extra-deps:
 - cheapskate-0.1.0.4
+- libffi-0.1
 resolver: nightly-2015-07-24


### PR DESCRIPTION
+ LibFFI is not in stackage and needs to be added as an extra dep.
+ To build Idris with FFI and GMP the flags need to be passed. Best add them to the stack file.