### PR TITLE
Use "" instead of <> for includes

### DIFF
--- a/src/IRTS/CodegenC.hs
+++ b/src/IRTS/CodegenC.hs
@@ -95,7 +95,7 @@ codegenC' defs out exec incs objs libs flags exports iface dbg
 
 headers xs =
   concatMap
-    (\h -> "#include <" ++ h ++ ">\n")
+    (\h -> "#include \"" ++ h ++ "\"\n")
     (xs ++ ["idris_rts.h", "idris_bitstring.h", "idris_stdfgn.h"])
 
 debug TRACE = "#define IDRIS_TRACE\n\n"


### PR DESCRIPTION
Both searches the standard include dirs. The difference is that with
"" the local dir is looked at first, which <> don't do.