### PR TITLE
Remove NErased

### DIFF
--- a/libs/base/Language/Reflection/Utils.idr
+++ b/libs/base/Language/Reflection/Utils.idr
@@ -85,14 +85,12 @@ mutual
     showPrec d (NS n ns)  = showCon d "NS" $ showArg n ++ showArg ns
     showPrec d (MN i str) = showCon d "MN" $ showArg i ++ showArg str
     showPrec d (SN sn)    = showCon d "SN" $ assert_total (showArg sn)
-    showPrec d NErased    = "NErased"
 
 mutual
   instance Eq TTName where
     (UN str1)  == (UN str2)     = str1 == str2
     (NS n ns)  == (NS n' ns')   = n == n' && ns == ns'
     (MN i str) == (MN i' str')  = i == i' && str == str'
-    NErased    == NErased       = True
     (SN sn)    == (SN sn')      = assert_total $ sn == sn'
     x          == y             = False
 

--- a/libs/prelude/Language/Reflection.idr
+++ b/libs/prelude/Language/Reflection.idr
@@ -40,9 +40,7 @@ mutual
               MN Int String |
               ||| Special names, to make conflicts impossible and language features
               ||| predictable
-              SN SpecialName |
-              ||| Name of something which is never used in scope
-              NErased
+              SN SpecialName
   %name TTName n, n'
 
   data SpecialName = WhereN Int TTName TTName
@@ -478,7 +476,6 @@ mutual
     quote (NS n xs) = `(NS ~(quote n) ~(quote xs))
     quote (MN x y) = `(MN ~(quote x) ~(quote y))
     quote (SN sn) = `(SN ~(assert_total $ quote sn))
-    quote NErased = `(NErased)
 
   instance Quotable SpecialName TT where
     quotedTy = `(SpecialName)
@@ -499,7 +496,6 @@ mutual
     quote (NS n xs) = `(NS ~(quote {t=Raw} n) ~(quote {t=Raw} xs))
     quote (MN x y) = `(MN ~(quote {t=Raw} x) ~(quote {t=Raw} y))
     quote (SN sn) = `(SN ~(assert_total $ quote sn))
-    quote NErased = `(NErased)
 
   instance Quotable SpecialName Raw where
     quotedTy = `(SpecialName)

--- a/libs/pruviloj/Pruviloj/Core.idr
+++ b/libs/pruviloj/Pruviloj/Core.idr
@@ -41,7 +41,6 @@ nameFrom (MN x n) =
                then "n"
                else n
 nameFrom (SN x) = gensym "SN"
-nameFrom NErased = gensym "wasErased"
 
 ||| Get the name at the head of the term, if it exists.
 headName : Raw -> Maybe TTName

--- a/src/Idris/Core/Binary.hs
+++ b/src/Idris/Core/Binary.hs
@@ -302,10 +302,9 @@ instance Binary Name where
                 MN x1 x2 -> do putWord8 2
                                put x1
                                put x2
-                NErased -> putWord8 3
-                SN x1 -> do putWord8 4
+                SN x1 -> do putWord8 3
                             put x1
-                SymRef x1 -> do putWord8 5
+                SymRef x1 -> do putWord8 4
                                 put x1
         get
           = do i <- getWord8
@@ -318,10 +317,9 @@ instance Binary Name where
                    2 -> do x1 <- get
                            x2 <- get
                            return (MN x1 x2)
-                   3 -> return NErased
-                   4 -> do x1 <- get
+                   3 -> do x1 <- get
                            return (SN x1)
-                   5 -> do x1 <- get
+                   4 -> do x1 <- get
                            return (SymRef x1)
                    _ -> error "Corrupted binary data for Name"
 

--- a/src/Idris/Core/DeepSeq.hs
+++ b/src/Idris/Core/DeepSeq.hs
@@ -13,7 +13,6 @@ instance NFData Name where
         rnf (UN x1) = rnf x1 `seq` ()
         rnf (NS x1 x2) = rnf x1 `seq` rnf x2 `seq` ()
         rnf (MN x1 x2) = rnf x1 `seq` rnf x2 `seq` ()
-        rnf NErased = ()
         rnf (SN x1) = rnf x1 `seq` ()
         rnf (SymRef x1) = rnf x1 `seq` ()
 

--- a/src/Idris/Core/TT.hs
+++ b/src/Idris/Core/TT.hs
@@ -447,7 +447,6 @@ traceWhen False _  a = a
 data Name = UN !T.Text -- ^ User-provided name
           | NS !Name [T.Text] -- ^ Root, namespaces
           | MN !Int !T.Text -- ^ Machine chosen names
-          | NErased -- ^ Name of something which is never used in scope
           | SN !SpecialName -- ^ Decorated function names
           | SymRef Int -- ^ Reference to IBC file symbol table (used during serialisation)
   deriving (Eq, Ord, Data, Typeable)
@@ -514,7 +513,6 @@ instance Pretty Name OutputAnnotation where
   pretty n@(SN s) = annotate (AnnName n Nothing Nothing Nothing) $ text (show s)
   pretty n@(SymRef i) = annotate (AnnName n Nothing Nothing Nothing) $
                         text $ "##symbol" ++ show i ++ "##"
-  pretty NErased = annotate (AnnName NErased Nothing Nothing Nothing) $ text "_"
 
 instance Pretty [Name] OutputAnnotation where
   pretty = encloseSep empty empty comma . map pretty
@@ -526,7 +524,6 @@ instance Show Name where
     show (MN i s) = "{" ++ str s ++ show i ++ "}"
     show (SN s) = show s
     show (SymRef i) = "##symbol" ++ show i ++ "##"
-    show NErased = "_"
 
 instance Show SpecialName where
     show (WhereN i p c) = show p ++ ", " ++ show c
@@ -566,7 +563,6 @@ showCG (SN s) = showCG' s
                         "_" ++ show (fst e) ++ "_" ++ show (snd e)
         cgFN = concatMap (\c -> if not (isDigit c || isLetter c) then "__" else [c])
 showCG (SymRef i) = error "can't do codegen for a symbol reference"
-showCG NErased = "_"
 
 
 -- |Contexts allow us to map names to things. A root name maps to a collection
@@ -1455,7 +1451,6 @@ nextName (SN x) = SN (nextName' x)
     nextName' (MethodN n) = MethodN (nextName n)
     nextName' (InstanceCtorN n) = InstanceCtorN (nextName n)
     nextName' (MetaN parent meta) = MetaN parent (nextName meta)
-nextName NErased = NErased
 nextName (SymRef i) = error "Can't generate a name from a symbol reference"
 
 type Term = TT Name

--- a/src/Idris/DSL.hs
+++ b/src/Idris/DSL.hs
@@ -42,7 +42,7 @@ mkTTName fc n =
                                                         , pexp (mkList fc ns)]
          MN i nm   -> PApp fc (PRef fc [] (reflm "MN")) [ pexp (intC i)
                                                         , pexp (stringC nm)]
-         otherwise -> PRef fc [] $ reflm "NErased"
+         _ -> error "Invalid name from user syntax for DSL name"
 
 expandSugar :: DSL -> PTerm -> PTerm
 expandSugar dsl (PLam fc n nfc ty tm)

--- a/src/Idris/IBC.hs
+++ b/src/Idris/IBC.hs
@@ -40,7 +40,7 @@ import System.Directory
 import Codec.Archive.Zip
 
 ibcVersion :: Word16
-ibcVersion = 122
+ibcVersion = 123
 
 data IBCFile = IBCFile { ver :: Word16,
                          sourcefile :: FilePath,


### PR DESCRIPTION
The name constructor `NErased` was produced precisely two places in the
source, each as a kind of failure representation rather than as a name
referring to something that had been erased, like the docs stated. The
vestigial constructor has been removed.