### PR TITLE
Remove direct dep on lens

### DIFF
--- a/idris.cabal
+++ b/idris.cabal
@@ -909,7 +909,6 @@ Library
                 , filepath < 1.5
                 , fingertree >= 0.1 && < 0.2
                 , haskeline >= 0.7 && < 0.8
-                , lens >= 4.1.1 && < 4.12
                 , mtl >= 2.1 && < 2.3
                 , network < 2.7
                 , optparse-applicative >= 0.11 && < 0.12


### PR DESCRIPTION
While lens is a transitive dep of trifecta, we're not using it directly.
Don't think specifying ranges on it is helpful for us.