### PR TITLE
Substring as primitive

### DIFF
--- a/CHANGELOG
+++ b/CHANGELOG
@@ -7,6 +7,8 @@ Language updates
 * Improved unification by implementing a pattern unification rule
 * The syntax `{{n}} quotes n without resolving it, allowing short syntax
   for defining new names. `{n} still quotes n to an existing name in scope.
+* A new primitive operator prim__strSubstr for more efficient extraction of
+  substrings. External code generators should implement this.
 
 Library updates
 ---------------

--- a/idris.cabal
+++ b/idris.cabal
@@ -550,6 +550,7 @@ Extra-source-files:
                        test/primitives001/run
                        test/primitives001/*.idr
                        test/primitives001/expected
+                       test/primitives001/input
                        test/primitives002/run
                        test/primitives002/expected
                        test/primitives003/run

--- a/libs/prelude/Prelude/Strings.idr
+++ b/libs/prelude/Prelude/Strings.idr
@@ -308,12 +308,15 @@ length : String -> Nat
 length = fromInteger . prim__zextInt_BigInt . prim_lenString
 
 ||| Returns a substring of a given string
-||| @index The (zero based) index of the string to extract. If this is
-||| beyond the end of the String, the function returns the empty string.
-||| @len The desired length of the substring. Truncated if this exceeds
-||| the length of the input.
-substr : (index : Nat) -> (len : Nat) -> String -> String
-substr i len = pack . List.take len . drop i . unpack
+|||
+||| @ index The (zero based) index of the string to extract. If this is
+|||         beyond the end of the string, the function returns the empty
+|||         string.
+||| @ len The desired length of the substring. Truncated if this exceeds
+|||       the length of the input.
+||| @ subject The string to return a portion of
+substr : (index : Nat) -> (len : Nat) -> (subject : String) -> String
+substr i len subject = prim__strSubstr (cast i) (cast len) subject
 
 ||| Lowercases all characters in the string.
 |||

--- a/rts/idris_rts.c
+++ b/rts/idris_rts.c
@@ -594,6 +594,17 @@ VAL idris_strIndex(VM* vm, VAL str, VAL i) {
     return MKINT((i_int)idx);
 }
 
+VAL idris_substr(VM* vm, VAL offset, VAL length, VAL str) {
+    char *start = idris_utf8_advance(GETSTR(str), GETINT(offset));
+    char *end = idris_utf8_advance(start, GETINT(length));
+    Closure* newstr = allocate(sizeof(Closure) + (end - start) +1, 0);
+    SETTY(newstr, STRING);
+    newstr -> info.str = (char*)newstr + sizeof(Closure);
+    memcpy(newstr -> info.str, start, end - start);
+    *(newstr -> info.str + (end - start) + 1) = '\0';
+    return newstr;
+}
+
 VAL idris_strRev(VM* vm, VAL str) {
     char *xstr = GETSTR(str);
     Closure* cl = allocate(sizeof(Closure) +

--- a/rts/idris_rts.h
+++ b/rts/idris_rts.h
@@ -314,6 +314,7 @@ VAL idris_strTail(VM* vm, VAL str);
 VAL idris_strCons(VM* vm, VAL x, VAL xs);
 VAL idris_strIndex(VM* vm, VAL str, VAL i);
 VAL idris_strRev(VM* vm, VAL str);
+VAL idris_substr(VM* vm, VAL offset, VAL length, VAL str);
 
 // system infox
 // used indices:

--- a/rts/idris_utf8.c
+++ b/rts/idris_utf8.c
@@ -78,6 +78,32 @@ unsigned idris_utf8_index(char* s, int idx) {
    return top;
 }
 
+char* idris_utf8_advance(char* str, int i) {
+    while (i > 0 && *str != '\0') {
+        // In a UTF8 single-byte char, the highest bit is 0.  In the
+        // first byte of a multi-byte char, the highest two bits are
+        // 11, but the rest of the bytes start with 10. So we can
+        // decrement our character counter when we see something other
+        // than 10 at the front.
+
+        // This is a bit of an overapproximation, as invalid multibyte
+        // sequences that are too long will be treated as if they are
+        // OK, but it's always paying attention to null-termination.
+        if ((*str & 0xc0) != 0x80) {
+            i--;
+        }
+        str++;
+    }
+    // Now we've found the first byte of the last character. Advance
+    // to the end of it, or the end of the string, whichever is first.
+    // Here, we don't risk overrunning the end of the string because
+    // ('\0' & 0xc0) != 0x80.
+    while ((*str & 0xc0) == 0x80) { str++; }
+
+    return str;
+}
+
+
 char* idris_utf8_fromChar(int x) {
     char* str;
     int bytes = 0, top = 0;

--- a/rts/idris_utf8.h
+++ b/rts/idris_utf8.h
@@ -18,5 +18,7 @@ unsigned idris_utf8_index(char* s, int j);
 char* idris_utf8_fromChar(int x);
 // Reverse a UTF8 encoded string, putting the result in 'result'
 char* idris_utf8_rev(char* s, char* result);
-
+// Advance a pointer into a string by i UTF8 characters.
+// Return original pointer if i <= 0.
+char* idris_utf8_advance(char* str, int i);
 #endif

--- a/src/IRTS/CodegenC.hs
+++ b/src/IRTS/CodegenC.hs
@@ -559,6 +559,7 @@ doOp v LStrCons [x, y] = v ++ "idris_strCons(vm, " ++ creg x ++ "," ++ creg y ++
 doOp v LStrIndex [x, y] = v ++ "idris_strIndex(vm, " ++ creg x ++ "," ++ creg y ++ ")"
 doOp v LStrRev [x] = v ++ "idris_strRev(vm, " ++ creg x ++ ")"
 doOp v LStrLen [x] = v ++ "idris_strlen(vm, " ++ creg x ++ ")"
+doOp v LStrSubstr [x,y,z] = v ++ "idris_substr(vm, " ++ creg x ++ "," ++ creg y ++ "," ++ creg z ++ ")"
 
 doOp v LFork [x] = v ++ "MKPTR(vm, vmThread(vm, " ++ cname (sMN 0 "EVAL") ++ ", " ++ creg x ++ "))"
 doOp v LPar [x] = v ++ creg x -- "MKPTR(vm, vmThread(vm, " ++ cname (MN 0 "EVAL") ++ ", " ++ creg x ++ "))"

--- a/src/IRTS/CodegenJavaScript.hs
+++ b/src/IRTS/CodegenJavaScript.hs
@@ -1140,6 +1140,15 @@ jsOP _ reg op args = JSAssign (translateReg reg) jsOP'
                 JSNum (JSInt 1),
                 JSBinOp "-" (JSProj v "length") (JSNum (JSInt 1))
               ]
+      | LStrSubstr <- op
+      , (offset:length:string:_) <- args =
+        let off = translateReg offset
+            len = translateReg length
+            str = translateReg string
+        in JSApp (JSProj str "substr") [
+             jsCall "Math.max" [JSNum (JSInt 0), off],
+             jsCall "Math.max" [JSNum (JSInt 0), len]
+           ]
 
       | LSystemInfo <- op
       , (arg:_) <- args = jsCall "i$systemInfo"  [translateReg arg]

--- a/src/IRTS/Lang.hs
+++ b/src/IRTS/Lang.hs
@@ -74,7 +74,7 @@ data PrimFn = LPlus ArithTy | LMinus ArithTy | LTimes ArithTy
             | LFExp | LFLog | LFSin | LFCos | LFTan | LFASin | LFACos | LFATan
             | LFSqrt | LFFloor | LFCeil | LFNegate
 
-            | LStrHead | LStrTail | LStrCons | LStrIndex | LStrRev
+            | LStrHead | LStrTail | LStrCons | LStrIndex | LStrRev | LStrSubstr
             | LReadStr | LWriteStr
 
             -- system info

--- a/src/Idris/DeepSeq.hs
+++ b/src/Idris/DeepSeq.hs
@@ -84,6 +84,7 @@ instance NFData PrimFn where
     rnf (LStrCons) = ()
     rnf (LStrIndex) = ()
     rnf (LStrRev) = ()
+    rnf (LStrSubstr) = ()
     rnf (LReadStr) = ()
     rnf (LWriteStr) = ()
     rnf (LSystemInfo) = ()

--- a/src/Idris/Primitives.hs
+++ b/src/Idris/Primitives.hs
@@ -15,6 +15,8 @@ import Data.Char
 import Data.Function (on)
 import qualified Data.Vector.Unboxed as V
 
+import Debug.Trace
+
 data Prim = Prim { p_name  :: Name,
                    p_type  :: Type,
                    p_arity :: Int,
@@ -165,6 +167,8 @@ primitives =
     (2, LStrIndex) partial,
    Prim (sUN "prim__strRev") (ty [StrType] StrType) 1 (p_strRev)
     (1, LStrRev) total,
+   Prim (sUN "prim__strSubstr") (ty [AType (ATInt ITNative), AType (ATInt ITNative), StrType] StrType) 3 (p_strSubstr)
+    (3, LStrSubstr) total,
 
    Prim (sUN "prim__readString") (ty [WorldType] StrType) 1 (p_cantreduce)
      (1, LReadStr) total, -- total is okay, because we have 'WorldType'
@@ -493,7 +497,7 @@ p_floatSqrt = p_fPrim sqrt
 p_floatFloor = p_fPrim (fromInteger . floor)
 p_floatCeil = p_fPrim (fromInteger . ceiling)
 
-p_strLen, p_strHead, p_strTail, p_strIndex, p_strCons, p_strRev :: [Const] -> Maybe Const
+p_strLen, p_strHead, p_strTail, p_strIndex, p_strCons, p_strRev, p_strSubstr :: [Const] -> Maybe Const
 p_strLen [Str xs] = Just $ I (length xs)
 p_strLen _ = Nothing
 p_strHead [Str (x:xs)] = Just $ Ch x
@@ -507,6 +511,9 @@ p_strCons [Ch x, Str xs] = Just $ Str (x:xs)
 p_strCons _ = Nothing
 p_strRev [Str xs] = Just $ Str (reverse xs)
 p_strRev _ = Nothing
+p_strSubstr [I offset, I length, Str input] = Just $ Str (take length (drop offset input))
+p_strSubstr _ = Nothing
+
 
 p_cantreduce :: a -> Maybe b
 p_cantreduce _ = Nothing

--- a/test/primitives001/expected
+++ b/test/primitives001/expected
@@ -3,3 +3,21 @@
 ("abc", "123")
 ([1, 2], [3, 4, 5])
 ([1, 2], [3, 4, 5])
+ello! here's the thing
+22
+0
+用的依赖类
+Idris
+[]
+is 是一个通用
+8
+is 是一个通用的依赖类型纯函数式编程语言，其类型系统与 Agda 以及 Epigram 相似。
+48
+Idris 是一个通用的依赖类型纯函
+18
+is is a 
+8
+is is a general-purpose purely functional programming language with dependent types. 
+85
+Idris is a general
+18

--- a/test/primitives001/input
+++ b/test/primitives001/input
@@ -1,0 +1,2 @@
+Idris 是一个通用的依赖类型纯函数式编程语言，其类型系统与 Agda 以及 Epigram 相似。
+Idris is a general-purpose purely functional programming language with dependent types. 

--- a/test/primitives001/run
+++ b/test/primitives001/run
@@ -1,4 +1,6 @@
 #!/usr/bin/env bash
 idris $@ test005.idr -o test005
 ./test005
-rm -f test005 test005.ibc
+idris $@ substring.idr -o substring
+./substring < input
+rm -f test005 substring *.ibc

--- a/test/primitives001/substring.idr
+++ b/test/primitives001/substring.idr
@@ -1,0 +1,51 @@
+-- This is a test of the substring primitive, both in the Idris
+-- evaluator and in some backend. It attempts to exercise that
+-- negative indices are equivalent to 0, that it works for mixed
+-- single- and multi-byte characters, and that overshooting the end
+-- doesn't break things.
+
+-- Single byte test
+foo : String
+foo = "Hello! here's the thing"
+
+-- The first sentence of the Chinese wikipedia article on Idris (to
+-- get mixed single-and-multibyte chars)
+firstSentence : String
+firstSentence = "Idris 是一个通用的依赖类型纯函数式编程语言，其类型系统与 Agda 以及 Epigram 相似。"
+
+emptyTest : prim__strSubstr 100000 14 firstSentence = ""
+emptyTest = Refl
+
+multiTest : prim__strSubstr 10 5 firstSentence = "用的依赖类"
+multiTest = Refl
+
+negative : prim__strSubstr (-10) 5 firstSentence = "Idris"
+negative = Refl
+
+negativeEnd : prim__strSubstr 0 (-1) firstSentence = ""
+negativeEnd = Refl
+
+main : IO ()
+main = do putStrLn $ prim__strSubstr 1 1004 foo
+          printLn $ length $ prim__strSubstr 1 1000 foo
+          printLn $ length $ prim__strSubstr 1000 2 firstSentence
+          putStrLn $ prim__strSubstr 10 5 firstSentence
+          putStrLn $ prim__strSubstr (-10) 5 firstSentence
+          putStrLn $ "[" ++ prim__strSubstr 0 (-1) firstSentence ++ "]"
+          -- Multi-byte dynamic string
+          input <- getLine
+          putStrLn $ prim__strSubstr 3 8 input
+          putStrLn $ show (length (prim__strSubstr 3 8 input))
+          putStrLn $ prim__strSubstr 3 8000 input
+          putStrLn $ show (length (prim__strSubstr 3 8000 input))
+          putStrLn $ prim__strSubstr (-13) 18 input
+          putStrLn $ show (length (prim__strSubstr (-13) 18 input))
+          -- Single-byte dynamic string
+          input <- getLine
+          putStrLn $ prim__strSubstr 3 8 input
+          putStrLn $ show (length (prim__strSubstr 3 8 input))
+          putStrLn $ prim__strSubstr 3 8000 input
+          putStrLn $ show (length (prim__strSubstr 3 8000 input))
+          putStrLn $ prim__strSubstr (-13) 18 input
+          putStrLn $ show (length (prim__strSubstr (-13) 18 input))
+


### PR DESCRIPTION
Introduce a new primitive for taking substrings. This can't really be done efficiently with strTail and strCons, so I think it deserves to exist as a primitive. Implementations are included for the evaluator as well as the C and JS backends. Other backends will need to implement it.

Supersedes #2613, with cleaned up history and tests.