### PR TITLE
rmFile: don't even try removing not existing files

### DIFF
--- a/src/Util/System.hs
+++ b/src/Util/System.hs
@@ -16,7 +16,6 @@ import System.Directory (getTemporaryDirectory
                         , removeFile
                         , removeDirectoryRecursive
                         , createDirectoryIfMissing
-                        , doesFileExist
                         )
 import System.FilePath ((</>), normalise)
 import System.IO
@@ -66,7 +65,7 @@ isATTY = do
 withTempdir :: String -> (FilePath -> IO a) -> IO a
 withTempdir subdir callback
   = do dir <- getTemporaryDirectory
-       let tmpDir = (normalise dir) </> subdir
+       let tmpDir = normalise dir </> subdir
        removeLater <- catchIO (createDirectoryIfMissing True tmpDir >> return True)
                               (\ ioError -> if isAlreadyExistsError ioError then return False
                                             else throw ioError
@@ -77,12 +76,14 @@ withTempdir subdir callback
 
 rmFile :: FilePath -> IO ()
 rmFile f = do
-  fileExists <- doesFileExist f
-  when fileExists
-   $ do putStrLn $ "Removing " ++ f
-        catchIO (removeFile f)
-                (\ioerr -> putStrLn $ "WARNING: Cannot remove file "
-                           ++ f ++ ", Error msg:" ++ show ioerr)
+  result <- try (removeFile f)
+  case result of
+    Right _ -> putStrLn $ "Removed: " ++ f
+    Left err -> handleExists err
+     where handleExists e
+            | isDoesNotExistError e = return ()
+            | otherwise = putStrLn $ "WARNING: Cannot remove file "
+                          ++ f ++ ", Error msg:" ++ show e
 
 setupBundledCC :: IO()
 #ifdef FREESTANDING

--- a/src/Util/System.hs
+++ b/src/Util/System.hs
@@ -16,9 +16,9 @@ import System.Directory (getTemporaryDirectory
                         , removeFile
                         , removeDirectoryRecursive
                         , createDirectoryIfMissing
-                        , doesDirectoryExist
+                        , doesFileExist
                         )
-import System.FilePath ((</>), normalise, isAbsolute, dropFileName)
+import System.FilePath ((</>), normalise)
 import System.IO
 import System.Info
 import System.IO.Error
@@ -76,10 +76,13 @@ withTempdir subdir callback
        return result
 
 rmFile :: FilePath -> IO ()
-rmFile f = do putStrLn $ "Removing " ++ f
-              catchIO (removeFile f)
-                      (\ioerr -> putStrLn $ "WARNING: Cannot remove file "
-                                 ++ f ++ ", Error msg:" ++ show ioerr)
+rmFile f = do
+  fileExists <- doesFileExist f
+  when fileExists
+   $ do putStrLn $ "Removing " ++ f
+        catchIO (removeFile f)
+                (\ioerr -> putStrLn $ "WARNING: Cannot remove file "
+                           ++ f ++ ", Error msg:" ++ show ioerr)
 
 setupBundledCC :: IO()
 #ifdef FREESTANDING


### PR DESCRIPTION
Often when I run idris --clean (specially automated) I see warnings due trying to remove files which are not present.
I wish to not see those annoying messages