### PR TITLE
Improvements to ipkg files for dependancies.

### DIFF
--- a/CHANGELOG
+++ b/CHANGELOG
@@ -35,6 +35,9 @@ Tool updates
 ------------
 * Records are now shown as records in :doc, rather than as the underlying
   datatype
+* iPKG files have a new option `pkgs` which takes a comma-separated list
+  of package names that the idris project depends on. This reduces bloat
+  in the `opts` option with mutliple package declarations.
 
 Miscellaneous updates
 ---------------------

--- a/docs/reference/packages.rst
+++ b/docs/reference/packages.rst
@@ -44,8 +44,11 @@ Other common fields which may be present in an ``ipkg`` file are:
 + ``main = <module>``, which takes the name of the main module, and
   must be present if the executable field is present.
 
-+ ``opts = "<idris options>"``, which allows options (such as other
-  packages) to be passed to Idris.
++ ``opts = "<idris options>"``, which allows options to be passed to
+  Idris.
+
++ ``pkgs = <pkg name> (',' <pkg name>)+``, a comma separated list of
+  package names that the Idris package requires.
 
 Binding to C
 ------------

--- a/src/Pkg/PParser.hs
+++ b/src/Pkg/PParser.hs
@@ -2,13 +2,6 @@
 #if !(MIN_VERSION_base(4,8,0))
 {-# LANGUAGE OverlappingInstances #-}
 #endif
---  ------------------------------------------------------------- [ PParser.hs ]
---  Module    : PParser.hs
---  Copyright : (c) The Idris Community.
---  License   : see LICENSE
---
---  The parser for Idris ipkg files.
---  -------------------------------------------------------------------- [ EOH ]
 module Pkg.PParser where
 
 import Text.Trifecta hiding (span, charLiteral, natural, symbol, char, string, whiteSpace)
@@ -112,5 +105,3 @@ pClause = do reserved "executable"; lchar '=';
              ts <- sepBy1 (fst <$> iName []) (lchar ',')
              st <- get
              put st { idris_tests = idris_tests st ++ ts }
-
---  -------------------------------------------------------------------- [ EOF ]

--- a/src/Pkg/PParser.hs
+++ b/src/Pkg/PParser.hs
@@ -2,7 +2,13 @@
 #if !(MIN_VERSION_base(4,8,0))
 {-# LANGUAGE OverlappingInstances #-}
 #endif
-
+--  ------------------------------------------------------------- [ PParser.hs ]
+--  Module    : PParser.hs
+--  Copyright : (c) The Idris Community.
+--  License   : see LICENSE
+--
+--  The parser for Idris ipkg files.
+--  -------------------------------------------------------------------- [ EOH ]
 module Pkg.PParser where
 
 import Text.Trifecta hiding (span, charLiteral, natural, symbol, char, string, whiteSpace)
@@ -18,21 +24,20 @@ import Control.Applicative
 
 import Util.System
 
-
 type PParser = StateT PkgDesc IdrisInnerParser
 
-data PkgDesc = PkgDesc { pkgname :: String,
-                         libdeps :: [String],
-                         objs :: [String],
-                         makefile :: Maybe String,
-                         idris_opts :: [Opt],
-                         sourcedir :: String,
-                         modules :: [Name],
-                         idris_main :: Name,
-                         execout :: Maybe String,
-                         idris_tests :: [Name]
-                       }
-    deriving Show
+data PkgDesc = PkgDesc {
+    pkgname     :: String
+  , libdeps     :: [String]
+  , objs        :: [String]
+  , makefile    :: Maybe String
+  , idris_opts  :: [Opt]
+  , sourcedir   :: String
+  , modules     :: [Name]
+  , idris_main  :: Name
+  , execout     :: Maybe String
+  , idris_tests :: [Name]
+  } deriving (Show)
 
 instance HasLastTokenSpan PParser where
   getLastTokenSpan = return Nothing
@@ -44,23 +49,25 @@ instance TokenParsing PParser where
 #endif
   someSpace = many (simpleWhiteSpace <|> singleLineComment <|> multiLineComment) *> pure ()
 
-
+defaultPkg :: PkgDesc
 defaultPkg = PkgDesc "" [] [] Nothing [] "" [] (sUN "") Nothing []
 
 parseDesc :: FilePath -> IO PkgDesc
-parseDesc fp = do p <- readFile fp
-                  case runparser pPkg defaultPkg fp p of
-                       Failure err -> fail (show err)
-                       Success x -> return x
+parseDesc fp = do
+    p <- readFile fp
+    case runparser pPkg defaultPkg fp p of
+      Failure err -> fail (show err)
+      Success x -> return x
 
 pPkg :: PParser PkgDesc
-pPkg = do reserved "package"; p <- fst <$> identifier
-          st <- get
-          put (st { pkgname = p })
-          some pClause
-          st <- get
-          eof
-          return st
+pPkg = do
+    reserved "package"; p <- fst <$> identifier
+    st <- get
+    put (st { pkgname = p })
+    some pClause
+    st <- get
+    eof
+    return st
 
 pClause :: PParser ()
 pClause = do reserved "executable"; lchar '=';
@@ -80,6 +87,11 @@ pClause = do reserved "executable"; lchar '=';
              st <- get
              let args = pureArgParser (words opts)
              put (st { idris_opts = args })
+      <|> do reserved "pkgs"; lchar '=';
+             ps <- sepBy1 (fst <$> identifier) (lchar ',')
+             st <- get
+             let pkgs = pureArgParser $ map (\x -> unwords ["-p", x]) ps
+             put (st {idris_opts = idris_opts st ++ pkgs})
       <|> do reserved "modules"; lchar '=';
              ms <- sepBy1 (fst <$> iName []) (lchar ',')
              st <- get
@@ -101,3 +113,4 @@ pClause = do reserved "executable"; lchar '=';
              st <- get
              put st { idris_tests = idris_tests st ++ ts }
 
+--  -------------------------------------------------------------------- [ EOF ]


### PR DESCRIPTION
iPKG files have a new option `pkgs` which takes a comma-separated list
of package names that the idris project depends on. This reduces bloat
in the `opts` option with mutliple package declarations.

So rather than have:

```
package foo

opts = "-p lightyear -p containers -p tests -p pruviloj -p effects -p x --log 4"
```

we can now say:

```
package foo

opts = "--log 4"

pkgs = lightyear, containers, tests, pruviloj, effects, x
```

The file `PkgParser.hs` file was also cleaned up a little.