### PR TITLE
Allow certain package options to be overridden from console.

### DIFF
--- a/CHANGELOG
+++ b/CHANGELOG
@@ -40,6 +40,9 @@ Tool updates
 * iPKG files have a new option `pkgs` which takes a comma-separated list
   of package names that the idris project depends on. This reduces bloat
   in the `opts` option with mutliple package declarations.
+* A limited set of command line options can be used to override package
+  declared options. Overridable options are currently, logging level,
+  default totality check, warn reach, IBC output folder, and idris path.
 
 Miscellaneous updates
 ---------------------

--- a/main/Main.hs
+++ b/main/Main.hs
@@ -57,7 +57,7 @@ runIdris opts = do
                        runIO $ exitWith ExitSuccess
        case opt getPkgCheck opts of
            [] -> return ()
-           fs -> do runIO $ mapM_ (checkPkg (WarnOnly `elem` opts) True) fs
+           fs -> do runIO $ mapM_ (checkPkg opts (WarnOnly `elem` opts) True) fs
                     runIO $ exitWith ExitSuccess
        case opt getPkgClean opts of
            [] -> return ()
@@ -65,18 +65,18 @@ runIdris opts = do
                     runIO $ exitWith ExitSuccess
        case opt getPkgMkDoc opts of                -- IdrisDoc
            [] -> return ()
-           fs -> do runIO $ mapM_ documentPkg fs
+           fs -> do runIO $ mapM_ (documentPkg opts) fs
                     runIO $ exitWith ExitSuccess
        case opt getPkgTest opts of
            [] -> return ()
-           fs -> do runIO $ mapM_ testPkg fs
+           fs -> do runIO $ mapM_ (testPkg opts) fs
                     runIO $ exitWith ExitSuccess
        case opt getPkg opts of
            [] -> case opt getPkgREPL opts of
                       [] -> idrisMain opts
-                      [f] -> replPkg f
+                      [f] -> replPkg opts f
                       _ -> ifail "Too many packages"
-           fs -> runIO $ mapM_ (buildPkg (WarnOnly `elem` opts)) fs
+           fs -> runIO $ mapM_ (buildPkg opts (WarnOnly `elem` opts)) fs
 
 showver :: IO b
 showver = do putStrLn $ "Idris version " ++ ver

--- a/src/Pkg/Package.hs
+++ b/src/Pkg/Package.hs
@@ -368,14 +368,7 @@ mergeOptions copts popts =
       (es, _)      -> Left $ genErrMsg es
   where
     pkgOptsFilter :: Opt -> Bool
-    pkgOptsFilter (PkgBuild   _) = False
-    pkgOptsFilter (PkgInstall _) = False
-    pkgOptsFilter (PkgClean   _) = False
-    pkgOptsFilter (PkgCheck   _) = False
-    pkgOptsFilter (PkgREPL    _) = False
-    pkgOptsFilter (PkgMkDoc   _) = False
-    pkgOptsFilter (PkgTest    _) = False
-    pkgOptsFilter _              = True
+    pkgOptsFilter _ = False
 
     copts' = filter pkgOptsFilter copts
 

--- a/src/Pkg/Package.hs
+++ b/src/Pkg/Package.hs
@@ -18,6 +18,8 @@ import Control.Monad.Trans.Except (runExceptT)
 import Data.List
 import Data.List.Split(splitOn)
 
+import Data.Either
+
 import Idris.Core.TT
 import Idris.REPL
 import Idris.Parser (loadModule)
@@ -27,85 +29,113 @@ import Idris.IdrisDoc
 import Idris.IBC
 import Idris.Output
 import Idris.Imports
+import Idris.Error (ifail)
 
 import Pkg.PParser
 
 import IRTS.System
 
--- To build a package:
--- * read the package description
--- * check all the library dependencies exist
--- * invoke the makefile if there is one
--- * invoke idris on each module, with idris_opts
--- * install everything into datadir/pname, if install flag is set
+{- Package Build Instructions
+
+To build a package:
+
+* read the package description
+* check all the library dependencies exist
+* invoke the makefile if there is one
+* invoke idris on each module, with idris_opts
+* install everything into datadir/pname, if install flag is set
+
+-}
 
 -- | Run the package through the idris compiler.
