### PR TITLE
Improve interaction between Command Line Options and Package File Options.

### DIFF
--- a/main/Main.hs
+++ b/main/Main.hs
@@ -57,7 +57,7 @@ runIdris opts = do
                        runIO $ exitWith ExitSuccess
        case opt getPkgCheck opts of
            [] -> return ()
-           fs -> do runIO $ mapM_ (checkPkg (WarnOnly `elem` opts) True) fs
+           fs -> do runIO $ mapM_ (checkPkg opts (WarnOnly `elem` opts) True) fs
                     runIO $ exitWith ExitSuccess
        case opt getPkgClean opts of
            [] -> return ()
@@ -65,18 +65,18 @@ runIdris opts = do
                     runIO $ exitWith ExitSuccess
        case opt getPkgMkDoc opts of                -- IdrisDoc
            [] -> return ()
-           fs -> do runIO $ mapM_ documentPkg fs
+           fs -> do runIO $ mapM_ (documentPkg opts) fs
                     runIO $ exitWith ExitSuccess
        case opt getPkgTest opts of
            [] -> return ()
-           fs -> do runIO $ mapM_ testPkg fs
+           fs -> do runIO $ mapM_ (testPkg opts) fs
                     runIO $ exitWith ExitSuccess
        case opt getPkg opts of
            [] -> case opt getPkgREPL opts of
                       [] -> idrisMain opts
-                      [f] -> replPkg f
+                      [f] -> replPkg opts f
                       _ -> ifail "Too many packages"
-           fs -> runIO $ mapM_ (buildPkg (WarnOnly `elem` opts)) fs
+           fs -> runIO $ mapM_ (buildPkg opts (WarnOnly `elem` opts)) fs
 
 showver :: IO b
 showver = do putStrLn $ "Idris version " ++ ver

--- a/test/pkg001/expected
+++ b/test/pkg001/expected
@@ -1,1 +1,6 @@
-Type checking ./Main.idr
+Not all command line options can be used to override package options.
+
+The only changeable options are:
+   --log <lvl>, --total, --warnpartial, --warnreach
+   --ibcsubdir <path>, -i --idrispath <path>
+

--- a/test/pkg001/run
+++ b/test/pkg001/run
@@ -1,3 +1,4 @@
 #!/usr/bin/env bash
 idris $@ --build test.ipkg
 rm -f  *.ibc
+idris $@ --build test.ipkg --quiet


### PR DESCRIPTION
 Package Options are now influenced by command line options.

This PR addresses in part: #1448, and #499.

When building packages preapproved command line options (if
specified) will be merged into the options list generated from the
iPKG file. The allowed options are placed at the head of the options
list. The allowed options are:

+ Logging levels
+ Default total, default partial
+ Warn partial
+ Warn reach
+ Location of IBC subdir
+ Location of import dir.