### PR TITLE
Parse operators as expressions in the REPL

### DIFF
--- a/CONTRIBUTORS
+++ b/CONTRIBUTORS
@@ -15,6 +15,7 @@ Jason Dagit
 Guglielmo Fachini
 Simon Fowler
 Google
+Zack Grannan
 Cezar Ionescu
 Heath Johns
 Irene Knapp

--- a/idris.cabal
+++ b/idris.cabal
@@ -535,6 +535,9 @@ Extra-source-files:
                        test/interactive009/input
                        test/interactive009/*.idr
                        test/interactive009/expected
+                       test/interactive010/expected
+                       test/interactive010/input
+                       test/interactive010/run
 
                        test/io001/run
                        test/io001/*.idr

--- a/src/Idris/REPLParser.hs
+++ b/src/Idris/REPLParser.hs
@@ -200,10 +200,15 @@ exprArg cmd name = do
         eof
         return $ Left ("Usage is :" ++ name ++ " <expression>")
 
+    let justOperator = do
+        (op, fc) <- P.maybeWithNS P.operatorFC False []
+        eof
+        return $ Right $ cmd (PRef fc [] op)
+
     let properArg = do
         t <- P.fullExpr defaultSyntax
         return $ Right (cmd t)
-    try noArg <|> properArg
+    try noArg <|> try justOperator <|> properArg
 
 
 

--- a/test/interactive010/expected
+++ b/test/interactive010/expected
@@ -3,11 +3,20 @@ Prelude.Strings.(++) : String -> String -> String
 Prelude.Classes./ : (__pi_arg : Float) →
                     (__pi_arg1 : Float) → Float
 Usage is :doc <functionname>
+Usage is :wc <functionname>
 Usage is :printdef <functionname>
 prim__divFloat
 Prelude.Classes./
 
  : Float -> Float -> Float
-prim__divFloat : Double -> Double -> Double
-(input):Can't infer argument a to (++)
+(input):1:1: error: expected: ":",
+    dependent type signature,
+    end of input
+/<EOF> 
+^      
+(input):1:1: error: expected: ":",
+    dependent type signature,
+    end of input
+++<EOF> 
+^       
 prim__divFloat

--- a/test/interactive010/expected
+++ b/test/interactive010/expected
@@ -1,7 +1,13 @@
-Idris> Prelude.List.(++) : List a -> List a -> List a
+Prelude.List.(++) : List a -> List a -> List a
 Prelude.Strings.(++) : String -> String -> String
-Idris> Prelude.List.(++) : List a -> List a -> List a
-Prelude.Strings.(++) : String -> String -> String
-Idris> (++) : List a -> List a -> List a
-Idris> (++) : List a -> List a -> List a
-Idris> Bye bye
+Prelude.Classes./ : (__pi_arg : Float) →
+                    (__pi_arg1 : Float) → Float
+Usage is :doc <functionname>
+Usage is :printdef <functionname>
+prim__divFloat
+Prelude.Classes./
+
+ : Float -> Float -> Float
+prim__divFloat : Double -> Double -> Double
+(input):Can't infer argument a to (++)
+prim__divFloat

--- a/test/interactive010/expected
+++ b/test/interactive010/expected
@@ -1,0 +1,7 @@
+Idris> Prelude.List.(++) : List a -> List a -> List a
+Prelude.Strings.(++) : String -> String -> String
+Idris> Prelude.List.(++) : List a -> List a -> List a
+Prelude.Strings.(++) : String -> String -> String
+Idris> (++) : List a -> List a -> List a
+Idris> (++) : List a -> List a -> List a
+Idris> Bye bye

--- a/test/interactive010/input
+++ b/test/interactive010/input
@@ -1,6 +1,7 @@
 :type ++
 :core /
 :doc +
+:wc +
 :printdef -
 :spec /
 :patt /

--- a/test/interactive010/input
+++ b/test/interactive010/input
@@ -1,0 +1,4 @@
+:type (++)
+:type ++
+:type List.(++)
+:type List.++

--- a/test/interactive010/input
+++ b/test/interactive010/input
@@ -1,4 +1,9 @@
-:type (++)
 :type ++
-:type List.(++)
-:type List.++
+:core /
+:doc +
+:printdef -
+:spec /
+:patt /
+/
+++
+:whnf /

--- a/test/interactive010/run
+++ b/test/interactive010/run
@@ -1,2 +1,2 @@
 #!/usr/bin/env bash
-idris --nobanner --nocolor < input
+idris --quiet --nobanner --nocolor  --consolewidth 80 < input

--- a/test/interactive010/run
+++ b/test/interactive010/run
@@ -1,0 +1,2 @@
+#!/usr/bin/env bash
+idris --nobanner --nocolor < input


### PR DESCRIPTION
This pull requests allows infix operators to be parsed as expressions in the REPL. Previously, the REPL did not parse infix operators as expressions.

This should resolve https://github.com/idris-lang/Idris-dev/issues/2642. However this applies to any repl command that takes an expression as an argument, not just the `:type` command.

Before:
```
Idris> :t ++
(input):1:4: error: expected: dependent type signature,
    end of input
:t ++<EOF> 
   ^   
```

After:
```
Idris> :t ++
Prelude.List.(++) : List a -> List a -> List a
Prelude.Strings.(++) : String -> String -> String
```