-buildPkg :: Bool -> (Bool, FilePath) -> IO ()
-buildPkg warnonly (install, fp)
-     = do pkgdesc <- parseDesc fp
-          dir <- getCurrentDirectory
-          let idx = PkgIndex (pkgIndex (pkgname pkgdesc))
-          ok <- mapM (testLib warnonly (pkgname pkgdesc)) (libdeps pkgdesc)
-          when (and ok) $
-            do m_ist <- inPkgDir pkgdesc $
-                          do make (makefile pkgdesc)
-                             case (execout pkgdesc) of
-                               Nothing -> buildMods (idx : NoREPL : Verbose : idris_opts pkgdesc)
-                                                    (modules pkgdesc)
-                               Just o -> do let exec = dir </> o
-                                            buildMods
-                                              (idx : NoREPL : Verbose : Output exec : idris_opts pkgdesc)
-                                              [idris_main pkgdesc]
-               case m_ist of
-                    Nothing -> exitWith (ExitFailure 1)
-                    Just ist -> do
-                       -- Quit with error code if there was a problem
-                       case errSpan ist of
-                            Just _ -> exitWith (ExitFailure 1)
-                            _ -> return ()
-                       when install $ installPkg pkgdesc
+buildPkg :: [Opt]            -- ^ Command Line Options
+         -> Bool             -- ^ Provide Warnings
+         -> (Bool, FilePath) -- ^ (Install as a well, Location of iPKG file)
+         -> IO ()
+buildPkg copts warnonly (install, fp) = do
+  pkgdesc <- parseDesc fp
+  dir <- getCurrentDirectory
+  let idx = PkgIndex (pkgIndex (pkgname pkgdesc))
+  ok <- mapM (testLib warnonly (pkgname pkgdesc)) (libdeps pkgdesc)
+  when (and ok) $ do
+    m_ist <- inPkgDir pkgdesc $ do
+      make (makefile pkgdesc)
+      case (execout pkgdesc) of
+        Nothing -> do
+          case (mergeOptions copts (idx : NoREPL : Verbose : idris_opts pkgdesc)) of
+               Left emsg -> do
+                 putStrLn emsg
+                 exitWith (ExitFailure 1)
+               Right opts -> buildMods opts (modules pkgdesc)
+        Just o  -> do
+          let exec = dir </> o
+          case (mergeOptions copts (idx : NoREPL : Verbose : Output exec : idris_opts pkgdesc)) of
+            Left emsg -> do
+              putStrLn emsg
+              exitWith (ExitFailure 1)
+            Right opts -> buildMods opts [idris_main pkgdesc]
+    case m_ist of
+      Nothing  -> exitWith (ExitFailure 1)
+      Just ist -> do
+        -- Quit with error code if there was a problem
+        case errSpan ist of
+          Just _ -> exitWith (ExitFailure 1)
+          _      -> return ()
+        when install $ installPkg pkgdesc
 
 -- | Type check packages only
 --
 -- This differs from build in that executables are not built, if the
 -- package contains an executable.
-checkPkg :: Bool         -- ^ Show Warnings
-            -> Bool      -- ^ quit on failure
-            -> FilePath  -- ^ Path to ipkg file.
-            -> IO ()
-checkPkg warnonly quit fpath
-  = do pkgdesc <- parseDesc fpath
-       ok <- mapM (testLib warnonly (pkgname pkgdesc)) (libdeps pkgdesc)
-       when (and ok) $
-         do res <- inPkgDir pkgdesc $
-                     do make (makefile pkgdesc)
-                        buildMods (NoREPL : Verbose : idris_opts pkgdesc)
-                                  (modules pkgdesc)
-            when quit $ case res of
-                          Nothing -> exitWith (ExitFailure 1)
-                          Just res' -> do
-                            case errSpan res' of
-                              Just _ -> exitWith (ExitFailure 1)
-                              _ -> return ()
+checkPkg :: [Opt]    -- ^ Command line options
+         -> Bool     -- ^ Show Warnings
+         -> Bool     -- ^ quit on failure
+         -> FilePath -- ^ Path to ipkg file.
+         -> IO ()
+checkPkg copts warnonly quit fpath = do
+  pkgdesc <- parseDesc fpath
+  ok <- mapM (testLib warnonly (pkgname pkgdesc)) (libdeps pkgdesc)
+  when (and ok) $ do
+    res <- inPkgDir pkgdesc $ do
+      make (makefile pkgdesc)
+      case mergeOptions copts (NoREPL : Verbose : idris_opts pkgdesc) of
+        Left emsg -> do
+          putStrLn emsg
+          exitWith (ExitFailure 1)
+        Right opts -> do
+          buildMods opts (modules pkgdesc)
+    when quit $ case res of
+                  Nothing   -> exitWith (ExitFailure 1)
+                  Just res' -> do
+                    case errSpan res' of
+                      Just _ -> exitWith (ExitFailure 1)
+                      _      -> return ()
 
 -- | Check a package and start a REPL
