### PR TITLE
Implement missing idris_mkFileError for windows rts files

### DIFF
--- a/rts/idris_heap.c
+++ b/rts/idris_heap.c
@@ -7,11 +7,11 @@
 
 
 /* Used for initializing the heap. */
-void alloc_heap(Heap * h, size_t heap_size, size_t growth, char * old) 
+void alloc_heap(Heap * h, size_t heap_size, size_t growth, char * old)
 {
-    char * mem = malloc(heap_size); 
+    char * mem = malloc(heap_size);
     if (mem == NULL) {
-        fprintf(stderr, 
+        fprintf(stderr,
                 "RTS ERROR: Unable to allocate heap. Requested %zd bytes.\n",
                 heap_size);
         exit(EXIT_FAILURE);
@@ -37,8 +37,8 @@ void alloc_heap(Heap * h, size_t heap_size, size_t growth, char * old)
 void free_heap(Heap * h) {
     free(h->heap);
 
-    if (h->old != NULL) { 
-        free(h->old); 
+    if (h->old != NULL) {
+        free(h->old);
     }
 }
 
@@ -47,7 +47,7 @@ void free_heap(Heap * h) {
 /******************** Heap testing ********************************************/
 void heap_check_underflow(Heap * heap) {
     if (!(heap->heap <= heap->next)) {
-       fprintf(stderr, "RTS ERROR: HEAP UNDERFLOW <bot %p> <cur %p>\n", 
+       fprintf(stderr, "RTS ERROR: HEAP UNDERFLOW <bot %p> <cur %p>\n",
                heap->heap, heap->next);
         exit(EXIT_FAILURE);
     }
@@ -55,7 +55,7 @@ void heap_check_underflow(Heap * heap) {
 
 void heap_check_overflow(Heap * heap) {
     if (!(heap->next <= heap->end)) {
-       fprintf(stderr, "RTS ERROR: HEAP OVERFLOW <cur %p> <end %p>\n", 
+       fprintf(stderr, "RTS ERROR: HEAP OVERFLOW <cur %p> <end %p>\n",
                heap->next, heap->end);
         exit(EXIT_FAILURE);
     }
@@ -65,13 +65,13 @@ int is_valid_ref(VAL v) {
     return (v != NULL) && !(ISINT(v));
 }
 
-int ref_in_heap(Heap * heap, VAL v) { 
+int ref_in_heap(Heap * heap, VAL v) {
     return ((VAL)heap->heap <= v) && (v < (VAL)heap->next);
 }
 
 // Checks three important properties:
 // 1. Closure.
-//      Check if all pointers in the _heap_ points only to heap. 
+//      Check if all pointers in the _heap_ points only to heap.
 // 2. Unidirectionality. (if compact gc)
 //      All references in the heap should be are unidirectional. In other words,
 //      more recently allocated closure can point only to earlier allocated one.
@@ -79,7 +79,7 @@ int ref_in_heap(Heap * heap, VAL v) {
 //
 void heap_check_pointers(Heap * heap) {
     char* scan = NULL;
-  
+
     size_t item_size = 0;
     for(scan = heap->heap; scan < heap->next; scan += item_size) {
        item_size = *((size_t*)scan);
@@ -96,7 +96,7 @@ void heap_check_pointers(Heap * heap) {
                  if (is_valid_ref(ptr)) {
                      // Check for closure.
                      if (!ref_in_heap(heap, ptr)) {
-                         fprintf(stderr, 
+                         fprintf(stderr,
                                  "RTS ERROR: heap closure broken. "\
                                  "<HEAP %p %p %p> <REF %p>\n",
                                  heap->heap, heap->next, heap->end, ptr);
@@ -105,7 +105,7 @@ void heap_check_pointers(Heap * heap) {
 #if 0 // TODO macro
                      // Check for unidirectionality.
                      if (!(ptr < heap_item)) {
-                         fprintf(stderr, 
+                         fprintf(stderr,
                                  "RTS ERROR: heap unidirectionality broken:" \
                                  "<CON %p> <FIELD %p>\n",
                                  heap_item, ptr);

--- a/rts/idris_heap.h
+++ b/rts/idris_heap.h
@@ -8,7 +8,7 @@ typedef struct {
     char*  heap;   // Point to bottom of heap
     char*  end;    // Point to top of heap
     size_t size;   // Size of _next_ heap. Size of current heap is /end - heap/.
-    size_t growth; // Quantity of heap growth in bytes. 
+    size_t growth; // Quantity of heap growth in bytes.
 
     char* old;
 } Heap;
@@ -23,7 +23,7 @@ void heap_check_all(Heap * heap);
 // Should be used _between_ gc's.
 #define HEAP_CHECK(vm) heap_check_all(&(vm->heap));
 #else
-#define HEAP_CHECK(vm) 
+#define HEAP_CHECK(vm)
 #endif // IDRIS_DEBUG
 
 #endif // _IDRIS_HEAP_H

--- a/rts/idris_net.c
+++ b/rts/idris_net.c
@@ -38,15 +38,15 @@ void idrnet_free(void* ptr) {
 }
 
 // We call this from quite a few functions. Given a textual host and an int port,
-// populates a struct addrinfo. 
-int idrnet_getaddrinfo(struct addrinfo** address_res, char* host, int port, 
+// populates a struct addrinfo.
+int idrnet_getaddrinfo(struct addrinfo** address_res, char* host, int port,
                        int family, int socket_type) {
 
     struct addrinfo hints;
     // Convert port into string
     char str_port[8];
     sprintf(str_port, "%d", port);
-    
+
     // Set up hints structure
     memset(&hints, 0, sizeof(hints)); // zero out hints
     hints.ai_family = family;
@@ -57,7 +57,7 @@ int idrnet_getaddrinfo(struct addrinfo** address_res, char* host, int port,
     if (strlen(host) == 0) {
         hints.ai_flags = AI_PASSIVE; // fill in IP automatically
         return getaddrinfo(NULL, str_port, &hints, address_res);
-    } 
+    }
     return getaddrinfo(host, str_port, &hints, address_res);
 
 }
@@ -75,7 +75,7 @@ int idrnet_bind(int sockfd, int family, int socket_type, char* host, int port) {
         //freeaddrinfo(address_res);
         //printf("Lib err: bind\n");
         return -1;
-    } 
+    }
     return 0;
 }
 
@@ -111,7 +111,7 @@ char* idrnet_sockaddr_ipv4(void* sockaddr) {
 
 int idrnet_sockaddr_ipv4_port(void* sockaddr) {
     struct sockaddr_in* addr = (struct sockaddr_in*) sockaddr;
-    return ((int) ntohs(addr->sin_port));  
+    return ((int) ntohs(addr->sin_port));
 }
 
 void* idrnet_create_sockaddr() {
@@ -141,13 +141,13 @@ int idrnet_send_buf(int sockfd, void* data, int len) {
 }
 
 void* idrnet_recv(int sockfd, int len) {
-    idrnet_recv_result* res_struct = 
+    idrnet_recv_result* res_struct =
         (idrnet_recv_result*) malloc(sizeof(idrnet_recv_result));
     char* buf = malloc(len + 1);
     memset(buf, 0, len + 1);
     int recv_res = recv(sockfd, buf, len, 0);
     res_struct->result = recv_res;
-    
+
     if (recv_res > 0) { // Data was received
         buf[recv_res + 1] = 0x00; // Null-term, so Idris can interpret it
     }
@@ -172,7 +172,7 @@ char* idrnet_get_recv_payload(void* res_struct) {
 }
 
 void idrnet_free_recv_struct(void* res_struct) {
-    idrnet_recv_result* i_res_struct = 
+    idrnet_recv_result* i_res_struct =
         (idrnet_recv_result*) res_struct;
     if (i_res_struct->payload != NULL) {
         free(i_res_struct->payload);
@@ -191,9 +191,9 @@ int idrnet_sendto(int sockfd, char* data, char* host, int port, int family) {
     int addr_res = idrnet_getaddrinfo(&remote_host, host, port, family, SOCK_DGRAM);
     if (addr_res == -1) {
         return -1;
-    } 
+    }
 
-    int send_res = sendto(sockfd, data, strlen(data), 0, 
+    int send_res = sendto(sockfd, data, strlen(data), 0,
                         remote_host->ai_addr, remote_host->ai_addrlen);
     freeaddrinfo(remote_host);
     return send_res;
@@ -206,11 +206,11 @@ int idrnet_sendto_buf(int sockfd, void* buf, int buf_len, char* host, int port, 
     if (addr_res == -1) {
         //printf("lib err: sendto getaddrinfo \n");
         return -1;
-    } 
+    }
 
     buf_htonl(buf, buf_len);
 
-    int send_res = sendto(sockfd, buf, buf_len, 0, 
+    int send_res = sendto(sockfd, buf, buf_len, 0,
                         remote_host->ai_addr, remote_host->ai_addrlen);
     if (send_res == -1) {
         perror("lib err: sendto \n");
@@ -224,13 +224,13 @@ int idrnet_sendto_buf(int sockfd, void* buf, int buf_len, char* host, int port, 
 void* idrnet_recvfrom(int sockfd, int len) {
 /*
  * int recvfrom(int sockfd, void *buf, int len, unsigned int flags,
-             struct sockaddr *from, int *fromlen); 
+             struct sockaddr *from, int *fromlen);
 */
     // Allocate the required structures, and nuke them
-    struct sockaddr_storage* remote_addr = 
+    struct sockaddr_storage* remote_addr =
         (struct sockaddr_storage*) malloc(sizeof(struct sockaddr_storage));
     char* buf = (char*) malloc(len + 1);
-    idrnet_recvfrom_result* ret = 
+    idrnet_recvfrom_result* ret =
         (idrnet_recvfrom_result*) malloc(sizeof(idrnet_recvfrom_result));
     memset(remote_addr, 0, sizeof(struct sockaddr_storage));
     memset(buf, 0, len + 1);
@@ -240,7 +240,7 @@ void* idrnet_recvfrom(int sockfd, int len) {
     int recv_res = recvfrom(sockfd, buf, len, 0, (struct sockaddr*) remote_addr, &fromlen);
     ret->result = recv_res;
     // Check for failure...
-    if (recv_res == -1) { 
+    if (recv_res == -1) {
         free(buf);
         free(remote_addr);
     } else {
@@ -255,12 +255,11 @@ void* idrnet_recvfrom(int sockfd, int len) {
     return ret;
 }
 
-
 void* idrnet_recvfrom_buf(int sockfd, void* buf, int len) {
     // Allocate the required structures, and nuke them
-    struct sockaddr_storage* remote_addr = 
+    struct sockaddr_storage* remote_addr =
         (struct sockaddr_storage*) malloc(sizeof(struct sockaddr_storage));
-    idrnet_recvfrom_result* ret = 
+    idrnet_recvfrom_result* ret =
         (idrnet_recvfrom_result*) malloc(sizeof(idrnet_recvfrom_result));
     memset(remote_addr, 0, sizeof(struct sockaddr_storage));
     memset(ret, 0, sizeof(idrnet_recvfrom_result));
@@ -269,7 +268,7 @@ void* idrnet_recvfrom_buf(int sockfd, void* buf, int len) {
     int recv_res = recvfrom(sockfd, buf, len, 0, (struct sockaddr*) remote_addr, &fromlen);
     // Check for failure... But don't free the buffer! Not our job.
     ret->result = recv_res;
-    if (recv_res == -1) { 
+    if (recv_res == -1) {
         free(remote_addr);
     }
     // Payload will be NULL -- since it's been put into the user-specified buffer. We
@@ -298,7 +297,7 @@ void* idrnet_get_recvfrom_sockaddr(void* res_struct) {
 int idrnet_get_recvfrom_port(void* res_struct) {
     idrnet_recvfrom_result* recv_struct = (idrnet_recvfrom_result*) res_struct;
     if (recv_struct->remote_addr != NULL) {
-        struct sockaddr_in* remote_addr_in = 
+        struct sockaddr_in* remote_addr_in =
             (struct sockaddr_in*) recv_struct->remote_addr;
         return ((int) ntohs(remote_addr_in->sin_port));
     }
@@ -316,5 +315,3 @@ void idrnet_free_recvfrom_struct(void* res_struct) {
         }
     }
 }
-
-

--- a/rts/idris_stdfgn.c
+++ b/rts/idris_stdfgn.c
@@ -25,13 +25,13 @@ void fileClose(void* h) {
 }
 
 int fileEOF(void* h) {
-  FILE* f = (FILE*)h;
-  return feof(f);
+    FILE* f = (FILE*)h;
+    return feof(f);
 }
 
 int fileError(void* h) {
-  FILE* f = (FILE*)h;
-  return ferror(f);
+    FILE* f = (FILE*)h;
+    return ferror(f);
 }
 
 int idris_writeStr(void* h, char* str) {
@@ -107,5 +107,5 @@ VAL idris_mkFileError(VM* vm) {
 }
 
 void idris_forceGC(void* vm) {
-   idris_gc((VM*)vm); 
+    idris_gc((VM*)vm);
 }

--- a/rts/windows/idris_net.c
+++ b/rts/windows/idris_net.c
@@ -12,7 +12,7 @@
 #include <Ws2tcpip.h>
 
 
-// inet_ntop isn't defined in the old mingw delivered with GHC, 
+// inet_ntop isn't defined in the old mingw delivered with GHC,
 // so put the prototype here, cribbed from a newer version of it
 WINSOCK_API_LINKAGE LPCSTR WSAAPI InetNtopA(INT Family, PVOID pAddr,
         LPSTR pStringBuf, size_t StringBufSize);
@@ -50,7 +50,7 @@ int idrnet_bind(int sockfd, int family, int socket_type, char* host, int port) {
     // Convert port into string
     char str_port[8];
     sprintf(str_port, "%d", port);
-    
+
     if (!check_init()) {
         return -1;
     }
@@ -73,7 +73,7 @@ int idrnet_bind(int sockfd, int family, int socket_type, char* host, int port) {
     int bind_res = bind(sockfd, address_res->ai_addr, address_res->ai_addrlen);
     if (bind_res == -1) {
         return -1;
-    } 
+    }
 
     return 0;
 }
@@ -152,13 +152,13 @@ void* idrnet_recv(int sockfd, int len) {
     if (!check_init()) {
         return NULL;
     }
-    idrnet_recv_result* res_struct = 
+    idrnet_recv_result* res_struct =
         (idrnet_recv_result*) malloc(sizeof(idrnet_recv_result));
 
     char* buf = malloc(len + 1);
     int recv_res = recv(sockfd, buf, len, 0);
     res_struct->result = recv_res;
-    
+
     if (recv_res > 0) { // Data was received
         buf[recv_res + 1] = 0x00; // Null-term, so Idris can interpret it
     }
@@ -182,7 +182,7 @@ char* idrnet_get_recv_payload(void* res_struct) {
 }
 
 void idrnet_free_recv_struct(void* res_struct) {
-    idrnet_recv_result* i_res_struct = 
+    idrnet_recv_result* i_res_struct =
         (idrnet_recv_result*) res_struct;
     if (i_res_struct->payload != NULL) {
         free(i_res_struct->payload);
@@ -193,4 +193,3 @@ void idrnet_free_recv_struct(void* res_struct) {
 int idrnet_errno() {
     return errno;
 }
-

--- a/rts/windows/idris_stdfgn.c
+++ b/rts/windows/idris_stdfgn.c
@@ -26,13 +26,13 @@ void fileClose(void* h) {
 }
 
 int fileEOF(void* h) {
-  FILE* f = (FILE*)h;
-  return feof(f);
+    FILE* f = (FILE*)h;
+    return feof(f);
 }
 
 int fileError(void* h) {
-  FILE* f = (FILE*)h;
-  return ferror(f);
+    FILE* f = (FILE*)h;
+    return ferror(f);
 }
 
 int idris_writeStr(void* h, char* str) {
@@ -77,6 +77,25 @@ VAL idris_time() {
     return MKBIGI(t);
 }
 
+VAL idris_mkFileError(VM* vm) {
+    VAL result;
+    switch(errno) {
+        // Make sure this corresponds to the FileError structure in
+        // Prelude.File
+        case ENOENT:
+            idris_constructor(result, vm, 2, 0, 0);
+            break;
+        case EACCES:
+            idris_constructor(result, vm, 3, 0, 0);
+            break;
+        default:
+            idris_constructor(result, vm, 4, 1, 0);
+            idris_setConArg(result, 0, MKINT((intptr_t)errno));
+            break;
+    }
+    return result;
+}
+
 void idris_forceGC(void* vm) {
-   idris_gc((VM*)vm);
+    idris_gc((VM*)vm);
 }


### PR DESCRIPTION
 - work around error: undefined reference to `idris_mkFileError'
 - minor code formatting corrections (use 4 spaces, no tailoring spaces)

(tested)