### PR TITLE
Update stack configuration to LTS Haskell 3.0

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -16,6 +16,8 @@ addons:
       - expect
       - cppcheck
       - hscolour
+      # Stack dependencies
+      - libgmp-dev
 
 matrix:
   include:
@@ -40,6 +42,7 @@ cache:
   directories:
     - $HOME/.cabsnap
     - $HOME/.cabal/packages
+    - $HOME/.stack
 
 before_cache:
   - rm -fv $HOME/.cabal/packages/hackage.haskell.org/build-reports.log
@@ -49,6 +52,10 @@ before_install:
   - unset CC
   - export PATH=/opt/ghc/$GHCVER/bin:/opt/cabal/$CABALVER/bin:$HOME/.cabal/bin:$PATH
   - env
+  - mkdir -p ~/.local/bin
+  - export PATH=$HOME/.local/bin:$PATH
+  - travis_retry curl -L https://github.com/commercialhaskell/stack/releases/download/v0.1.4.0/stack-0.1.4.0-x86_64-linux.tar.gz | tar xz -C ~/.local/bin
+
 
 install:
   - cabal --version
@@ -107,3 +114,5 @@ script:
       echo "make -j2 $test";
       make -j2 $test;
     done
+  # Stack test to build Idris, using system ghc.
+  - stack --no-terminal --system-ghc build

--- a/.travis.yml
+++ b/.travis.yml
@@ -37,6 +37,9 @@ matrix:
       compiler: ": #GHC 7.10.2"
     - env: CABALVER="1.22" GHCVER="7.10.2" TESTS="test_c"
       compiler: ": #GHC 7.10.2"
+    - env: CABALVER="1.22" GHCVER="7.10.2" STACKTEST="stack_test"
+      compiler: ": #GHC 7.10.2"
+
 
 cache:
   directories:
@@ -102,19 +105,23 @@ before_script:
   - cd ..
   - tar -xf Idris-dev/dist/idris*.tar.gz
   - cd idris*
+
 script:
-  - cabal configure -f FFI -f CI
-  - cabal build
-  - cabal copy
-  - cabal register
-  - if [[ "$TESTS" == "test_c" ]]; then
-      cppcheck -i 'mini-gmp.c' rts;
-    fi
-  - for test in $TESTS; do
-      echo "make -j2 $test";
-      make -j2 $test;
-    done
-  # Stack test to build Idris, using system ghc if possible.
-  - if [[ "$GHCVER" == "7.10.2" ]]; then
-      stack --no-terminal --system-ghc build
+  - if [[ "$STACKTEST" == "stack_test" ]];
+    then
+      stack --no-terminal --system-ghc build;
+    else
+      cabal configure -f FFI -f CI;
+      cabal build;
+      cabal copy;
+      cabal register;
+      if [[ "$TESTS" == "test_c" ]];
+      then
+        cppcheck -i 'mini-gmp.c' rts;
+      fi
+      for test in $TESTS;
+      do
+        echo "make -j2 $test";
+        make -j2 $test;
+      done
     fi

--- a/.travis.yml
+++ b/.travis.yml
@@ -51,54 +51,10 @@ before_cache:
   - rm -fv $HOME/.cabal/packages/hackage.haskell.org/build-reports.log
   - rm -fv $HOME/.cabal/packages/hackage.haskell.org/00-index.tar
 
