### PR TITLE
Unescape '\' in list of non–user-definable symbols

### DIFF
--- a/docs/tutorial/typesfuns.rst
+++ b/docs/tutorial/typesfuns.rst
@@ -107,7 +107,7 @@ symbols:
 
 Some operators built from these symbols can't be user defined. These are
 ``:``,  ``=>``,  ``->``,  ``<-``,  ``=``,  ``?=``,  ``|``,  ``**``,
-``==>``,  ``\\``,  ``%``,  ``~``,  ``?``,  and ``!``.
+``==>``,  ``\``,  ``%``,  ``~``,  ``?``,  and ``!``.
 
 Functions
 =========


### PR DESCRIPTION
The docs made it seem that a double-backslash was not user definable.
It turns out that it's a single backslash that's not user definable;
the docs preserved escaping from the Haskell implementation
(cf. src/Idris/ParseHelpers.hs:/invalidOperators/).

Thanks to @mietek, niklasl2, and @Melvar for pointing this out
in #idris.