### PR TITLE
Document interactive theorem proving as deprecated.

### DIFF
--- a/docs/proofs/interactive.rst
+++ b/docs/proofs/interactive.rst
@@ -1,6 +1,12 @@
-***************************
-Interactive Theorem Proving
-***************************
+***************************************
+DEPRECATED: Interactive Theorem Proving
+***************************************
+
+.. warning::
+   **Interactive theorem-proving has been deprecated.**
+   Support for tactic-based theorem proving will eventually be removed from
+   Idris.
+   Existing tactic-based proofs should be rewritten to use ``rewrite`` instead.
 
 Idris also supports interactive theorem proving via tactics. This
 is generally not recommended to be used directly, but rather used as a

--- a/docs/proofs/interactive.rst
+++ b/docs/proofs/interactive.rst
@@ -3,10 +3,8 @@ DEPRECATED: Interactive Theorem Proving
 ***************************************
 
 .. warning::
-   **Interactive theorem-proving has been deprecated.**
-   Support for tactic-based theorem proving will eventually be removed from
-   Idris.
-   Existing tactic-based proofs should be rewritten to use ``rewrite`` instead.
+   The interactive theorem-proving interface documented here has been
+   deprecated in favor of :ref:`elaborator-reflection`.
 
 Idris also supports interactive theorem proving via tactics. This
 is generally not recommended to be used directly, but rather used as a

--- a/docs/reference/elaborator-reflection.rst
+++ b/docs/reference/elaborator-reflection.rst
@@ -1,3 +1,5 @@
+.. _elaborator-reflection:
+
 *********************
 Elaborator Reflection
 *********************


### PR DESCRIPTION
Puts "DEPRECATED:" in the chapter title and also adds a warning paragraph
at the start of the tutorial chapter.