### PR TITLE
For discussion: Add function to forcefully tighten Fin bound

### DIFF
--- a/libs/base/Data/Fin.idr
+++ b/libs/base/Data/Fin.idr
@@ -86,6 +86,15 @@ last : Fin (S n)
 last {n=Z} = FZ
 last {n=S _} = FS last
 
+||| Forcefully tighten the bound on a Fin.
+||| If tightening the bound would not work with the current value,
+||| decrement the value such that it is within the tightened bound.
+crimp : Fin (S (S n)) -> Fin (S n)
+crimp x =
+  case (strengthen x) of
+       Left _ => last
+       Right x' => x'
+
 total FSinjective : {f : Fin n} -> {f' : Fin n} -> (FS f = FS f') -> f = f'
 FSinjective Refl = Refl
 


### PR DESCRIPTION
If tightening the bound would not work with the value, the value is
decremented. I called it `crimp` because I wanted to gave a name that
clearly distinguished it from the existing `strengthen` function.

I don't have a rule of three on this function. How do you determine what
functions are useful to add to the base library? Do you try to apply a
rule of three? I have an intuition that this is a useful variation of `strengthen`,
but then again, if you don't have a rule of three...

Honestly I'm submitting this pull request to learn more than anything.
I am still early in my understanding of Idris, but I'm already eager to
contribute. Don't feel bad about closing this pull request if you don't
like it. Any feedback/guidance about future contributions would also
be welcome.