### PR TITLE
Fixed comment of Effect type; ordering incorrect and vague.

### DIFF
--- a/libs/effects/Effects.idr
+++ b/libs/effects/Effects.idr
@@ -12,9 +12,9 @@ import Data.Vect
 ||| The Effect type describes effectful computations.
 |||
 ||| This type is parameterised by:
-||| + The input resource.
 ||| + The return type of the computation.
-||| + The computation to run on the resource.
+||| + The input resource.
+||| + The computation to run on the resource given the return value.
 Effect : Type
 Effect = (x : Type) -> Type -> (x -> Type) -> Type
 


### PR DESCRIPTION
It's not clear to me whether the last comment `The computation to run on the resource` meant that the computation takes the resource as an argument or that it meant it computes the output resource type. If the former, then it's incorrect since the computation takes the return value of the effect, not the input resource. If the latter, then I made clear that the computation takes the return value of the effect, not the input resource. All full (i.e. dependently typed) uses of the Effect type have `(ret : Type) -> (res_in : Type) -> (res_out : ret -> Type) -> Type` so I'm convinced the comments are out-of-date. This pull request will refresh them.