### PR TITLE
[WIP] Well-founded recursion

### DIFF
--- a/libs/prelude/Prelude/WellFounded.idr
+++ b/libs/prelude/Prelude/WellFounded.idr
@@ -1,0 +1,41 @@
+||| Well-founded recursion
+module WellFounded
+
+import Builtins
+
+%access public
+%default total
+
+||| An element is accessible for a relation
+||| @ R The relation
+||| @ x The element that is accessible for `R`
+data Accessible : (R : a -> a -> Type) -> (x : a) -> Type where
+  ||| An element is accessible if every element that relates to it is accessible
+  MkAccessible : ((y : _) -> r y x -> Accessible r y) -> Accessible r x
+
+||| The type of well-founded relations
+||| @ R The relation that is well-founded
+wellFounded : (R : a -> a -> Type) -> Type
+wellFounded r = (x : _) -> Accessible r x
+
+||| Recurse over a well-founded relation
+recurse : (wellFounded r) ->
+          .{p : a -> Type} ->
+          ((x : a) -> ((y : a) -> r y x -> p y) -> p x) ->
+          (x : a) -> p x
+recurse {r} {p} wf rec x = recurse' x (wf x) where
+  recurse' : (x : a) ->
+             (Accessible r x) ->
+             p x
+  recurse' x (MkAccessible base) = rec x (\y => \r => recurse' y (base y r))
+
+||| Prove one term smaller than another over a relation
+|||
+||| If used to satisfy the termination checker, all recursive calls must go through
+||| `prove_smaller` with the same relation.
+prove_smaller : .(wellFounded r) -> .(x : a) -> (y : a) -> .(r y x) -> a
+prove_smaller _ _ y _ = y
+
+||| Automatically prove one term smaller than another over a relation
+smaller : .(wellFounded r) -> .(x : a) -> (y : a) -> .{auto pf : r y x} -> a
+smaller wf x y {pf} = prove_smaller wf x y pf

--- a/libs/prelude/prelude.ipkg
+++ b/libs/prelude/prelude.ipkg
@@ -9,7 +9,7 @@ modules = Builtins, Prelude, IO,
           Prelude.Strings, Prelude.Chars, Prelude.Show, Prelude.Functor,
           Prelude.Foldable, Prelude.Traversable, Prelude.Bits, Prelude.Stream,
           Prelude.Uninhabited, Prelude.Pairs, Prelude.Providers,
-          Prelude.Interactive, Prelude.File, Prelude.Doubles,
+          Prelude.Interactive, Prelude.File, Prelude.Doubles, Prelude.WellFounded,
 
           Language.Reflection, Language.Reflection.Errors, Language.Reflection.Elab,
 


### PR DESCRIPTION
This is the start of work to add a richer notion of well-founded recursion to the language, inspired by Coq's standard library. The next step is to teach the compiler about the notions added here, which I can think of doing in 2 ways:

1. Trust instances of `prove_smaller` like `assert_smaller`, *only if* every recursive call passes the argument we're recursing on through `prove_smaller` with the same well-founded relation
2. Add syntax that desugars into a call to `recurse` (and remove `prove_smaller` and `smaller`).

I'm pretty sure 1 is safe (though I haven't proven it), but 2 may be easier to swallow. Let me know if this is something we want and which approach is preferred if so.