### PR TITLE
Decidable.Equality: properties of decEq.

### DIFF
--- a/libs/prelude/Decidable/Equality.idr
+++ b/libs/prelude/Decidable/Equality.idr
@@ -8,6 +8,7 @@ import Prelude.Either
 import Prelude.List
 import Prelude.Nat
 import Prelude.Maybe
+import Prelude.Uninhabited
 
 --------------------------------------------------------------------------------
 -- Utility lemmas
@@ -26,6 +27,20 @@ negEqSym p h = p (sym h)
 class DecEq t where
   ||| Decide whether two elements of `t` are propositionally equal
   total decEq : (x1 : t) -> (x2 : t) -> Dec (x1 = x2)
+
+||| `decEq` produces `Yes Refl` when applied to the same argument twice.
+total decEq_refl : (DecEq t) => (x : t) -> decEq x x = Yes Refl
+decEq_refl x with (decEq x x)
+  decEq_refl x | Yes Refl = Refl
+  decEq_refl x | No notEq = absurd (notEq Refl)
+
+||| When two terms are not propositionally equal, `decEq`'s result reflects
+||| this.
+total decEq_not : (DecEq t) => (x, y : t) -> Not (x = y) ->
+                  (c ** decEq x y = No c)
+decEq_not x y neq with (decEq x y)
+  decEq_not x x neq | Yes Refl = absurd (neq Refl)
+  decEq_not x y neq | No contra = (contra ** Refl)
 
 --------------------------------------------------------------------------------
 --- Unit


### PR DESCRIPTION
These trivial properties can be proven for any implementation of DecEq.
They come in handy for discharging `with (decEq x y)` clauses using
`rewrite`.

There are several areas for potential discussion here.  Off the top of my head:

- Should properties like this go into `Decidable.Equality` or some sub-module like `Decidable.Equality.Properties`?  Personally, I'd argue either for the former, or for `Decidable.Equality` to re-export `...Properties`, for discoverability reasons.

- Naming.  I've used the camel-case-separated-by-underscores pattern that was discussed on the mailing list recently.  This is unusual but not without precedent in the standard library.

I'm wide open to suggestions on both points.