### PR TITLE
Avoid confusion between the compiler and codegens

### DIFF
--- a/codegen/idris-codegen-c/Main.hs
+++ b/codegen/idris-codegen-c/Main.hs
@@ -21,8 +21,9 @@ data Opts = Opts { really :: Bool,
                    interface :: Bool,
                    output :: FilePath }
 
-showUsage = do putStrLn "A code generator which is intended to be called by the compiler, not by a user.\n"
-               putStrLn "Usage: idris-codegen-c --yes-really <ibc-files> [-o <output-file>]"
+showUsage = do putStrLn "A code generator which is intended to be called by the compiler, not by a user."
+               putStrLn "To call the code generator manually, pass the --yes-really option.\n"
+               putStrLn "Usage: idris-codegen-c [--yes-really] <ibc-files> [-o <output-file>]"
                exitWith ExitSuccess
 
 getOpts :: IO Opts

--- a/codegen/idris-codegen-c/Main.hs
+++ b/codegen/idris-codegen-c/Main.hs
@@ -21,7 +21,8 @@ data Opts = Opts { really :: Bool,
                    interface :: Bool,
                    output :: FilePath }
 
-showUsage = do putStrLn "Usage: idris-codegen-c --yes-really <ibc-files> [-o <output-file>]"
+showUsage = do putStrLn "A code generator which is intended to be called by the compiler, not by a user.\n"
+               putStrLn "Usage: idris-codegen-c --yes-really <ibc-files> [-o <output-file>]"
                exitWith ExitSuccess
 
 getOpts :: IO Opts
@@ -49,6 +50,7 @@ main = do opts <- getOpts
           if (null (inputs opts))
              then showUsage
              else if (not $ really opts)
-                     then do putStrLn "This is not what you may expect it is."
-                             showUsage
+                     then do putStrLn "This code generator is intended to be called by the Idris compiler. \
+                                      \Please pass Idris the '--codegen' flag to choose a backend."
+                             exitWith ExitSuccess
                      else runMain (c_main opts)

--- a/codegen/idris-codegen-c/Main.hs
+++ b/codegen/idris-codegen-c/Main.hs
@@ -16,17 +16,19 @@ import Paths_idris
 
 import Util.System
 
