### PR TITLE
No need to add .exe to the output name, it will be done later anyway

### DIFF
--- a/src/Pkg/PParser.hs
+++ b/src/Pkg/PParser.hs
@@ -66,10 +66,7 @@ pClause :: PParser ()
 pClause = do reserved "executable"; lchar '=';
              exec <- fst <$> iName []
              st <- get
-             put (st { execout = Just (if isWindows
-                                          then ((show exec) ++ ".exe")
-                                          else ( show exec )
-                                      ) })
+             put (st { execout = Just (show exec) })
       <|> do reserved "main"; lchar '=';
              main <- fst <$> iName []
              st <- get


### PR DESCRIPTION
And we don't know what code generator is used.

Fixes #2523