### PR TITLE
Fix #2241 by adding a customized display for records documentation

### DIFF
--- a/src/Idris/AbsSyntax.hs
+++ b/src/Idris/AbsSyntax.hs
@@ -397,6 +397,10 @@ addClass n i
                       _ -> i
         putIState $ ist { idris_classes = addDef n i' (idris_classes ist) }
 
+addRecord :: Name -> RecordInfo -> Idris ()
+addRecord n ri = do ist <- getIState
+                    putIState $ ist { idris_records = addDef n ri (idris_records ist) }
+
 addAutoHint :: Name -> Name -> Idris ()
 addAutoHint n hint =
     do ist <- getIState

--- a/src/Idris/AbsSyntaxTree.hs
+++ b/src/Idris/AbsSyntaxTree.hs
@@ -177,6 +177,7 @@ data IState = IState {
     idris_implicits :: Ctxt [PArg],
     idris_statics :: Ctxt [Bool],
     idris_classes :: Ctxt ClassInfo,
+    idris_records :: Ctxt RecordInfo,
     idris_dsls :: Ctxt DSL,
     idris_optimisation :: Ctxt OptInfo,
     idris_datatypes :: Ctxt TypeInfo,
@@ -336,7 +337,7 @@ idrisInit = IState initContext S.empty []
                    emptyContext emptyContext emptyContext emptyContext
                    emptyContext emptyContext emptyContext emptyContext
                    emptyContext emptyContext emptyContext emptyContext
-                   emptyContext
+                   emptyContext emptyContext
                    [] [] [] defaultOpts 6 [] [] [] [] emptySyntaxRules [] [] [] [] [] [] []
                    [] [] Nothing [] Nothing [] [] Nothing Nothing [] Hidden False [] Nothing [] []
                    (RawOutput stdout) True defaultTheme [] (0, emptyContext) emptyContext M.empty
@@ -1276,6 +1277,12 @@ data ClassInfo = CI { instanceCtorName :: Name,
 deriving instance Binary ClassInfo
 deriving instance NFData ClassInfo
 !-}
+
+-- Record data
+data RecordInfo = RI { record_parameters :: [(Name,PTerm)],
+                       record_constructor :: Name,
+                       record_projections :: [Name] }
+    deriving Show
 
 -- Type inference data
 

--- a/src/Idris/AbsSyntaxTree.hs
+++ b/src/Idris/AbsSyntaxTree.hs
@@ -291,6 +291,7 @@ data IBCWrite = IBCFix FixDecl
               | IBCImp Name
               | IBCStatic Name
               | IBCClass Name
+              | IBCRecord Name
               | IBCInstance Bool Bool Name Name
               | IBCDSL Name
               | IBCData Name

--- a/src/Idris/DeepSeq.hs
+++ b/src/Idris/DeepSeq.hs
@@ -346,6 +346,10 @@ instance NFData ClassInfo where
           = rnf x1 `seq`
               rnf x2 `seq` rnf x3 `seq` rnf x4 `seq` rnf x5 `seq` rnf x6 `seq` rnf x7 `seq` ()
 
+instance NFData RecordInfo where
+        rnf (RI x1 x2 x3)
+          = rnf x1 `seq` rnf x2 `seq` rnf x3 `seq` ()
+
 instance NFData OptInfo where
         rnf (Optimise x1 x2)
           = rnf x1 `seq` rnf x2 `seq` ()

--- a/src/Idris/Docs.hs
+++ b/src/Idris/Docs.hs
@@ -334,7 +334,7 @@ docRecord n ri
   = do i <- getIState
        let docStrings = listToMaybe $ lookupCtxt n $ idris_docstrings i
            docstr = maybe emptyDocstring fst docStrings
-           params = map (\(pn,pt) -> (pn, pt, docStrings >>= (lookup pn . snd)))
+           params = map (\(pn,pt) -> (pn, pt, docStrings >>= (lookup (nsroot pn) . snd)))
                         (record_parameters ri)
        pdocs <- mapM docFun (record_projections ri)
        ctorDocs <- docFun $ record_constructor ri

--- a/src/Idris/Elab/Record.hs
+++ b/src/Idris/Elab/Record.hs
@@ -68,6 +68,7 @@ elabRecord info what doc rsyn fc opts tyn nfc params paramDocs fields cname cdoc
        let parameters = [(n,pt) | (n, _, _, pt) <- params]
        let projections = [n | (n, _, _, _, _) <- fieldsWithName]
        addRecord tyn (RI parameters dconName projections)
+       addIBC (IBCRecord tyn)
 
        when (what /= ETypes) $ do
            logLvl 1 $ "fieldsWithName " ++ show fieldsWithName

--- a/src/Idris/Elab/Record.hs
+++ b/src/Idris/Elab/Record.hs
@@ -64,6 +64,11 @@ elabRecord info what doc rsyn fc opts tyn nfc params paramDocs fields cname cdoc
                            _ -> PDatadecl tyn NoFC tycon [(cdoc, dconsArgDocs, dconName, NoFC, dconTy, fc, [])]
        elabData info rsyn doc paramDocs fc opts datadecl
 
+       -- Keep track of the record
+       let parameters = [(n,pt) | (n, _, _, pt) <- params]
+       let projections = [n | (n, _, _, _, _) <- fieldsWithName]
+       addRecord tyn (RI parameters dconName projections)
+
        when (what /= ETypes) $ do
            logLvl 1 $ "fieldsWithName " ++ show fieldsWithName
            logLvl 1 $ "fieldsWIthNameAndDoc " ++ show fieldsWithNameAndDoc

--- a/src/Idris/IdrisDoc.hs
+++ b/src/Idris/IdrisDoc.hs
@@ -602,9 +602,12 @@ createOtherDoc ist (RecordDoc n doc ctor projs params) = do
     H.span ! class_ "name type"
            ! title (toValue $ show n)
            $ toHtml $ name $ nsroot n
-    H.span ! class_ "signature" $ nbsp
+    H.span ! class_ "type" $ do nbsp ; prettyParameters
   H.dd $ do
     (if nullDocstring doc then Empty else Docstrings.renderHtml doc)
+    if not $ null params
+       then H.dl $ forM_ params genParam
+       else Empty
     H.dl ! class_ "decls" $ createFunDoc ist ctor
     H.dl ! class_ "decls" $ forM_ projs (createFunDoc ist)
   where name (NS n ns) = show (NS (sUN $ name n) ns)
@@ -612,6 +615,12 @@ createOtherDoc ist (RecordDoc n doc ctor projs params) = do
                          in if (head n') `elem` opChars
                                then '(':(n' ++ ")")
                                else n'
+
+        genParam (name, pt, docstring) = do
+          H.dt $ toHtml $ show (nsroot name)
+          H.dd $ maybe nbsp Docstrings.renderHtml docstring
+
+        prettyParameters = toHtml $ unwords [show $ nsroot n | (n,_,_) <- params]
 
 createOtherDoc ist (DataDoc fd@(FD n docstring args _ _) fds) = do
   H.dt ! (A.id $ toValue $ show n) $ do

--- a/src/Idris/IdrisDoc.hs
+++ b/src/Idris/IdrisDoc.hs
@@ -221,6 +221,7 @@ referredNss (n, Just d, _) =
   where getFunDocs (FunDoc f)                  = [f]
         getFunDocs (DataDoc f fs)              = f:fs
         getFunDocs (ClassDoc _ _ fs _ _ _ _ _) = fs
+        getFunDocs (RecordDoc _ _ f fs _)      = f:fs
         getFunDocs (NamedInstanceDoc _ fd)     = [fd]
         getFunDocs (ModDoc _ _)                = []
         types (FD _ _ args t _)                = t:(map second args)
@@ -594,6 +595,23 @@ createOtherDoc ist (ClassDoc n docstring fds _ _ _ _ c) = do
                          in  if (head n') `elem` opChars
                                 then '(':(n' ++ ")")
                                 else n'
+
+createOtherDoc ist (RecordDoc n doc ctor projs params) = do
+  H.dt ! (A.id $ toValue $ show n) $ do
+    H.span ! class_ "word" $ do "record"; nbsp
+    H.span ! class_ "name type"
+           ! title (toValue $ show n)
+           $ toHtml $ name $ nsroot n
+    H.span ! class_ "signature" $ nbsp
+  H.dd $ do
+    (if nullDocstring doc then Empty else Docstrings.renderHtml doc)
+    H.dl ! class_ "decls" $ createFunDoc ist ctor
+    H.dl ! class_ "decls" $ forM_ projs (createFunDoc ist)
+  where name (NS n ns) = show (NS (sUN $ name n) ns)
+        name n         = let n' = show n
+                         in if (head n') `elem` opChars
+                               then '(':(n' ++ ")")
+                               else n'
 
 createOtherDoc ist (DataDoc fd@(FD n docstring args _ _) fds) = do
   H.dt ! (A.id $ toValue $ show n) $ do


### PR DESCRIPTION
Fix #2241

Records documentation is now reported with a customized display that lists parameters, constructor and projections.
The changes are visible in the REPL (with :doc) or in the HTML documentation (--mkdoc). 

Examples of code:
```idris
import Data.Vect

record Person where
    constructor MkPerson
    firstName : String
    middleName : String
    lastName : String
    age : Int

record SizedClass (size : Nat) where
    constructor SizedClassInfo 
    students : Vect size Person
    className : String
    
record Prod a b where
    constructor Times
    fst : a
    snd : b
```
Example of documentation:
```
> :doc Person
Record Person

Constructor:
    MkPerson : (firstName : String) ->
        (middleName : String) ->
        (lastName : String) -> (age : Int) -> Person
        
        
Projections:
    firstName : (rec : Person) -> String
        
        
    middleName : (rec : Person) -> String
        
        
    lastName : (rec : Person) -> String
        
        
    age : (rec : Person) -> Int
        
        
> :doc SizedClass
Record SizedClass

Parameters:
    size : Nat

Constructor:
    SizedClassInfo : (students : Vect size Person) ->
        (className : String) -> SizedClass size
        
        
Projections:
    students : (rec : SizedClass size) -> Vect size Person
        
        
    className : (rec : SizedClass size) -> String
        
        
> :doc Prod 
Record Prod

Parameters:
    a : Type, b : Type

Constructor:
    Times : (fst : a) -> (snd : b) -> Prod a b
        
        
Projections:
    fst : (rec : Prod a b) -> a
        
        
    snd : (rec : Prod a b) -> b
        
        

```