### PR TITLE
Add a getLine primitive to browser js

### DIFF
--- a/jsrts/Runtime-browser.js
+++ b/jsrts/Runtime-browser.js
@@ -1,3 +1,7 @@
+var i$getLine = function() {
+    return prompt("Prelude.getLine");
+}
+
 var i$putStr = function(s) {
   console.log(s);
 };


### PR DESCRIPTION
Making console apps to run in the browser is likely a minority taste.
But prompt works for input as it's synchronous.