### PR TITLE
docs: Update the "Interactively Building Elab Scripts" section

### DIFF
--- a/docs/reference/elaborator-reflection.rst
+++ b/docs/reference/elaborator-reflection.rst
@@ -79,6 +79,7 @@ It takes the name of a hole as an argument.
 To list all available holes, use the command ``:m``.
 
 In interactive elaboration shell, the following commands are available:
+
 -  ``:q`` - Quits the elaboration shell (gives up on proving current lemma).
 -  ``:abandon`` - Same as :q
 -  ``:state`` - Displays the current state of the term being constructed.

--- a/docs/reference/elaborator-reflection.rst
+++ b/docs/reference/elaborator-reflection.rst
@@ -88,7 +88,7 @@ using the ``:qed`` command and receive in return an elaboration script
 that fills the hole.
 
 The interactive elaboration shell accepts a limited number of commands,
-including a subset of the commands understood by the normal Idris reply
+including a subset of the commands understood by the normal Idris REPL
 as well as some elaboration-specific commands.
 
 General-purpose commands that remain available in the elaboration shell:

--- a/docs/reference/elaborator-reflection.rst
+++ b/docs/reference/elaborator-reflection.rst
@@ -91,7 +91,7 @@ The interactive elaboration shell accepts a limited number of commands,
 including a subset of the commands understood by the normal Idris REPL
 as well as some elaboration-specific commands.
 
-General-purpose commands that remain available in the elaboration shell:
+General-purpose commands:
 
 - ``:eval <EXPR>``, or ``:e <EXPR>`` for short, evaluates the provided expression
   and prints the result.

--- a/docs/reference/elaborator-reflection.rst
+++ b/docs/reference/elaborator-reflection.rst
@@ -113,7 +113,7 @@ Commands for viewing the proof state:
 - ``:term`` displays the current proof term as well as its yet-to-be-filled holes.
 
 
-Commands for manipulating the manipulating the proof state:
+Commands for manipulating the proof state:
 
 - ``:undo`` undoes the effects of the last tactic.
 

--- a/docs/reference/elaborator-reflection.rst
+++ b/docs/reference/elaborator-reflection.rst
@@ -81,8 +81,7 @@ to enter the elaboration shell.
 
 The interactive elaboration shell accepts the following commands:
 
-- ``:abandon``, or ``:q`` for short,
-  quits the elaboration shell, which abandons proving the current lemma.
+- ``:abandon`` gives up on proving the current lemma and quits the elaboration shell.
 
 -  ``:state`` displays the current state of the term being constructed.
 

--- a/docs/reference/elaborator-reflection.rst
+++ b/docs/reference/elaborator-reflection.rst
@@ -74,18 +74,25 @@ We can generate identity functions at any concrete type using the same script:
 Interactively Building Elab Scripts
 ===================================
 
-To build an ``Elab`` script interactively, use the ``:elab`` command at the REPL.
-It takes the name of a hole as an argument.
-To list all available holes, use the command ``:m``.
+You can build an ``Elab`` script interactively at the REPL.
+Use the command ``:metavars``, or ``:m`` for short, to list the available holes.
+Then, issue the ``:elab <hole>`` command at the REPL
+to enter the elaboration shell.
 
-In interactive elaboration shell, the following commands are available:
+The interactive elaboration shell accepts the following commands:
 
--  ``:q`` - Quits the elaboration shell (gives up on proving current lemma).
--  ``:abandon`` - Same as :q
--  ``:state`` - Displays the current state of the term being constructed.
--  ``:term`` - Displays the current proof term complete with its yet-to-be-filled holes.
--  ``:undo`` - Undoes the last tactic.
--  ``:qed`` - Once the elaboration shell tells you "No more goals," you get to type this in celebration! (Completes the construction and exits the shell)
+- ``:abandon``, or ``:q`` for short,
+  quits the elaboration shell, which abandons proving the current lemma.
+
+-  ``:state`` displays the current state of the term being constructed.
+
+-  ``:term`` displays the current proof term as well as its yet-to-be-filled holes.
+
+-  ``:undo`` undoes the last tactic.
+
+-  ``:qed`` finishes the script and exits the elaboration shell. The shell will only accept
+  this command once it reports, "No more goals." On exit, it will print out the finished
+  elaboration script for you to copy into your program.
 
 
 Failure

--- a/docs/reference/elaborator-reflection.rst
+++ b/docs/reference/elaborator-reflection.rst
@@ -80,9 +80,8 @@ Then, issue the ``:elab <hole>`` command at the REPL
 to enter the elaboration shell.
 
 At the shell, you can enter proof tactics to alter the proof state.
-It is recommended to issue ``:module Language.Reflection.Elab``
-prior to entering the elaboration shell in order to have the system-provided
-tactics available to you.
+You can view the system-provided tactics prior to entering the shell
+by issuing the REPL command ``:browse Language.Reflection.Elab.Tactics``.
 When you have discharged all goals, you can complete the proof
 using the ``:qed`` command and receive in return an elaboration script
 that fills the hole.

--- a/docs/reference/elaborator-reflection.rst
+++ b/docs/reference/elaborator-reflection.rst
@@ -79,17 +79,47 @@ Use the command ``:metavars``, or ``:m`` for short, to list the available holes.
 Then, issue the ``:elab <hole>`` command at the REPL
 to enter the elaboration shell.
 
-The interactive elaboration shell accepts the following commands:
+At the shell, you can enter proof tactics to alter the proof state.
+It is recommended to issue ``:module Language.Reflection.Elab``
+prior to entering the elaboration shell in order to have the system-provided
+tactics available to you.
+When you have discharged all goals, you can complete the proof
+using the ``:qed`` command and receive in return an elaboration script
+that fills the hole.
+
+The interactive elaboration shell accepts a limited number of commands,
+including a subset of the commands understood by the normal Idris reply
+as well as some elaboration-specific commands.
+
+General-purpose commands that remain available in the elaboration shell:
+
+- ``:eval <EXPR>``, or ``:e <EXPR>`` for short, evaluates the provided expression
+  and prints the result.
+
+- ``:type <EXPR>``, or ``:t <EXPR>`` for short, prints the provided expression
+  together with its type.
+
+- ``:search <TYPE>`` searches for definitions having the provided type.
+
+- ``:doc <NAME>`` searches for definitions with the provided name and prints their
+  documentation.
+
+
+Commands for viewing the proof state:
+
+- ``:state`` displays the current state of the term being constructed. It lists both
+  other goals and the current goal.
+
+- ``:term`` displays the current proof term as well as its yet-to-be-filled holes.
+
+
+Commands for manipulating the manipulating the proof state:
+
+- ``:undo`` undoes the effects of the last tactic.
 
 - ``:abandon`` gives up on proving the current lemma and quits the elaboration shell.
 
--  ``:state`` displays the current state of the term being constructed.
-
--  ``:term`` displays the current proof term as well as its yet-to-be-filled holes.
-
--  ``:undo`` undoes the last tactic.
-
--  ``:qed`` finishes the script and exits the elaboration shell. The shell will only accept
+- ``:qed`` finishes the script and exits the elaboration shell. The shell will only accept
   this command once it reports, "No more goals." On exit, it will print out the finished
   elaboration script for you to copy into your program.
 


### PR DESCRIPTION
- Fixes bulleted list rendering.
- Updates the elaboration shell commands to match those parsed by [`parseElabShellStep`](https://github.com/idris-lang/Idris-dev/blob/master/src/Idris/Parser.hs#L1415-L1428).
- Points out that you probably want to import `Language.Reflection.Elab` before entering the shell. (This tripped me up the first time I tried using this.)