### PR TITLE
Blacklist directory 1.2.3.0

### DIFF
--- a/idris.cabal
+++ b/idris.cabal
@@ -900,7 +900,7 @@ Library
                 , cheapskate < 0.2
                 , containers >= 0.5 && < 0.6
                 , deepseq < 1.5
-                , directory >= 1.2.2.0 && < 1.3
+                , directory >= 1.2.2.0 && < 1.2.3.0 || > 1.2.3.0
                 , filepath < 1.5
                 , fingertree >= 0.1 && < 0.2
                 , haskeline >= 0.7 && < 0.8


### PR DESCRIPTION
This is to work around an issue with directory on older GHCs.
Hopefully this will prevent directory issue 30 from messing up Travis.