### PR TITLE
Check for TTY when setting colour

### DIFF
--- a/src/Idris/REPL.hs
+++ b/src/Idris/REPL.hs
@@ -1626,7 +1626,8 @@ idrisMain opts =
 
        when (DefaultTotal `elem` opts) $ do i <- getIState
                                             putIState (i { default_total = True })
-       setColourise $ not quiet && last (True : opt getColour opts)
+       tty <- runIO $ isATTY
+       setColourise $ not quiet && last (tty : opt getColour opts)
 
 
 


### PR DESCRIPTION
This means that when doing a redirect to file, one doesn't have to turn
off colour manually.

@david-christiansen not anything to do with the Windows commit, just a tweak I saw now that I don't live in a monochrome world.