-replPkg :: FilePath -> Idris ()
-replPkg fp = do orig <- getIState
-                runIO $ checkPkg False False fp
-                pkgdesc <- runIO $ parseDesc fp -- bzzt, repetition!
-                let opts = idris_opts pkgdesc
-                let mod = idris_main pkgdesc
-                let f = toPath (showCG mod)
-                putIState orig
-                dir <- runIO $ getCurrentDirectory
-                runIO $ setCurrentDirectory $ dir </> sourcedir pkgdesc
+replPkg :: [Opt]    -- ^ Command line options
+        -> FilePath -- ^ Path to ipkg file.
+        -> Idris ()
+replPkg copts fp = do
+  orig <- getIState
+  runIO $ checkPkg copts False False fp
+  pkgdesc <- runIO $ parseDesc fp -- bzzt, repetition!
 
-                if (f /= "")
-                   then idrisMain ((Filename f) : opts)
-                   else iputStrLn "Can't start REPL: no main module given"
-                runIO $ setCurrentDirectory dir
+  case mergeOptions copts (idris_opts pkgdesc) of
+    Left emsg  -> ifail emsg
+    Right opts -> do
+      let mod = idris_main pkgdesc
+      let f = toPath (showCG mod)
+      putIState orig
+      dir <- runIO $ getCurrentDirectory
+      runIO $ setCurrentDirectory $ dir </> sourcedir pkgdesc
 
-    where toPath n = foldl1' (</>) $ splitOn "." n
+      if (f /= "")
+        then idrisMain ((Filename f) : opts)
+        else iputStrLn "Can't start REPL: no main module given"
+      runIO $ setCurrentDirectory dir
+
+    where
+      toPath n = foldl1' (</>) $ splitOn "." n
 
 -- | Clean Package build files
 cleanPkg :: FilePath -- ^ Path to ipkg file.
@@ -127,79 +157,96 @@ cleanPkg fp
 --
 -- Issue number #1572 on the issue tracker
 --       https://github.com/idris-lang/Idris-dev/issues/1572
-documentPkg :: FilePath -- ^ Path to .ipkg file.
+documentPkg :: [Opt]    -- ^ Command line options
+            -> FilePath -- ^ Path to iPKG file.
             -> IO ()
-documentPkg fp =
+documentPkg copts fp =
   do pkgdesc        <- parseDesc fp
      cd             <- getCurrentDirectory
      let pkgDir      = cd </> takeDirectory fp
          outputDir   = cd </> pkgname pkgdesc ++ "_doc"
