### PR TITLE
Show source location of case block names

### DIFF
--- a/libs/base/Language/Reflection/Utils.idr
+++ b/libs/base/Language/Reflection/Utils.idr
@@ -61,6 +61,12 @@ binderTy (Guess t1 t2) = t1
 binderTy (PVar t)      = t
 binderTy (PVTy t)      = t
 
+instance Show SourceLocation where
+  showPrec d (FileLoc filename line col) = showCon d "FileLoc" $ showArg filename ++ showArg line ++ showArg col
+
+instance Eq SourceLocation where
+  (FileLoc fn s e) == (FileLoc fn' s' e') = fn == fn' && s == s' && e == e'
+
 mutual
   instance Show SpecialName where
     showPrec d (WhereN i n1 n2) = showCon d "WhereN" $ showArg i ++
@@ -69,7 +75,7 @@ mutual
     showPrec d (InstanceN i ss) = showCon d "InstanceN" $ showArg i ++ showArg ss
     showPrec d (ParentN n s) = showCon d "ParentN" $ showArg n ++ showArg s
     showPrec d (MethodN n) = showCon d "MethodN" $ showArg n
-    showPrec d (CaseN n) = showCon d "CaseN" $ showArg n
+    showPrec d (CaseN fc n) = showCon d "CaseN" $ showArg fc ++ showArg n
     showPrec d (ElimN n) = showCon d "ElimN" $ showArg n
     showPrec d (InstanceCtorN n) = showCon d "InstanceCtorN" $ showArg n
     showPrec d (MetaN parent meta) = showCon d "MetaN" $ showArg parent ++ showArg meta
@@ -96,7 +102,7 @@ mutual
     (InstanceN i ss)    == (InstanceN i' ss')    = i == i' && ss == ss'
     (ParentN n s)       == (ParentN n' s')       = n == n' && s == s'
     (MethodN n)         == (MethodN n')          = n == n'
-    (CaseN n)           == (CaseN n')            = n == n'
+    (CaseN fc n)        == (CaseN fc' n')        = fc == fc' && n == n'
     (ElimN n)           == (ElimN n')            = n == n'
     (InstanceCtorN n)   == (InstanceCtorN n')    = n == n'
     (MetaN parent meta) == (MetaN parent' meta') = parent == parent' && meta == meta'
@@ -272,8 +278,6 @@ instance Show Raw where
           my_show d RType = "RType"
           my_show d (RConstant c) = showCon d "RConstant" $ showArg c
 
-instance Show SourceLocation where
-  showPrec d (FileLoc filename line col) = showCon d "FileLoc" $ showArg filename ++ showArg line ++ showArg col
 
 instance Show Err where
   showPrec d (Msg x) = showCon d "Msg" $ showArg x

--- a/src/IRTS/Compiler.hs
+++ b/src/IRTS/Compiler.hs
@@ -167,7 +167,7 @@ showCaseTrees = showSep "\n\n" . map showCT . sortBy (comparing defnRank)
     snRank (InstanceN n args) = "2" ++ nameRank n ++ concatMap show args
     snRank (ParentN n s) = "3" ++ nameRank n ++ show s
     snRank (MethodN n) = "4" ++ nameRank n
-    snRank (CaseN n) = "5" ++ nameRank n
+    snRank (CaseN _ n) = "5" ++ nameRank n
     snRank (ElimN n) = "6" ++ nameRank n
     snRank (InstanceCtorN n) = "7" ++ nameRank n
     snRank (WithN i n) = "8" ++ nameRank n ++ show i
@@ -205,7 +205,7 @@ mkLDecl n (CaseOp ci _ _ _ pats cd)
     (args, sc) = cases_runtime cd
 
     -- Always attempt to inline functions arising from 'case' expressions
-    caseName (SN (CaseN _)) = True
+    caseName (SN (CaseN _ _)) = True
     caseName (SN (WithN _ _)) = True
     caseName (NS n _) = caseName n
     caseName _ = False

--- a/src/Idris/Core/Binary.hs
+++ b/src/Idris/Core/Binary.hs
@@ -287,6 +287,9 @@ instance Binary FC where
                          return (FileFC x1)
                  _ -> error "Corrupted binary data for FC"
 
+instance Binary FC' where
+    put (FC' fc) = put fc
+    get = fmap FC' get
 
 instance Binary Name where
         put x
@@ -337,7 +340,7 @@ instance Binary SpecialName where
                                     put x2
                 MethodN x1 -> do putWord8 3
                                  put x1
-                CaseN x1 -> do putWord8 4; put x1
+                CaseN x1 x2 -> do putWord8 4; put x1; put x2
                 ElimN x1 -> do putWord8 5; put x1
                 InstanceCtorN x1 -> do putWord8 6; put x1
                 WithN x1 x2 -> do putWord8 7
@@ -362,7 +365,8 @@ instance Binary SpecialName where
                    3 -> do x1 <- get
                            return (MethodN x1)
                    4 -> do x1 <- get
-                           return (CaseN x1)
+                           x2 <- get
+                           return (CaseN x1 x2)
                    5 -> do x1 <- get
                            return (ElimN x1)
                    6 -> do x1 <- get

--- a/src/Idris/Core/DeepSeq.hs
+++ b/src/Idris/Core/DeepSeq.hs
@@ -65,7 +65,7 @@ instance NFData SpecialName where
         rnf (InstanceN x1 x2) = rnf x1 `seq` rnf x2 `seq` ()
         rnf (ParentN x1 x2) = rnf x1 `seq` rnf x2 `seq` ()
         rnf (MethodN x1) = rnf x1 `seq` ()
-        rnf (CaseN x1) = rnf x1 `seq` ()
+        rnf (CaseN x1 x2) = rnf x1 `seq` rnf x2 `seq` ()
         rnf (ElimN x1) = rnf x1 `seq` ()
         rnf (InstanceCtorN x1) = rnf x1 `seq` ()
         rnf (MetaN x1 x2) = rnf x1 `seq` rnf x2 `seq` ()
@@ -87,6 +87,9 @@ instance NFData FC where
         rnf (FC x1 x2 x3) = rnf x1 `seq` rnf x2 `seq` rnf x3 `seq` ()
         rnf NoFC = ()
         rnf (FileFC f) = rnf f `seq` ()
+
+instance NFData FC' where
+        rnf (FC' fc) = rnf fc `seq` ()
 
 instance NFData Provenance where
         rnf ExpectedType = ()

--- a/src/Idris/Core/ProofState.hs
+++ b/src/Idris/Core/ProofState.hs
@@ -722,7 +722,7 @@ casetac tm induction ctxt env (Bind x (Hole t) (P _ x' _)) | x == x' = do
   let tmt' = normalise ctxt env tmt
   let (tacn, tacstr, tactt) = if induction
               then (ElimN, "eliminator", "Induction")
-              else (CaseN, "case analysis", "Case analysis")
+              else (CaseN (FC' emptyFC), "case analysis", "Case analysis")
   case unApply tmt' of
     (P _ tnm _, tyargs) -> do
         case lookupTy (SN (tacn tnm)) ctxt of

--- a/src/Idris/Delaborate.hs
+++ b/src/Idris/Delaborate.hs
@@ -192,7 +192,7 @@ delabTy' ist imps tm fullname mvs = de [] imps tm
     isCaseApp tm | P _ n _ <- fst (unApply tm) = isCN n
                  | otherwise = False
       where isCN (NS n _) = isCN n
-            isCN (SN (CaseN _)) = True
+            isCN (SN (CaseN _ _)) = True
             isCN _ = False
 
     delabCase :: [(Name, Name)] -> [PArg] -> Name -> Term -> Name -> [Term] -> Maybe PTerm

--- a/src/Idris/Elab/Data.hs
+++ b/src/Idris/Elab/Data.hs
@@ -350,7 +350,7 @@ elabCaseFun ind paramPos n ty cons info = do
         elimFC = fileFC "(casefun)"
 
         elimDeclName :: Name
-        elimDeclName = if ind then SN . ElimN $ n else SN . CaseN $ n
+        elimDeclName = if ind then SN . ElimN $ n else SN . CaseN (FC' emptyFC) $ n
 
         applyNS :: Name -> [String] -> Name
         applyNS n []  = n

--- a/src/Idris/Elab/Term.hs
+++ b/src/Idris/Elab/Term.hs
@@ -1058,7 +1058,7 @@ elab ist info emode opts fn tm
              let args' = filter (\(n, _) -> n `notElem` argsDropped) args
 
              attack
-             cname' <- defer argsDropped (mkN (mkCaseName fn))
+             cname' <- defer argsDropped (mkN (mkCaseName fc fn))
              solve
 
              -- if the scrutinee is one of the 'args' in env, we should
@@ -1071,8 +1071,8 @@ elab ist info emode opts fn tm
              -- if we haven't got the type yet, hopefully we'll get it later!
              movelast tyn
              solve
-        where mkCaseName (NS n ns) = NS (mkCaseName n) ns
-              mkCaseName n = SN (CaseN n)
+        where mkCaseName fc (NS n ns) = NS (mkCaseName fc n) ns
+              mkCaseName fc n = SN (CaseN (FC' fc) n)
 --               mkCaseName (UN x) = UN (x ++ "_case")
 --               mkCaseName (MN i x) = MN i (x ++ "_case")
               mkN n@(NS _ _) = n

--- a/test/reg006/expected
+++ b/test/reg006/expected
@@ -1,2 +1,2 @@
 reg006.idr:17:1:
-RBTree.lookup is possibly not total due to: RBTree.case block in lookup
+RBTree.lookup is possibly not total due to: RBTree.case block in lookup at reg006.idr:19:8

--- a/test/totality009/expected
+++ b/test/totality009/expected
@@ -1,8 +1,8 @@
-TestLambdaPossible.idr:9:25:Warning - TestLambdaPossible.case block in wrongPossible is not total as there are missing cases
-TestLambdaPossible.idr:9:1:Warning - TestLambdaPossible.wrongPossible is possibly not total due to: TestLambdaPossible.case block in wrongPossible
-TestLambdaPossible.idr:12:25:Warning - TestLambdaPossible.case block in wrongPossible' is not total as there are missing cases
-TestLambdaPossible.idr:12:1:Warning - TestLambdaPossible.wrongPossible' is possibly not total due to: TestLambdaPossible.case block in wrongPossible'
-TestLambdaPossible.idr:9:15:Warning - TestLambdaPossible.case block in wrongPossible is not total as there are missing cases
-TestLambdaPossible.idr:9:1:Warning - TestLambdaPossible.wrongPossible is possibly not total due to: TestLambdaPossible.case block in wrongPossible
-TestLambdaPossible.idr:12:16:Warning - TestLambdaPossible.case block in wrongPossible' is not total as there are missing cases
-TestLambdaPossible.idr:12:1:Warning - TestLambdaPossible.wrongPossible' is possibly not total due to: TestLambdaPossible.case block in wrongPossible'
+TestLambdaPossible.idr:9:25:Warning - TestLambdaPossible.case block in wrongPossible at TestLambdaPossible.idr:9:25 is not total as there are missing cases
+TestLambdaPossible.idr:9:1:Warning - TestLambdaPossible.wrongPossible is possibly not total due to: TestLambdaPossible.case block in wrongPossible at TestLambdaPossible.idr:9:25
+TestLambdaPossible.idr:12:25:Warning - TestLambdaPossible.case block in wrongPossible' at TestLambdaPossible.idr:12:25 is not total as there are missing cases
+TestLambdaPossible.idr:12:1:Warning - TestLambdaPossible.wrongPossible' is possibly not total due to: TestLambdaPossible.case block in wrongPossible' at TestLambdaPossible.idr:12:25
+TestLambdaPossible.idr:9:15:Warning - TestLambdaPossible.case block in wrongPossible at TestLambdaPossible.idr:9:25 is not total as there are missing cases
+TestLambdaPossible.idr:9:1:Warning - TestLambdaPossible.wrongPossible is possibly not total due to: TestLambdaPossible.case block in wrongPossible at TestLambdaPossible.idr:9:25
+TestLambdaPossible.idr:12:16:Warning - TestLambdaPossible.case block in wrongPossible' at TestLambdaPossible.idr:12:25 is not total as there are missing cases
+TestLambdaPossible.idr:12:1:Warning - TestLambdaPossible.wrongPossible' is possibly not total due to: TestLambdaPossible.case block in wrongPossible' at TestLambdaPossible.idr:12:25


### PR DESCRIPTION
Names for case block functions (such as "case block in f") now show the
source location from which they originated. This will make it easier to
diagnose problems like totality warnings coming from case blocks,
staging restriction errors from %runElab, and similar.