-before_install:
-  - unset CC
-  - export PATH=/opt/ghc/$GHCVER/bin:/opt/cabal/$CABALVER/bin:$HOME/.cabal/bin:$PATH
-  - env
-  - mkdir -p ~/.local/bin
-  - export PATH=$HOME/.local/bin:$PATH
-  - travis_retry curl -L https://github.com/commercialhaskell/stack/releases/download/v0.1.4.0/stack-0.1.4.0-x86_64-linux.tar.gz | tar xz -C ~/.local/bin
+before_install: ./scripts/travis-before-install.sh
 
 
-install:
-  - cabal --version
-  - echo "$(ghc --version) [$(ghc --print-project-git-commit-id 2> /dev/null || echo '?')]"
-  - if [ -f $HOME/.cabal/packages/hackage.haskell.org/00-index.tar.gz ];
-    then
-      zcat $HOME/.cabal/packages/hackage.haskell.org/00-index.tar.gz >
-          $HOME/.cabal/packages/hackage.haskell.org/00-index.tar;
-    fi
-  - travis_retry cabal update -v
-  # Run build with 2 parallel jobs
-  # The container environment reports 16 cores,
-  # causing cabal's default configuration (jobs: $ncpus)
-  # to run into the GHC #9221 bug which can result in longer build-times.
-  - sed -i -r 's/(^jobs:).*/\1 2/' $HOME/.cabal/config
-  - cabal install -f FFI --only-dependencies --enable-tests --dry -v > installplan.txt
-  - sed -i -e '1,/^Resolving /d' installplan.txt; cat installplan.txt
-
-  # check whether current requested install-plan matches cached package-db snapshot
-  - if diff -u installplan.txt $HOME/.cabsnap/installplan.txt;
-    then
-      echo "cabal build-cache HIT";
-      rm -rfv .ghc;
-      cp -a $HOME/.cabsnap/ghc $HOME/.ghc;
-      cp -a $HOME/.cabsnap/lib $HOME/.cabsnap/share $HOME/.cabsnap/bin $HOME/.cabal/;
-    else
-      echo "cabal build-cache MISS";
-      rm -rf $HOME/.cabsnap;
-      mkdir -p $HOME/.ghc $HOME/.cabal/lib $HOME/.cabal/share $HOME/.cabal/bin;
-      cabal install -f FFI --only-dependencies --enable-tests;
-    fi
-
-  # snapshot package-db on cache miss
-  - if [ ! -d $HOME/.cabsnap ];
-    then
-      echo "snapshotting package-db to build-cache";
-      mkdir $HOME/.cabsnap;
-      cp -a $HOME/.ghc $HOME/.cabsnap/ghc;
-      cp -a $HOME/.cabal/lib $HOME/.cabal/share $HOME/.cabal/bin installplan.txt $HOME/.cabsnap/;
-    fi
+install: ./scripts/travis-install.sh
 
 before_script:
   - cabal sdist
@@ -106,22 +62,4 @@ before_script:
   - tar -xf Idris-dev/dist/idris*.tar.gz
   - cd idris*
 
-script:
-  - if [[ "$STACKTEST" == "stack_test" ]];
-    then
-      stack --no-terminal --system-ghc build;
-    else
-      cabal configure -f FFI -f CI;
-      cabal build;
-      cabal copy;
-      cabal register;
-      if [[ "$TESTS" == "test_c" ]];
-      then
-        cppcheck -i 'mini-gmp.c' rts;
-      fi
-      for test in $TESTS;
-      do
-        echo "make -j2 $test";
-        make -j2 $test;
-      done
-    fi
+script: ./scripts/travis-test.sh

--- a/.travis.yml
+++ b/.travis.yml
@@ -114,5 +114,7 @@ script:
       echo "make -j2 $test";
       make -j2 $test;
     done
-  # Stack test to build Idris, using system ghc.
-  - stack --no-terminal --system-ghc build
+  # Stack test to build Idris, using system ghc if possible.
+  - if [[ "$GHCVER" == "7.10.2" ]]; then
+      stack --no-terminal --system-ghc build
+    fi

--- a/CHANGELOG
+++ b/CHANGELOG
@@ -48,7 +48,7 @@ Miscellaneous updates
 * Disable the deprecation warnings for %elim and old-style tactic scripts
   with the --no-elim-deprecation-warnings and --no-tactic-deprecation-warnings
   flags.
-
+* Experimental support for building Idris using Stack.
 
 New in 0.9.19:
 --------------