-         opts        = NoREPL : Verbose : idris_opts pkgdesc
+         opts'       = NoREPL : Verbose : idris_opts pkgdesc
          mods        = modules pkgdesc
          fs          = map (foldl1' (</>) . splitOn "." . showCG) mods
      setCurrentDirectory $ pkgDir </> sourcedir pkgdesc
      make (makefile pkgdesc)
      setCurrentDirectory pkgDir
-     let run l       = runExceptT . execStateT l
-         load []     = return ()
-         load (f:fs) = do loadModule f; load fs
-         loader      = do idrisMain opts; addImportDir (sourcedir pkgdesc); load fs
-     idrisInstance  <- run loader idrisInit
-     setCurrentDirectory cd
-     case idrisInstance of
-          Left  err -> do putStrLn $ pshow idrisInit err; exitWith (ExitFailure 1)
-          Right ist ->
-                do docRes <- generateDocs ist mods outputDir
-                   case docRes of
-                        Right _  -> return ()
-                        Left msg -> do putStrLn msg
-                                       exitWith (ExitFailure 1)
+     case mergeOptions copts opts' of
+       Left emsg -> do
+         putStrLn emsg
+         exitWith (ExitFailure 1)
+       Right opts -> do
+         let run l       = runExceptT . execStateT l
+             load []     = return ()
+             load (f:fs) = do loadModule f; load fs
+             loader      = do idrisMain opts; addImportDir (sourcedir pkgdesc); load fs
+         idrisInstance  <- run loader idrisInit
+         setCurrentDirectory cd
+         case idrisInstance of
+              Left  err -> do putStrLn $ pshow idrisInit err; exitWith (ExitFailure 1)
+              Right ist ->
+                    do docRes <- generateDocs ist mods outputDir
+                       case docRes of
+                            Right _  -> return ()
+                            Left msg -> do putStrLn msg
+                                           exitWith (ExitFailure 1)
 
 -- | Build a package with a sythesized main function that runs the tests
-testPkg :: FilePath -> IO ()
-testPkg fp
-     = do pkgdesc <- parseDesc fp
-          ok <- mapM (testLib True (pkgname pkgdesc)) (libdeps pkgdesc)
-          when (and ok) $
-            do m_ist <- inPkgDir pkgdesc $
-                          do make (makefile pkgdesc)
-                             -- Get a temporary file to save the tests' source in
-                             (tmpn, tmph) <- tempIdr
-                             hPutStrLn tmph $
-                               "module Test_______\n" ++
-                               concat ["import " ++ show m ++ "\n"
-                                       | m <- modules pkgdesc] ++
-                               "namespace Main\n" ++
-                               "  main : IO ()\n" ++
-                               "  main = do " ++
-                               concat [show t ++ "\n            "
-                                       | t <- idris_tests pkgdesc]
-                             hClose tmph
-                             (tmpn', tmph') <- tempfile
-                             hClose tmph'
-                             m_ist <- idris (Filename tmpn : NoREPL : Verbose : Output tmpn' : idris_opts pkgdesc)
-                             rawSystem tmpn' []
-                             return m_ist
-               case m_ist of
-                 Nothing -> exitWith (ExitFailure 1)
-                 Just ist -> do
-                    -- Quit with error code if problem building
-                    case errSpan ist of
-                      Just _ -> exitWith (ExitFailure 1)
-                      _      -> return ()
-  where tempIdr :: IO (FilePath, Handle)
+testPkg :: [Opt]    -- ^ Command line options
+        -> FilePath -- ^ Path to iPKG File.
+        -> IO ()
+testPkg copts fp = do
+  pkgdesc <- parseDesc fp
+  ok <- mapM (testLib True (pkgname pkgdesc)) (libdeps pkgdesc)
+  when (and ok) $ do
+    m_ist <- inPkgDir pkgdesc $ do
+      make (makefile pkgdesc)
+      -- Get a temporary file to save the tests' source in
+      (tmpn, tmph) <- tempIdr
+      hPutStrLn tmph $
+        "module Test_______\n" ++
+        concat ["import " ++ show m ++ "\n"
+               | m <- modules pkgdesc] ++
+        "namespace Main\n" ++
+        "  main : IO ()\n" ++
+        "  main = do " ++
+        concat [show t ++ "\n            "
+               | t <- idris_tests pkgdesc]
+      hClose tmph
+      (tmpn', tmph') <- tempfile
+      hClose tmph'
+      let popts = (Filename tmpn : NoREPL : Verbose : Output tmpn' : idris_opts pkgdesc)
+      case mergeOptions copts popts of
+        Left emsg  -> do
+          putStrLn emsg
+          exitWith (ExitFailure 1)
+        Right opts -> do
+          m_ist <- idris opts
+          rawSystem tmpn' []
+          return m_ist
+
+    case m_ist of
+      Nothing  -> exitWith (ExitFailure 1)
+      Just ist -> do
+        -- Quit with error code if problem building
+        case errSpan ist of
+          Just _ -> exitWith (ExitFailure 1)
+          _      -> return ()
+      where
+        tempIdr :: IO (FilePath, Handle)
         tempIdr = do dir <- getTemporaryDirectory
                      openTempFile (normalise dir) "idristests.idr"
 
--- | Install package
+-- | Do the act of installation for a package.
 installPkg :: PkgDesc -> IO ()
-installPkg pkgdesc
-     = inPkgDir pkgdesc $
-         do case (execout pkgdesc) of
-              Nothing -> do mapM_ (installIBC (pkgname pkgdesc)) (modules pkgdesc)
-                            installIdx (pkgname pkgdesc)
-              Just o -> return () -- do nothing, keep executable locally, for noe
-            mapM_ (installObj (pkgname pkgdesc)) (objs pkgdesc)
+installPkg pkgdesc =
+  inPkgDir pkgdesc $ do
+    case (execout pkgdesc) of
+      Nothing -> do
+        mapM_ (installIBC (pkgname pkgdesc)) (modules pkgdesc)
+        installIdx (pkgname pkgdesc)
+      Just o -> return () -- do nothing, keep executable locally, for noe
+    mapM_ (installObj (pkgname pkgdesc)) (objs pkgdesc)
 
 -- ---------------------------------------------------------- [ Helper Methods ]
 -- Methods for building, testing, installing, and removal of idris
@@ -257,7 +304,7 @@ installIBC p m = do let f = toIBCFile m
 installIdx :: String -> IO ()
 installIdx p = do d <- getTargetDir
                   let f = pkgIndex p
-                  let destdir = d </> p 
+                  let destdir = d </> p
                   putStrLn $ "Installing " ++ f ++ " to " ++ destdir
                   createDirectoryIfMissing True destdir
                   copyFile f (destdir </> takeFileName f)
@@ -301,5 +348,51 @@ clean :: Maybe String -> IO ()
 clean Nothing = return ()
 clean (Just s) = do rawSystem "make" ["-f", s, "clean"]
                     return ()
+
+-- | Merge an option list representing the command line options into those specified for a package description.
+--
+-- This is not a complete union between the two options sets. First,
+-- to prevent important package specified options from being
+-- overwritten. Second, the semantics for this merge are not fully
+-- defined.
+--
+-- A discussion for this is on the issue tracker:
+--     https://github.com/idris-lang/Idris-dev/issues/1448
+--
+mergeOptions :: [Opt] -- ^ The command line options
+             -> [Opt] -- ^ The package options
+             -> Either String [Opt]
+mergeOptions copts popts =
+    case partitionEithers (map chkOpt copts') of
+      ([], copts') -> Right (copts' ++ popts)
+      (es, _)      -> Left $ genErrMsg es
+  where
+    pkgOptsFilter :: Opt -> Bool
+    pkgOptsFilter (PkgBuild   _) = False
+    pkgOptsFilter (PkgInstall _) = False
+    pkgOptsFilter (PkgClean   _) = False
+    pkgOptsFilter (PkgCheck   _) = False
+    pkgOptsFilter (PkgREPL    _) = False
+    pkgOptsFilter (PkgMkDoc   _) = False
+    pkgOptsFilter (PkgTest    _) = False
+    pkgOptsFilter _              = True
+
+    copts' = filter pkgOptsFilter copts
+
+    chkOpt :: Opt -> Either String Opt
+    chkOpt o@(OLogging _)     = Right o
+    chkOpt o@(DefaultTotal)   = Right o
+    chkOpt o@(DefaultPartial) = Right o
+    chkOpt o@(WarnPartial)    = Right o
+    chkOpt o@(WarnReach)      = Right o
+    chkOpt o@(IBCSubDir _)    = Right o
+    chkOpt o@(ImportDir _ )   = Right o
+    chkOpt o                  = Left (unwords ["\t", show o, "\n"])
+
+    genErrMsg :: [String] -> String
+    genErrMsg es = unlines [ "Not all command line options can be used to override package options."
+                          , "\nThe only changeable options are:"
+                          , "   --log <lvl>, --total, --warnpartial, --warnreach"
+                          , "   --ibcsubdir <path>, -i --idrispath <path>"]
 
 -- --------------------------------------------------------------------- [ EOF ]

--- a/test/pkg001/expected
+++ b/test/pkg001/expected
@@ -1,6 +1,6 @@
+Type checking ./Main.idr
 Not all command line options can be used to override package options.
 
 The only changeable options are:
    --log <lvl>, --total, --warnpartial, --warnreach
    --ibcsubdir <path>, -i --idrispath <path>
-

--- a/test/pkg001/expected
+++ b/test/pkg001/expected
@@ -1,1 +1,6 @@
-Type checking ./Main.idr
+Not all command line options can be used to override package options.
+
+The only changeable options are:
+   --log <lvl>, --total, --warnpartial, --warnreach
+   --ibcsubdir <path>, -i --idrispath <path>
+

--- a/test/pkg001/run
+++ b/test/pkg001/run
@@ -1,3 +1,4 @@
 #!/usr/bin/env bash
 idris $@ --build test.ipkg
 rm -f  *.ibc
+idris $@ --build test.ipkg --quiet


### PR DESCRIPTION
This PR addresses in part: #1448, #499.

When building packages a preapproved command line options (if
specified) will be merged into the options list generated from the
iPKG file. The allowed options are placed at the head of the options
list such that they. The allowed options are:

+ Logging levels
+ Default total, default partial
+ Warn partial
+ Warn reach
+ Location of IBC subdir
+ Location of import dir.

Idris also reports an error if invalid command lines options are
specified when used to override package specified options.

The code will also facilitate specific reporting of the offending
flags, if we choose to want such functionality.