### PR TITLE
Implement support for C callbacks

### DIFF
--- a/idris.cabal
+++ b/idris.cabal
@@ -468,6 +468,11 @@ Extra-source-files:
                        test/ffi006/*.c
                        test/ffi006/run
                        test/ffi006/expected
+                       test/ffi007/*.idr
+                       test/ffi007/*.c
+                       test/ffi007/*.h
+                       test/ffi007/run
+                       test/ffi007/expected
 
                        test/folding001/*.idr
                        test/folding001/run

--- a/rts/idris_rts.c
+++ b/rts/idris_rts.c
@@ -78,6 +78,14 @@ VM* idris_vm() {
     return vm;
 }
 
+VM* get_vm(void) {
+#ifdef HAS_PTHREAD
+    return pthread_getspecific(vm_key);
+#else
+    return global_vm;
+#endif
+}
+
 void close_vm(VM* vm) {
     terminate(vm);
 }

--- a/rts/idris_rts.h
+++ b/rts/idris_rts.h
@@ -115,6 +115,9 @@ typedef struct VM_t VM;
 // Create a new VM
 VM* init_vm(int stack_size, size_t heap_size,
             int max_threads);
+
+// Get the VM for the current thread
+VM* get_vm(void);
 // Initialise thread-local data for this VM
 void init_threaddata(VM *vm);
 // Clean up a VM once it's no longer needed

--- a/test/Makefile
+++ b/test/Makefile
@@ -12,7 +12,7 @@ info: runtest
 	@./runtest $(patsubst %.test,%,$@) -q
 
 test_js: runtest
-	@./runtest without sugar004 reg029 reg052 io001 dsl002 io003 effects001 effects002 basic007 basic011 ffi006 primitives005 opts --codegen node
+	@./runtest without sugar004 reg029 reg052 io001 dsl002 io003 effects001 effects002 basic007 basic011 ffi006 ffi007 primitives005 opts --codegen node
 
 update: runtest
 	@./runtest all -u

--- a/test/ffi007/expected
+++ b/test/ffi007/expected
@@ -1,0 +1,5 @@
+8
+5
+Before calling callback
+In an Idris callback
+After calling callback

--- a/test/ffi007/ffi007.c
+++ b/test/ffi007/ffi007.c
@@ -1,0 +1,21 @@
+#include <stdio.h>
+
+typedef int (*callback)(int);
+typedef int (*cb2)(char *);
+
+void test_ffi(callback cb)
+{
+    printf("%d\n", cb(3));
+}
+
+void test_ffi2(cb2 cb)
+{
+    printf("%d\n", cb("hello"));
+}
+
+void test_ffi3(void (*cb)(void))
+{
+    printf("Before calling callback\n");
+    cb();
+    printf("After calling callback\n");
+}

--- a/test/ffi007/ffi007.h
+++ b/test/ffi007/ffi007.h
@@ -1,0 +1,4 @@
+void test_ffi(int (*cb)(int));
+
+void test_ffi2(int (*cb)(char*));
+void test_ffi3(void (*cb)(void));

--- a/test/ffi007/ffi007.idr
+++ b/test/ffi007/ffi007.idr
@@ -1,0 +1,35 @@
+module Main
+
+%include c "ffi007.h"
+
+getInt : Int -> Int
+getInt _ = 8
+
+test : IO ()
+test = foreign FFI_C "test_ffi" (CFnPtr (Int -> Int) -> IO ()) (MkCFnPtr getInt)
+
+strLen : String -> Int
+strLen s = cast $ length s
+
+test2 : IO ()
+test2 = foreign FFI_C "test_ffi2" (CFnPtr (String -> Int) -> IO ()) (MkCFnPtr strLen)
+
+-- Do IO
+printIt : () -> ()
+printIt _ = unsafePerformIO $ do
+    putStrLn "In an Idris callback"
+
+test3 : IO ()
+test3 = foreign FFI_C "test_ffi3" (CFnPtr (() -> ()) -> IO ()) (MkCFnPtr printIt)
+
+test4 : IO Ptr
+test4 = foreign FFI_C "_idris_get_wrapper" (CFnPtr (() -> ()) -> IO Ptr) (MkCFnPtr printIt)
+
+
+main : IO ()
+main = do
+            test
+            test2
+            test3
+            ptr <- test4
+            return ()

--- a/test/ffi007/run
+++ b/test/ffi007/run
@@ -1,0 +1,4 @@
+#!/usr/bin/env bash
+${IDRIS:-idris} $@ ffi007.idr -o ffi007 --cg-opt "ffi007.c"
+./ffi007
+rm -f ffi007 *.ibc


### PR DESCRIPTION
This adds support for wrapping up Idris functions so they can be passed to C as callbacks.

It also has functionality to get the function pointer in case they need to be stuffed into structures.

Functions in IO doesn't work yet. That will need to be fixed before it can be merged.