### PR TITLE
Bug fix for infinite loop while executing a callback in the Javascript runtime

### DIFF
--- a/src/IRTS/CodegenJavaScript.hs
+++ b/src/IRTS/CodegenJavaScript.hs
@@ -604,7 +604,7 @@ jsBASETOP _ 0 = JSAssign jsSTACKBASE jsSTACKTOP
 jsBASETOP _ n = JSAssign jsSTACKBASE (JSBinOp "+" jsSTACKTOP (JSNum (JSInt n)))
 
 jsNULL :: CompileInfo -> Reg -> JS
-jsNULL _ r = JSDelete (translateReg r)
+jsNULL _ r = JSClear (translateReg r)
 
 jsERROR :: CompileInfo -> String -> JS
 jsERROR _ = JSError
@@ -1277,4 +1277,3 @@ toFType (FApp c [_,ity])
 toFType (FApp c [_,fty])
     | c == sUN "JS_FnT" = toFnType fty
 toFType t = error (show t ++ " not yet defined in toFType")
-

--- a/src/IRTS/JavaScript/AST.hs
+++ b/src/IRTS/JavaScript/AST.hs
@@ -77,6 +77,7 @@ data JS = JSRaw String
         | JSFFI String [JS]
         | JSAnnotation JSAnnotation JS
         | JSDelete JS
+        | JSClear JS
         | JSNoop
         deriving Eq
 
@@ -132,6 +133,9 @@ compileJS' indent (JSAnnotation annotation js) =
 
 compileJS' indent (JSDelete js) =
   "delete " `T.append` compileJS' 0 js
+
+compileJS' indent (JSClear js) =
+   compileJS' 0 js `T.append` " = undefined"
 
 compileJS' indent (JSFFI raw args) =
   ffi raw (map (T.unpack . compileJS' indent) args)
@@ -398,4 +402,3 @@ jsPackSBits16 js = JSNew "Int16Array" [JSArray [js]]
 
 jsPackSBits32 :: JS -> JS
 jsPackSBits32 js = JSNew "Int32Array" [JSArray [js]]
-


### PR DESCRIPTION
The `NULL` `BC` operation, which is supposed to clear a register (according to the docs) was translated as `delete` in the Javascript backend. This worked fine for clearing registers from the stack, but did not work well while trying to clear `i$RT`. This cause an infinite loop in `i$ffiWrap` which was checking the return value should have been cleared but continued to hold its old value (essentially ignoring the delete operation). Callbacks work fine now in my tests.