### PR TITLE
Replace private Show FunClause with public one

### DIFF
--- a/libs/base/Language/Reflection/Utils.idr
+++ b/libs/base/Language/Reflection/Utils.idr
@@ -349,3 +349,7 @@ instance Show CtorArg where
 instance Show TyDecl where
   showPrec d (Declare fn args ret) = showCon d "Declare" $ showArg fn ++
                                      showArg args ++ showArg ret
+
+instance Show FunClause where
+  showPrec d (MkFunClause lhs rhs) = showCon d "MkFunClause" $ showArg lhs ++
+                                     showArg rhs

--- a/libs/pruviloj/Pruviloj/Derive/Eliminators.idr
+++ b/libs/pruviloj/Pruviloj/Derive/Eliminators.idr
@@ -248,9 +248,6 @@ getElimClauses info elimn ctors =
   in traverse (\(i, con) => getElimClause info elimn methodCount con i)
               (enumerate ctors)
 
-instance Show FunClause where
-  show (MkFunClause x y) = "(MkFunClause " ++ show x ++ " " ++ show y ++ ")"
-
 abstract
 deriveElim : (tyn, elimn : TTName) -> Elab ()
 deriveElim tyn elimn =


### PR DESCRIPTION
The existence of the private one prevented defining one in any consumer of Pruviloj as noted in #2835, but it should presumably be in `Language.Reflection.Utils` like the other `Show` instances for reflection data.