### PR TITLE
Ioexcept golf

### DIFF
--- a/libs/base/Control/Catchable.idr
+++ b/libs/base/Control/Catchable.idr
@@ -16,14 +16,14 @@ instance Catchable (Either a) a where
     catch (Left err) h = h err
     catch (Right x)  h = (Right x)
 
-    throw x = Left x
+    throw = Left
 
 instance Catchable (IOExcept err) err where
     catch (IOM prog) h = IOM (do p' <- prog
                                  case p' of
                                       Left e => let IOM he = h e in he
                                       Right val => return (Right val))
-    throw x = IOM (return (Left x))
+    throw = ioe_fail
 
 instance Catchable List () where
     catch [] h = h ()

--- a/libs/base/Control/IOExcept.idr
+++ b/libs/base/Control/IOExcept.idr
@@ -10,8 +10,7 @@ instance Functor (IOExcept e) where
 
 instance Applicative (IOExcept e) where
      pure x = IOM (pure (pure x))
-     (IOM f) <*> (IOM a) = IOM (do f' <- f; a' <- a
-                                   return (f' <*> a'))
+     (IOM f) <*> (IOM a) = IOM [| f <*> a |]
 
 instance Monad (IOExcept e) where
      (IOM x) >>= k = IOM (do x' <- x;
@@ -21,15 +20,10 @@ instance Monad (IOExcept e) where
                                   Left err => return (Left err))
 
 ioe_lift : IO a -> IOExcept err a
-ioe_lift op = IOM (do op' <- op
-                      return (Right op'))
+ioe_lift op = IOM $ map Right op
 
 ioe_fail : err -> IOExcept err a
-ioe_fail e = IOM (return (Left e))
+ioe_fail e = IOM $ pure (Left e)
 
 ioe_run : IOExcept err a -> (err -> IO b) -> (a -> IO b) -> IO b
-ioe_run (IOM act) err ok = do act' <- act
-                              case act' of
-                                   Left e => err e
-                                   Right v => ok v
-
+ioe_run (IOM act) err ok = either err ok !act

--- a/libs/effects/Effect/Exception.idr
+++ b/libs/effects/Effect/Exception.idr
@@ -18,7 +18,7 @@ instance Show a => Handler (Exception a) IO where
                                believe_me (exit 1)
 
 instance Handler (Exception a) (IOExcept a) where
-     handle _ (Raise e) k = IOM (return (Left e))
+     handle _ (Raise e) k = ioe_fail e
 
 instance Handler (Exception a) (Either a) where
      handle _ (Raise e) k = Left e

--- a/libs/effects/Effects.idr
+++ b/libs/effects/Effects.idr
@@ -245,6 +245,11 @@ pureM = Value
 (<*>) prog v = do fn <- prog
                   arg <- v
                   return (fn arg)
+
+(*>) : EffM m a xs (\v => xs) ->
+       EffM m b xs (\v => xs) -> EffM m b xs (\v => xs)
+a *> b = do a
+            b
      
 new : Handler e' m => (e : EFFECT) -> resTy ->
       {auto prf : e = MkEff resTy e'} ->


### PR DESCRIPTION
 Simplify some expressions in IOExcept.
 It seemed weird to be to be implementing <*> in terms of >>=, even though it's at a different level... Tried to make it look more like "apply the thing to the inner thing using the outer thing's version of that", like is the case with map and pure.

Use ioe_fail helper method where appropriate in Catchable and Exception Effect.

Add *> as a shortcut for do a; b on Effects
    
Like Haskell's >>.
Was surprised *> wasn't already available on Effects, until I realized
their >>= wasn't from Monad.