### PR TITLE
"Can't find name" message was missing a space

### DIFF
--- a/src/Idris/Elab/Term.hs
+++ b/src/Idris/Elab/Term.hs
@@ -1621,7 +1621,7 @@ findHighlight n = do ctxt <- get_context
                        Nothing -> case lookupTyExact n ctxt of
                                     Just _ -> return $ AnnName n Nothing Nothing Nothing
                                     Nothing -> lift . tfail . InternalMsg $
-                                                 "Can't find name" ++ show n
+                                                 "Can't find name " ++ show n
 
 -- Try again to solve auto implicits
 solveAuto :: IState -> Name -> Bool -> (Name, [FailContext]) -> ElabD ()


### PR DESCRIPTION
I keep seeing this error message (I'm too lazy to actually read my code before I compile it). The mild annoyance of the obvious typo has compounded over many occasions, and finally it reached the tipping point for me to actually go ahead and make the one-character change.