### PR TITLE
Corrected "List" to "Vect" in "Maybe" example

### DIFF
--- a/docs/tutorial/typesfuns.rst
+++ b/docs/tutorial/typesfuns.rst
@@ -774,12 +774,12 @@ given type, or there isn’t:
     data Maybe a = Just a | Nothing
 
 ``Maybe`` is one way of giving a type to an operation that may
-fail. For example, looking something up in a ``List`` (rather than a
-vector) may result in an out of bounds error:
+fail. For example, looking something up in a ``Vect`` (rather than a
+list) may result in an out of bounds error:
 
 .. code-block:: idris
 
-    list_lookup : Nat -> List a -> Maybe a
+    list_lookup : Nat -> Vect n a -> Maybe a
     list_lookup _     Nil         = Nothing
     list_lookup Z     (x :: xs) = Just x
     list_lookup (S k) (x :: xs) = list_lookup k xs


### PR DESCRIPTION
Example for using `Maybe` for out of bounds checking, function `list_lookup`.
I assume that was the intention. Not sure how a `List` can be accessed out of bounds, unless I'm missing something.