### PR TITLE
Fix indentation in PCAF parser

### DIFF
--- a/src/Idris/ParseHelpers.hs
+++ b/src/Idris/ParseHelpers.hs
@@ -450,8 +450,9 @@ pushIndent = do pos <- position
 -- | Pops indentation from stack
 popIndent :: IdrisParser ()
 popIndent = do ist <- get
-               let (x : xs) = indent_stack ist
-               put (ist { indent_stack = xs })
+               case indent_stack ist of
+                 [] -> error "The impossible happened! Tried to pop an indentation level where none was pushed (underflow)."
+                 (x : xs) -> put (ist { indent_stack = xs })
 
 
 -- | Gets current indentation

--- a/src/Idris/Parser.hs
+++ b/src/Idris/Parser.hs
@@ -834,8 +834,9 @@ CAF ::= 'let' FnName '=' Expr Terminator;
 caf :: SyntaxInfo -> IdrisParser PDecl
 caf syn = do reservedHL "let"
              n_in <- fst <$> fnName; let n = expandNS syn n_in
+             pushIndent
              lchar '='
-             t <- expr syn
+             t <- indented $ expr syn
              terminator
              fc <- getFC
              return (PCAF fc n t)


### PR DESCRIPTION
Fixes #2512. Additionally, the crash on indentation stack underflow is now more informative, should it occur in the future.