### PR TITLE
Ignore SIGPIPE on the unicies.

### DIFF
--- a/rts/idris_main.c
+++ b/rts/idris_main.c
@@ -21,6 +21,7 @@ int main(int argc, char* argv[]) {
     init_gmpalloc();
 
     init_nullaries();
+    init_signals();
 
     _idris__123_runMain0_125_(vm, NULL);
 

--- a/rts/idris_rts.c
+++ b/rts/idris_rts.c
@@ -72,6 +72,7 @@ VM* idris_vm() {
     init_threaddata(vm);
     init_gmpalloc();
     init_nullaries();
+    init_signals();
 
     return vm;
 }
@@ -89,6 +90,12 @@ void init_threadkeys() {
 void init_threaddata(VM *vm) {
 #ifdef HAS_PTHREAD
     pthread_setspecific(vm_key, vm);
+#endif
+}
+
+void init_signals() {
+#if (__linux__ || __APPLE__ || __FreeBSD__)
+    signal(SIGPIPE, SIG_IGN);
 #endif
 }
 

--- a/rts/idris_rts.h
+++ b/rts/idris_rts.h
@@ -9,6 +9,9 @@
 #include <pthread.h>
 #endif
 #include <stdint.h>
+#if (__linux__ || __APPLE__ || __FreeBSD__)
+#include <signal.h>
+#endif
 
 #include "idris_heap.h"
 #include "idris_stats.h"
@@ -255,6 +258,8 @@ void idris_free(void* ptr, size_t size);
 extern VAL* nullary_cons;
 void init_nullaries();
 void free_nullaries();
+
+void init_signals();
 
 void* vmThread(VM* callvm, func f, VAL arg);
 


### PR DESCRIPTION
Some UNIXy systems will produce a `SIGPIPE` signal when calling things like
`send()`, `sendto()`, `write()` - since there is no handler, this causes the
process to terminate unexpectedly. This change makes Idris ignore SIGPIPE, so
that an EPIPE error can be handled properly.