### PR TITLE
PParser.hs: filename: Report the specific failed check on error

### DIFF
--- a/CHANGELOG
+++ b/CHANGELOG
@@ -45,6 +45,10 @@ Tool updates
 * iPKG files have a new option `pkgs` which takes a comma-separated list
   of package names that the idris project depends on. This reduces bloat
   in the `opts` option with multiple package declarations.
+* iPKG files now allow `executable = "your filename here"` in addition to
+  the existing `executable = yourFilenameHere` style. While the unquoted
+  version is limited to filenames that look like namespaced Idris identifiers
+  (`your.filename.here`), the quoted version accepts any valid filename.
 * Add definition command (\d in Vim, Ctrl-Alt-A in Atom, C-c C-s in Emacs) now
   adds missing clauses if there is already a definition.
 

--- a/src/Pkg/PParser.hs
+++ b/src/Pkg/PParser.hs
@@ -15,6 +15,7 @@ import Idris.CmdOptions
 import Control.Monad.State.Strict
 import Control.Applicative
 import System.FilePath (takeFileName, isValid)
+import Data.Maybe (isNothing, fromJust)
 
 import Util.System
 
@@ -79,18 +80,33 @@ filename = (do
         -- Through at least version 0.9.19.1, IPKG executable values were
         -- possibly namespaced identifiers, like foo.bar.baz.
         show <$> fst <$> iName []
-    if isValidFilename filename
+    let errorMessage = filenameErrorMessage filename
+    if isNothing errorMessage
       then return filename
-      else fail "a filename must be non-empty and have no directory component")
+      else fail $ fromJust errorMessage)
     <?> "filename"
     where
-        isValidFilename :: FilePath -> Bool
-        isValidFilename path =
-            and [isNonEmpty, isValidPath, hasNoDirectoryComponent]
+        -- TODO: Report failing span better! We could lookAhead,
+        -- or do something with DeltaParsing?
+        filenameErrorMessage :: FilePath -> Maybe String
+        filenameErrorMessage path = either Just (const Nothing) $ do
+            checkEmpty path
+            checkValid path
+            checkNoDirectoryComponent path
             where
-                isNonEmpty = path /= ""
-                isValidPath = System.FilePath.isValid path
-                hasNoDirectoryComponent = path == takeFileName path
+                checkThat ok message =
+                    if ok then Right () else Left message
+
+                checkEmpty path =
+                    checkThat (path /= "") "filename must not be empty"
+
+                checkValid path =
+                    checkThat (System.FilePath.isValid path)
+                        "filename must contain only valid characters"
+
+                checkNoDirectoryComponent path =
+                    checkThat (path == takeFileName path)
+                        "filename must contain no directory component"
 
 
 pClause :: PParser ()

--- a/src/Pkg/PParser.hs
+++ b/src/Pkg/PParser.hs
@@ -80,10 +80,9 @@ filename = (do
         -- Through at least version 0.9.19.1, IPKG executable values were
         -- possibly namespaced identifiers, like foo.bar.baz.
         show <$> fst <$> iName []
-    let errorMessage = filenameErrorMessage filename
-    if isNothing errorMessage
-      then return filename
-      else fail $ fromJust errorMessage)
+    case filenameErrorMessage filename of
+      Just errorMessage -> fail errorMessage
+      Nothing -> return filename)
     <?> "filename"
     where
         -- TODO: Report failing span better! We could lookAhead,

--- a/test/pkg003/run
+++ b/test/pkg003/run
@@ -3,4 +3,4 @@
 ### containing a valid filename.
 idris $@ --build test.ipkg
 rm -f *.ibc
-rm -f 'quoting-allows-hyphens and spaces? and fun stuff!'
+rm -f 'quoting-allows-hyphens and spaces and fun stuff!'

--- a/test/pkg004/expected
+++ b/test/pkg004/expected
@@ -1,6 +1,5 @@
-Uncaught error: user error (test.ipkg:10:1: error: a
-    filename must be non-empty and
-    have no directory
+Uncaught error: user error ([1mtest.ipkg[0m:[1m10[0m:[1m1[0m: [91merror[0m: filename
+    must contain no directory
     component, expected: space
-<EOF> 
-^     )
+[1m[94m<EOF>[0;1m[0m 
+[92m^[0m     )


### PR DESCRIPTION
This makes the error message more specific and so more useful to the
person trying to debug their iPKG file.

This is an addendum to #2728. I've been sitting on it for a week or so as I tried to work out how to improve the reported span, but it benefits no-one hiding on my hard-drive. :)