### PR TITLE
WIP: sticking string length in the RTS

### DIFF
--- a/rts/idris_gmp.c
+++ b/rts/idris_gmp.c
@@ -384,12 +384,11 @@ VAL idris_castBigStr(VM* vm, VAL i) {
 
     // Compute the appropriate size in bytes for a C string holding the result
     size_t max_len = mpz_sizeinbase(GETMPZ(GETBIG(vm, i)), 10) + 2;
-    char *temp = (char *)malloc(max_len);
+    char *temp = (char *)calloc(max_len, sizeof(char));
     if (temp == NULL) {
         fprintf(stderr, "Couldn't allocate %lu bytes for bigint as string", (unsigned long)max_len);
         exit(EXIT_FAILURE);
     }
-    memset(temp, '\0', max_len);
     mpz_get_str(temp, 10, GETMPZ(GETBIG(vm, i)));
 
     unsigned int j;

--- a/rts/idris_gmp.c
+++ b/rts/idris_gmp.c
@@ -6,6 +6,7 @@
 #endif
 #include <stdlib.h>
 #include <string.h>
+#include <ctype.h>
 
 // TMP HACK! Require this much space in the heap before a GMP operation
 // so it doesn't garbage collect in the middle.
@@ -374,11 +375,37 @@ VAL idris_castFloatBig(VM* vm, VAL f) {
 }
 
 VAL idris_castStrBig(VM* vm, VAL i) {
-    return MKBIGC(vm, GETSTR(i));
+    // TODO: validate that the string is actually an integer
+    return MKBIGC(vm, (char *) GETSTR(i).str_data);
 }
 
 VAL idris_castBigStr(VM* vm, VAL i) {
-    char* str = mpz_get_str(NULL, 10, GETMPZ(GETBIG(vm, i)));
-    return MKSTR(vm, str);
+
+
+    // Compute the appropriate size in bytes for a C string holding the result
+    size_t max_len = mpz_sizeinbase(GETMPZ(GETBIG(vm, i)), 10) + 2;
+    char *temp = (char *)malloc(max_len);
+    if (temp == NULL) {
+        fprintf(stderr, "Couldn't allocate %lu bytes for bigint as string", (unsigned long)max_len);
+        exit(EXIT_FAILURE);
+    }
+    memset(temp, '\0', max_len);
+    mpz_get_str(temp, 10, GETMPZ(GETBIG(vm, i)));
+
+    unsigned int j;
+    for (j = 0; j < max_len; j++) {
+        if (temp[j] != '\0' && !(isdigit(temp[j])) && temp[j] != '-') {
+            fprintf(stderr, "Fatal error: invalid output from sprintf on an int!");
+            fprintf(stderr, "It was [%c] at index [%u] in [%s].\n", temp[j], j, temp);
+            exit(EXIT_FAILURE);
+        }
+    }
+
+
+    // TODO: validate that mpz_get_str created valid UTF-8
+    VAL res = MKSTR(vm, (utf8_byte *)temp);
+    free(temp);
+
+    return res;
 }
 

--- a/rts/idris_rts.c
+++ b/rts/idris_rts.c
@@ -456,9 +456,12 @@ VAL idris_castIntStr(VM* vm, VAL i) {
 }
 
 VAL idris_castBitsStr(VM* vm, VAL i) {
-    ClosureType ty = i->ty;
+
     // max length 64 bit unsigned int str 20 chars (18,446,744,073,709,551,615)
-    char temp[21] = { 0 };
+    #define MAX_DIGITS_FOR_64_BITS 20
+    ClosureType ty = i->ty;
+
+    char temp[MAX_DIGITS_FOR_64_BITS + 1] = { 0 };
 
     switch (ty) {
     case BITS8:
@@ -480,7 +483,7 @@ VAL idris_castBitsStr(VM* vm, VAL i) {
 
     // avoid invalid UTF-8: all ASCII digits are acceptable as UTF-8 characters.
     int j;
-    for (j = 0; j < 21; j++) {
+    for (j = 0; j < MAX_DIGITS_FOR_64_BITS + 1; j++) {
         if (temp[j] != '\0' && !(isdigit(temp[j]))) {
             fprintf(stderr, "Fatal error: invalid output from sprintf on bit type %d!", ty);
             exit(EXIT_FAILURE);
@@ -519,14 +522,17 @@ VAL idris_castStrInt(VM* vm, VAL i) {
 }
 
 VAL idris_castFloatStr(VM* vm, VAL i) {
-    char temp[32] = { 0 };
-    // snprintf will put a null at the end, so 31 chars are available for the float
-    snprintf(temp, 32, "%.16g", GETFLOAT(i));
+    // Use a maximum of 31 digits to print floats here, plus 1 char for null
+    const unsigned int MAX_CHARS_FOR_DOUBLE = 32;
+    char temp[MAX_CHARS_FOR_DOUBLE];
+    memset(temp, '\0', MAX_CHARS_FOR_DOUBLE);
+
+    snprintf(temp, MAX_CHARS_FOR_DOUBLE, "%.16g", GETFLOAT(i));
 
     // avoid invalid UTF-8: all ASCII digits, plus period, plus, and
     // minus, are acceptable as UTF-8 characters.
     int j;
-    for (j = 0; j < 21; j++) {
+    for (j = 0; j < MAX_CHARS_FOR_DOUBLE; j++) {
         if (temp[j] != '\0' &&
             temp[j] != '.' &&
             temp[j] != '-' &&

--- a/rts/idris_rts.c
+++ b/rts/idris_rts.c
@@ -551,7 +551,8 @@ VAL idris_castFloatStr(VM* vm, VAL i) {
 VAL idris_castStrFloat(VM* vm, VAL i) {
     SizedString str = GETSTR(i);
 
-    // First, we need to alloc a C string that's long enough (to get null-termination)
+    // First, we need to alloc a C string that's long enough for the
+    // data and the null at the end
     char *temp = (char *) malloc(str.size + 1);
     if (temp == NULL) {
         fprintf(stderr, "Couldn't allocate temp buffer of size %lu for int->string conversion", str.size);

--- a/rts/idris_rts.h
+++ b/rts/idris_rts.h
@@ -12,6 +12,7 @@
 
 #include "idris_heap.h"
 #include "idris_stats.h"
+#include "idris_utf8.h"
 
 #ifndef EXIT_SUCCESS
 #define EXIT_SUCCESS 0
@@ -56,7 +57,7 @@ typedef struct Closure {
         con c;
         int i;
         double f;
-        char* str;
+        SizedString* str;
         StrOffset* str_offset;
         void* ptr;
         uint8_t bits8;
@@ -140,7 +141,8 @@ typedef void(*func)(VM*, VAL*);
 #define ALIGN(__p, __alignment) ((__p + __alignment - 1) & ~(__alignment - 1))
 
 // Retrieving values
-#define GETSTR(x) (ISSTR(x) ? (((VAL)(x))->info.str) : GETSTROFF(x))
+#define GETSTR(x) (ISSTR(x) ? (*(((VAL)(x))->info.str)) : GETSTROFF(x))
+#define GETCSTR(x) (idris_get_c_str(GETSTR(x)))
 #define GETPTR(x) (((VAL)(x))->info.ptr)
 #define GETMPTR(x) (((VAL)(x))->info.mptr->data)
 #define GETFLOAT(x) (((VAL)(x))->info.f)
@@ -195,9 +197,14 @@ typedef intptr_t i_int;
 #define CALL(f) f(vm, myoldbase);
 #define TAILCALL(f) f(vm, oldbase);
 
+// Set up the memory layout of a bounds-checked string that will take
+// up size bytes in UTF-8. outerlock is forwarded on to
+// allocate. Return a pointer to the object.
+Closure *idris_allocate_string(size_t size, int outerlock);
+
 // Creating new values (each value placed at the top of the stack)
 VAL MKFLOAT(VM* vm, double val);
-VAL MKSTR(VM* vm, const char* str);
+VAL MKSTR(VM* vm, const utf8_byte* str);
 VAL MKPTR(VM* vm, void* ptr);
 VAL MKMPTR(VM* vm, void* ptr, size_t size);
 VAL MKB8(VM* vm, uint8_t b);
@@ -208,11 +215,12 @@ VAL MKB64(VM* vm, uint64_t b);
 // following versions don't take a lock when allocating
 VAL MKFLOATc(VM* vm, double val);
 VAL MKSTROFFc(VM* vm, StrOffset* off);
-VAL MKSTRc(VM* vm, char* str);
+VAL MKSTRc(VM* vm, SizedString* str);
 VAL MKPTRc(VM* vm, void* ptr);
 VAL MKMPTRc(VM* vm, void* ptr, size_t size);
 
-char* GETSTROFF(VAL stroff);
+SizedString GETSTROFF(VAL stroff);
+char *idris_get_c_str(SizedString str);
 
 // #define SETTAG(x, a) (x)->info.c.tag = (a)
 #define SETARG(x, i, a) ((x)->info.c.args)[i] = ((VAL)(a))

--- a/rts/idris_utf8.h
+++ b/rts/idris_utf8.h
@@ -1,24 +1,38 @@
 #ifndef _IDRIS_UTF8
 #define _IDRIS_UTF8
 
+#include <stdint.h>
+#include <stdlib.h>
+
 /* Various functions for dealing with UTF8 encoding. These are probably
    not very efficient (and I'm (EB) making no guarantees about their
    correctness.) Nevertheless, they mean that we can treat Strings as
    UFT8. Patches welcome :). */
 
+typedef uint8_t utf8_byte;
+
+// Pascal-style strings with their lengths.
+typedef struct {
+    size_t size;
+    utf8_byte* str_data;
+} SizedString;
+
+
+// Get the number of encoding units in a UTF8 string (equivalent to strlen)
+size_t idris_utf8_unitlen(const utf8_byte* s);
 // Get length of a UTF8 encoded string in characters
-int idris_utf8_strlen(char *s);
+unsigned int idris_utf8_strlen(SizedString s);
 // Get number of bytes the first character takes in a string
-int idris_utf8_charlen(char* s);
+unsigned int idris_utf8_charlen(SizedString str);
 // Return int representation of string at an index.
 // Assumes in bounds.
-unsigned idris_utf8_index(char* s, int j);
-// Convert a char as an integer to a char* as a byte sequence
-// Null terminated; caller responsible for freeing
-char* idris_utf8_fromChar(int x);
+unsigned idris_utf8_index(utf8_byte* s, int j);
+// Convert a char as an integer to a char* as a sized string.
+// Caller responsible for freeing the underlying bytes.
+SizedString idris_utf8_fromChar(unsigned int x);
 // Reverse a UTF8 encoded string, putting the result in 'result'
-char* idris_utf8_rev(char* s, char* result);
+utf8_byte* idris_utf8_rev(utf8_byte* s, utf8_byte* result, size_t length);
 // Advance a pointer into a string by i UTF8 characters.
 // Return original pointer if i <= 0.
-char* idris_utf8_advance(char* str, int i);
+utf8_byte* idris_utf8_advance(utf8_byte* str, size_t length, int i);
 #endif

--- a/src/IRTS/CodegenC.hs
+++ b/src/IRTS/CodegenC.hs
@@ -250,7 +250,7 @@ bcc i (CONSTCASE r code def)
      = concatMap (iCase (creg r)) code ++
        indent i ++ "{\n" ++ showDefS i def ++ indent i ++ "}\n"
    | strConsts code
-     = concatMap (strCase ("GETSTR(" ++ creg r ++ ")")) code ++
+     = concatMap (strCase ("GETCSTR(" ++ creg r ++ ")")) code ++
        indent i ++ "{\n" ++ showDefS i def ++ indent i ++ "}\n"
    | bigintConsts code
      = concatMap (biCase (creg r)) code ++
@@ -364,7 +364,7 @@ irts_c (FArith (ATInt ITNative)) x = "GETINT(" ++ x ++ ")"
 irts_c (FArith (ATInt ITChar)) x = irts_c (FArith (ATInt ITNative)) x
 irts_c (FArith (ATInt (ITFixed ity))) x
     = "(" ++ x ++ "->info.bits" ++ show (nativeTyWidth ity) ++ ")"
-irts_c FString x = "GETSTR(" ++ x ++ ")"
+irts_c FString x = "GETCSTR(" ++ x ++ ")"
 irts_c FUnit x = x
 irts_c FPtr x = "GETPTR(" ++ x ++ ")"
 irts_c FManagedPtr x = "GETMPTR(" ++ x ++ ")"
@@ -546,10 +546,9 @@ doOp v LStrLt [l,r] = v ++ "idris_strlt(vm, " ++ creg l ++ ", " ++ creg r ++ ")"
 doOp v LStrEq [l,r] = v ++ "idris_streq(vm, " ++ creg l ++ ", " ++ creg r ++ ")"
 
 doOp v LReadStr [_] = v ++ "idris_readStr(vm, stdin)"
-doOp v LWriteStr [_,s] 
+doOp v LWriteStr [_,s]
              = v ++ "MKINT((i_int)(idris_writeStr(stdout"
-                 ++ ",GETSTR("
-                 ++ creg s ++ "))))"
+                 ++ ",GETCSTR(" ++ creg s ++ "))))"
 
 
 -- String functions which need to know we're UTF8
@@ -578,7 +577,7 @@ doOp v (LExternal rf) [_,x]
 doOp v (LExternal wf) [_,x,s] 
    | wf == sUN "prim__writeFile"
        = v ++ "MKINT((i_int)(idris_writeStr(GETPTR(" ++ creg x
-                              ++ "),GETSTR("
+                              ++ "),GETCSTR("
                               ++ creg s ++ "))))"
 doOp v (LExternal vm) [] | vm == sUN "prim__vm" = v ++ "MKPTR(vm, vm)"
 doOp v (LExternal si) [] | si == sUN "prim__stdin" = v ++ "MKPTR(vm, stdin)"


### PR DESCRIPTION
This is a WIP pull request so that the skilled C hackers can get critique in early. It's not done yet!

The idea is that an explicit length field means we're not dependent on null-termination. This has, in my view, two benefits:
1. Less chance of accidental buffer overruns from malformed UTF-8 strings
2. It becomes possible to use \0 inside of strings, giving the type `String` the semantics "sequence of code points" rather than "sequence of nonzero code points" which is at least elegant and possibly even useful.

A null terminator is retained to avoid marshalling issues or excess copying when calling C functions.

This pull request does the following:
- [X] Add a length field to the runtime representation of strings, tracking their size in bytes
- [X] Refactor string allocations to do all object initialization in one place, to help avoid mistakes
- [X] Modify the UTF-8 functions to not access memory outside the size size of the string
- [X] Crash with informative messages on partial string operations (like `strTail ""`)
- [X] Validate the output of primitive conversions, like `prim__floatToStr` to make sure that library code is returning what we expect
- [ ] Stop using C string functions that assume null-termination (partially complete)
- [ ] Check for `NULL` return from all `malloc` calls (partially complete)
- [X] Pass the test suite
- [ ] Validate that strings from calls to C code are actually real UTF-8 (I may punt on this or implement a poor version of it until we get a proper Unicode library integrated)
- [X] Validate that purported characters (represented as `Int` under the hood) are actually in the Unicode range before consing onto a string
- [X] Add `assert`s about the byte size invariants
- [ ] Make the C codegen actually allow `'\0'` in the middle of Idris strings, and display them appropriately using the print functions in the library
- [ ] Factor out checks for `NULL` after `malloc` into a function

Potential things to do:
1. Also cache the length in characters (would make some things more elegant, but adds overhead and complexity and may not be worth it)
2. More thorough Unicode testing