-data Opts = Opts { inputs :: [FilePath],
+data Opts = Opts { really :: Bool,
+                   inputs :: [FilePath],
                    interface :: Bool,
                    output :: FilePath }
 
-showUsage = do putStrLn "Usage: idris-c <ibc-files> [-o <output-file>]"
+showUsage = do putStrLn "Usage: idris-codegen-c --yes-really <ibc-files> [-o <output-file>]"
                exitWith ExitSuccess
 
 getOpts :: IO Opts
 getOpts = do xs <- getArgs
-             return $ process (Opts [] False "a.out") xs
+             return $ process (Opts False [] False "a.out") xs
   where
+    process opts ("--yes-really":xs) = process (opts { really = True }) xs
     process opts ("-o":o:xs) = process (opts { output = o }) xs
     process opts ("--interface":xs) = process (opts { interface = True }) xs
     process opts (x:xs) = process (opts { inputs = x:inputs opts }) xs
@@ -36,7 +38,7 @@ c_main :: Opts -> Idris ()
 c_main opts = do runIO setupBundledCC
                  elabPrims
                  loadInputs (inputs opts) Nothing
-                 mainProg <- if interface opts 
+                 mainProg <- if interface opts
                                 then liftM Just elabMain
                                 else return Nothing
                  ir <- compile (Via "c") (output opts) mainProg
@@ -44,9 +46,9 @@ c_main opts = do runIO setupBundledCC
 
 main :: IO ()
 main = do opts <- getOpts
-          if (null (inputs opts)) 
+          if (null (inputs opts))
              then showUsage
-             else runMain (c_main opts)
-
-
-
+             else if (not $ really opts)
+                     then do putStrLn "This is not what you may expect it is."
+                             showUsage
+                     else runMain (c_main opts)

--- a/codegen/idris-codegen-javascript/Main.hs
+++ b/codegen/idris-codegen-javascript/Main.hs
@@ -18,8 +18,9 @@ data Opts = Opts { really :: Bool
                  , output :: FilePath
                  }
 
-showUsage = do putStrLn "A code generator which is intended to be called by the compiler, not by a user.\n"
-               putStrLn "Usage: idris-codegen-javascript --yes-really <ibc-files> [-o <output-file>]"
+showUsage = do putStrLn "A code generator which is intended to be called by the compiler, not by a user."
+               putStrLn "To call the code generator manually, pass the --yes-really option.\n"
+               putStrLn "Usage: idris-codegen-c [--yes-really] <ibc-files> [-o <output-file>]"
                exitWith ExitSuccess
 
 getOpts :: IO Opts

--- a/codegen/idris-codegen-javascript/Main.hs
+++ b/codegen/idris-codegen-javascript/Main.hs
@@ -18,7 +18,8 @@ data Opts = Opts { really :: Bool
                  , output :: FilePath
                  }
 
-showUsage = do putStrLn "Usage: idris-codegen-javascript --yes-really <ibc-files> [-o <output-file>]"
+showUsage = do putStrLn "A code generator which is intended to be called by the compiler, not by a user.\n"
+               putStrLn "Usage: idris-codegen-javascript --yes-really <ibc-files> [-o <output-file>]"
                exitWith ExitSuccess
 
 getOpts :: IO Opts
@@ -42,6 +43,7 @@ main = do opts <- getOpts
           if (null (inputs opts))
              then showUsage
              else if (not $ really opts)
-                     then do putStrLn "This is not what you may expect it is."
-                             showUsage
+                     then do putStrLn "This code generator is intended to be called by the Idris compiler. \
+                                      \Please pass Idris the '--codegen' flag to choose a backend."
+                             exitWith ExitSuccess
                      else runMain (jsMain opts)

--- a/codegen/idris-codegen-javascript/Main.hs
+++ b/codegen/idris-codegen-javascript/Main.hs
@@ -13,17 +13,19 @@ import System.Exit
 
 import Paths_idris
 
-data Opts = Opts { inputs :: [FilePath]
+data Opts = Opts { really :: Bool
+                 , inputs :: [FilePath]
                  , output :: FilePath
                  }
 
-showUsage = do putStrLn "Usage: idris-javascript <ibc-files> [-o <output-file>]"
+showUsage = do putStrLn "Usage: idris-codegen-javascript --yes-really <ibc-files> [-o <output-file>]"
                exitWith ExitSuccess
 
 getOpts :: IO Opts
 getOpts = do xs <- getArgs
-             return $ process (Opts [] "main.js") xs
+             return $ process (Opts False [] "main.js") xs
   where
+    process opts ("--yes-really":xs) = process (opts { really = True }) xs
     process opts ("-o":o:xs) = process (opts { output = o }) xs
     process opts (x:xs) = process (opts { inputs = x:inputs opts }) xs
     process opts [] = opts
@@ -39,4 +41,7 @@ main :: IO ()
 main = do opts <- getOpts
           if (null (inputs opts))
              then showUsage
-             else runMain (jsMain opts)
+             else if (not $ really opts)
+                     then do putStrLn "This is not what you may expect it is."
+                             showUsage
+                     else runMain (jsMain opts)

--- a/codegen/idris-codegen-node/Main.hs
+++ b/codegen/idris-codegen-node/Main.hs
@@ -13,17 +13,19 @@ import System.Exit
 
 import Paths_idris
 
-data Opts = Opts { inputs :: [FilePath]
+data Opts = Opts { really :: Bool
+                 , inputs :: [FilePath]
                  , output :: FilePath
                  }
 
-showUsage = do putStrLn "Usage: idris-node <ibc-files> [-o <output-file>]"
+showUsage = do putStrLn "Usage: idris-codegen-node --yes-really <ibc-files> [-o <output-file>]"
                exitWith ExitSuccess
 
 getOpts :: IO Opts
 getOpts = do xs <- getArgs
-             return $ process (Opts [] "main.js") xs
+             return $ process (Opts False [] "main.js") xs
   where
+    process opts ("--yes-really":xs) = process (opts { really = True }) xs
     process opts ("-o":o:xs) = process (opts { output = o }) xs
     process opts (x:xs) = process (opts { inputs = x:inputs opts }) xs
     process opts [] = opts
@@ -39,4 +41,7 @@ main :: IO ()
 main = do opts <- getOpts
           if (null (inputs opts))
              then showUsage
-             else runMain (jsMain opts)
+             else if (not $ really opts)
+                     then do putStrLn "This is not what you may expect it is."
+                             showUsage
+                     else runMain (jsMain opts)

--- a/codegen/idris-codegen-node/Main.hs
+++ b/codegen/idris-codegen-node/Main.hs
@@ -18,8 +18,9 @@ data Opts = Opts { really :: Bool
                  , output :: FilePath
                  }
 
-showUsage = do putStrLn "A code generator which is intended to be called by the compiler, not by a user.\n"
-               putStrLn "Usage: idris-codegen-node --yes-really <ibc-files> [-o <output-file>]"
+showUsage = do putStrLn "A code generator which is intended to be called by the compiler, not by a user."
+               putStrLn "To call the code generator manually, pass the --yes-really option.\n"
+               putStrLn "Usage: idris-codegen-c [--yes-really] <ibc-files> [-o <output-file>]"
                exitWith ExitSuccess
 
 getOpts :: IO Opts

--- a/codegen/idris-codegen-node/Main.hs
+++ b/codegen/idris-codegen-node/Main.hs
@@ -18,7 +18,8 @@ data Opts = Opts { really :: Bool
                  , output :: FilePath
                  }
 
-showUsage = do putStrLn "Usage: idris-codegen-node --yes-really <ibc-files> [-o <output-file>]"
+showUsage = do putStrLn "A code generator which is intended to be called by the compiler, not by a user.\n"
+               putStrLn "Usage: idris-codegen-node --yes-really <ibc-files> [-o <output-file>]"
                exitWith ExitSuccess
 
 getOpts :: IO Opts
@@ -42,6 +43,7 @@ main = do opts <- getOpts
           if (null (inputs opts))
              then showUsage
              else if (not $ really opts)
-                     then do putStrLn "This is not what you may expect it is."
-                             showUsage
+                     then do putStrLn "This code generator is intended to be called by the Idris compiler. \
+                                      \Please pass Idris the '--codegen' flag to choose a backend."
+                             exitWith ExitSuccess
                      else runMain (jsMain opts)

--- a/idris.cabal
+++ b/idris.cabal
@@ -991,9 +991,9 @@ Executable idris
   ghc-prof-options: -auto-all -caf-all
   ghc-options:      -threaded -rtsopts -funbox-strict-fields
 
-Executable idris-c
+Executable idris-codegen-c
   Main-is:        Main.hs
-  hs-source-dirs: codegen/idris-c
+  hs-source-dirs: codegen/idris-codegen-c
 
   Build-depends:  idris
                 , base
@@ -1004,9 +1004,9 @@ Executable idris-c
   ghc-prof-options: -auto-all -caf-all
   ghc-options:      -threaded -rtsopts -funbox-strict-fields
 
-Executable idris-javascript
+Executable idris-codegen-javascript
   Main-is:        Main.hs
-  hs-source-dirs: codegen/idris-javascript
+  hs-source-dirs: codegen/idris-codegen-javascript
 
   Build-depends:  idris
                 , base
@@ -1017,9 +1017,9 @@ Executable idris-javascript
   ghc-prof-options: -auto-all -caf-all
   ghc-options:      -threaded -rtsopts -funbox-strict-fields
 
-Executable idris-node
+Executable idris-codegen-node
   Main-is:        Main.hs
-  hs-source-dirs: codegen/idris-node
+  hs-source-dirs: codegen/idris-codegen-node
 
   Build-depends:  idris
                 , base

--- a/src/IRTS/Compiler.hs
+++ b/src/IRTS/Compiler.hs
@@ -135,8 +135,8 @@ generate codegen mainmod ir
        -- Built-in code generators (FIXME: lift these out!)
        Via "c" -> codegenC ir
        -- Any external code generator
-       Via cg -> do let cmd = "idris-" ++ cg
-                        args = [mainmod, "-o", outputFile ir] ++ compilerFlags ir
+       Via cg -> do let cmd = "idris-codegen-" ++ cg
+                        args = ["--yes-really", mainmod, "-o", outputFile ir] ++ compilerFlags ir
                     exit <- rawSystem cmd args
                     when (exit /= ExitSuccess) $
                        putStrLn ("FAILURE: " ++ show cmd ++ " " ++ show args)


### PR DESCRIPTION
Two things are done

- `idris-‹codegen name›` is now `idris-codegen-‹codegen name›`
- Added flag `--yes-really` to avoid *accidental* usage of codegens instead of the compiler

Resolves https://github.com/idris-lang/Idris-dev/issues/2194.
