### PR TITLE
Revert "Added deleteAt, replaceAt and insertAt for Lists"

### DIFF
--- a/libs/prelude/Prelude/List.idr
+++ b/libs/prelude/Prelude/List.idr
@@ -113,21 +113,6 @@ index' Z     (x::xs) = Just x
 index' (S n) (x::xs) = index' n xs
 index' _     []      = Nothing
 
-||| Delete a particular element of a list.
-deleteAt : (n : Nat) -> (xs : List a) -> {auto ok : InBounds n xs} -> List a
-deleteAt Z (_ :: xs) = xs
-deleteAt (S n) (x :: xs) {ok = InLater ok} = x :: deleteAt {ok} n xs
-
-||| Insert an element into a list at a particular point.
-insertAt : (n : Nat) -> a -> (xs : List a) -> {auto ok : InBounds n xs} -> List a
-insertAt Z elem xs = elem :: xs
-insertAt (S n) elem (x :: xs) {ok = InLater ok} = x :: insertAt {ok} n elem xs
-
-||| Replace a particular element of a list.
-replaceAt : (n : Nat) -> a -> (xs : List a) -> {auto ok : InBounds n xs} -> List a
-replaceAt Z elem (_ :: xs) = (elem :: xs)
-replaceAt (S n) elem (x :: xs) {ok = InLater ok} = x :: replaceAt {ok} n elem xs
-
 ||| Get the first element of a non-empty list
 ||| @ ok proof that the list is non-empty
 head : (l : List a) -> {auto ok : NonEmpty l} -> a
@@ -899,21 +884,4 @@ foldlAsFoldr f z t = foldr (flip (.) . flip f) id t z
 foldlMatchesFoldr : (f : b -> a -> b) -> (q : b) -> (xs : List a) -> foldl f q xs = foldlAsFoldr f q xs
 foldlMatchesFoldr f q [] = Refl
 foldlMatchesFoldr f q (x :: xs) = foldlMatchesFoldr f (f q x) xs
-
-replaceIsDeleteAndInsert : insertAt {ok=ok1} n x (deleteAt {ok=ok2} n xs) = replaceAt {ok=ok3} n x xs
-replaceIsDeleteAndInsert {xs = []} {ok3 = InFirst} impossible
-replaceIsDeleteAndInsert {xs = []} {ok3 = InLater _} impossible
-replaceIsDeleteAndInsert {xs = _ :: _} {ok3 = InFirst} = Refl
-replaceIsDeleteAndInsert {xs = _ :: _} {ok3 = InLater _} {ok2 = InFirst} impossible
-replaceIsDeleteAndInsert {xs = _ :: _} {ok3 = InLater _} {ok1 = InFirst} impossible
-replaceIsDeleteAndInsert {xs = x :: xs} {ok3 = InLater ok3} {ok1 = InLater ok1} {ok2 = InLater ok2} =
-  cong (replaceIsDeleteAndInsert {ok1} {ok2} {ok3})
-
-deleteOppositeInsert : deleteAt {ok=ok1} n (insertAt {ok=ok2} n x xs) = xs
-deleteOppositeInsert {xs = []} {ok2 = InFirst} impossible
-deleteOppositeInsert {xs = []} {ok2 = InLater _} impossible
-deleteOppositeInsert {xs = _ :: _} {ok2 = InFirst} = Refl
-deleteOppositeInsert {xs = _ :: _} {ok1 = InLater _} {ok2 = InFirst} impossible
-deleteOppositeInsert {xs = x :: xs} {ok1 = InLater ok1} {ok2 = InLater ok2} =
-  cong (deleteOppositeInsert {ok1} {ok2})
 


### PR DESCRIPTION
Reverts idris-lang/Idris-dev#2772

I don't think that we should have merged this - these operations don't seem like they would be generally applicable and useful enough to go in the Prelude, and additions to the Prelude should at the very least come with some justification as to why they should be in scope for every single Idris program.

The reason that I'm skeptical about how useful this particular set of functions would be is is that in order for the auto implicit to work, the list would have to be available as a literal (or at least the elements up to the one to be deleted). In that case, one could just leave it out.

I'd be happy to stick this in contrib, but I think we should revert the merge to Prelude.
