### PR TITLE
Disable the DecEq deriving test, due to slowness

### DIFF
--- a/test/meta002/Deriving.idr
+++ b/test/meta002/Deriving.idr
@@ -1,6 +1,8 @@
 ||| Test some deriving features
 module Deriving
 
+-- NB: test disabled due to excess memory consumption
+
 import Pruviloj
 import Pruviloj.Derive.DecEq
 

--- a/test/meta002/run
+++ b/test/meta002/run
@@ -1,5 +1,6 @@
 #!/usr/bin/env bash
 idris $@ -p pruviloj --nocolour --check --consolewidth 70 Tacs.idr
 idris $@ -p pruviloj --nocolour --check --consolewidth 70 AgdaStyleReflection.idr
-idris $@ -p pruviloj --nocolour --check --consolewidth 70 Deriving.idr
+# Disabled due to excess memory consumption
+# idris $@ -p pruviloj --nocolour --check --consolewidth 70 Deriving.idr
 rm -f *.ibc


### PR DESCRIPTION
Fixes #2785.