### PR TITLE
IPKG: Relax requirement that executable name be a valid identifier [#2721]

### DIFF
--- a/CHANGELOG
+++ b/CHANGELOG
@@ -41,7 +41,7 @@ Tool updates
   datatype
 * iPKG files have a new option `pkgs` which takes a comma-separated list
   of package names that the idris project depends on. This reduces bloat
-  in the `opts` option with mutliple package declarations.
+  in the `opts` option with multiple package declarations.
 
 Miscellaneous updates
 ---------------------

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -166,4 +166,4 @@ To help increase the chance of your pull request being accepted:
 * [General GitHub Documentation](https://help.github.com/).
 
 
-Adapted from the most excellent contributing files from the [Puppet project](https://github.com/puppetlabs/puppet) and [Factroy Girl Rails](https://github.com/thoughtbot/factory_girl_rails/blob/master/CONTRIBUTING.md)
+Adapted from the most excellent contributing files from the [Puppet project](https://github.com/puppetlabs/puppet) and [Factory Girl Rails](https://github.com/thoughtbot/factory_girl_rails/blob/master/CONTRIBUTING.md)

--- a/CONTRIBUTORS
+++ b/CONTRIBUTORS
@@ -35,6 +35,7 @@ Adam Sandberg Eriksson
 Seo Sanghyeon
 Benjamin Saunders
 Alexander Shabalin
+Jeremy W. Sherman
 Timo Petteri Sinnemäki
 JP Smith
 startling

--- a/src/Pkg/PParser.hs
+++ b/src/Pkg/PParser.hs
@@ -72,9 +72,9 @@ filename = try $ (token $ stringLiteral <|> (fst <$> identifier)) <?> "filename"
 
 pClause :: PParser ()
 pClause = do reserved "executable"; lchar '=';
-             exec <- fst <$> iName []
+             exec <- filename
              st <- get
-             put (st { execout = Just (show exec) })
+             put (st { execout = Just exec })
       <|> do reserved "main"; lchar '=';
              main <- fst <$> iName []
              st <- get

--- a/src/Pkg/PParser.hs
+++ b/src/Pkg/PParser.hs
@@ -1,4 +1,4 @@
-{-# LANGUAGE CPP #-}
+{-# LANGUAGE CPP, ConstraintKinds #-}
 #if !(MIN_VERSION_base(4,8,0))
 {-# LANGUAGE OverlappingInstances #-}
 #endif

--- a/src/Pkg/PParser.hs
+++ b/src/Pkg/PParser.hs
@@ -67,7 +67,7 @@ pPkg = do
 -- |
 -- | Treated for now as an identifier or a double-quoted string.
 filename :: (MonadicParsing m, HasLastTokenSpan m) => m String
-filename = try $ (token $ stringLiteral <|> (fst <$> identifier)) <?> "filename"
+filename = (token $ stringLiteral <|> (fst <$> identifier)) <?> "filename"
 
 
 pClause :: PParser ()

--- a/src/Pkg/PParser.hs
+++ b/src/Pkg/PParser.hs
@@ -67,7 +67,17 @@ pPkg = do
 -- |
 -- | Treated for now as an identifier or a double-quoted string.
 filename :: (MonadicParsing m, HasLastTokenSpan m) => m String
-filename = (token $ stringLiteral <|> (fst <$> identifier)) <?> "filename"
+filename = token $
+    -- Treat a double-quoted string as a filename to support spaces.
+    -- This also moves away from tying filenames to identifiers, so
+    -- it will also accept hyphens
+    -- (https://github.com/idris-lang/Idris-dev/issues/2721)
+    stringLiteral
+    <|>
+    -- Through at least version 0.9.19.1, IPKG executable values were
+    -- possibly namespaced identifiers, like foo.bar.baz.
+    show <$> fst <$> iName []
+    <?> "filename"
 
 
 pClause :: PParser ()

--- a/src/Pkg/PParser.hs
+++ b/src/Pkg/PParser.hs
@@ -79,8 +79,9 @@ filename = (do
         -- Through at least version 0.9.19.1, IPKG executable values were
         -- possibly namespaced identifiers, like foo.bar.baz.
         show <$> fst <$> iName []
-    guard $ isValidFilename filename
-    return filename)
+    if isValidFilename filename
+      then return filename
+      else fail "a filename must be non-empty and have no directory component")
     <?> "filename"
     where
         isValidFilename :: FilePath -> Bool

--- a/src/Pkg/PParser.hs
+++ b/src/Pkg/PParser.hs
@@ -62,6 +62,14 @@ pPkg = do
     eof
     return st
 
+
+-- | Parses a filename.
+-- |
+-- | Treated for now as an identifier or a double-quoted string.
+filename :: (MonadicParsing m, HasLastTokenSpan m) => m String
+filename = try $ (token $ stringLiteral <|> (fst <$> identifier)) <?> "filename"
+
+
 pClause :: PParser ()
 pClause = do reserved "executable"; lchar '=';
              exec <- fst <$> iName []

--- a/src/Pkg/PParser.hs
+++ b/src/Pkg/PParser.hs
@@ -14,7 +14,7 @@ import Idris.CmdOptions
 
 import Control.Monad.State.Strict
 import Control.Applicative
-import System.FilePath (takeFileName)
+import System.FilePath (takeFileName, isValid)
 
 import Util.System
 
@@ -85,9 +85,11 @@ filename = (do
     <?> "filename"
     where
         isValidFilename :: FilePath -> Bool
-        isValidFilename path = isNonEmpty && hasNoDirectoryComponent
+        isValidFilename path =
+            and [isNonEmpty, isValidPath, hasNoDirectoryComponent]
             where
                 isNonEmpty = path /= ""
+                isValidPath = System.FilePath.isValid path
                 hasNoDirectoryComponent = path == takeFileName path
 
 

--- a/test/pkg002/Main.idr
+++ b/test/pkg002/Main.idr
@@ -1,0 +1,4 @@
+module Main
+
+main : IO ()
+main = putStrLn "CouCou!"

--- a/test/pkg002/expected
+++ b/test/pkg002/expected
@@ -1,0 +1,1 @@
+Type checking ./Main.idr

--- a/test/pkg002/run
+++ b/test/pkg002/run
@@ -1,0 +1,5 @@
+#!/usr/bin/env bash
+### Test: IPKG executable names can be any namespaced identifier.
+idris $@ --build test.ipkg
+rm -f *.ibc
+rm -f some.namespaced.identifier

--- a/test/pkg002/test.ipkg
+++ b/test/pkg002/test.ipkg
@@ -1,0 +1,6 @@
+package test
+
+modules = Main
+
+main = Main
+executable = some.namespaced.identifier

--- a/test/pkg003/Main.idr
+++ b/test/pkg003/Main.idr
@@ -1,0 +1,4 @@
+module Main
+
+main : IO ()
+main = putStrLn "CouCou!"

--- a/test/pkg003/expected
+++ b/test/pkg003/expected
@@ -1,0 +1,1 @@
+Type checking ./Main.idr

--- a/test/pkg003/run
+++ b/test/pkg003/run
@@ -1,0 +1,6 @@
+#!/usr/bin/env bash
+### Test: IPKG executable names can be a quoted string
+### containing a valid filename.
+idris $@ --build test.ipkg
+rm -f *.ibc
+rm -f 'quoting-allows-hyphens and spaces? and fun stuff!'

--- a/test/pkg003/test.ipkg
+++ b/test/pkg003/test.ipkg
@@ -1,0 +1,6 @@
+package test
+
+modules = Main
+
+main = Main
+executable = "quoting-allows-hyphens and spaces? and fun stuff!"

--- a/test/pkg004/Main.idr
+++ b/test/pkg004/Main.idr
@@ -1,0 +1,4 @@
+module Main
+
+main : IO ()
+main = putStrLn "CouCou!"

--- a/test/pkg004/expected
+++ b/test/pkg004/expected
@@ -1,0 +1,6 @@
+Uncaught error: user error ([1mtest.ipkg[0m:[1m7[0m:[1m1[0m: [91merror[0m: a filename
+    must be non-empty and have no
+    directory
+    component, expected: space
+[1m[94m<EOF>[0;1m[0m 
+[92m^[0m     )

--- a/test/pkg004/run
+++ b/test/pkg004/run
@@ -1,0 +1,6 @@
+#!/usr/bin/env bash
+### Test: IPKG executable names CANNOT include a directory separator.
+# TODO: Verify that a name like "a/b\c" is rejected by both *NIX and Windows
+# (assuming these tests get run on Windows).
+idris $@ --consolewidth 80 --nobanner --nocolor --build test.ipkg
+rm -f *.ibc

--- a/test/pkg004/test.ipkg
+++ b/test/pkg004/test.ipkg
@@ -1,0 +1,6 @@
+package test
+
+modules = Main
+
+main = Main
+executable = "filenames/cannot include\a directory separator"


### PR DESCRIPTION
- Preserves support for current format like `executable = some.namespaced.identifier` (test/pkg002)
- Adds new format using a quoted string like `executable = "some-name-with-hyphens and spaces"` (test/pkg003)
    - New format rejects names that have a directory component like `invalid/filename`. (test/pkg004)

TODO:

- [x] Address ["illegal tuple constraint" warning](https://github.com/idris-lang/Idris-dev/pull/2728#issuecomment-147666654) under GHC 7.6/7.8
- [ ] Replace `iName`/`identifier` with a quote-free flavor of filename parsing
- [x] Add check that it's a valid path (so no bogus characters) [using `System.FilePath.isValid`](https://github.com/idris-lang/Idris-dev/pull/2728#issuecomment-147690603)
- [ ] Add entry to CHANGELOG