### PR TITLE
Add docs, stack.yaml and benchmarks to idris.cabal

### DIFF
--- a/idris.cabal
+++ b/idris.cabal
@@ -76,9 +76,23 @@ Data-files:            idrisdoc/styles.css
                        rts/mini-gmp.h
                        rts/libtest.c
 
+Extra-doc-files:
+                       CHANGELOG
+                       CITATION.md
+                       CONTRIBUTING.md
+                       CONTRIBUTORS
+                       README.md
+                       idris-tutorial.pdf
+                       man/idris.1
+                       samples/effects/*.idr
+                       samples/misc/*.idr
+                       samples/misc/*.lidr
+                       samples/tutorial/*.idr
+
 Extra-source-files:
                        Makefile
                        config.mk
+                       stack.yaml
 
                        rts/*.c
                        rts/*.h
@@ -745,6 +759,22 @@ Extra-source-files:
                        test/docs003/*.idr
                        test/docs003/expected
 
+                       benchmarks/ALL
+                       benchmarks/*.pl
+                       benchmarks/README
+
+                       benchmarks/fasta/fasta.idr
+                       benchmarks/fasta/fasta.ipkg
+
+                       benchmarks/pidigits/pidigits.idr
+                       benchmarks/pidigits/pidigits.ipkg
+
+                       benchmarks/quasigroups/board
+                       benchmarks/quasigroups/*.idr
+                       benchmarks/quasigroups/qgsolve.ipkg
+
+                       benchmarks/trivial/sortvec.idr
+                       benchmarks/trivial/sortvec.ipkg
 
 source-repository head
   type:     git


### PR DESCRIPTION
Added the text and Markdown documentation to sdists and installations
with the extra-doc-files cabal field. This misses all the Sphinx docs -
the effect of that field is just to copy the files as is and we really
want the outputted HTML. I'm sure it's possible to generate the HTML
with Sphinx at the same time as Haddock, I just didn't bother figuring
out how. I'll add an issue.

Added stack.yaml and the benchmarks to extra-source-files. This just
copies them in sdists.