### PR TITLE
Add option to desugar nats in REPL output

### DIFF
--- a/src/Idris/AbsSyntax.hs
+++ b/src/Idris/AbsSyntax.hs
@@ -800,6 +800,18 @@ setEvalTypes n = do i <- getIState
                     let opt' = opts { opt_evaltypes = n }
                     putIState $ i { idris_options = opt' }
 
+getDesugarNats :: Idris Bool
+getDesugarNats = do i <- getIState
+                    let opts = idris_options i
+                    return (opt_desugarnats opts)
+
+
+setDesugarNats :: Bool -> Idris ()
+setDesugarNats n = do i <- getIState
+                      let opts = idris_options i
+                      let opt' = opts { opt_desugarnats = n }
+                      putIState $ i { idris_options = opt' }
+
 setQuiet :: Bool -> Idris ()
 setQuiet q = do i <- getIState
                 let opts = idris_options i

--- a/src/Idris/DeepSeq.hs
+++ b/src/Idris/DeepSeq.hs
@@ -125,6 +125,7 @@ instance NFData Opt where
     rnf (WarnPartial) = ()
     rnf (WarnReach) = ()
     rnf (EvalTypes) = ()
+    rnf (DesugarNats) = ()
     rnf (NoCoverage) = ()
     rnf (ErrContext) = ()
     rnf (ShowImpl) = ()
@@ -192,7 +193,8 @@ instance NFData IOption where
          opt_autoImport
          opt_optimise
          opt_printdepth
-         opt_evaltypes) =
+         opt_evaltypes
+         opt_desugarnats) =
          rnf opt_logLevel
          `seq` rnf opt_typecase
          `seq` rnf opt_typeintype
@@ -216,6 +218,7 @@ instance NFData IOption where
          `seq` rnf opt_optimise
          `seq` rnf opt_printdepth
          `seq` rnf opt_evaltypes
+         `seq` rnf opt_desugarnats
          `seq` ()
 
 instance NFData LanguageExt where

--- a/src/Idris/Delaborate.hs
+++ b/src/Idris/Delaborate.hs
@@ -1,6 +1,6 @@
 {-# LANGUAGE PatternGuards #-}
 {-# OPTIONS_GHC -fwarn-incomplete-patterns #-}
-module Idris.Delaborate (annName, bugaddr, delab, delab', delabMV, delabSugared, delabTy, delabTy', fancifyAnnots, pprintDelab, pprintDelabTy, pprintErr, resugar) where
+module Idris.Delaborate (annName, bugaddr, delab, delab', delabMV, delabSugared, delabTy, delabTy', fancifyAnnots, pprintDelab, pprintNoDelab, pprintDelabTy, pprintErr, resugar) where
 
 -- Convert core TT back into high level syntax, primarily for display
 -- purposes.
@@ -225,6 +225,10 @@ indented = nest errorIndent . (line <>)
 pprintDelab :: IState -> Term -> Doc OutputAnnotation
 pprintDelab ist tm = annotate (AnnTerm [] tm)
                               (prettyIst ist (delabSugared ist tm))
+
+pprintNoDelab :: IState -> Term -> Doc OutputAnnotation
+pprintNoDelab ist tm = annotate (AnnTerm [] tm)
+                              (prettyIst ist (delab ist tm))
 
 -- | Pretty-print the type of some name
 pprintDelabTy :: IState -> Name -> Doc OutputAnnotation

--- a/src/Idris/REPL.hs
+++ b/src/Idris/REPL.hs
@@ -808,7 +808,7 @@ process fn (Eval t)
                       logLvl 3 $ "Raw: " ++ show (tm', ty')
                       logLvl 10 $ "Debug: " ++ showEnvDbg [] tm'
                       let tmDoc = pprintDelab ist tm'
-                          tyDoc = pprintDelab ist ty'
+                          tyDoc =  pprintDelab ist ty'
                       iPrintTermWithType tmDoc tyDoc
   where perhapsForce tm | termSmallerThan 100 tm = force tm
                         | otherwise = tm
@@ -1265,6 +1265,9 @@ process fn (SetOpt WarnReach)     = fmodifyState opts_idrisCmdline $ nub . (Warn
 process fn (UnsetOpt WarnReach)   = fmodifyState opts_idrisCmdline $ delete WarnReach
 process fn (SetOpt EvalTypes)     = setEvalTypes True
 process fn (UnsetOpt EvalTypes)   = setEvalTypes False
+
+process fn (SetOpt DesugarNats)   = setDesugarNats True
+process fn (UnsetOpt DesugarNats) = setDesugarNats False
 
 process fn (SetOpt _) = iPrintError "Not a valid option"
 process fn (UnsetOpt _) = iPrintError "Not a valid option"

--- a/src/Idris/REPLParser.hs
+++ b/src/Idris/REPLParser.hs
@@ -260,6 +260,7 @@ optArg cmd name = do
               <|> do discard (P.symbol "nobanner") ; return NoBanner
               <|> do discard (P.symbol "warnreach"); return WarnReach
               <|> do discard (P.symbol "evaltypes"); return EvalTypes
+              <|> do discard (P.symbol "desugarnats"); return DesugarNats
 
 proofArg :: (Bool -> Int -> Name -> Command) -> String -> P.IdrisParser (Either String Command)
 proofArg cmd name = do


### PR DESCRIPTION
Added option 'desugarnats' to REPL's ':set' and ':unset' commands.
Setting this option prevents the pretty-printer from resugaring terms
of type Nat, as resugaring may obscure unification performed by an
implicit search.  The 'desugarnats' option is set to 'false' by default.

Resolves: #2507