### PR TITLE
Make test totality010 work when ncurses is enabled

### DIFF
--- a/test/totality010/run
+++ b/test/totality010/run
@@ -1,3 +1,3 @@
 #!/usr/bin/env bash
-idris $@ totality010.idr --check
+idris $@ totality010.idr --nocolour --consolewidth 80 --check
 rm -f *.ibc


### PR DESCRIPTION
Otherwise, I get escape sequences in the output, making the test fail when I run it locally.