--- a/INSTALL.md
+++ b/INSTALL.md
@@ -1,0 +1,88 @@
+# Idris Installation Guide
+
+Copyright (C) 2015, The Idris Community
+
+This file provides information over obtaining and installing Idris.
+
+## Installing Idris from Hackage
+
+This repository represents the latest development version of the language,
+and may contain bugs that are being actively worked on.
+For those who wish to use a more stable version of Idris please consider
+installing the latest version that has been released on Hackage.
+Installation instructions for various platforms can be [found on the Idris Wiki](https://github.com/idris-lang/Idris-dev/wiki/Installation-Instructions).
+
+## Installing Development Versions
+
+If you like to work against the latest development version, please consider
+using Cabal Sandboxes to minimise disruption to your local Haskell setup.
+Instructions for installing Idris HEAD within a cabal sandbox are
+[available on the Idris Wiki](https://github.com/idris-lang/Idris-dev/wiki/Installing-an-Idris-Development-version-in-a-sandbox).
+
+To configure, edit config.mk. The default values should work for most people.
+
+Idris is built using a Makefile common targets include:
+
+* `make` This will install everything using cabal and
+typecheck the libraries.
+* `make test` This target execute the test suite.
+* `make relib` This target will typecheck and recompile the standard library.
+
+Idris has an optional buildtime dependency on the C library
+`libffi`. If you would like to use the features that it enables, make
+sure that it is compiled for the same architecture as your Haskell
+compiler (e.g. 64 bit libraries for 64 bit ghc). By default, Idris
+builds without it. To build with it, pass the flag `-f FFI`.
+
+A secondary optional buildtime dependency is on `libGMP`, this allows
+better support for numeric operations. As with `libFFI` Idris builds
+with out it, to enable `GMP` support use the flag `-f GMP`
+
+To build with `libffi` and `libGMP` by default, create a `custom.mk` file and add the
+following line to it:
+
+`CABALFLAGS += -f FFI -f GMP`
+
+The file `custom.mk-alldeps` is a suitable example.
+
+The continuous integration builds on travis-ci.org are built using the
+ghc-flag -Werror. To enable this behaviour locally also, please compile
+using `make CI=true` or adding the following line into `custom.mk`:
+
+`CI = true`
+
+If you are only compiling for installing the most current version, you can
+omit the CI flag, but please make sure you use it if you want to contribute.
+
+## Experimental Support for Building with Stack
+
+[Stack](https://github.com/commercialhaskell/stack) is a new
+cross-platform program for developing Haskell projects, that enhances
+the functionality provided by Cabal. There is experimental support for
+building Idris from source using with stack, that uses a nightly
+version of stackage dated `2015-09-22`, and has been tested on Ubuntu
+14.04 LTS, only.
+
+To build Idris with stack the following commands are recommended:
+
+* `stack build`
+
+This will install Idris (and related executables) into `./local/bin/`
+on Unix based systems and an appropriate place on Windows. If you
+haven't used stack before this will also setup the related
+infrastructure. For more information about Stack please visit the
+[Stack website](https://github.com/commercialhaskell/stack).
+
+### System GHC
+
+The flag `--system-ghc` can be added to enforce use of your system's version of GHC.
+
+### `libGMP` and `libFFI`
+
+To build with support for `libGMP` and `libFFI` you need to pass build
+commands for the Idris library either from the command line:
+
+* `stack build --flag idris:GMP --flag idris:FFI`
+
+or add the options `idris:GMP` and `idris:FFI` to the `stack.yaml`
+file.

--- a/README.md
+++ b/README.md
@@ -7,50 +7,16 @@
 Idris (http://idris-lang.org/) is a general-purpose functional programming
 language with dependent types.
 
-## Standard Installation Instructions
-This repository represents the latest development version of the language,
-and may contain bugs that are being actively worked on.
-For those who wish to use a more stable version of Idris please consider
+## Installation Guides.
+
+This repository represents the latest development version of the
+language, and may contain bugs that are being actively worked on.  For
+those who wish to use a more stable version of Idris please consider
 installing the latest version that has been released on Hackage.
-Installation instructions for various platforms can be [found on the Idris Wiki](https://github.com/idris-lang/Idris-dev/wiki/Installation-Instructions).
+Installation instructions for various platforms can be
+[found on the Idris Wiki](https://github.com/idris-lang/Idris-dev/wiki/Installation-Instructions).
 
-## Installing Development Versions
-
-If you like to work against the latest development version, please consider
-using Cabal Sandboxes to minimise disruption to your local Haskell setup.
-Instructions for installing Idris HEAD within a cabal sandbox are
-[available on the Idris Wiki](https://github.com/idris-lang/Idris-dev/wiki/Installing-an-Idris-Development-version-in-a-sandbox).
-
-To configure, edit config.mk. The default values should work for most people.
-
-Idris is built using a Makefile common targets include:
-
-* `make` This will install everything using cabal and
-typecheck the libraries.
-* `make test` This target execute the test suite.
-* `make relib` This target will typecheck and recompile the standard library.
-
-Idris has an optional buildtime dependency on the C library `libffi`. If you
-would like to use the features that it enables, make sure that it is compiled
-for the same architecture as your Haskell compiler (e.g. 64 bit libraries
-for 64 bit ghc). By default, Idris builds without it. To build with it, pass
-the flag `-f FFI`.
-
-To build with `libffi` by default, create a `custom.mk` file and add the
-following line to it:
-
-`CABALFLAGS += -f FFI`
-
-The file custom.mk-alldeps is a suitable example.
-
-The continuous integration builds on travis-ci.org are built using the
-ghc-flag -Werror. To enable this behaviour locally also, please compile
-using `make CI=true` or adding the following line into `custom.mk`:
-
-`CI = true`
-
-If you are only compiling for installing the most current version, you can
-omit the CI flag, but please make sure you use it if you want to contribute.
+More information about building Idris from source has been detailed in the [Installation Guide](INSTALL.md)
 
 ## Code Generation
 

--- a/scripts/README.org
+++ b/scripts/README.org
@@ -1,0 +1,5 @@
+#+TITLE: Scripts
+
+This directory contains various scripts used as part of the Idris
+building and testing process. If run incorrectly they may not work as
+intended.

--- a/scripts/travis-before-install.sh
+++ b/scripts/travis-before-install.sh
@@ -1,0 +1,52 @@
+#!/bin/bash
+# ------------------------------------------------- [ travis-before-install.sh ]
+#
+# The before install script used as part of the travis set up.
+#
+# ---------------------------------------------------------------------- [ EOH ]
+
+set -ev
+
+#  ---------------------------------------------- [ Local Copy of Travis Retry ]
+#
+# Common bash functions used by travis but not exposed or runnable as
+# sub-commands. See:
+#
+# https://twitter.com/plexus/status/499194992632811520
+#
+ANSI_RED="\033[31;1m"
+ANSI_GREEN="\033[32;1m"
+ANSI_RESET="\033[0m"
+ANSI_CLEAR="\033[0K"
+
+travis_retry() {
+  local result=0
+  local count=1
+  while [ $count -le 3 ]; do
+    [ $result -ne 0 ] && {
+      echo -e "\n${ANSI_RED}The command \"$@\" failed. Retrying, $count of 3.${ANSI_RESET}\n" >&2
+    }
+    "$@"
+    result=$?
+    [ $result -eq 0 ] && break
+    count=$(($count + 1))
+    sleep 1
+  done
+
+  [ $count -gt 3 ] && {
+    echo -e "\n${ANSI_RED}The command \"$@\" failed 3 times.${ANSI_RESET}\n" >&2
+  }
+
+  return $result
+}
+
+#  -------------------------------------------------------------- [ The Script ]
+
+unset CC
+export PATH=/opt/ghc/$GHCVER/bin:/opt/cabal/$CABALVER/bin:$HOME/.cabal/bin:$PATH
+env
+mkdir -p ~/.local/bin
+export PATH=$HOME/.local/bin:$PATH
+travis_retry curl -L https://github.com/commercialhaskell/stack/releases/download/v0.1.4.0/stack-0.1.4.0-x86_64-linux.tar.gz | tar xz -C ~/.local/bin
+
+#  --------------------------------------------------------------------- [ EOS ]

--- a/scripts/travis-install.sh
+++ b/scripts/travis-install.sh
@@ -1,0 +1,96 @@
+#!/bin/bash
+# -------------------------------------------------------- [ travis-install.sh ]
+#
+# Tee install script used as part of the travis set up.
+#
+# ---------------------------------------------------------------------- [ EOH ]
+
+set -ev
+
+#  ---------------------------------------------- [ Local Copy of Travis Retry ]
+#
+# Common bash functions used by travis but not exposed or runnable as
+# sub-commands. See:
+#
+# https://twitter.com/plexus/status/499194992632811520
+#
+ANSI_RED="\033[31;1m"
+ANSI_GREEN="\033[32;1m"
+ANSI_RESET="\033[0m"
+ANSI_CLEAR="\033[0K"
+
+travis_retry() {
+  local result=0
+  local count=1
+  while [ $count -le 3 ]; do
+    [ $result -ne 0 ] && {
+      echo -e "\n${ANSI_RED}The command \"$@\" failed. Retrying, $count of 3.${ANSI_RESET}\n" >&2
+    }
+    "$@"
+    result=$?
+    [ $result -eq 0 ] && break
+    count=$(($count + 1))
+    sleep 1
+  done
+
+  [ $count -gt 3 ] && {
+    echo -e "\n${ANSI_RED}The command \"$@\" failed 3 times.${ANSI_RESET}\n" >&2
+  }
+
+  return $result
+}
+
+#  ------------------------------------------------------------------- [ Setup ]
+
+cabal --version
+echo "$(ghc --version) [$(ghc --print-project-git-commit-id 2> /dev/null || echo '?')]"
+
+if [ -f $HOME/.cabal/packages/hackage.haskell.org/00-index.tar.gz ];
+then
+    zcat $HOME/.cabal/packages/hackage.haskell.org/00-index.tar.gz >
+         $HOME/.cabal/packages/hackage.haskell.org/00-index.tar;
+fi
+
+travis_retry cabal update -v
+
+#  ---------------------------------------------------------- [ Do The Install ]
+
+# Run build with 2 parallel jobs.  The container environment reports
+# 16 cores, causing cabal's default configuration (jobs: $ncpus) to
+# run into the GHC #9221 bug which can result in longer build-times.
+
+sed -i -r 's/(^jobs:).*/\1 2/' $HOME/.cabal/config
+cabal install -f FFI --only-dependencies --enable-tests --dry -v > installplan.txt
+sed -i -e '1,/^Resolving /d' installplan.txt; cat installplan.txt
+
+
+#  ---------------------------------------------------------- [ Package Checks ]
+#
+# check whether current requested install-plan matches cached package-db snapshot
+
+if diff -u installplan.txt $HOME/.cabsnap/installplan.txt;
+then
+    echo "cabal build-cache HIT";
+    rm -rfv .ghc;
+    cp -a $HOME/.cabsnap/ghc $HOME/.ghc;
+    cp -a $HOME/.cabsnap/lib $HOME/.cabsnap/share $HOME/.cabsnap/bin $HOME/.cabal/;
+else
+    echo "cabal build-cache MISS";
+    rm -rf $HOME/.cabsnap;
+    mkdir -p $HOME/.ghc $HOME/.cabal/lib $HOME/.cabal/share $HOME/.cabal/bin;
+    cabal install -f FFI --only-dependencies --enable-tests;
+fi
+
+#  ------------------------------------------------------- [ Package-DB Saving ]
+#
+# snapshot package-db on cache miss
+
+if [ ! -d $HOME/.cabsnap ];
+then
+    echo "snapshotting package-db to build-cache";
+    mkdir $HOME/.cabsnap;
+    cp -a $HOME/.ghc $HOME/.cabsnap/ghc;
+    cp -a $HOME/.cabal/lib $HOME/.cabal/share $HOME/.cabal/bin installplan.txt $HOME/.cabsnap/;
+fi
+
+#  --------------------------------------------------------------------- [ EOS ]

--- a/scripts/travis-test.sh
+++ b/scripts/travis-test.sh
@@ -1,0 +1,28 @@
+#!/bin/bash
+# ---------------------------------------------------------- [ travis-test.sh ]
+# The test script used as part of the travis set up.
+#
+# --------------------------------------------------------------------- [ EOH ]
+
+set -ev
+
+if [[ "$STACKTEST" == "stack_test" ]];
+then
+    stack --no-terminal --system-ghc build;
+else
+    cabal configure -f FFI -f CI;
+    cabal build;
+    cabal copy;
+    cabal register;
+    if [[ "$TESTS" == "test_c" ]];
+    then
+        cppcheck -i 'mini-gmp.c' rts;
+    fi
+    for test in $TESTS;
+    do
+        echo "make -j2 $test";
+        make -j2 $test;
+    done
+fi
+
+#  --------------------------------------------------------------------- [ EOS ]

--- a/stack.yaml
+++ b/stack.yaml
@@ -1,8 +1,6 @@
 flags: {}
 packages:
 - '.'
-extra-deps: 
-- cheapskate-0.1.0.4
-- hscurses-1.4.2.0
+extra-deps:
 - libffi-0.1
-resolver: lts-3.0
+resolver: nightly-2015-09-21

--- a/stack.yaml
+++ b/stack.yaml
@@ -3,4 +3,6 @@ packages:
 - '.'
 extra-deps: 
 - cheapskate-0.1.0.4
-resolver: nightly-2015-07-24
+- hscurses-1.4.2.0
+- libffi-0.1
+resolver: lts-3.0


### PR DESCRIPTION
The stack configuration file has been updated to use LTS Haskell 3.0 resolver, and the inclusion of dependencies for the ffi and curses flags.

Flags are called per package either in the stack file or with cmd opts of `--flag <pkg name>:<flag>` before I wanted to explicitly state the flags but I think it best we do this using command line options.

Further to get Idris to use LTS Haskell, lens had to be bumped up to the latest version used in LTS Haskell.

I have tested this against Idris HEAD using the following setup:

+ Ubuntu LTS 14.04.3
+ GHC 7.10.2
+ Cabal-Install 1.22.6.0 with library 1.22.4.0
+ Stack Version 0.1.2.0 with resolver lts-3.0

and command

    stack install --flag idris:FFI --flag idris:GMP

My only concern is building Idris using Stack and the other flags i.e. curses and CI and release, and on other platforms i.e. Mac OS X, and Windows.
