### PR TITLE
Tweak show instances in Logging effect

### DIFF
--- a/libs/effects/Effect/Logging/Category.idr
+++ b/libs/effects/Effect/Logging/Category.idr
@@ -26,7 +26,7 @@ record LogRes (a : Type) where
   getCategories : List a
 
 instance (Show a) => Show (LogRes a) where
-  show (MkLogRes l cs) = unwords ["Log Settings:", show l, show cs]
+  showPrec d (MkLogRes l cs) = showCon "MkLogRes" $ showArg l ++ showArg cs
 
 instance Default (LogRes a) where
   default = MkLogRes OFF Nil

--- a/libs/effects/Effect/Logging/Level.idr
+++ b/libs/effects/Effect/Logging/Level.idr
@@ -58,15 +58,15 @@ instance Cast (LogLevel n) Nat where
   cast {n} _ = n
 
 instance Show (LogLevel n) where
-  show OFF        = "OFF"
-  show TRACE      = "TRACE"
-  show DEBUG      = "DEBUG"
-  show INFO       = "INFO"
-  show WARN       = "WARN"
-  show FATAL      = "FATAL"
-  show ERROR      = "ERROR"
-  show ALL        = "ALL"
-  show (CUSTOM n) = unwords ["CUSTOM", show n]
+  showPrec d OFF        = "OFF"
+  showPrec d TRACE      = "TRACE"
+  showPrec d DEBUG      = "DEBUG"
+  showPrec d INFO       = "INFO"
+  showPrec d WARN       = "WARN"
+  showPrec d FATAL      = "FATAL"
+  showPrec d ERROR      = "ERROR"
+  showPrec d ALL        = "ALL"
+  showPrec d (CUSTOM n) = showCon d "CUSTOM" $ showArg n
 
 instance Eq (LogLevel n) where
   (==) x y = lvlEq x y


### PR DESCRIPTION
@jfdm I’m not sure what you intended with the `Show` instance for `LogRes`.