### PR TITLE
Allow an extension on tempfiles

### DIFF
--- a/src/IRTS/CodegenC.hs
+++ b/src/IRTS/CodegenC.hs
@@ -66,7 +66,7 @@ codegenC' defs out exec incs objs libs flags exports iface dbg
            MavenProject -> putStrLn ("FAILURE: output type not supported")
            Raw -> writeSource out cout
            _ -> do
-             (tmpn, tmph) <- tempfile
+             (tmpn, tmph) <- tempfile ".c"
              hPutStr tmph cout
              hFlush tmph
              hClose tmph
@@ -78,7 +78,7 @@ codegenC' defs out exec incs objs libs flags exports iface dbg
                         gccFlags iface ++
                         -- # Any flags defined here which alter the RTS API must also be added to config.mk
                         ["-DHAS_PTHREAD", "-DIDRIS_ENABLE_STATS",
-                         "-I."] ++ objs ++ ["-x", "c"] ++ envFlags ++
+                         "-I."] ++ objs ++ envFlags ++
                         (if (exec == Executable) then [] else ["-c"]) ++
                         [tmpn] ++
                         (if not iface then concatMap words libFlags else []) ++

--- a/src/Idris/REPL.hs
+++ b/src/Idris/REPL.hs
@@ -1189,7 +1189,7 @@ process fn (Execute tm)
                    = idrisCatch
                        (do ist <- getIState
                            (m, _) <- elabVal recinfo ERHS (elabExec fc tm)
-                           (tmpn, tmph) <- runIO tempfile
+                           (tmpn, tmph) <- runIO $ tempfile ""
                            runIO $ hClose tmph
                            t <- codegen
                            -- gcc adds .exe when it builds windows programs

--- a/src/Pkg/Package.hs
+++ b/src/Pkg/Package.hs
@@ -164,7 +164,7 @@ testPkg fp
             do m_ist <- inPkgDir pkgdesc $
                           do make (makefile pkgdesc)
                              -- Get a temporary file to save the tests' source in
-                             (tmpn, tmph) <- tempIdr
+                             (tmpn, tmph) <- tempfile ".idr"
                              hPutStrLn tmph $
                                "module Test_______\n" ++
                                concat ["import " ++ show m ++ "\n"
@@ -175,7 +175,7 @@ testPkg fp
                                concat [show t ++ "\n            "
                                        | t <- idris_tests pkgdesc]
                              hClose tmph
-                             (tmpn', tmph') <- tempfile
+                             (tmpn', tmph') <- tempfile ""
                              hClose tmph'
                              m_ist <- idris (Filename tmpn : NoREPL : Verbose : Output tmpn' : idris_opts pkgdesc)
                              rawSystem tmpn' []
@@ -187,9 +187,6 @@ testPkg fp
                     case errSpan ist of
                       Just _ -> exitWith (ExitFailure 1)
                       _      -> return ()
-  where tempIdr :: IO (FilePath, Handle)
-        tempIdr = do dir <- getTemporaryDirectory
-                     openTempFile (normalise dir) "idristests.idr"
 
 -- | Install package
 installPkg :: PkgDesc -> IO ()
@@ -214,7 +211,7 @@ testLib :: Bool -> String -> String -> IO Bool
 testLib warn p f
     = do d <- getDataDir
          gcc <- getCC
-         (tmpf, tmph) <- tempfile
+         (tmpf, tmph) <- tempfile ""
          hClose tmph
          let libtest = d </> "rts" </> "libtest.c"
          e <- rawSystem gcc [libtest, "-l" ++ f, "-o", tmpf]

--- a/src/Util/System.hs
+++ b/src/Util/System.hs
@@ -37,9 +37,10 @@ throwIO = CE.throw
 isWindows :: Bool
 isWindows = os `elem` ["win32", "mingw32", "cygwin32"]
 
-tempfile :: IO (FilePath, Handle)
-tempfile = do dir <- getTemporaryDirectory
-              openTempFile (normalise dir) "idris"
+-- | Create a temp file with the extensiom ext (in the format ".xxx")
+tempfile :: String -> IO (FilePath, Handle)
+tempfile ext = do dir <- getTemporaryDirectory
+                  openTempFile (normalise dir) $ "idris" ++ ext
 
 -- | Read a source file, same as readFile but make sure the encoding is utf-8.
 readSource :: FilePath -> IO String


### PR DESCRIPTION
It's nice when files have the correct extension.

And I could remove the "-x c" argument, which presupposes that everything on the gcc command line is c files, which is bad when one tries to pass in object files and other stuff.  