### PR TITLE
Remove +, -, and * on Fin

### DIFF
--- a/CHANGELOG
+++ b/CHANGELOG
@@ -16,6 +16,7 @@ such, the (-) operator and 'abs' have been moved there from 'Num'.
 * A special version of (-) on 'Nat' requires that the second argument is
 smaller than or equal to the first. 'minus' retains the old behaviour,
 returning Z if there is an underflow.
+* The (+), (-), and (*) operations on Fin have been removed.
 * New Logging Effects have been added to facilitate logging of effectful
   programmes.
 

--- a/libs/base/Data/Fin.idr
+++ b/libs/base/Data/Fin.idr
@@ -42,7 +42,7 @@ finToNatInjective FZ     FZ     Refl = Refl
 finToNatInjective (FS m) FZ     Refl impossible
 finToNatInjective FZ     (FS n) Refl impossible
 finToNatInjective (FS m) (FS n) prf  =
-  cong (finToNatInjective m n (succInjective (finToNat m) (finToNat n) prf)) 
+  cong (finToNatInjective m n (succInjective (finToNat m) (finToNat n) prf))
 
 instance Cast (Fin n) Nat where
     cast x = finToNat x
@@ -94,31 +94,13 @@ instance Ord (Fin n) where
   compare  FZ    (FS _) = LT
   compare (FS _)  FZ    = GT
   compare (FS x) (FS y) = compare x y
-  
+
 instance MinBound (Fin (S n)) where
   minBound = FZ
 
 instance MaxBound (Fin (S n)) where
   maxBound = last
 
-
-||| Add two Fins, extending the bound
-(+) : Fin n -> Fin m -> Fin (n + m)
-(+) {n=S n} {m=m} FZ f' = rewrite plusCommutative n m in weaken (weakenN n f')
-(+) (FS f) f' = FS (f + f')
-
-||| Substract two Fins, keeping the bound of the minuend
-(-) : Fin n -> Fin m -> Fin n
-FZ - _ = FZ
-f - FZ = f
-(FS f) - (FS f') = weaken $ f - f'
-
-||| Multiply two Fins, extending the bound
-(*) : Fin n -> Fin m -> Fin (n * m)
-(*) {n=Z} f f' = FinZElim f
-(*) {m=Z} f f' = FinZElim f'
-(*) {n=S n} {m=S m} FZ     f' = FZ
-(*) {n=S n} {m=S m} (FS f) f' = f' + (f * f')
 
 -- Construct a Fin from an integer literal which must fit in the given Fin
 


### PR DESCRIPTION
There are a number of reasonable type signatures for these, and there
doesn't seem to be a reason to prioritize the particular versions in the
library. They generated more questions than actual use.