### PR TITLE
Gather timing data for tests.

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -36,6 +36,9 @@ test_all:
 	$(MAKE) test_llvm
 	$(MAKE) test_java
 
+test_timed:
+	$(MAKE) -C test IDRIS=../dist/build/idris time
+
 lib_clean:
 	$(MAKE) -C libs IDRIS=../../dist/build/idris/idris RTS=../../dist/build/rts/libidris_rts clean
 

--- a/test/Makefile
+++ b/test/Makefile
@@ -1,4 +1,4 @@
-.PHONY: test test_java test_js update diff distclean $(TESTS)
+.PHONY: test test_java test_js time update diff distclean $(TESTS)
 
 TESTS = $(sort $(patsubst %/,%.test,$(wildcard */)))
 
@@ -15,6 +15,9 @@ update:
 
 diff:
 	/usr/bin/env perl ./runtest.pl all -d
+
+time:
+	/usr/bin/env perl ./runtest.pl all -t
 
 distclean:
 	rm -f *~

--- a/test/runtest.pl
+++ b/test/runtest.pl
@@ -49,7 +49,7 @@ sub sandbox_path {
 # output and report results.
 #
 sub runtest {
-    my ($test, $update) = @_;
+    my ($test, $update, $showTime) = @_;
 
     my $sandbox = sandbox_path($test);
 
@@ -63,7 +63,9 @@ sub runtest {
     my $endTime = time();
     my $elapsedTime = $endTime - $startTime;
 
-    printf("Duration of $test was %d\n", $elapsedTime);
+    if ($showTime == 1 ){
+      printf("Duration of $test was %d\n", $elapsedTime);
+    }
 
     # Allow for variant expected output for tests by overriding expected
     # when there is an expected.<os> file in the test.
@@ -161,15 +163,17 @@ else {
 
 # Run the tests.
 
-my $update  = 0;
-my $diff    = 0;
-my $show    = 0;
-my $usejava = 0;
+my $update   = 0;
+my $diff     = 0;
+my $show     = 0;
+my $usejava  = 0;
+my $showTime = 0;
 
 while (my $opt = shift @opts) {
     if    ($opt eq "-u") { $update = 1; }
     elsif ($opt eq "-d") { $diff = 1; }
     elsif ($opt eq "-s") { $show = 1; }
+    elsif ($opt eq "-t") { $showTime = 1; }
     else { push(@idrOpts, $opt); }
 }
 
@@ -181,7 +185,7 @@ my $startTime = time();
 
 foreach my $test (@tests) {
     if ($diff == 0 && $show == 0) {
-	    runtest($test,$update);
+	    runtest($test,$update,$showTime);
     }
     else {
         chdir $test;
@@ -203,6 +207,8 @@ foreach my $test (@tests) {
 my $endTime = time();
 my $elapsedTime = $endTime - $startTime;
 
-printf("Duration of Entire Test Suite was %d\n", $elapsedTime);
+if ($showTime == 1) {
+  printf("Duration of Entire Test Suite was %d\n", $elapsedTime);
+}
 
 exit $exitstatus;

--- a/test/runtest.pl
+++ b/test/runtest.pl
@@ -55,9 +55,15 @@ sub runtest {
 
     chdir($test);
 
+    my $startTime = time();
     print "Running $test...\n";
     my $got = `$sandbox ./run @idrOpts`;
     my $exp = `cat expected`;
+
+    my $endTime = time();
+    my $elapsedTime = $endTime - $startTime;
+
+    print "Duration of $test was $elapsedTime\n";
 
     # Allow for variant expected output for tests by overriding expected
     # when there is an expected.<os> file in the test.

--- a/test/runtest.pl
+++ b/test/runtest.pl
@@ -63,7 +63,7 @@ sub runtest {
     my $endTime = time();
     my $elapsedTime = $endTime - $startTime;
 
-    print "Duration of $test was $elapsedTime\n";
+    printf("Duration of $test was %d\n", $elapsedTime);
 
     # Allow for variant expected output for tests by overriding expected
     # when there is an expected.<os> file in the test.
@@ -203,6 +203,6 @@ foreach my $test (@tests) {
 my $endTime = time();
 my $elapsedTime = $endTime - $startTime;
 
-print "Duration of Entire Test Suite was $elapsedTime\n";
+printf("Duration of Entire Test Suite was %d\n", $elapsedTime);
 
 exit $exitstatus;

--- a/test/runtest.pl
+++ b/test/runtest.pl
@@ -177,6 +177,8 @@ my $idris  = $ENV{IDRIS};
 my $path   = $ENV{PATH};
 $ENV{PATH} = cwd() . "/" . $idris . ":" . $path;
 
+my $startTime = time();
+
 foreach my $test (@tests) {
     if ($diff == 0 && $show == 0) {
 	    runtest($test,$update);
@@ -197,5 +199,10 @@ foreach my $test (@tests) {
         chdir "..";
     }
 }
+
+my $endTime = time();
+my $elapsedTime = $endTime - $startTime;
+
+print "Duration of Entire Test Suite was $elapsedTime\n";
 
 exit $exitstatus;


### PR DESCRIPTION
To aid in the managment of the test suit, the perl script now records
the duration of each test for compilation and execution. The resulting
time is then displayed to stdout in the form:

    Duration of <test name> was <time>

When running tests locally, test output can be grep'd and graphs
plotted. A good improvement will be the automatic storing of the
results in a dat file.