### PR TITLE
Define void with an elab script, not elim_for

### DIFF
--- a/libs/prelude/Builtins.idr
+++ b/libs/prelude/Builtins.idr
@@ -48,6 +48,12 @@ namespace Builtins
     
 ||| The eliminator for the `Void` type.
 void : Void -> a
+-- We can't define void yet. We can't define a function with no clauses without
+-- elaborator reflection, and we can't do elaborator reflection without
+-- Language.Reflection.Elab, and Language.Reflection.Elab depends on Builtins.
+-- We can't delay the declaration of void, because Prelude.Uninhabited depends on
+-- it, Prelude.Nat depends on Prelude.Uninhabited, and Language.Reflection.Elab
+-- depends on Prelude.Nat. Instead, void is defined in Prelude.idr
 
 ||| For 'symbol syntax. 'foo becomes Symbol_ "foo"
 data Symbol_ : String -> Type where

--- a/libs/prelude/Builtins.idr
+++ b/libs/prelude/Builtins.idr
@@ -48,7 +48,6 @@ namespace Builtins
     
 ||| The eliminator for the `Void` type.
 void : Void -> a
-void {a} v = elim_for Void (\_ => a) v
 
 ||| For 'symbol syntax. 'foo becomes Symbol_ "foo"
 data Symbol_ : String -> Type where

--- a/libs/prelude/Prelude.idr
+++ b/libs/prelude/Prelude.idr
@@ -37,6 +37,8 @@ import public Language.Reflection.Errors
 %default total
 
 -- Things that can't be elsewhere for import cycle reasons
+-- See comment after declaration of void in Builtins.idr
+-- for explanation of this definition's location
 %runElab (defineFunction $ DefineFun `{void} [])
 
 decAsBool : Dec p -> Bool

--- a/libs/prelude/Prelude.idr
+++ b/libs/prelude/Prelude.idr
@@ -37,6 +37,8 @@ import public Language.Reflection.Errors
 %default total
 
 -- Things that can't be elsewhere for import cycle reasons
+%runElab (defineFunction $ DefineFun `{void} [])
+
 decAsBool : Dec p -> Bool
 decAsBool (Yes _) = True
 decAsBool (No _)  = False


### PR DESCRIPTION
Eliminator generation is deprecated, so let's remove this use of a generated eliminator.