### PR TITLE
Category based logging for Idris.

### DIFF
--- a/CHANGELOG
+++ b/CHANGELOG
@@ -1,3 +1,14 @@
+New in 0.9.21:
+==============
+
+* Idris' logging infrastructure has been categorised. Command line and repl
+  are available. For command line the option `--logging-categories CATS`
+  is used to pass in the categories. Here `CATS` is a colon separated quoted
+  string containing the categories to log. The REPL command is `logcats CATS`.
+  Where `CATS` is a whitespace separated list of categoriese. Default is for
+  all categories to be logged.
+
+
 New in 0.9.20:
 ==============
 
@@ -19,7 +30,7 @@ Language updates
 * Name binding in patterns follows the same rule as name binding for implicits
   in types: names which begin with lower case letters, not applied to any
   arguments, are treated as bound pattern variables.
-* Added %deprecate directive, which gives a warning and a message when a 
+* Added %deprecate directive, which gives a warning and a message when a
   deprecated name is referenced.
 
 Library updates
@@ -39,7 +50,7 @@ Library updates
   from Effectful programs.
 * Some constructors that never actually occurred have been removed from
   the TT and Raw reflection datatypes in Language.Reflection.
-* File IO operations (for example openFile/fread/fwrite) now return 
+* File IO operations (for example openFile/fread/fwrite) now return
   'Either FileError ty' where the return type was previously 'ty' to indicate
   that they may fail.
 

--- a/src/Idris/AbsSyntax.hs
+++ b/src/Idris/AbsSyntax.hs
@@ -980,6 +980,12 @@ setColour ct c = do i <- getIState
 logLvl :: Int -> String -> Idris ()
 logLvl = logLvlCats []
 
+logCoverage :: Int -> String -> Idris ()
+logCoverage = logLvlCats [ICoverage]
+
+logErasure :: Int -> String -> Idris ()
+logErasure = logLvlCats [IErasure]
+
 -- | Log an action of the parser
 logParser :: Int -> String -> Idris ()
 logParser = logLvlCats parserCats

--- a/src/Idris/AbsSyntax.hs
+++ b/src/Idris/AbsSyntax.hs
@@ -699,6 +699,13 @@ setLogLevel l = do i <- getIState
                    let opt' = opts { opt_logLevel = l }
                    putIState $ i { idris_options = opt' }
 
+setLogCats :: [LogCat] -> Idris ()
+setLogCats cs = do
+  i <- getIState
+  let opts = idris_options i
+  let opt' = opts { opt_logcats = cs }
+  putIState $ i { idris_options = opt' }
+
 setCmdLine :: [Opt] -> Idris ()
 setCmdLine opts = do i <- getIState
                      let iopts = idris_options i
@@ -969,15 +976,73 @@ setColour ct c = do i <- getIState
           setColour' PromptColour    c t = t { promptColour = c }
           setColour' PostulateColour c t = t { postulateColour = c }
 
+
 logLvl :: Int -> String -> Idris ()
-logLvl l str = do i <- getIState
-                  let lvl = opt_logLevel (idris_options i)
-                  when (lvl >= l) $
-                    case idris_outputmode i of
-                      RawOutput h -> do runIO $ hPutStrLn h str
-                      IdeMode n h ->
-                        do let good = SexpList [IntegerAtom (toInteger l), toSExp str]
-                           runIO . hPutStrLn h $ convSExp "log" good n
+logLvl = logLvlCats []
+
+logParser :: Int -> String -> Idris ()
+logParser = logLvlCats parserCats
+
+logParse :: Int -> String -> Idris ()
+logParse = logLvlCats [IParse]
+
+logTypeChecking :: Int -> String -> Idris ()
+logTypeChecking = logLvlCats checkingCats
+
+logElab :: Int -> String -> Idris ()
+logElab = logLvlCats [IElab]
+
+logCover :: Int -> String -> Idris ()
+logCover = logLvlCats [ICover]
+
+logUnify :: Int -> String -> Idris ()
+logUnify = logLvlCats [IUnify]
+
+logTotal :: Int -> String -> Idris ()
+logTotal = logLvlCats [ITotal]
+
+logErase :: Int -> String -> Idris ()
+logErase = logLvlCats [IErase]
+
+logBackend :: Int -> String -> Idris ()
+logBackend = logLvlCats backendCats
+
+logDefun :: Int -> String -> Idris ()
+logDefun = logLvlCats [IDefun]
+
+logInline :: Int -> String -> Idris ()
+logInline = logLvlCats [IInline]
+
+logResolve :: Int -> String -> Idris ()
+logResolve = logLvlCats [IResolve]
+
+logCodeGen :: Int -> String -> Idris ()
+logCodeGen = logLvlCats [ICodeGen]
+
+-- | Log aspect of Idris execution
+--
+-- An empty set of logging levels is used to denote all categories.
+--
+-- @TODO update IDE protocol
+logLvlCats :: [LogCat] -- ^ The categories that the message should appear under.
+           -> Int      -- ^ The Logging level the message should appear.
+           -> String   -- ^ The message to show the developer.
+           -> Idris ()
+logLvlCats cs l str = do
+    i <- getIState
+    let lvl  = opt_logLevel (idris_options i)
+    let cats = opt_logcats (idris_options i)
+    when (lvl >= l) $
+      when (inCat cs cats || null cats) $
+        case idris_outputmode i of
+          RawOutput h -> do
+            runIO $ hPutStrLn h str
+          IdeMode n h -> do
+            let good = SexpList [IntegerAtom (toInteger l), toSExp str]
+            runIO . hPutStrLn h $ convSExp "log" good n
+  where
+    inCat :: [LogCat] -> [LogCat] -> Bool
+    inCat cs cats = or $ map (\x -> elem x cats) cs
 
 cmdOptType :: Opt -> Idris Bool
 cmdOptType x = do i <- getIState
@@ -1396,7 +1461,7 @@ getUnboundImplicits i t tm = getImps t (collectImps tm)
         scopedimpl (Just i) = not (toplevel_imp i)
         scopedimpl _ = False
 
-        getImps (Bind n (Pi i _ _) sc) imps 
+        getImps (Bind n (Pi i _ _) sc) imps
              | scopedimpl i = getImps sc imps
         getImps (Bind n (Pi _ t _) sc) imps
             | Just (p, t') <- lookup n imps = argInfo n p t' : getImps sc imps
@@ -1628,7 +1693,7 @@ addImpl' inpat env infns imp_meths ist ptm
     ai inpat qq env ds (PApp fc ftm@(PRef ffc hl f) as)
         | f `elem` infns = ai inpat qq env ds (PApp fc (PInferRef ffc hl f) as)
         | not (f `elem` map fst env)
-                          = let as' = map (fmap (ai inpat qq env ds)) as 
+                          = let as' = map (fmap (ai inpat qq env ds)) as
                                 asdotted' = map (fmap (ai False qq env ds)) as in
                                 handleErr $ aiFn topname inpat False qq imp_meths ist fc f ffc ds as' asdotted'
         | Just (Just ty) <- lookup f env =
@@ -1707,7 +1772,7 @@ aiFn :: Name -> Bool -> Bool -> Bool
      -> Either Err PTerm
 aiFn topname inpat True qq imp_meths ist fc f ffc ds [] _
   | inpat && implicitable f && unqualified f = Right $ PPatvar ffc f
-  | otherwise 
+  | otherwise
      = case lookupDef f (tt_ctxt ist) of
         [] -> Right $ PPatvar ffc f
         alts -> let ialts = lookupCtxtName f (idris_implicits ist) in
@@ -1743,7 +1808,7 @@ aiFn topname inpat expat qq imp_meths ist fc f ffc ds as asexp
                          [] -> nh
                          x -> x
           case ns' of
-            [(f',ns)] -> Right $ mkPApp fc (length ns) (PRef ffc [ffc] (isImpName f f')) 
+            [(f',ns)] -> Right $ mkPApp fc (length ns) (PRef ffc [ffc] (isImpName f f'))
                                      (insertImpl ns (chooseArgs f' as asexp))
             [] -> if f `elem` (map fst (idris_metavars ist))
                     then Right $ PApp fc (PRef ffc [ffc] f) as
@@ -2173,7 +2238,7 @@ shadow n n' t = sm 0 t where
 -- | Rename any binders which are repeated (so that we don't have to mess
 -- about with shadowing anywhere else).
 mkUniqueNames :: [Name] -> [(Name, Name)] -> PTerm -> PTerm
-mkUniqueNames env shadows tm 
+mkUniqueNames env shadows tm
       = evalState (mkUniq 0 initMap tm) (S.fromList env) where
 
   initMap = M.fromList shadows
@@ -2295,4 +2360,3 @@ mkUniqueNames env shadows tm
   mkUniq ql nmap (PUnquote tm) = fmap PUnquote (mkUniq (ql - 1) nmap tm)
 
   mkUniq ql nmap tm = descendM (mkUniq ql nmap) tm
-                      

--- a/src/Idris/AbsSyntax.hs
+++ b/src/Idris/AbsSyntax.hs
@@ -998,6 +998,8 @@ logElab = logLvlCats elabCats
 logCodeGen :: Int -> String -> Idris ()
 logCodeGen = logLvlCats codegenCats
 
+logIBC :: Int -> String -> Idris ()
+logIBC = logLvlCats [IIBC]
 
 -- | Log aspect of Idris execution
 --

--- a/src/Idris/AbsSyntax.hs
+++ b/src/Idris/AbsSyntax.hs
@@ -980,44 +980,18 @@ setColour ct c = do i <- getIState
 logLvl :: Int -> String -> Idris ()
 logLvl = logLvlCats []
 
+-- | Log an action of the parser
 logParser :: Int -> String -> Idris ()
 logParser = logLvlCats parserCats
 
-logParse :: Int -> String -> Idris ()
-logParse = logLvlCats [IParse]
-
-logTypeChecking :: Int -> String -> Idris ()
-logTypeChecking = logLvlCats checkingCats
-
+-- | Log an action of the elaborator.
 logElab :: Int -> String -> Idris ()
-logElab = logLvlCats [IElab]
+logElab = logLvlCats elabCats
 
-logCover :: Int -> String -> Idris ()
-logCover = logLvlCats [ICover]
-
-logUnify :: Int -> String -> Idris ()
-logUnify = logLvlCats [IUnify]
-
-logTotal :: Int -> String -> Idris ()
-logTotal = logLvlCats [ITotal]
-
-logErase :: Int -> String -> Idris ()
-logErase = logLvlCats [IErase]
-
-logBackend :: Int -> String -> Idris ()
-logBackend = logLvlCats backendCats
-
-logDefun :: Int -> String -> Idris ()
-logDefun = logLvlCats [IDefun]
-
-logInline :: Int -> String -> Idris ()
-logInline = logLvlCats [IInline]
-
-logResolve :: Int -> String -> Idris ()
-logResolve = logLvlCats [IResolve]
-
+-- | Log an action of the compiler.
 logCodeGen :: Int -> String -> Idris ()
-logCodeGen = logLvlCats [ICodeGen]
+logCodeGen = logLvlCats codegenCats
+
 
 -- | Log aspect of Idris execution
 --

--- a/src/Idris/AbsSyntaxTree.hs
+++ b/src/Idris/AbsSyntaxTree.hs
@@ -462,6 +462,7 @@ data LogCat = IParse
             | ICodeGen
             | IErasure
             | ICoverage
+            | IIBC
             deriving (Show, Eq, Ord)
 
 codegenCats :: [LogCat]

--- a/src/Idris/AbsSyntaxTree.hs
+++ b/src/Idris/AbsSyntaxTree.hs
@@ -460,6 +460,8 @@ data OutputFmt = HTMLOutput | LaTeXOutput
 data LogCat = IParse
             | IElab
             | ICodeGen
+            | IErasure
+            | ICoverage
             deriving (Show, Eq, Ord)
 
 codegenCats :: [LogCat]

--- a/src/Idris/AbsSyntaxTree.hs
+++ b/src/Idris/AbsSyntaxTree.hs
@@ -455,26 +455,21 @@ data Command = Quit
 data OutputFmt = HTMLOutput | LaTeXOutput
 
 -- | Recognised logging categories for the Idris compiler.
+--
+-- @TODO add in sub categories.
 data LogCat = IParse
             | IElab
-            | ICover
-            | IUnify
-            | ITotal
-            | IErase
-            | IDefun
-            | IInline
-            | IResolve
             | ICodeGen
             deriving (Show, Eq, Ord)
 
-backendCats :: [LogCat]
-backendCats =  [IDefun, IInline, IResolve, ICodeGen]
+codegenCats :: [LogCat]
+codegenCats =  [ICodeGen]
 
 parserCats :: [LogCat]
 parserCats = [IParse]
 
-checkingCats :: [LogCat]
-checkingCats = [IElab, ICover, IUnify, ITotal, IElab]
+elabCats :: [LogCat]
+elabCats = [IElab]
 
 data Opt = Filename String
          | Quiet

--- a/src/Idris/AbsSyntaxTree.hs
+++ b/src/Idris/AbsSyntaxTree.hs
@@ -68,34 +68,36 @@ toplevel = EInfo [] emptyContext id Nothing Nothing (\_ _ _ -> fail "Not impleme
 eInfoNames :: ElabInfo -> [Name]
 eInfoNames info = map fst (params info) ++ M.keys (inblock info)
 
-data IOption = IOption { opt_logLevel     :: Int,
-                         opt_typecase     :: Bool,
-                         opt_typeintype   :: Bool,
-                         opt_coverage     :: Bool,
-                         opt_showimp      :: Bool, -- ^^ show implicits
-                         opt_errContext   :: Bool,
-                         opt_repl         :: Bool,
-                         opt_verbose      :: Bool,
-                         opt_nobanner     :: Bool,
-                         opt_quiet        :: Bool,
-                         opt_codegen      :: Codegen,
-                         opt_outputTy     :: OutputType,
-                         opt_ibcsubdir    :: FilePath,
-                         opt_importdirs   :: [FilePath],
-                         opt_triple       :: String,
-                         opt_cpu          :: String,
-                         opt_cmdline      :: [Opt], -- remember whole command line
-                         opt_origerr      :: Bool,
-                         opt_autoSolve    :: Bool, -- ^ automatically apply "solve" tactic in prover
-                         opt_autoImport   :: [FilePath], -- ^ e.g. Builtins+Prelude
-                         opt_optimise     :: [Optimisation],
-                         opt_printdepth   :: Maybe Int,
-                         opt_evaltypes    :: Bool, -- ^ normalise types in :t
-                         opt_desugarnats  :: Bool
-       }
-    deriving (Show, Eq)
+data IOption = IOption {
+    opt_logLevel     :: Int
+  , opt_logcats      :: [LogCat]      -- ^ List of logging categories.
+  , opt_typecase     :: Bool
+  , opt_typeintype   :: Bool
+  , opt_coverage     :: Bool
+  , opt_showimp      :: Bool          -- ^ show implicits
+  , opt_errContext   :: Bool
+  , opt_repl         :: Bool
+  , opt_verbose      :: Bool
+  , opt_nobanner     :: Bool
+  , opt_quiet        :: Bool
+  , opt_codegen      :: Codegen
+  , opt_outputTy     :: OutputType
+  , opt_ibcsubdir    :: FilePath
+  , opt_importdirs   :: [FilePath]
+  , opt_triple       :: String
+  , opt_cpu          :: String
+  , opt_cmdline      :: [Opt]          -- remember whole command line
+  , opt_origerr      :: Bool
+  , opt_autoSolve    :: Bool           -- ^ automatically apply "solve" tactic in prover
+  , opt_autoImport   :: [FilePath]     -- ^ e.g. Builtins+Prelude
+  , opt_optimise     :: [Optimisation]
+  , opt_printdepth   :: Maybe Int
+  , opt_evaltypes    :: Bool           -- ^ normalise types in :t
+  , opt_desugarnats  :: Bool
+  } deriving (Show, Eq)
 
 defaultOpts = IOption { opt_logLevel   = 0
+                      , opt_logcats    = []
                       , opt_typecase   = False
                       , opt_typeintype = False
                       , opt_coverage   = True
@@ -135,7 +137,7 @@ defaultOptimise = [PETransform]
 
 -- | Pretty printing options with default verbosity.
 defaultPPOption :: PPOption
-defaultPPOption = PPOption { ppopt_impl = False, 
+defaultPPOption = PPOption { ppopt_impl = False,
                              ppopt_desugarnats = False,
                              ppopt_pinames = False,
                              ppopt_depth = Just 200 }
@@ -406,6 +408,7 @@ data Command = Quit
              | Proofs
              | Universes
              | LogLvl Int
+             | LogCategory [LogCat]
              | Spec PTerm
              | WHNF PTerm
              | TestInline PTerm
@@ -451,6 +454,28 @@ data Command = Quit
 
 data OutputFmt = HTMLOutput | LaTeXOutput
 
+-- | Recognised logging categories for the Idris compiler.
+data LogCat = IParse
+            | IElab
+            | ICover
+            | IUnify
+            | ITotal
+            | IErase
+            | IDefun
+            | IInline
+            | IResolve
+            | ICodeGen
+            deriving (Show, Eq, Ord)
+
+backendCats :: [LogCat]
+backendCats =  [IDefun, IInline, IResolve, ICodeGen]
+
+parserCats :: [LogCat]
+parserCats = [IParse]
+
+checkingCats :: [LogCat]
+checkingCats = [IElab, ICover, IUnify, ITotal, IElab]
+
 data Opt = Filename String
          | Quiet
          | NoBanner
@@ -466,6 +491,7 @@ data Opt = Filename String
          | NoBuiltins -- only for the really primitive stuff!
          | NoREPL
          | OLogging Int
+         | OLogCats [LogCat]
          | Output String
          | Interface
          | TypeCase
@@ -767,7 +793,7 @@ data PData' t  = PDatadecl { d_name :: Name, -- ^ The name of the datatype
                | PLaterdecl { d_name :: Name, d_name_fc :: FC, d_tcon :: t }
                  -- ^ "Placeholder" for data whose constructors are defined later
     deriving Functor
-    
+
 -- | Transform the FCs in a PData and its associated terms. The first
 -- function transforms the general-purpose FCs, and the second transforms
 -- those that are used for semantic source highlighting, so they can be
@@ -1088,7 +1114,7 @@ data PTactic' t = Intro [Name] | Intros | Focus Name
                 | MatchRefine Name
                 | LetTac Name t | LetTacTy Name t t
                 | Exact t | Compute | Trivial | TCInstance
-                | ProofSearch Bool Bool Int (Maybe Name) 
+                | ProofSearch Bool Bool Int (Maybe Name)
                               [Name] -- allowed local names
                               [Name] -- hints
                   -- ^ the bool is whether to search recursively
@@ -1179,7 +1205,7 @@ type PDo = PDo' PTerm
 data PArg' t = PImp { priority :: Int,
                       machine_inf :: Bool, -- true if the machine inferred it
                       argopts :: [ArgOpt],
-                      pname :: Name, 
+                      pname :: Name,
                       getTm :: t }
              | PExp { priority :: Int,
                       argopts :: [ArgOpt],
@@ -1890,7 +1916,7 @@ pprintPTerm ppo bnd docArgs infixes = prettySe (ppopt_depth ppo) startPrec bnd
       bracket p funcAppPrec . group . align . hang 2 $
       text "%runElab" <$>
       prettySe (decD d) funcAppPrec bnd tm
-    prettySe d p bnd (PConstSugar fc tm) = prettySe d p bnd tm -- should never occur, but harmless 
+    prettySe d p bnd (PConstSugar fc tm) = prettySe d p bnd tm -- should never occur, but harmless
 
     prettySe d p bnd _ = text "missing pretty-printer for term"
 
@@ -2137,7 +2163,7 @@ showTm ist = displayDecorated (consoleDecorate ist) .
 showTmImpls :: PTerm -> String
 showTmImpls = flip (displayS . renderCompact . prettyImp verbosePPOption) ""
 
--- | Show a term with specific options 
+-- | Show a term with specific options
 showTmOpts :: PPOption -> PTerm -> String
 showTmOpts opt = flip (displayS . renderPretty 1.0 10000000 . prettyImp opt) ""
 
@@ -2253,7 +2279,7 @@ boundNamesIn tm = S.toList (ni 0 S.empty tm)
 
 -- Return names which are valid implicits in the given term (type).
 implicitNamesIn :: [Name] -> IState -> PTerm -> [Name]
-implicitNamesIn uvars ist tm 
+implicitNamesIn uvars ist tm
       = let (imps, fns) = execState (ni 0 [] tm) ([], []) in
             nub imps \\ nub fns
   where
@@ -2282,15 +2308,15 @@ implicitNamesIn uvars ist tm
     ni 0 env (PRef _ _ n)
         | not (n `elem` env) && implicitable n || n `elem` uvars = addImp n
     ni 0 env (PApp _ f@(PRef _ _ n) as)
-        | n `elem` uvars = do ni 0 env f 
+        | n `elem` uvars = do ni 0 env f
                               mapM_ (ni 0 env) (map getTm as)
         | otherwise = do case lookupTy n (tt_ctxt ist) of
                               [] -> return ()
                               _ -> addFn n
                          mapM_ (ni 0 env) (map getTm as)
-    ni 0 env (PApp _ f as) = do ni 0 env f 
+    ni 0 env (PApp _ f as) = do ni 0 env f
                                 mapM_ (ni 0 env) (map getTm as)
-    ni 0 env (PAppBind _ f as) = do ni 0 env f 
+    ni 0 env (PAppBind _ f as) = do ni 0 env f
                                     mapM_ (ni 0 env) (map getTm as)
     ni 0 env (PCase _ c os)  = do ni 0 env c
     -- names in 'os', not counting the names bound in the cases
@@ -2307,7 +2333,7 @@ implicitNamesIn uvars ist tm
     ni 0 env (PTyped l r)    = do ni 0 env l; ni 0 env r
     ni 0 env (PPair _ _ _ l r)   = do ni 0 env l; ni 0 env r
     ni 0 env (PDPair _ _ _ (PRef _ _ n) t r) = do ni 0 env t; ni 0 (n:env) r
-    ni 0 env (PDPair _ _ _ l t r) = do ni 0 env l 
+    ni 0 env (PDPair _ _ _ l t r) = do ni 0 env l
                                        ni 0 env t
                                        ni 0 env r
     ni 0 env (PAlternative ns a as) = mapM_ (ni 0 env) as

--- a/src/Idris/CmdOptions.hs
+++ b/src/Idris/CmdOptions.hs
@@ -89,7 +89,7 @@ parseFlags = many $
   <|> (OLogCats <$> option (str >>= parseLogCats)
                            (long "logging-categories"
                          <> metavar "CATS"
-                         <> help "Colon separated logging categories: parser, elab, codegen"))
+                         <> help "Colon separated logging categories: parser, elab, codegen, coverage, erasure"))
 
   -- Turn off Certain libraries.
   <|> flag' NoBasePkgs (long "nobasepkgs" <> help "Do not use the given base package")

--- a/src/Idris/CmdOptions.hs
+++ b/src/Idris/CmdOptions.hs
@@ -193,6 +193,7 @@ parseLogCats s =
               <|> (string "elab"     *> return elabCats)
               <|> (string "codegen"  *> return codegenCats)
               <|> (string "coverage" *> return [ICoverage])
+              <|> (string "ibc"      *> return [IIBC])
               <|> (string "erasure"  *> return [IErasure])
               <|> parseLogCatBad
 

--- a/src/Idris/CmdOptions.hs
+++ b/src/Idris/CmdOptions.hs
@@ -87,9 +87,9 @@ parseFlags = many $
   -- Logging Flags
   <|> (OLogging <$> option auto (long "log" <> metavar "LEVEL" <> help "Debugging log level"))
   <|> (OLogCats <$> option (str >>= parseLogCats)
-                           (long "logcats"
+                           (long "logging-categories"
                          <> metavar "CATS"
-                         <> help "Colon separated logging categories: parser, tychecker, backend, parse, elaborator, coverage, unifyer, totality, eraser, defunc, inliner, resolver, codegen"))
+                         <> help "Colon separated logging categories: parser, elab, codegen"))
 
   -- Turn off Certain libraries.
   <|> flag' NoBasePkgs (long "nobasepkgs" <> help "Do not use the given base package")
@@ -189,19 +189,9 @@ parseLogCats s =
       return (concat cs)
 
     parseLogCat :: ReadP [LogCat]
-    parseLogCat = (string "parser"     *> return parserCats)
-              <|> (string "tychecker"  *> return checkingCats)
-              <|> (string "backend"    *> return backendCats)
-              <|> (string "parse"      *> return [IParse])
-              <|> (string "elaborator" *> return [IElab])
-              <|> (string "coverage"   *> return [ICover])
-              <|> (string "unifyer"    *> return [IUnify])
-              <|> (string "totality"   *> return [ITotal])
-              <|> (string "eraser"     *> return [IErase])
-              <|> (string "defunc"     *> return [IDefun])
-              <|> (string "inliner"    *> return [IInline])
-              <|> (string "resolver"   *> return [IResolve])
-              <|> (string "codegen"    *> return [ICodeGen])
+    parseLogCat = (string "parser"   *> return parserCats)
+              <|> (string "elab"     *> return elabCats)
+              <|> (string "codegen"  *> return codegenCats)
               <|> parseLogCatBad
 
     parseLogCatBad :: ReadP [LogCat]

--- a/src/Idris/CmdOptions.hs
+++ b/src/Idris/CmdOptions.hs
@@ -192,6 +192,8 @@ parseLogCats s =
     parseLogCat = (string "parser"   *> return parserCats)
               <|> (string "elab"     *> return elabCats)
               <|> (string "codegen"  *> return codegenCats)
+              <|> (string "coverage" *> return [ICoverage])
+              <|> (string "erasure"  *> return [IErasure])
               <|> parseLogCatBad
 
     parseLogCatBad :: ReadP [LogCat]

--- a/src/Idris/DeepSeq.hs
+++ b/src/Idris/DeepSeq.hs
@@ -116,6 +116,7 @@ instance NFData Opt where
     rnf (NoBuiltins) = ()
     rnf (NoREPL) = ()
     rnf (OLogging i) = rnf  i `seq` ()
+    rnf (OLogCats cs) = rnf  cs `seq` ()
     rnf (Output str) = rnf  str `seq` ()
     rnf (Interface) = ()
     rnf (TypeCase) = ()
@@ -174,6 +175,7 @@ instance NFData TIData where
 instance NFData IOption where
     rnf (IOption
          opt_logLevel
+         opt_logcats
          opt_typecase
          opt_typeintype
          opt_coverage
@@ -226,7 +228,7 @@ instance NFData IOption where
 instance NFData LanguageExt where
     rnf TypeProviders = ()
     rnf ErrorReflection = ()
-    
+
 instance NFData Optimisation where
     rnf PETransform = ()
 
@@ -357,6 +359,9 @@ instance NFData FnInfo where
 instance NFData Codegen where
         rnf (Via x1) = rnf x1 `seq` ()
         rnf Bytecode = ()
+
+instance NFData LogCat where
+       rnf _ = ()
 
 instance NFData CGInfo where
         rnf (CGInfo x1 x2 x3 x4 x5)
@@ -563,7 +568,7 @@ instance NFData PTerm where
 instance NFData PAltType where
         rnf (ExactlyOne x1) = rnf x1 `seq` ()
         rnf FirstSuccess = ()
-        rnf TryImplicit = () 
+        rnf TryImplicit = ()
 
 instance (NFData t) => NFData (PTactic' t) where
         rnf (Intro x1) = rnf x1 `seq` ()
@@ -687,7 +692,7 @@ instance NFData OutputMode where
 
 
 instance NFData IState where
-  rnf (IState x1 x2 x3 x4 x5 x6 x7 x8 x9 x10 x11 x12 x13 x14 x15 x16 x17 x18 x19 x20 
+  rnf (IState x1 x2 x3 x4 x5 x6 x7 x8 x9 x10 x11 x12 x13 x14 x15 x16 x17 x18 x19 x20
               x21 x22 x23 x24 x25 x26 x27 x28 x29 x30 x31 x32 x33 x34 x35 x36 x37 x38 x39 x40
               x41 x42 x43 x44 x45 x46 x47 x48 x49 x50 x51 x52 x53 x54 x55 x56 x57 x58 x59 x60
               x61 x62 x63 x64 x65 x66 x67 x68 x69 x70 x71 x72 x73 x74)

--- a/src/Idris/Elab/Class.hs
+++ b/src/Idris/Elab/Class.hs
@@ -78,7 +78,7 @@ elabClass info syn_in doc fc constraints tn tnfc ps pDocs fds ds mcn cd
          let idecls = filter instdecl ds -- default superclass instance declarations
          mapM_ checkDefaultSuperclassInstance idecls
          let mnames = map getMName mdecls
-         logLvl 1 $ "Building methods " ++ show mnames
+         logElab 1 $ "Building methods " ++ show mnames
          ims <- mapM (tdecl mnames) mdecls
          defs <- mapM (defdecl (map (\ (x,y,z) -> z) ims) constraint)
                       (filter clause ds)
@@ -94,7 +94,7 @@ elabClass info syn_in doc fc constraints tn tnfc ps pDocs fds ds mcn cd
          let cons = [(cd, pDocs ++ mapMaybe memberDocs ds, cn, NoFC, cty, fc, [])]
          let ddecl = PDatadecl tn NoFC tty cons
 
-         logLvl 5 $ "Class data " ++ show (showDImp verbosePPOption ddecl)
+         logElab 5 $ "Class data " ++ show (showDImp verbosePPOption ddecl)
 
          -- Elaborate the data declaration
          elabData info (syn { no_imp = no_imp syn ++ mnames,
@@ -109,7 +109,7 @@ elabClass info syn_in doc fc constraints tn tnfc ps pDocs fds ds mcn cd
          -- for each method, build a top level function
          fns <- mapM (tfun cn constraint (syn { imp_methods = mnames })
                            (map fst imethods)) imethods
-         logLvl 5 $ "Functions " ++ show fns
+         logElab 5 $ "Functions " ++ show fns
          -- Elaborate the the top level methods
          mapM_ (rec_elabDecl info EAll info) (concat fns)
 
@@ -159,7 +159,7 @@ elabClass info syn_in doc fc constraints tn tnfc ps pDocs fds ds mcn cd
     getMName (PTy _ _ _ _ _ n nfc _) = nsroot n
     tdecl allmeths (PTy doc _ syn _ o n nfc t)
            = do t' <- implicit' info syn (map (\(n, _, _) -> n) ps ++ allmeths) n t
-                logLvl 2 $ "Method " ++ show n ++ " : " ++ showTmImpls t'
+                logElab 2 $ "Method " ++ show n ++ " : " ++ showTmImpls t'
                 return ( (n, (toExp (map (\(pn, _, _) -> pn) ps) Exp t')),
                          (n, (nfc, doc, o, (toExp (map (\(pn, _, _) -> pn) ps)
                                               (\ l s p -> Imp l s p Nothing) t'))),
@@ -174,7 +174,7 @@ elabClass info syn_in doc fc constraints tn tnfc ps pDocs fds ds mcn cd
                  let ds = map (decorateid defaultdec)
                               [PTy emptyDocstring [] syn fc [] n nfc ty',
                                PClauses fc (o ++ opts) n cs]
-                 logLvl 1 (show ds)
+                 logElab 1 (show ds)
                  return (n, ((defaultdec n, ds!!1), ds))
             _ -> ifail $ show n ++ " is not a method"
     defdecl _ _ _ = ifail "Can't happen (defdecl)"
@@ -199,8 +199,8 @@ elabClass info syn_in doc fc constraints tn tnfc ps pDocs fds ds mcn cd
              let lhs = PApp fc (PRef fc [] cfn) [pconst capp]
              let rhs = PResolveTC (fileFC "HACK")
              let ty = PPi constraint cnm NoFC c con
-             logLvl 2 ("Dictionary constraint: " ++ showTmImpls ty)
-             logLvl 2 (showTmImpls lhs ++ " = " ++ showTmImpls rhs)
+             logElab 2 ("Dictionary constraint: " ++ showTmImpls ty)
+             logElab 2 (showTmImpls lhs ++ " = " ++ showTmImpls rhs)
              i <- getIState
              let conn = case con of
                             PRef _ _ n -> n
@@ -230,9 +230,9 @@ elabClass info syn_in doc fc constraints tn tnfc ps pDocs fds ds mcn cd
              let anames = map (\x -> sMN x "arg") [0..]
              let lhs = PApp fc (PRef fc [] m) (pconst capp : lhsArgs margs anames)
              let rhs = PApp fc (getMeth mnames all m) (rhsArgs margs anames)
-             logLvl 2 ("Top level type: " ++ showTmImpls ty')
-             logLvl 1 (show (m, ty', capp, margs))
-             logLvl 2 ("Definition: " ++ showTmImpls lhs ++ " = " ++ showTmImpls rhs)
+             logElab 2 ("Top level type: " ++ showTmImpls ty')
+             logElab 1 (show (m, ty', capp, margs))
+             logElab 2 ("Definition: " ++ showTmImpls lhs ++ " = " ++ showTmImpls rhs)
              return [PTy doc [] syn fc o m mfc ty',
                      PClauses fc [Inlinable] m [PClause fc m lhs [] rhs []]]
 
@@ -318,5 +318,3 @@ findDets n ns =
        | n `elem` ns = i : getDetPos (i + 1) ns sc
        | otherwise = getDetPos (i + 1) ns sc
     getDetPos _ _ _ = []
-
-

--- a/src/Idris/Elab/Instance.hs
+++ b/src/Idris/Elab/Instance.hs
@@ -71,7 +71,7 @@ elabInstance info syn doc argDocs what fc cs n nfc ps t expn ds = do
     let constraint = PApp fc (PRef fc [] n) (map pexp ps)
     let iname = mkiname n (namespace info) ps expn
     let emptyclass = null (class_methods ci)
-    when (what /= EDefns) $ do 
+    when (what /= EDefns) $ do
          nty <- elabType' True info syn doc argDocs fc [] iname NoFC t
          -- if the instance type matches any of the instances we have already,
          -- and it's not a named instance, then it's overlapping, so report an error
@@ -106,19 +106,19 @@ elabInstance info syn doc argDocs what fc cs n nfc ps t expn ds = do
                        (decorate ns iname n,
                            op, coninsert cs t', t'))
               (class_methods ci)
-         logLvl 3 (show (mtys, ips))
-         logLvl 5 ("Before defaults: " ++ show ds ++ "\n" ++ show (map fst (class_methods ci)))
+         logElab 3 (show (mtys, ips))
+         logElab 5 ("Before defaults: " ++ show ds ++ "\n" ++ show (map fst (class_methods ci)))
          let ds_defs = insertDefaults i iname (class_defaults ci) ns ds
-         logLvl 3 ("After defaults: " ++ show ds_defs ++ "\n")
+         logElab 3 ("After defaults: " ++ show ds_defs ++ "\n")
          let ds' = reorderDefs (map fst (class_methods ci)) $ ds_defs
-         logLvl 1 ("Reordered: " ++ show ds' ++ "\n")
+         logElab 1 ("Reordered: " ++ show ds' ++ "\n")
          mapM_ (warnMissing ds' ns iname) (map fst (class_methods ci))
          mapM_ (checkInClass (map fst (class_methods ci))) (concatMap defined ds')
          let wbTys = map mkTyDecl mtys
          let wbVals = map (decorateid (decorate ns iname)) ds'
          let wb = wbTys ++ wbVals
-         logLvl 3 $ "Method types " ++ showSep "\n" (map (show . showDeclImp verbosePPOption . mkTyDecl) mtys)
-         logLvl 3 $ "Instance is " ++ show ps ++ " implicits " ++
+         logElab 3 $ "Method types " ++ showSep "\n" (map (show . showDeclImp verbosePPOption . mkTyDecl) mtys)
+         logElab 3 $ "Instance is " ++ show ps ++ " implicits " ++
                                       show (concat (nub wparams))
 
          -- Bring variables in instance head into scope
@@ -134,12 +134,12 @@ elabInstance info syn doc argDocs what fc cs n nfc ps t expn ds = do
          let rhs = PApp fc (PRef fc [] (instanceCtorName ci))
                            (map (pexp . mkMethApp) mtys)
 
-         logLvl 5 $ "Instance LHS " ++ show lhs ++ " " ++ show headVars
-         logLvl 5 $ "Instance RHS " ++ show rhs
+         logElab 5 $ "Instance LHS " ++ show lhs ++ " " ++ show headVars
+         logElab 5 $ "Instance RHS " ++ show rhs
 
          let idecls = [PClauses fc [Dictionary] iname
                                  [PClause fc iname lhs [] rhs wb]]
-         logLvl 1 (show idecls)
+         logElab 1 (show idecls)
          push_estack iname True
          mapM_ (rec_elabDecl info EAll info) idecls
          pop_estack
@@ -267,11 +267,11 @@ elabInstance info syn doc argDocs what fc cs n nfc ps t expn ds = do
     reorderDefs :: [Name] -> [PDecl] -> [PDecl]
     reorderDefs ns [] = []
     reorderDefs [] ds = ds
-    reorderDefs (n : ns) ds = case pick n [] ds of 
+    reorderDefs (n : ns) ds = case pick n [] ds of
                                   Just (def, ds') -> def : reorderDefs ns ds'
                                   Nothing -> reorderDefs ns ds
 
-    pick n acc [] = Nothing 
+    pick n acc [] = Nothing
     pick n acc (def@(PClauses _ _ cn cs) : ds)
          | nsroot n == nsroot cn = Just (def, acc ++ ds)
     pick n acc (d : ds) = pick n (acc ++ [d]) ds
@@ -313,13 +313,13 @@ checkInjectiveArgs fc n ds (Just ty)
         let (_, args) = unApply (instantiateRetTy ty)
         ci 0 ist args
   where
-    ci i ist (a : as) | i `elem` ds 
+    ci i ist (a : as) | i `elem` ds
        = if isInj ist a then ci (i + 1) ist as
             else tclift $ tfail (At fc (InvalidTCArg n a))
     ci i ist (a : as) = ci (i + 1) ist as
     ci i ist [] = return ()
 
-    isInj i (P Bound n _) = True 
+    isInj i (P Bound n _) = True
     isInj i (P _ n _) = isConName n (tt_ctxt i)
     isInj i (App _ f a) = isInj i f && isInj i a
     isInj i (V _) = True
@@ -329,4 +329,3 @@ checkInjectiveArgs fc n ds (Just ty)
     instantiateRetTy (Bind n (Pi _ _ _) sc)
        = substV (P Bound n Erased) (instantiateRetTy sc)
     instantiateRetTy t = t
-

--- a/src/Idris/Elab/Provider.hs
+++ b/src/Idris/Elab/Provider.hs
@@ -84,7 +84,7 @@ elabProvider doc info syn fc nfc what n
          rhs <- execute (mkApp (P Ref (sUN "run__provider") Erased)
                                           [Erased, e])
          let rhs' = normalise ctxt [] rhs
-         logLvl 3 $ "Normalised " ++ show n ++ "'s RHS to " ++ show rhs
+         logElab 3 $ "Normalised " ++ show n ++ "'s RHS to " ++ show rhs
 
          -- Extract the provided term or postulate from the type provider
          provided <- getProvided fc rhs'
@@ -95,11 +95,11 @@ elabProvider doc info syn fc nfc what n
                do -- Finally add a top-level definition of the provided term
                   elabType info syn doc [] fc [] n NoFC ty
                   elabClauses info fc [] n [PClause fc n (PApp fc (PRef fc [] n) []) [] (delab i tm) []]
-                  logLvl 3 $ "Elaborated provider " ++ show n ++ " as: " ++ show tm
+                  logElab 3 $ "Elaborated provider " ++ show n ++ " as: " ++ show tm
              | ProvPostulate _ <- what ->
                do -- Add the postulate
                   elabPostulate info syn doc fc nfc [] n (delab i tm)
-                  logLvl 3 $ "Elaborated provided postulate " ++ show n
+                  logElab 3 $ "Elaborated provided postulate " ++ show n
              | otherwise ->
                ierror . Msg $ "Attempted to provide a postulate where a term was expected."
 

--- a/src/Idris/Elab/Record.hs
+++ b/src/Idris/Elab/Record.hs
@@ -47,18 +47,18 @@ elabRecord :: ElabInfo
            -> SyntaxInfo -- ^ Constructor SyntaxInfo
            -> Idris ()
 elabRecord info what doc rsyn fc opts tyn nfc params paramDocs fields cname cdoc csyn
-  = do logLvl 1 $ "Building data declaration for " ++ show tyn
+  = do logElab 1 $ "Building data declaration for " ++ show tyn
        -- Type constructor
        let tycon = generateTyConType params
-       logLvl 1 $ "Type constructor " ++ showTmImpls tycon
-       
+       logElab 1 $ "Type constructor " ++ showTmImpls tycon
+
        -- Data constructor
        dconName <- generateDConName (fmap fst cname)
        let dconTy = generateDConType params fieldsWithNameAndDoc
-       logLvl 1 $ "Data constructor: " ++ showTmImpls dconTy
+       logElab 1 $ "Data constructor: " ++ showTmImpls dconTy
 
        -- Build data declaration for elaboration
-       logLvl 1 $ foldr (++) "" $ intersperse "\n" (map show dconsArgDocs)
+       logElab 1 $ foldr (++) "" $ intersperse "\n" (map show dconsArgDocs)
        let datadecl = case what of
                            ETypes -> PLaterdecl tyn NoFC tycon
                            _ -> PDatadecl tyn NoFC tycon [(cdoc, dconsArgDocs, dconName, NoFC, dconTy, fc, [])]
@@ -71,8 +71,8 @@ elabRecord info what doc rsyn fc opts tyn nfc params paramDocs fields cname cdoc
        addIBC (IBCRecord tyn)
 
        when (what /= ETypes) $ do
-           logLvl 1 $ "fieldsWithName " ++ show fieldsWithName
-           logLvl 1 $ "fieldsWIthNameAndDoc " ++ show fieldsWithNameAndDoc
+           logElab 1 $ "fieldsWithName " ++ show fieldsWithName
+           logElab 1 $ "fieldsWIthNameAndDoc " ++ show fieldsWithNameAndDoc
            elabRecordFunctions info rsyn fc tyn paramsAndDoc fieldsWithNameAndDoc dconName target
 
            sendHighlighting $
@@ -162,10 +162,10 @@ elabRecordFunctions :: ElabInfo -> SyntaxInfo -> FC
                     -> PTerm -- ^ Target type
                     -> Idris ()
 elabRecordFunctions info rsyn fc tyn params fields dconName target
-  = do logLvl 1 $ "Elaborating helper functions for record " ++ show tyn
+  = do logElab 1 $ "Elaborating helper functions for record " ++ show tyn
 
-       logLvl 1 $ "Fields: " ++ show fieldNames
-       logLvl 1 $ "Params: " ++ show paramNames
+       logElab 1 $ "Fields: " ++ show fieldNames
+       logElab 1 $ "Params: " ++ show paramNames
        -- The elaborated constructor type for the data declaration
        i <- getIState
        ttConsTy <-
@@ -175,11 +175,11 @@ elabRecordFunctions info rsyn fc tyn params fields dconName target
 
        -- The arguments to the constructor
        let constructorArgs = getArgTys ttConsTy
-       logLvl 1 $ "Cons args: " ++ show constructorArgs
-       logLvl 1 $ "Free fields: " ++ show (filter (not . isFieldOrParam') constructorArgs)
+       logElab 1 $ "Cons args: " ++ show constructorArgs
+       logElab 1 $ "Free fields: " ++ show (filter (not . isFieldOrParam') constructorArgs)
        -- If elaborating the constructor has resulted in some new implicit fields we make projection functions for them.
        let freeFieldsForElab = map (freeField i) (filter (not . isFieldOrParam') constructorArgs)
-           
+
        -- The parameters for elaboration with their documentation
        -- Parameter functions are all prefixed with "param_".
        let paramsForElab = [((nsroot n), (paramName n), impl, t, d) | (n, _, _, t, d) <- params] -- zipParams i params paramDocs]
@@ -187,14 +187,14 @@ elabRecordFunctions info rsyn fc tyn params fields dconName target
        -- The fields (written by the user) with their documentation.
        let userFieldsForElab = [((nsroot n), n, p, t, d) | (n, nfc, p, t, d) <- fields]
 
-       -- All things we need to elaborate projection functions for, together with a number denoting their position in the constructor.           
-       let projectors = [(n, n', p, t, d, i) | ((n, n', p, t, d), i) <- zip (freeFieldsForElab ++ paramsForElab ++ userFieldsForElab) [0..]]       
+       -- All things we need to elaborate projection functions for, together with a number denoting their position in the constructor.
+       let projectors = [(n, n', p, t, d, i) | ((n, n', p, t, d), i) <- zip (freeFieldsForElab ++ paramsForElab ++ userFieldsForElab) [0..]]
        -- Build and elaborate projection functions
        elabProj dconName projectors
 
-       logLvl 1 $ "Dependencies: " ++ show fieldDependencies
+       logElab 1 $ "Dependencies: " ++ show fieldDependencies
 
-       logLvl 1 $ "Depended on: " ++ show dependedOn
+       logElab 1 $ "Depended on: " ++ show dependedOn
 
        -- All things we need to elaborate update functions for, together with a number denoting their position in the constructor.
        let updaters = [(n, n', p, t, d, i) | ((n, n', p, t, d), i) <- zip (paramsForElab ++ userFieldsForElab) [0..]]
@@ -237,7 +237,7 @@ elabRecordFunctions info rsyn fc tyn params fields dconName target
                           plicity = impl -- All free fields are implicit as they are machine generated
                           fieldType = delab i (snd arg) -- The type of the field
                           doc = emptyDocstring -- No docmentation for machine generated fields
-                      in (nameInCons, nameFree, plicity, fieldType, doc) 
+                      in (nameInCons, nameFree, plicity, fieldType, doc)
 
     freeName :: Name -> Name
     freeName (UN n) = sUN ("free_" ++ str n)
@@ -278,7 +278,7 @@ elabRecordFunctions info rsyn fc tyn params fields dconName target
     -- | Decides whether a setter should be generated for a field or not.
     optionalSetter :: Name -> Bool
     optionalSetter n = n `elem` dependedOn
-        
+
     -- | A map from a field name to the other fields it depends on.
     fieldDependencies :: [(Name, [Name])]
     fieldDependencies = map (uncurry fieldDep) [(n, t) | (n, _, _, t, _) <- fields ++ params]
@@ -314,15 +314,15 @@ elabProjection :: ElabInfo
                -> Int -- ^ Argument Index
                -> Idris ()
 elabProjection info cname pname plicity projTy pdoc psyn fc targetTy cn phArgs fnames index
-  = do logLvl 1 $ "Generating Projection for " ++ show pname
-       
+  = do logElab 1 $ "Generating Projection for " ++ show pname
+
        let ty = generateTy
-       logLvl 1 $ "Type of " ++ show pname ++ ": " ++ show ty
-       
+       logElab 1 $ "Type of " ++ show pname ++ ": " ++ show ty
+
        let lhs = generateLhs
-       logLvl 1 $ "LHS of " ++ show pname ++ ": " ++ showTmImpls lhs
+       logElab 1 $ "LHS of " ++ show pname ++ ": " ++ showTmImpls lhs
        let rhs = generateRhs
-       logLvl 1 $ "RHS of " ++ show pname ++ ": " ++ showTmImpls rhs
+       logElab 1 $ "RHS of " ++ show pname ++ ": " ++ showTmImpls rhs
 
        rec_elabDecl info EAll info ty
 
@@ -372,24 +372,24 @@ elabUpdate :: ElabInfo
            -> Bool -- ^ Optional
            -> Idris ()
 elabUpdate info cname pname plicity pty pdoc psyn fc sty cn args fnames i optional
-  = do logLvl 1 $ "Generating Update for " ++ show pname
-       
-       let ty = generateTy
-       logLvl 1 $ "Type of " ++ show set_pname ++ ": " ++ show ty
-       
-       let lhs = generateLhs
-       logLvl 1 $ "LHS of " ++ show set_pname ++ ": " ++ showTmImpls lhs
-       
-       let rhs = generateRhs
-       logLvl 1 $ "RHS of " ++ show set_pname ++ ": " ++ showTmImpls rhs
+  = do logElab 1 $ "Generating Update for " ++ show pname
 
-       let clause = PClause fc set_pname lhs [] rhs []       
+       let ty = generateTy
+       logElab 1 $ "Type of " ++ show set_pname ++ ": " ++ show ty
+
+       let lhs = generateLhs
+       logElab 1 $ "LHS of " ++ show set_pname ++ ": " ++ showTmImpls lhs
+
+       let rhs = generateRhs
+       logElab 1 $ "RHS of " ++ show set_pname ++ ": " ++ showTmImpls rhs
+
+       let clause = PClause fc set_pname lhs [] rhs []
 
        idrisCatch (do rec_elabDecl info EAll info ty
                       rec_elabDecl info EAll info $ PClauses fc [] set_pname [clause])
-         (\err -> logLvl 1 $ "Could not generate update function for " ++ show pname)
+         (\err -> logElab 1 $ "Could not generate update function for " ++ show pname)
                   {-if optional
-                  then logLvl 1 $ "Could not generate update function for " ++ show pname
+                  then logElab 1 $ "Could not generate update function for " ++ show pname
                   else tclift $ tfail $ At fc (Elaborating "record update function " pname err)) -}
   where
     -- | The type of the update function.
@@ -463,4 +463,3 @@ projectInType xs = mapPT st
 -- | Creates an PArg from a plicity and a name where the term is a PRef.
 asPRefArg :: Plicity -> Name -> PArg
 asPRefArg p n = asArg p (nsroot n) $ PRef emptyFC [] (nsroot n)
-

--- a/src/Idris/Elab/Term.hs
+++ b/src/Idris/Elab/Term.hs
@@ -91,7 +91,7 @@ build ist info emode opts fn tm
                                 g <- goal
                                 ptm <- get_term
                                 resolveTC' True True 10 g fn ist) ivs
-         
+
          when (not pattern) $ solveAutos ist fn False
 
          tm <- get_term
@@ -138,7 +138,7 @@ build ist info emode opts fn tm
 -- (Separate, so we don't go overboard resolving things that we don't
 -- know about yet on the LHS of a pattern def)
 
-buildTC :: IState -> ElabInfo -> ElabMode -> FnOpts -> Name -> 
+buildTC :: IState -> ElabInfo -> ElabMode -> FnOpts -> Name ->
          [Name] -> -- Cached names in the PTerm, before adding PAlternatives
          PTerm ->
          ElabD ElabResult
@@ -147,7 +147,7 @@ buildTC ist info emode opts fn ns tm
          let inf = case lookupCtxt fn (idris_tyinfodata ist) of
                         [TIPartial] -> True
                         _ -> False
-         -- set name supply to begin after highest index in tm 
+         -- set name supply to begin after highest index in tm
          initNextNameFrom ns
          elab ist info emode opts fn tm
          probs <- get_probs
@@ -171,7 +171,7 @@ buildTC ist info emode opts fn ns tm
             else return (ElabResult tm ds (map snd is) ctxt impls highlights)
   where pattern = emode == ELHS
 
--- return whether arguments of the given constructor name can be 
+-- return whether arguments of the given constructor name can be
 -- matched on. If they're polymorphic, no, unless the type has beed made
 -- concrete by the time we get around to elaborating the argument.
 getUnmatchable :: Context -> Name -> [Bool]
@@ -180,11 +180,11 @@ getUnmatchable ctxt n | isDConName n ctxt && n /= inferCon
           Nothing -> []
           Just ty -> checkArgs [] [] ty
   where checkArgs :: [Name] -> [[Name]] -> Type -> [Bool]
-        checkArgs env ns (Bind n (Pi _ t _) sc) 
+        checkArgs env ns (Bind n (Pi _ t _) sc)
             = let env' = case t of
                               TType _ -> n : env
                               _ -> env in
-                  checkArgs env' (intersect env (refsIn t) : ns) 
+                  checkArgs env' (intersect env (refsIn t) : ns)
                             (instantiate (P Bound n t) sc)
         checkArgs env ns t
             = map (not . null) (reverse ns)
@@ -193,7 +193,7 @@ getUnmatchable ctxt n = []
 
 data ElabCtxt = ElabCtxt { e_inarg :: Bool,
                            e_isfn :: Bool, -- ^ Function part of application
-                           e_guarded :: Bool, 
+                           e_guarded :: Bool,
                            e_intype :: Bool,
                            e_qq :: Bool,
                            e_nomatching :: Bool -- ^ can't pattern match
@@ -267,17 +267,17 @@ elab ist info emode opts fn tm
     -- normally correct to call elabE - the ones that don't are desugarings
     -- typically
     elabE :: ElabCtxt -> Maybe FC -> PTerm -> ElabD ()
-    elabE ina fc' t = 
+    elabE ina fc' t =
      do solved <- get_recents
         as <- get_autos
         hs <- get_holes
         -- If any of the autos use variables which have recently been solved,
         -- have another go at solving them now.
-        mapM_ (\(a, (failc, ns)) -> 
+        mapM_ (\(a, (failc, ns)) ->
                        if any (\n -> n `elem` solved) ns && head hs /= a
                               then solveAuto ist fn False (a, failc)
                               else return ()) as
-     
+
         itm <- if not pattern then insertImpLam ina t else return t
         ct <- insertCoerce ina itm
         t' <- insertLazy ct
@@ -343,7 +343,7 @@ elab ist info emode opts fn tm
 --  elab' (_,_,inty) (PConstant c)
 --     | constType c && pattern && not reflection && not inty
 --       = lift $ tfail (Msg "Typecase is not allowed")
-    elab' ina fc tm@(PConstant fc' c) 
+    elab' ina fc tm@(PConstant fc' c)
          | pattern && not reflection && not (e_qq ina) && not (e_intype ina)
            && isTypeConst c
               = lift $ tfail $ Msg ("No explicit types on left hand side: " ++ show tm)
@@ -397,7 +397,7 @@ elab ist info emode opts fn tm
                 UType _ -> elab' ina (Just fc) (PApp fc (PRef fc hls upairTy)
                                                       [pexp l,pexp r])
                 _ -> case tc of
-                        P _ n _ | n == upairTy 
+                        P _ n _ | n == upairTy
                           -> elab' ina (Just fc) (PApp fc (PRef fc hls upairCon)
                                                 [pimp (sUN "A") Placeholder False,
                                                  pimp (sUN "B") Placeholder False,
@@ -509,7 +509,7 @@ elab ist info emode opts fn tm
         ty <- goal
         let doelab = elab' ina fc orig
         tryCatch doelab
-            (\err -> 
+            (\err ->
                 if recoverableErr err
                    then -- trace ("NEED IMPLICIT! " ++ show orig ++ "\n" ++
                         --      show alts ++ "\n" ++
@@ -547,7 +547,7 @@ elab ist info emode opts fn tm
         pruneAlts err alts _ = filter isLend alts
 
         hasArg n env ap | isLend ap = True -- special case hack for 'Borrowed'
-        hasArg n env (PApp _ (PRef _ _ a) _) 
+        hasArg n env (PApp _ (PRef _ _ a) _)
              = case lookupTyExact a (tt_ctxt ist) of
                     Just ty -> let args = map snd (getArgTys (normalise (tt_ctxt ist) env ty)) in
                                    any (fnIs n) args
@@ -662,7 +662,7 @@ elab ist info emode opts fn tm
                introTy (Var tyn) (Just n)
                addPSname n -- okay for proof search
                focus tyn
-               
+
                elabE (ec { e_inarg = True, e_intype = True }) (Just fc) ty
                elabE (ec { e_inarg = True }) (Just fc) sc
                solve
@@ -701,10 +701,10 @@ elab ist info emode opts fn tm
                    Placeholder -> return ()
                    _ -> do focus tyn
                            explicit tyn
-                           elabE (ina { e_inarg = True, e_intype = True }) 
+                           elabE (ina { e_inarg = True, e_intype = True })
                                  (Just fc) ty
                focus valn
-               elabE (ina { e_inarg = True, e_intype = True }) 
+               elabE (ina { e_inarg = True, e_intype = True })
                      (Just fc) val
                ivs' <- get_instances
                env <- get_env
@@ -808,14 +808,14 @@ elab ist info emode opts fn tm
             annot <- findHighlight f
             mapM_ checkKnownImplicit args_in
             let args = insertScopedImps fc (normalise ctxt env fty) args_in
-            let unmatchableArgs = if pattern 
+            let unmatchableArgs = if pattern
                                      then getUnmatchable (tt_ctxt ist) f
                                      else []
---             trace ("BEFORE " ++ show f ++ ": " ++ show ty) $ 
+--             trace ("BEFORE " ++ show f ++ ": " ++ show ty) $
             when (pattern && not reflection && not (e_qq ina) && not (e_intype ina)
                           && isTConName f (tt_ctxt ist)) $
               lift $ tfail $ Msg ("No explicit types on left hand side: " ++ show tm)
---             trace (show (f, args_in, args)) $ 
+--             trace (show (f, args_in, args)) $
             if (f `elem` map fst env && length args == 1 && length args_in == 1)
                then -- simple app, as below
                     do simple_app False
@@ -853,7 +853,7 @@ elab ist info emode opts fn tm
                     mapM (uncurry highlightSource) $
                       (ffc, annot) : map (\f -> (f, annot)) hls
 
-                    elabArgs ist (ina { e_inarg = e_inarg ina || not isinf }) 
+                    elabArgs ist (ina { e_inarg = e_inarg ina || not isinf })
                            [] fc False f
                              (zip ns (unmatchableArgs ++ repeat False))
                              (f == sUN "Force")
@@ -880,7 +880,7 @@ elab ist info emode opts fn tm
                                  ivs' <- get_instances
                                  -- Attempt to resolve any type classes which have 'complete' types,
                                  -- i.e. no holes in them
-                                 when (not pattern || (e_inarg ina && not tcgen && 
+                                 when (not pattern || (e_inarg ina && not tcgen &&
                                                       not (e_guarded ina))) $
                                     mapM_ (\n -> do focus n
                                                     g <- goal
@@ -893,14 +893,14 @@ elab ist info emode opts fn tm
                                                      else movelast n)
                                           (ivs' \\ ivs)
                                  return []
-      where 
+      where
             -- Run the elaborator, which returns how many implicit
             -- args were needed, then run it again with those args. We need
             -- this because we have to elaborate the whole application to
             -- find out whether any computations have caused more implicits
             -- to be needed.
             implicitApp :: ElabD [ImplicitInfo] -> ElabD ()
-            implicitApp elab 
+            implicitApp elab
               | pattern || intransform = do elab; return ()
               | otherwise
                 = do s <- get
@@ -909,7 +909,7 @@ elab ist info emode opts fn tm
                           [] -> return ()
                           es -> do put s
                                    elab' ina topfc (PAppImpl tm es)
-   
+
             checkKnownImplicit imp
                  | UnknownImp `elem` argopts imp
                     = lift $ tfail $ UnknownImplicit (pname imp) f
@@ -966,7 +966,7 @@ elab ist info emode opts fn tm
               headRef (PAlternative _ _ as) = all headRef as
               headRef _ = False
 
-    elab' ina fc (PAppImpl f es) = do appImpl (reverse es) -- not that we look... 
+    elab' ina fc (PAppImpl f es) = do appImpl (reverse es) -- not that we look...
                                       solve
         where appImpl [] = elab' (ina { e_isfn = False }) fc f -- e_isfn not set, so no recursive expansion of implicits
               appImpl (e : es) = simple_app False
@@ -1028,14 +1028,14 @@ elab ist info emode opts fn tm
                    solve
     elab' ina _ c@(PCase fc scr opts)
         = do attack
-             
+
              tyn <- getNameFrom (sMN 0 "scty")
              claim tyn RType
              valn <- getNameFrom (sMN 0 "scval")
              scvn <- getNameFrom (sMN 0 "scvar")
              claim valn (Var tyn)
              letbind scvn (Var tyn) (Var valn)
-             
+
              -- Start filling in the scrutinee type, if we can work one
              -- out from the case options
              let scrTy = getScrType (map fst opts)
@@ -1056,7 +1056,7 @@ elab ist info emode opts fn tm
 
              -- Drop the unique arguments used in the term already
              -- and in the scrutinee (since it's
-             -- not valid to use them again anyway) 
+             -- not valid to use them again anyway)
              --
              -- Also drop unique arguments which don't appear explicitly
              -- in either case branch so they don't count as used
@@ -1065,7 +1065,7 @@ elab ist info emode opts fn tm
              ptm <- get_term
              let inOpts = (filter (/= scvn) (map fst args)) \\ (concatMap (\x -> allNamesIn (snd x)) opts)
 
-             let argsDropped = filter (isUnique envU) 
+             let argsDropped = filter (isUnique envU)
                                    (nub $ allNamesIn scr ++ inApp ptm ++
                                     inOpts)
 
@@ -1097,9 +1097,9 @@ elab ist info emode opts fn tm
               getScrType [] = Nothing
               getScrType (f : os) = maybe (getScrType os) Just (getAppType f)
 
-              getAppType (PRef _ _ n) = 
+              getAppType (PRef _ _ n) =
                  case lookupTyName n (tt_ctxt ist) of
-                      [(n', ty)] | isDConName n' (tt_ctxt ist) -> 
+                      [(n', ty)] | isDConName n' (tt_ctxt ist) ->
                          case unApply (getRetTy ty) of
                            (P _ tyn _, args) ->
                                Just (PApp fc (PRef fc [] tyn)
@@ -1250,12 +1250,12 @@ elab ist info emode opts fn tm
                [] -> lift . tfail . NoSuchVariable $ n
                more -> lift . tfail . CantResolveAlts $ map fst more
     elab' ina fc (PAs _ n t) = lift . tfail . Msg $ "@-pattern not allowed here"
-    elab' ina fc (PHidden t) 
+    elab' ina fc (PHidden t)
       | reflection = elab' ina fc t
       | otherwise
         = do (h : hs) <- get_holes
              -- Dotting a hole means that either the hole or any outer
-             -- hole (a hole outside any occurrence of it) 
+             -- hole (a hole outside any occurrence of it)
              -- must be solvable by unification as well as being filled
              -- in directly.
              -- Delay dotted things to the end, then when we elaborate them
@@ -1323,7 +1323,7 @@ elab ist info emode opts fn tm
     -- The delayed things with lower numbered priority will be elaborated
     -- first. (In practice, this means delayed alternatives, then PHidden
     -- things.)
-    delayElab pri t 
+    delayElab pri t
        = updateAux (\e -> e { delayed_elab = delayed_elab e ++ [(pri, t)] })
 
     isScr :: PTerm -> (Name, Binder Term) -> (Name, (Bool, Binder Term))
@@ -1476,7 +1476,7 @@ elab ist info emode opts fn tm
            let t' = case (t, cs) of
                          (PCoerced tm, _) -> tm
                          (_, []) -> t
-                         (_, cs) -> PAlternative [] TryImplicit 
+                         (_, cs) -> PAlternative [] TryImplicit
                                          (t : map (mkCoerce env t) cs)
            return t'
        where
@@ -1598,7 +1598,7 @@ pruneByType env (P _ n _) ist as
                [] -> asV
                _ -> as'
   where
-    ctxt = tt_ctxt ist 
+    ctxt = tt_ctxt ist
 
     headIs var f (PRef _ _ f') = typeHead var f f'
     headIs var f (PApp _ (PRef _ _ (UN l)) [_, _, arg])
@@ -1617,7 +1617,7 @@ pruneByType env (P _ n _) ist as
                             _ -> let ty' = normalise ctxt [] ty in
                                      case unApply (getRetTy ty') of
                                           (P _ ftyn _, _) -> ftyn == f
-                                          (V _, _) -> 
+                                          (V _, _) ->
                                             -- keep, variable
 --                                             trace ("Keeping " ++ show (f', ty')
 --                                                      ++ " for " ++ show n) $
@@ -1634,22 +1634,22 @@ pruneByType _ t _ as = as
 -- (FIXME: This isn't complete, but I'm leaving it here and coming back
 -- to it later - just returns 'var' for now. EB)
 isPlausible :: IState -> Bool -> Env -> Name -> Type -> Bool
-isPlausible ist var env n ty 
+isPlausible ist var env n ty
     = let (hvar, classes) = collectConstraints [] [] ty in
           case hvar of
                Nothing -> True
                Just rth -> var -- trace (show (rth, classes)) var
    where
-     collectConstraints :: [Name] -> [(Term, [Name])] -> Type -> 
+     collectConstraints :: [Name] -> [(Term, [Name])] -> Type ->
                                      (Maybe Name, [(Term, [Name])])
      collectConstraints env tcs (Bind n (Pi _ ty _) sc)
          = let tcs' = case unApply ty of
-                           (P _ c _, _) -> 
+                           (P _ c _, _) ->
                                case lookupCtxtExact c (idris_classes ist) of
-                                    Just tc -> ((ty, map fst (class_instances tc)) 
-                                                     : tcs) 
+                                    Just tc -> ((ty, map fst (class_instances tc))
+                                                     : tcs)
                                     Nothing -> tcs
-                           _ -> tcs 
+                           _ -> tcs
                       in
                collectConstraints (n : env) tcs' sc
      collectConstraints env tcs t
@@ -1669,7 +1669,7 @@ findHighlight n = do ctxt <- get_context
 
 -- Try again to solve auto implicits
 solveAuto :: IState -> Name -> Bool -> (Name, [FailContext]) -> ElabD ()
-solveAuto ist fn ambigok (n, failc) 
+solveAuto ist fn ambigok (n, failc)
   = do hs <- get_holes
        when (not (null hs)) $ do
         env <- get_env
@@ -1682,8 +1682,8 @@ solveAuto ist fn ambigok (n, failc)
              (lift $ Error (addLoc failc
                    (CantSolveGoal g (map (\(n, b) -> (n, binderTy b)) env))))
         return ()
-  where addLoc (FailContext fc f x : prev) err 
-           = At fc (ElaboratingArg f x 
+  where addLoc (FailContext fc f x : prev) err
+           = At fc (ElaboratingArg f x
                    (map (\(FailContext _ f' x') -> (f', x')) prev) err)
         addLoc _ err = err
 
@@ -1728,7 +1728,7 @@ collectDeferred top casenames ctxt tm = cd [] tm
            t' <- collectDeferred top casenames ctxt t
            when (not (n `elem` map fst ds)) $ put (ds ++ [(n, (i, top, t', psns))])
            cd env app
-    cd env (Bind n b t) 
+    cd env (Bind n b t)
          = do b' <- cdb b
               t' <- cd ((n, b) : env) t
               return (Bind n b' t')
@@ -1737,7 +1737,7 @@ collectDeferred top casenames ctxt tm = cd [] tm
         cdb (Guess t v) = liftM2 Guess (cd env t) (cd env v)
         cdb b           = do ty' <- cd env (binderTy b)
                              return (b { binderTy = ty' })
-    cd env (App s f a) = liftM2 (App s) (cd env f) 
+    cd env (App s f a) = liftM2 (App s) (cd env f)
                                         (cd env a)
     cd env t = return t
 
@@ -2148,7 +2148,7 @@ runElabAction ist fc env tm ns = do tm' <- eval tm
       | n == tacN "Prim__Fixity", [op'] <- args
       = do opTm <- eval op'
            case opTm of
-             Constant (Str op) -> 
+             Constant (Str op) ->
                let opChars = ":!#$%&*+./<=>?@\\^|-~"
                    invalidOperators = [":", "=>", "->", "<-", "=", "?=", "|", "**", "==>", "\\", "%", "~", "?", "!"]
                    fixities = idris_infixes ist
@@ -2185,7 +2185,7 @@ runTac autoSolve ist perhapsFC fn tac
         bname _ = Nothing
     runT (Intro xs) = mapM_ (\x -> do attack; intro (Just x)) xs
     runT Intros = do g <- goal
-                     attack; 
+                     attack;
                      intro (bname g)
                      try' (runT Intros)
                           (return ()) True
@@ -2430,18 +2430,18 @@ elaboratingArgErr ((f,x):during) err = fromMaybe err (rewrite err)
 withErrorReflection :: Idris a -> Idris a
 withErrorReflection x = idrisCatch x (\ e -> handle e >>= ierror)
     where handle :: Err -> Idris Err
-          handle e@(ReflectionError _ _)  = do logLvl 3 "Skipping reflection of error reflection result"
+          handle e@(ReflectionError _ _)  = do logElab 3 "Skipping reflection of error reflection result"
                                                return e -- Don't do meta-reflection of errors
-          handle e@(ReflectionFailed _ _) = do logLvl 3 "Skipping reflection of reflection failure"
+          handle e@(ReflectionFailed _ _) = do logElab 3 "Skipping reflection of reflection failure"
                                                return e
           -- At and Elaborating are just plumbing - error reflection shouldn't rewrite them
-          handle e@(At fc err) = do logLvl 3 "Reflecting body of At"
+          handle e@(At fc err) = do logElab 3 "Reflecting body of At"
                                     err' <- handle err
                                     return (At fc err')
-          handle e@(Elaborating what n ty err) = do logLvl 3 "Reflecting body of Elaborating"
+          handle e@(Elaborating what n ty err) = do logElab 3 "Reflecting body of Elaborating"
                                                     err' <- handle err
                                                     return (Elaborating what n ty err')
-          handle e@(ElaboratingArg f a prev err) = do logLvl 3 "Reflecting body of ElaboratingArg"
+          handle e@(ElaboratingArg f a prev err) = do logElab 3 "Reflecting body of ElaboratingArg"
                                                       hs <- getFnHandlers f a
                                                       err' <- if null hs
                                                                  then handle err
@@ -2451,8 +2451,8 @@ withErrorReflection x = idrisCatch x (\ e -> handle e >>= ierror)
           handle (ProofSearchFail e) = handle e
           -- TODO: argument-specific error handlers go here for ElaboratingArg
           handle e = do ist <- getIState
-                        logLvl 2 "Starting error reflection"
-                        logLvl 5 (show e)
+                        logElab 2 "Starting error reflection"
+                        logElab 5 (show e)
                         let handlers = idris_errorhandlers ist
                         applyHandlers e handlers
           getFnHandlers :: Name -> Name -> Idris [Name]
@@ -2466,7 +2466,7 @@ withErrorReflection x = idrisCatch x (\ e -> handle e >>= ierror)
           applyHandlers e handlers =
                       do ist <- getIState
                          let err = fmap (errReverse ist) e
-                         logLvl 3 $ "Using reflection handlers " ++
+                         logElab 3 $ "Using reflection handlers " ++
                                     concat (intersperse ", " (map show handlers))
                          let reports = map (\n -> RApp (Var n) (reflectErr err)) handlers
 
@@ -2478,7 +2478,7 @@ withErrorReflection x = idrisCatch x (\ e -> handle e >>= ierror)
                          -- Normalize error handler terms to produce the new messages
                          ctxt <- getContext
                          let results = map (normalise ctxt []) (map fst handlers)
-                         logLvl 3 $ "New error message info: " ++ concat (intersperse " and " (map show results))
+                         logElab 3 $ "New error message info: " ++ concat (intersperse " and " (map show results))
 
                          -- For each handler term output, either discard it if it is Nothing or reify it the Haskell equivalent
                          let errorpartsTT = mapMaybe unList (mapMaybe fromTTMaybe results)
@@ -2499,8 +2499,8 @@ processTacticDecls info steps =
   -- establish metavars that later function bodies resolve.
   forM_ (reverse steps) $ \case
     RTyDeclInstrs n fc impls ty ->
-      do logLvl 3 $ "Declaration from tactics: " ++ show n ++ " : " ++ show ty
-         logLvl 3 $ "  It has impls " ++ show impls
+      do logElab 3 $ "Declaration from tactics: " ++ show n ++ " : " ++ show ty
+         logElab 3 $ "  It has impls " ++ show impls
          updateIState $ \i -> i { idris_implicits =
                                     addDef n impls (idris_implicits i) }
          addIBC (IBCImp n)
@@ -2517,13 +2517,13 @@ processTacticDecls info steps =
              in addDeferred ds'
            _ -> return ()
     RAddInstance className instName ->
-      do -- The type class resolution machinery relies on a special 
-         logLvl 2 $ "Adding elab script instance " ++ show instName ++
+      do -- The type class resolution machinery relies on a special
+         logElab 2 $ "Adding elab script instance " ++ show instName ++
                     " for " ++ show className
          addInstance False True className instName
          addIBC (IBCInstance False True className instName)
     RClausesInstrs n cs ->
-      do logLvl 3 $ "Pattern-matching definition from tactics: " ++ show n
+      do logElab 3 $ "Pattern-matching definition from tactics: " ++ show n
          solveDeferred n
          let lhss = map (\(_, lhs, _) -> lhs) cs
          let fc = fileFC "elab_reflected"
@@ -2553,7 +2553,7 @@ processTacticDecls info steps =
                  calls = findCalls sc' scargs
                  used = findUsedArgs sc' scargs'
                  cg = CGInfo scargs' calls [] used []
-             in do logLvl 2 $ "Called names in reflected elab: " ++ show cg
+             in do logElab 2 $ "Called names in reflected elab: " ++ show cg
                    addToCG n cg
                    addToCalledG n (nub (map fst calls))
                    addIBC $ IBCCG n

--- a/src/Idris/Elab/Transform.hs
+++ b/src/Idris/Elab/Transform.hs
@@ -53,7 +53,7 @@ elabTransform info fc safe lhs_in@(PApp _ (PRef _ _ tf) _) rhs_in
     = do ctxt <- getContext
          i <- getIState
          let lhs = addImplPat i lhs_in
-         logLvl 5 ("Transform LHS input: " ++ showTmImpls lhs)
+         logElab 5 ("Transform LHS input: " ++ showTmImpls lhs)
          (ElabResult lhs' dlhs [] ctxt' newDecls highlights, _) <-
               tclift $ elaborate ctxt (idris_datatypes i) (sMN 0 "transLHS") infP initEState
                        (erun fc (buildTC i info ETransLHS [] (sUN "transform")
@@ -67,11 +67,11 @@ elabTransform info fc safe lhs_in@(PApp _ (PRef _ _ tf) _) rhs_in
 
          (clhs_tm_in, clhs_ty) <- recheckC_borrowing False False [] fc id [] lhs_tm
          let clhs_tm = renamepats pnames clhs_tm_in
-         logLvl 3 ("Transform LHS " ++ show clhs_tm)
-         logLvl 3 ("Transform type " ++ show clhs_ty)
-         
+         logElab 3 ("Transform LHS " ++ show clhs_tm)
+         logElab 3 ("Transform type " ++ show clhs_ty)
+
          let rhs = addImplBound i (map fst newargs) rhs_in
-         logLvl 5 ("Transform RHS input: " ++ showTmImpls rhs)
+         logElab 5 ("Transform RHS input: " ++ showTmImpls rhs)
 
          ((rhs', defer, ctxt', newDecls), _) <-
               tclift $ elaborate ctxt (idris_datatypes i) (sMN 0 "transRHS") clhs_ty initEState
@@ -88,7 +88,7 @@ elabTransform info fc safe lhs_in@(PApp _ (PRef _ _ tf) _) rhs_in
 
          (crhs_tm_in, crhs_ty) <- recheckC_borrowing False False [] fc id [] rhs'
          let crhs_tm = renamepats pnames crhs_tm_in
-         logLvl 3 ("Transform RHS " ++ show crhs_tm)
+         logElab 3 ("Transform RHS " ++ show crhs_tm)
 
          -- Types must always convert
          case converts ctxt [] clhs_ty crhs_ty of
@@ -118,6 +118,5 @@ elabTransform info fc safe lhs_in@(PApp _ (PRef _ _ tf) _) rhs_in
     -- with any other names when applying rules, so rename here.
     pnames = map (\i -> sMN i ("tvar" ++ show i)) [0..]
 
-elabTransform info fc safe lhs_in rhs_in 
+elabTransform info fc safe lhs_in rhs_in
    = ierror (At fc (Msg "Invalid transformation rule (must be function application)"))
-

--- a/src/Idris/Elab/Type.hs
+++ b/src/Idris/Elab/Type.hs
@@ -1,5 +1,5 @@
 {-# LANGUAGE PatternGuards #-}
-module Idris.Elab.Type (buildType, elabType, elabType', 
+module Idris.Elab.Type (buildType, elabType, elabType',
                         elabPostulate, elabExtern) where
 
 import Idris.AbsSyntax
@@ -52,20 +52,20 @@ import Data.List.Split (splitOn)
 
 import Util.Pretty(pretty, text)
 
-buildType :: ElabInfo -> SyntaxInfo -> FC -> FnOpts -> Name -> PTerm -> 
+buildType :: ElabInfo -> SyntaxInfo -> FC -> FnOpts -> Name -> PTerm ->
              Idris (Type, Type, PTerm, [(Int, Name)])
 buildType info syn fc opts n ty' = do
          ctxt <- getContext
          i <- getIState
 
-         logLvl 2 $ show n ++ " pre-type " ++ showTmImpls ty' ++ show (no_imp syn)
+         logElab 2 $ show n ++ " pre-type " ++ showTmImpls ty' ++ show (no_imp syn)
          ty' <- addUsingConstraints syn fc ty'
          ty' <- addUsingImpls syn n fc ty'
          let ty = addImpl (imp_methods syn) i ty'
 
-         logLvl 5 $ show n ++ " type pre-addimpl " ++ showTmImpls ty'
-         logLvl 5 $ show "with methods " ++ show (imp_methods syn)
-         logLvl 2 $ show n ++ " type " ++ show (using syn) ++ "\n" ++ showTmImpls ty
+         logElab 5 $ show n ++ " type pre-addimpl " ++ showTmImpls ty'
+         logElab 5 $ show "with methods " ++ show (imp_methods syn)
+         logElab 2 $ show n ++ " type " ++ show (using syn) ++ "\n" ++ showTmImpls ty
 
          (ElabResult tyT' defer is ctxt' newDecls highlights, log) <-
             tclift $ elaborate ctxt (idris_datatypes i) n (TType (UVal 0)) initEState
@@ -76,7 +76,7 @@ buildType info syn fc opts n ty' = do
 
          let tyT = patToImp tyT'
 
-         logLvl 3 $ show ty ++ "\nElaborated: " ++ show tyT'
+         logElab 3 $ show ty ++ "\nElaborated: " ++ show tyT'
 
          ds <- checkAddDef True False fc iderr defer
          -- if the type is not complete, note that we'll need to infer
@@ -86,20 +86,20 @@ buildType info syn fc opts n ty' = do
 
          mapM_ (elabCaseBlock info opts) is
          ctxt <- getContext
-         logLvl 5 $ "Rechecking"
-         logLvl 6 $ show tyT
-         logLvl 10 $ "Elaborated to " ++ showEnvDbg [] tyT
+         logElab 5 $ "Rechecking"
+         logElab 6 $ show tyT
+         logElab 10 $ "Elaborated to " ++ showEnvDbg [] tyT
          (cty, ckind)   <- recheckC fc id [] tyT
 
          -- record the implicit and inaccessible arguments
          i <- getIState
          let (inaccData, impls) = unzip $ getUnboundImplicits i cty ty
          let inacc = inaccessibleImps 0 cty inaccData
-         logLvl 3 $ show n ++ ": inaccessible arguments: " ++ show inacc ++
+         logElab 3 $ show n ++ ": inaccessible arguments: " ++ show inacc ++
                      " from " ++ show cty ++ "\n" ++ showTmImpls ty
 
          putIState $ i { idris_implicits = addDef n impls (idris_implicits i) }
-         logLvl 3 ("Implicit " ++ show n ++ " " ++ show impls)
+         logElab 3 ("Implicit " ++ show n ++ " " ++ show impls)
          addIBC (IBCImp n)
 
          when (Constructor `notElem` opts) $ do
@@ -114,7 +114,7 @@ buildType info syn fc opts n ty' = do
     patToImp (Bind n b sc) = Bind n b (patToImp sc)
     patToImp t = t
 
-    param_pos i ns (Bind n (Pi _ t _) sc) 
+    param_pos i ns (Bind n (Pi _ t _) sc)
         | n `elem` ns = i : param_pos (i + 1) ns sc
         | otherwise = param_pos (i + 1) ns sc
     param_pos i ns t = []
@@ -140,9 +140,9 @@ elabType' norm info syn doc argDocs fc opts n nfc ty' = {- let ty' = piBind (par
          let nty = cty -- normalise ctxt [] cty
          -- if the return type is something coinductive, freeze the definition
          ctxt <- getContext
-         logLvl 2 $ "Rechecked to " ++ show nty
+         logElab 2 $ "Rechecked to " ++ show nty
          let nty' = normalise ctxt [] nty
-         logLvl 2 $ "Rechecked to " ++ show nty'
+         logElab 2 $ "Rechecked to " ++ show nty'
 
          -- Add function name to internals (used for making :addclause know
          -- the name unambiguously)
@@ -158,7 +158,7 @@ elabType' norm info syn doc argDocs fc opts n nfc ty' = {- let ty' = piBind (par
                                         [TI _ True _ _ _] -> True
                                         _ -> False
                         _ -> False
-         -- Productivity checking now via checking for guarded 'Delay' 
+         -- Productivity checking now via checking for guarded 'Delay'
          let opts' = opts -- if corec then (Coinductive : opts) else opts
          let usety = if norm then nty' else nty
          ds <- checkDef fc iderr [(n, (-1, Nothing, usety, []))]
@@ -177,7 +177,7 @@ elabType' norm info syn doc argDocs fc opts n nfc ty' = {- let ty' = piBind (par
          addIBC (IBCOpt n)
          when (Implicit `elem` opts') $ do addCoercion n
                                            addIBC (IBCCoercion n)
-         when (AutoHint `elem` opts') $ 
+         when (AutoHint `elem` opts') $
              case fam of
                 P _ tyn _ -> do addAutoHint tyn n
                                 addIBC (IBCAutoHint tyn n)
@@ -201,7 +201,7 @@ elabType' norm info syn doc argDocs fc opts n nfc ty' = {- let ty' = piBind (par
          sendHighlighting [(nfc, AnnName n Nothing Nothing Nothing)]
          -- if it's an export list type, make a note of it
          case (unApply usety) of
-              (P _ ut _, _) 
+              (P _ ut _, _)
                  | ut == ffiexport -> do addIBC (IBCExport n)
                                          addExport n
               _ -> return ()
@@ -256,6 +256,3 @@ elabExtern info syn doc fc nfc opts n ty = do
 
     -- remove it from the deferred definitions list
     solveDeferred n
-
-
-

--- a/src/Idris/Elab/Utils.hs
+++ b/src/Idris/Elab/Utils.hs
@@ -37,14 +37,14 @@ recheckC_borrowing uniq_check addConstrs bs fc mkerr env t
          (tm, ty, cs) <- tclift $ case recheck_borrowing uniq_check bs ctxt env t' t of
                                    Error e -> tfail (At fc (mkerr e))
                                    OK x -> return x
-         logLvl 6 $ "CONSTRAINTS ADDED: " ++ show (tm, ty, cs)
+         logElab 6 $ "CONSTRAINTS ADDED: " ++ show (tm, ty, cs)
          when addConstrs $ addConstraints fc cs
          mapM_ (checkDeprecated fc) (allTTNames tm)
          mapM_ (checkDeprecated fc) (allTTNames ty)
          return (tm, ty)
 
 checkDeprecated :: FC -> Name -> Idris ()
-checkDeprecated fc n 
+checkDeprecated fc n
     = do r <- getDeprecated n
          case r of
               Nothing -> return ()
@@ -64,9 +64,9 @@ checkAddDef :: Bool -> Bool -> FC -> (Name -> Err -> Err)
             -> [(Name, (Int, Maybe Name, Type, [Name]))]
             -> Idris [(Name, (Int, Maybe Name, Type, [Name]))]
 checkAddDef add toplvl fc mkerr [] = return []
-checkAddDef add toplvl fc mkerr ((n, (i, top, t, psns)) : ns) 
+checkAddDef add toplvl fc mkerr ((n, (i, top, t, psns)) : ns)
                = do ctxt <- getContext
-                    logLvl 5 $ "Rechecking deferred name " ++ show (n, t)
+                    logElab 5 $ "Rechecking deferred name " ++ show (n, t)
                     (t', _) <- recheckC fc (mkerr n) [] t
                     when add $ do addDeferred [(n, (i, top, t, psns, toplvl))]
                                   addIBC (IBCDef n)
@@ -93,7 +93,7 @@ inaccessibleArgs _ _ = []
 elabCaseBlock :: ElabInfo -> FnOpts -> PDecl -> Idris ()
 elabCaseBlock info opts d@(PClauses f o n ps)
         = do addIBC (IBCDef n)
-             logLvl 5 $ "CASE BLOCK: " ++ show (n, d)
+             logElab 5 $ "CASE BLOCK: " ++ show (n, d)
              let opts' = nub (o ++ opts)
              -- propagate totality assertion to the new definitions
              when (AssertTotal `elem` opts) $ setFlags n [AssertTotal]
@@ -104,16 +104,16 @@ elabCaseBlock info opts d@(PClauses f o n ps)
 -- they are the same!)
 checkInferred :: FC -> PTerm -> PTerm -> Idris ()
 checkInferred fc inf user =
-     do logLvl 6 $ "Checked to\n" ++ showTmImpls inf ++ "\n\nFROM\n\n" ++
+     do logElab 6 $ "Checked to\n" ++ showTmImpls inf ++ "\n\nFROM\n\n" ++
                                      showTmImpls user
-        logLvl 10 $ "Checking match"
+        logElab 10 $ "Checking match"
         i <- getIState
         tclift $ case matchClause' True i user inf of
             _ -> return ()
 --             Left (x, y) -> tfail $ At fc
 --                                     (Msg $ "The type-checked term and given term do not match: "
 --                                            ++ show x ++ " and " ++ show y)
-        logLvl 10 $ "Checked match"
+        logElab 10 $ "Checked match"
 --                           ++ "\n" ++ showImp True inf ++ "\n" ++ showImp True user)
 
 -- | Return whether inferred term is different from given term
@@ -121,7 +121,7 @@ checkInferred fc inf user =
 inferredDiff :: FC -> PTerm -> PTerm -> Idris Bool
 inferredDiff fc inf user =
      do i <- getIState
-        logLvl 6 $ "Checked to\n" ++ showTmImpls inf ++ "\n" ++
+        logElab 6 $ "Checked to\n" ++ showTmImpls inf ++ "\n" ++
                                      showTmImpls user
         tclift $ case matchClause' True i user inf of
             Right vs -> return False
@@ -152,7 +152,7 @@ decorateid decorate (PClauses f o n cs)
 
 -- if 't' is a type class application, assume its arguments are injective
 pbinds :: IState -> Term -> ElabD ()
-pbinds i (Bind n (PVar t) sc) 
+pbinds i (Bind n (PVar t) sc)
     = do attack; patbind n
          env <- get_env
          case unApply (normalise (tt_ctxt i) env t) of
@@ -207,14 +207,14 @@ getFlexInType i env ps tm@(App _ f a)
     | (P nt tn _, args) <- unApply tm, nt /= Bound
        = case lookupCtxtExact tn (idris_datatypes i) of
             Just t -> nub $ paramNames args env [x | x <- [0..length args],
-                                                     not (x `elem` param_pos t)] 
+                                                     not (x `elem` param_pos t)]
                           ++ getFlexInType i env ps f ++
                              getFlexInType i env ps a
             Nothing -> let ppos = case lookupCtxtExact tn (idris_fninfo i) of
                                        Just fi -> fn_params fi
                                        Nothing -> []
                        in nub $ paramNames args env [x | x <- [0..length args],
-                                                         not (x `elem` ppos)] 
+                                                         not (x `elem` ppos)]
                            ++ getFlexInType i env ps f ++
                               getFlexInType i env ps a
     | otherwise = nub $ getFlexInType i env ps f ++
@@ -228,7 +228,7 @@ getParamsInType i env ps t = let fix = getFixedInType i env ps t
                                  flex = getFlexInType i env fix t in
                                  [x | x <- fix, not (x `elem` flex)]
 
-getTCinj i (Bind n (Pi _ t _) sc) 
+getTCinj i (Bind n (Pi _ t _) sc)
     = getTCinj i t ++ getTCinj i (instantiate (P Bound n t) sc)
 getTCinj i ap@(App _ f a)
     | (P _ n _, args) <- unApply ap,
@@ -258,7 +258,7 @@ paramNames args env (p : ps)
 getUniqueUsed :: Context -> Term -> [Name]
 getUniqueUsed ctxt tm = execState (getUniq [] [] tm) []
   where
-    getUniq :: Env -> [(Name, Bool)] -> Term -> State [Name] () 
+    getUniq :: Env -> [(Name, Bool)] -> Term -> State [Name] ()
     getUniq env us (Bind n b sc)
        = let uniq = case check ctxt env (forgetEnv (map fst env) (binderTy b)) of
                          OK (_, UType UniqueType) -> True
@@ -285,9 +285,9 @@ getUniqueUsed ctxt tm = execState (getUniq [] [] tm) []
 -- In a functional application, return the names which are used
 -- directly in a static position
 getStaticNames :: IState -> Term -> [Name]
-getStaticNames ist (Bind n (PVar _) sc) 
+getStaticNames ist (Bind n (PVar _) sc)
     = getStaticNames ist (instantiate (P Bound n Erased) sc)
-getStaticNames ist tm 
+getStaticNames ist tm
     | (P _ fn _, args) <- unApply tm
         = case lookupCtxtExact fn (idris_statics ist) of
                Just stpos -> getStatics args stpos
@@ -305,15 +305,12 @@ getStatics ns (Bind n (Pi _ _ _) t)
 getStatics _ _ = []
 
 mkStatic :: [Name] -> PDecl -> PDecl
-mkStatic ns (PTy doc argdocs syn fc o n nfc ty) 
+mkStatic ns (PTy doc argdocs syn fc o n nfc ty)
     = PTy doc argdocs syn fc o n nfc (mkStaticTy ns ty)
 mkStatic ns t = t
 
 mkStaticTy :: [Name] -> PTerm -> PTerm
-mkStaticTy ns (PPi p n fc ty sc) 
+mkStaticTy ns (PPi p n fc ty sc)
     | n `elem` ns = PPi (p { pstatic = Static }) n fc ty (mkStaticTy ns sc)
     | otherwise = PPi p n fc ty (mkStaticTy ns sc)
 mkStaticTy ns t = t
-
-
-

--- a/src/Idris/Elab/Value.hs
+++ b/src/Idris/Elab/Value.hs
@@ -1,6 +1,6 @@
 {-# LANGUAGE PatternGuards #-}
 {-# OPTIONS_GHC -fwarn-incomplete-patterns #-}
-module Idris.Elab.Value(elabVal, elabValBind, elabDocTerms, 
+module Idris.Elab.Value(elabVal, elabValBind, elabDocTerms,
                         elabExec, elabREPL) where
 
 import Idris.AbsSyntax
@@ -58,7 +58,7 @@ elabValBind info aspat norm tm_in
    = do ctxt <- getContext
         i <- getIState
         let tm = addImpl [] i tm_in
-        logLvl 10 (showTmImpls tm)
+        logElab 10 (showTmImpls tm)
         -- try:
         --    * ordinary elaboration
         --    * elaboration as a Type
@@ -80,7 +80,7 @@ elabValBind info aspat norm tm_in
         addDeferred def''
         mapM_ (elabCaseBlock info []) is
 
-        logLvl 3 ("Value: " ++ show vtm)
+        logElab 3 ("Value: " ++ show vtm)
         (vtm_in, vty) <- recheckC (fileFC "(input)") id [] vtm
 
         let vtm = if norm then normalise (tt_ctxt i) [] vtm_in
@@ -127,7 +127,7 @@ elabExec fc tm = runtm (PAlternative [] FirstSuccess
                     printtm tm
                     ])
   where
-    runtm t = PApp fc (PRef fc [] (sUN "run__IO")) 
+    runtm t = PApp fc (PRef fc [] (sUN "run__IO"))
                   [pimp (sUN "ffi") (PRef fc [] (sUN "FFI_C")) False, pexp t]
     printtm t = PApp fc (PRef fc [] (sUN "printLn"))
                   [pimp (sUN "ffi") (PRef fc [] (sUN "FFI_C")) False, pexp t]

--- a/src/Idris/ElabDecls.hs
+++ b/src/Idris/ElabDecls.hs
@@ -159,25 +159,25 @@ elabDecl' _ info (PSyntax _ p)
      = return () -- nothing to elaborate
 elabDecl' what info (PTy doc argdocs s f o n nfc ty)
   | what /= EDefns
-    = do logLvl 1 $ "Elaborating type decl " ++ show n ++ show o
+    = do logElab 1 $ "Elaborating type decl " ++ show n ++ show o
          elabType info s doc argdocs f o n nfc ty
          return ()
 elabDecl' what info (PPostulate b doc s f nfc o n ty)
   | what /= EDefns
-    = do logLvl 1 $ "Elaborating postulate " ++ show n ++ show o
-         if b 
+    = do logElab 1 $ "Elaborating postulate " ++ show n ++ show o
+         if b
             then elabExtern info s doc f nfc o n ty
             else elabPostulate info s doc f nfc o n ty
 elabDecl' what info (PData doc argDocs s f co d)
   | what /= ETypes
-    = do logLvl 1 $ "Elaborating " ++ show (d_name d)
+    = do logElab 1 $ "Elaborating " ++ show (d_name d)
          elabData info s doc argDocs f co d
   | otherwise
-    = do logLvl 1 $ "Elaborating [type of] " ++ show (d_name d)
+    = do logElab 1 $ "Elaborating [type of] " ++ show (d_name d)
          elabData info s doc argDocs f co (PLaterdecl (d_name d) (d_name_fc d) (d_tcon d))
 elabDecl' what info d@(PClauses f o n ps)
   | what /= ETypes
-    = do logLvl 1 $ "Elaborating clause " ++ show n
+    = do logElab 1 $ "Elaborating clause " ++ show n
          i <- getIState -- get the type options too
          let o' = case lookupCtxt n (idris_flags i) of
                     [fs] -> fs
@@ -191,11 +191,11 @@ elabDecl' what info (PMutual f ps)
          -- record mutually defined data definitions
          let datans = concatMap declared (filter isDataDecl ps)
          mapM_ (setMutData datans) datans
-         logLvl 1 $ "Rechecking for positivity " ++ show datans
+         logElab 1 $ "Rechecking for positivity " ++ show datans
          mapM_ (\x -> do setTotality x Unchecked) datans
          -- Do totality checking after entire mutual block
          i <- get
-         mapM_ (\n -> do logLvl 5 $ "Simplifying " ++ show n
+         mapM_ (\n -> do logElab 5 $ "Simplifying " ++ show n
                          ctxt' <- do ctxt <- getContext
                                      tclift $ simplifyCasedef n (getErasureInfo i) ctxt
                          setContext ctxt')
@@ -216,7 +216,7 @@ elabDecl' what info (PMutual f ps)
 
 elabDecl' what info (PParams f ns ps)
     = do i <- getIState
-         logLvl 1 $ "Expanding params block with " ++ show ns ++ " decls " ++
+         logElab 1 $ "Expanding params block with " ++ show ns ++ " decls " ++
                 show (concatMap tldeclared ps)
          let nblock = pblock i
          mapM_ (elabDecl' what info) nblock
@@ -240,17 +240,17 @@ elabDecl' what info (PNamespace n nfc ps) =
 
 elabDecl' what info (PClass doc s f cs n nfc ps pdocs fds ds cn cd)
   | what /= EDefns
-    = do logLvl 1 $ "Elaborating class " ++ show n
+    = do logElab 1 $ "Elaborating class " ++ show n
          elabClass info (s { syn_params = [] }) doc f cs n nfc ps pdocs fds ds cn cd
 elabDecl' what info (PInstance doc argDocs s f cs n nfc ps t expn ds)
-    = do logLvl 1 $ "Elaborating instance " ++ show n
+    = do logElab 1 $ "Elaborating instance " ++ show n
          elabInstance info s doc argDocs what f cs n nfc ps t expn ds
 elabDecl' what info (PRecord doc rsyn fc opts name nfc ps pdocs fs cname cdoc csyn)
-    = do logLvl 1 $ "Elaborating record " ++ show name
+    = do logElab 1 $ "Elaborating record " ++ show name
          elabRecord info what doc rsyn fc opts name nfc ps pdocs fs cname cdoc csyn
 {-
   | otherwise
-    = do logLvl 1 $ "Elaborating [type of] " ++ show tyn
+    = do logElab 1 $ "Elaborating [type of] " ++ show tyn
          elabData info s doc [] f [] (PLaterdecl tyn ty)
 -}
 elabDecl' _ info (PDSL n dsl)
@@ -261,7 +261,7 @@ elabDecl' what info (PDirective i)
   | what /= EDefns = directiveAction i
 elabDecl' what info (PProvider doc syn fc nfc provWhat n)
   | what /= EDefns
-    = do logLvl 1 $ "Elaborating type provider " ++ show n
+    = do logElab 1 $ "Elaborating type provider " ++ show n
          elabProvider doc info syn fc nfc provWhat n
 elabDecl' what info (PTransform fc safety old new)
     = do elabTransform info fc safety old new

--- a/src/Idris/IBC.hs
+++ b/src/Idris/IBC.hs
@@ -113,7 +113,7 @@ loadIBC reexport fp
                                 Nothing -> True
                                 Just p -> not p && reexport
                 when redo $
-                  do logCodeGen 1 $ "Loading ibc " ++ fp ++ " " ++ show reexport
+                  do logIBC 1 $ "Loading ibc " ++ fp ++ " " ++ show reexport
                      archiveFile <- runIO $ B.readFile fp
                      case toArchiveOrFail archiveFile of
                         Left _ -> ifail $ fp ++ " isn't loadable, it may have an old ibc format.\n"
@@ -189,7 +189,7 @@ writeArchive fp i = do let a = L.foldl (\x y -> addEntryToArchive y x) emptyArch
 
 writeIBC :: FilePath -> FilePath -> Idris ()
 writeIBC src f
-    = do logCodeGen 1 $ "Writing ibc " ++ show f
+    = do logIBC 1 $ "Writing ibc " ++ show f
          i <- getIState
 --          case (Data.List.map fst (idris_metavars i)) \\ primDefs of
 --                 (_:_) -> ifail "Can't write ibc when there are unsolved metavariables"
@@ -198,8 +198,8 @@ writeIBC src f
          ibcf <- mkIBC (ibc_write i) (initIBC { sourcefile = src })
          idrisCatch (do runIO $ createDirectoryIfMissing True (dropFileName f)
                         writeArchive f ibcf
-                        logCodeGen 1 "Written")
-            (\c -> do logCodeGen 1 $ "Failed " ++ pshow i c)
+                        logIBC 1 "Written")
+            (\c -> do logIBC 1 $ "Failed " ++ pshow i c)
          return ()
 
 -- Write a package index containing all the imports in the current IState
@@ -208,20 +208,20 @@ writePkgIndex :: FilePath -> Idris ()
 writePkgIndex f
     = do i <- getIState
          let imps = map (\ (x, y) -> (True, x)) $ idris_imported i
-         logCodeGen 1 $ "Writing package index " ++ show f ++ " including\n" ++
+         logIBC 1 $ "Writing package index " ++ show f ++ " including\n" ++
                 show (map snd imps)
          resetNameIdx
          let ibcf = initIBC { ibc_imports = imps }
          idrisCatch (do runIO $ createDirectoryIfMissing True (dropFileName f)
                         writeArchive f ibcf
-                        logCodeGen 1 "Written")
-            (\c -> do logCodeGen 1 $ "Failed " ++ pshow i c)
+                        logIBC 1 "Written")
+            (\c -> do logIBC 1 $ "Failed " ++ pshow i c)
          return ()
 
 mkIBC :: [IBCWrite] -> IBCFile -> Idris IBCFile
 mkIBC [] f = return f
 mkIBC (i:is) f = do ist <- getIState
-                    logCodeGen 5 $ show i ++ " " ++ show (L.length is)
+                    logIBC 5 $ show i ++ " " ++ show (L.length is)
                     f' <- ibc ist i f
                     mkIBC is f'
 
@@ -319,7 +319,7 @@ process :: Bool -- ^ Reexporting
 process reexp i fn = do
                 ver <- getEntry 0 "ver" i
                 when (ver /= ibcVersion) $ do
-                                    logCodeGen 1 "ibc out of date"
+                                    logIBC 1 "ibc out of date"
                                     let e = if ver < ibcVersion
                                             then " an earlier " else " a later "
                                     ifail $ "Incompatible ibc version.\nThis library was built with"
@@ -416,10 +416,10 @@ pImports reexp fs
                        putIState (i { imported = f : imported i })
                        case fp of
                             LIDR fn -> do
-                              logCodeGen 1 $ "Failed at " ++ fn
+                              logIBC 1 $ "Failed at " ++ fn
                               ifail "Must be an ibc"
                             IDR fn -> do
-                              logCodeGen 1 $ "Failed at " ++ fn
+                              logIBC 1 $ "Failed at " ++ fn
                               ifail "Must be an ibc"
                             IBC fn src -> loadIBC (reexp && re) fn)
              fs
@@ -517,13 +517,13 @@ pDefs reexp ds
                do d' <- updateDef d
                   case d' of
                        TyDecl _ _ -> return ()
-                       _ -> do logCodeGen 1 $ "SOLVING " ++ show n
+                       _ -> do logIBC 1 $ "SOLVING " ++ show n
                                solveDeferred n
                   updateIState (\i -> i { tt_ctxt = addCtxtDef n d' (tt_ctxt i) })
 --                   logLvl 1 $ "Added " ++ show (n, d')
-                  if (not reexp) then do logCodeGen 1 $ "Not exporting " ++ show n
+                  if (not reexp) then do logIBC 1 $ "Not exporting " ++ show n
                                          setAccessibility n Hidden
-                                 else logCodeGen 1 $ "Exporting " ++ show n) ds
+                                 else logIBC 1 $ "Exporting " ++ show n) ds
   where
     updateDef (CaseOp c t args o s cd)
       = do o' <- mapM updateOrig o
@@ -588,7 +588,7 @@ pAccess :: Bool -- ^ Reexporting?
 pAccess reexp ds
         = mapM_ (\ (n, a_in) ->
                       do let a = if reexp then a_in else Hidden
-                         logCodeGen 3 $ "Setting " ++ show (a, n) ++ " to " ++ show a
+                         logIBC 3 $ "Setting " ++ show (a, n) ++ " to " ++ show a
                          updateIState (\i -> i { tt_ctxt = setAccess n a (tt_ctxt i) })) ds
 
 pFlags :: [(Name, [FnOpt])] -> Idris ()

--- a/src/Idris/IBC.hs
+++ b/src/Idris/IBC.hs
@@ -113,7 +113,7 @@ loadIBC reexport fp
                                 Nothing -> True
                                 Just p -> not p && reexport
                 when redo $
-                  do logLvl 1 $ "Loading ibc " ++ fp ++ " " ++ show reexport
+                  do logCodeGen 1 $ "Loading ibc " ++ fp ++ " " ++ show reexport
                      archiveFile <- runIO $ B.readFile fp
                      case toArchiveOrFail archiveFile of
                         Left _ -> ifail $ fp ++ " isn't loadable, it may have an old ibc format.\n"
@@ -189,7 +189,7 @@ writeArchive fp i = do let a = L.foldl (\x y -> addEntryToArchive y x) emptyArch
 
 writeIBC :: FilePath -> FilePath -> Idris ()
 writeIBC src f
-    = do logLvl 1 $ "Writing ibc " ++ show f
+    = do logCodeGen 1 $ "Writing ibc " ++ show f
          i <- getIState
 --          case (Data.List.map fst (idris_metavars i)) \\ primDefs of
 --                 (_:_) -> ifail "Can't write ibc when there are unsolved metavariables"
@@ -198,8 +198,8 @@ writeIBC src f
          ibcf <- mkIBC (ibc_write i) (initIBC { sourcefile = src })
          idrisCatch (do runIO $ createDirectoryIfMissing True (dropFileName f)
                         writeArchive f ibcf
-                        logLvl 1 "Written")
-            (\c -> do logLvl 1 $ "Failed " ++ pshow i c)
+                        logCodeGen 1 "Written")
+            (\c -> do logCodeGen 1 $ "Failed " ++ pshow i c)
          return ()
 
 -- Write a package index containing all the imports in the current IState
@@ -208,20 +208,20 @@ writePkgIndex :: FilePath -> Idris ()
 writePkgIndex f
     = do i <- getIState
          let imps = map (\ (x, y) -> (True, x)) $ idris_imported i
-         logLvl 1 $ "Writing package index " ++ show f ++ " including\n" ++
+         logCodeGen 1 $ "Writing package index " ++ show f ++ " including\n" ++
                 show (map snd imps)
          resetNameIdx
          let ibcf = initIBC { ibc_imports = imps }
          idrisCatch (do runIO $ createDirectoryIfMissing True (dropFileName f)
                         writeArchive f ibcf
-                        logLvl 1 "Written")
-            (\c -> do logLvl 1 $ "Failed " ++ pshow i c)
+                        logCodeGen 1 "Written")
+            (\c -> do logCodeGen 1 $ "Failed " ++ pshow i c)
          return ()
 
 mkIBC :: [IBCWrite] -> IBCFile -> Idris IBCFile
 mkIBC [] f = return f
 mkIBC (i:is) f = do ist <- getIState
-                    logLvl 5 $ show i ++ " " ++ show (L.length is)
+                    logCodeGen 5 $ show i ++ " " ++ show (L.length is)
                     f' <- ibc ist i f
                     mkIBC is f'
 
@@ -319,7 +319,7 @@ process :: Bool -- ^ Reexporting
 process reexp i fn = do
                 ver <- getEntry 0 "ver" i
                 when (ver /= ibcVersion) $ do
-                                    logLvl 1 "ibc out of date"
+                                    logCodeGen 1 "ibc out of date"
                                     let e = if ver < ibcVersion
                                             then " an earlier " else " a later "
                                     ifail $ "Incompatible ibc version.\nThis library was built with"
@@ -415,10 +415,12 @@ pImports reexp fs
 --                         then logLvl 1 $ "Already read " ++ f
                        putIState (i { imported = f : imported i })
                        case fp of
-                            LIDR fn -> do logLvl 1 $ "Failed at " ++ fn
-                                          ifail "Must be an ibc"
-                            IDR fn -> do logLvl 1 $ "Failed at " ++ fn
-                                         ifail "Must be an ibc"
+                            LIDR fn -> do
+                              logCodeGen 1 $ "Failed at " ++ fn
+                              ifail "Must be an ibc"
+                            IDR fn -> do
+                              logCodeGen 1 $ "Failed at " ++ fn
+                              ifail "Must be an ibc"
                             IBC fn src -> loadIBC (reexp && re) fn)
              fs
 
@@ -515,13 +517,13 @@ pDefs reexp ds
                do d' <- updateDef d
                   case d' of
                        TyDecl _ _ -> return ()
-                       _ -> do logLvl 1 $ "SOLVING " ++ show n
+                       _ -> do logCodeGen 1 $ "SOLVING " ++ show n
                                solveDeferred n
                   updateIState (\i -> i { tt_ctxt = addCtxtDef n d' (tt_ctxt i) })
 --                   logLvl 1 $ "Added " ++ show (n, d')
-                  if (not reexp) then do logLvl 1 $ "Not exporting " ++ show n
+                  if (not reexp) then do logCodeGen 1 $ "Not exporting " ++ show n
                                          setAccessibility n Hidden
-                                 else logLvl 1 $ "Exporting " ++ show n) ds
+                                 else logCodeGen 1 $ "Exporting " ++ show n) ds
   where
     updateDef (CaseOp c t args o s cd)
       = do o' <- mapM updateOrig o
@@ -586,7 +588,7 @@ pAccess :: Bool -- ^ Reexporting?
 pAccess reexp ds
         = mapM_ (\ (n, a_in) ->
                       do let a = if reexp then a_in else Hidden
-                         logLvl 3 $ "Setting " ++ show (a, n) ++ " to " ++ show a
+                         logCodeGen 3 $ "Setting " ++ show (a, n) ++ " to " ++ show a
                          updateIState (\i -> i { tt_ctxt = setAccess n a (tt_ctxt i) })) ds
 
 pFlags :: [(Name, [FnOpt])] -> Idris ()
@@ -1843,7 +1845,7 @@ instance Binary PTerm where
                    _ -> error "Corrupted binary data for PTerm"
 
 instance Binary PAltType where
-        put x 
+        put x
           = case x of
                 ExactlyOne x1 -> do putWord8 0
                                     put x1

--- a/src/Idris/Parser.hs
+++ b/src/Idris/Parser.hs
@@ -189,7 +189,7 @@ decl syn = try (externalDecl syn)
            <?> "declaration"
 
 internalDecl :: SyntaxInfo -> IdrisParser [PDecl]
-internalDecl syn 
+internalDecl syn
          = do fc <- getFC
               -- if we're after maxline, stop at the next type declaration
               -- (so we get all cases of a definition to preserve totality
@@ -204,7 +204,7 @@ internalDecl syn
               -- the end of the definition, reset the state. But I've lost
               -- patience with trying to find out how to do that from the
               -- trifecta docs, so this does the job instead.
-              if continue then 
+              if continue then
                  do notEndBlock
                     declBody continue
                 else try (do notEndBlock
@@ -283,7 +283,7 @@ declExtensions syn rules = declExtension syn [] (filter isDeclRule rules)
      isDeclRule (DeclRule _ _) = True
      isDeclRule _ = False
 
-declExtension :: SyntaxInfo -> [Maybe (Name, SynMatch)] -> [Syntax] 
+declExtension :: SyntaxInfo -> [Maybe (Name, SynMatch)] -> [Syntax]
                  -> IdrisParser [PDecl]
 declExtension syn ns rules =
   choice $ flip map (groupBy (ruleGroup `on` syntaxSymbols) rules) $ \rs ->
@@ -318,7 +318,7 @@ declExtension syn ns rules =
     updateNs :: [(Name, SynMatch)] -> PDecl -> PDecl
     updateNs ns (PTy doc argdoc s fc o n fc' t)
           = PTy doc argdoc s fc o (updateB ns n) fc' t
-    updateNs ns (PClauses fc o n cs) 
+    updateNs ns (PClauses fc o n cs)
          = PClauses fc o (updateB ns n) (map (updateClause ns) cs)
     updateNs ns (PCAF fc n t) = PCAF fc (updateB ns n) t
     updateNs ns (PData ds cds s fc o dat)
@@ -338,10 +338,10 @@ declExtension syn ns rules =
                   cdocs
     updateNs ns (PInstance docs pdocs s fc cs cn fc' ps ity ni ds)
          = PInstance docs pdocs s fc cs (updateB ns cn) fc'
-                     ps ity (fmap (updateB ns) ni) 
+                     ps ity (fmap (updateB ns) ni)
                             (map (updateNs ns) ds)
     updateNs ns (PMutual fc ds) = PMutual fc (map (updateNs ns) ds)
-    updateNs ns (PProvider docs s fc fc' pw n) 
+    updateNs ns (PProvider docs s fc fc' pw n)
         = PProvider docs s fc fc' pw (updateB ns n)
     updateNs ns d = d
 
@@ -482,7 +482,7 @@ syntaxRule syn
        where ts = dropWhile isSpace . dropWhileEnd isSpace $ s
     mkSimple' (e : es) = e : mkSimple' es
     mkSimple' [] = []
-    
+
     -- Prevent syntax variable capture by making all binders under syntax unique
     -- (the ol' Common Lisp GENSYM approach)
     uniquifyBinders :: [Name] -> PTerm -> IdrisParser PTerm

--- a/src/Idris/Parser.hs
+++ b/src/Idris/Parser.hs
@@ -1552,7 +1552,7 @@ loadModule' f
         ids <- allImportDirs
         fp <- findImport ids ibcsd file
         if file `elem` imported i
-          then do logLvl 1 $ "Already read " ++ file
+          then do logParser 1 $ "Already read " ++ file
                   return Nothing
           else do putIState (i { imported = file : imported i })
                   case fp of
@@ -1560,7 +1560,7 @@ loadModule' f
                     LIDR fn -> loadSource True  fn Nothing
                     IBC fn src ->
                       idrisCatch (loadIBC True fn)
-                                 (\c -> do logLvl 1 $ fn ++ " failed " ++ pshow i c
+                                 (\c -> do logParser 1 $ fn ++ " failed " ++ pshow i c
                                            case src of
                                              IDR sfn -> loadSource False sfn Nothing
                                              LIDR sfn -> loadSource True sfn Nothing)
@@ -1569,7 +1569,7 @@ loadModule' f
 {- | Load idris code from file -}
 loadFromIFile :: Bool -> IFileType -> Maybe Int -> Idris ()
 loadFromIFile reexp i@(IBC fn src) maxline
-   = do logLvl 1 $ "Skipping " ++ getSrcFile i
+   = do logParser 1 $ "Skipping " ++ getSrcFile i
         idrisCatch (loadIBC reexp fn)
                 (\err -> ierror $ LoadingFailed fn err)
   where
@@ -1593,7 +1593,7 @@ loadSource' lidr r maxline
 {- | Load Idris source code-}
 loadSource :: Bool -> FilePath -> Maybe Int -> Idris ()
 loadSource lidr f toline
-             = do logLvl 1 ("Reading " ++ f)
+             = do logParser 1 ("Reading " ++ f)
                   i <- getIState
                   let def_total = default_total i
                   file_in <- runIO $ readSource f
@@ -1637,7 +1637,7 @@ loadSource lidr f toline
                                    ]
                       histogram = groupBy ((==) `on` fst) . sortBy (comparing fst) $ aliasNames
                   case map head . filter ((/= 1) . length) $ histogram of
-                    []       -> logLvl 3 $ "Module aliases: " ++ show (M.toList modAliases)
+                    []       -> logParser 3 $ "Module aliases: " ++ show (M.toList modAliases)
                     (n,fc):_ -> throwError . At fc . Msg $ "import alias not unique: " ++ show n
 
                   i <- getIState
@@ -1676,7 +1676,7 @@ loadSource lidr f toline
                   -- Parsing done, now process declarations
 
                   let ds = namespaces mname ds'
-                  logLvl 3 (show $ showDecls verbosePPOption ds)
+                  logParser 3 (show $ showDecls verbosePPOption ds)
                   i <- getIState
                   logLvl 10 (show (toAlist (idris_implicits i)))
                   logLvl 3 (show (idris_infixes i))

--- a/src/Idris/REPL.hs
+++ b/src/Idris/REPL.hs
@@ -805,7 +805,7 @@ process fn (Eval t)
                       getIState >>= flip warnDisamb t
                       (tm, ty) <- elabREPL recinfo ERHS t
                       ctxt <- getContext
-                      let tm' = perhapsForce $ normaliseBlocking ctxt [] 
+                      let tm' = perhapsForce $ normaliseBlocking ctxt []
                                                   [sUN "foreign",
                                                    sUN "prim_read",
                                                    sUN "prim_write"]
@@ -951,10 +951,10 @@ process fn (Check (PRef _ _ n))
                = let current = case n of
                                    MN _ _ -> text ""
                                    UN nm | ('_':'_':_) <- str nm -> text ""
-                                   _ -> text "  " <> 
+                                   _ -> text "  " <>
                                         bindingOf n False
-                                            <+> colon 
-                                            <+> align (tPretty bnd ist t) 
+                                            <+> colon
+                                            <+> align (tPretty bnd ist t)
                                             <> line
                  in
                     current <> putTy ppo ist (i-1) ((n,False):bnd) sc
@@ -986,8 +986,8 @@ process fn (Core t)
         iPrintTermWithType (pprintTT [] tm) (pprintTT [] ty)
 
 process fn (DocStr (Left n) w)
-  | UN ty <- n, ty == T.pack "Type" = getIState >>= iRenderResult . pprintTypeDoc  
-  | otherwise = do    
+  | UN ty <- n, ty == T.pack "Type" = getIState >>= iRenderResult . pprintTypeDoc
+  | otherwise = do
         ist <- getIState
         let docs = lookupCtxtName n (idris_docstrings ist) ++
                    map (\(n,d)-> (n, (d, [])))
@@ -1010,7 +1010,7 @@ process fn (DocStr (Right c) _) -- constants only have overviews
 process fn Universes
                      = do i <- getIState
                           let cs = idris_constraints i
-                          let cslist = S.toAscList cs 
+                          let cslist = S.toAscList cs
 --                        iputStrLn $ showSep "\n" (map show cs)
                           iputStrLn $ show (map uconstraint cslist)
                           let n = length cslist
@@ -1226,6 +1226,7 @@ process fn (Compile codegen f)
                        runIO $ generate codegen (fst (head (idris_imported i))) ir
   where fc = fileFC "main"
 process fn (LogLvl i) = setLogLevel i
+process fn (LogCategory cs) = setLogCats cs
 -- Elaborate as if LHS of a pattern (debug command)
 process fn (Pattelab t)
      = do (tm, ty) <- elabVal recinfo ELHS t
@@ -1528,7 +1529,7 @@ loadInputs inputs toline -- furthest line to read in input source files
            let ninputs = zip [1..] inputs
            ifiles <- mapWhileOK (\(num, input) ->
                 do putIState ist
-                   modTree <- buildTree 
+                   modTree <- buildTree
                                    (map snd (take (num-1) ninputs))
                                    importlists
                                    input
@@ -1777,12 +1778,13 @@ idrisMain opts =
        ok <- noErrors
        when (not ok) $ runIO (exitWith (ExitFailure 1))
   where
-    makeOption (OLogging i) = setLogLevel i
-    makeOption TypeCase = setTypeCase True
-    makeOption TypeInType = setTypeInType True
-    makeOption NoCoverage = setCoverage False
-    makeOption ErrContext = setErrContext True
-    makeOption _ = return ()
+    makeOption (OLogging i)  = setLogLevel i
+    makeOption (OLogCats cs) = setLogCats cs
+    makeOption TypeCase      = setTypeCase True
+    makeOption TypeInType    = setTypeInType True
+    makeOption NoCoverage    = setCoverage False
+    makeOption ErrContext    = setErrContext True
+    makeOption _             = return ()
 
     addPkgDir :: String -> Idris ()
     addPkgDir p = do ddir <- runIO $ getIdrisLibDir

--- a/src/Idris/REPL.hs
+++ b/src/Idris/REPL.hs
@@ -801,7 +801,7 @@ process fn (ModImport f) = do fmod <- loadModule f
                                 Nothing -> iPrintError $ "Can't find import " ++ f
 process fn (Eval t)
                  = withErrorReflection $
-                   do logLvl 5 $ show t
+                   do logParser 5 $ show t
                       getIState >>= flip warnDisamb t
                       (tm, ty) <- elabREPL recinfo ERHS t
                       ctxt <- getContext
@@ -814,8 +814,8 @@ process fn (Eval t)
                       -- Add value to context, call it "it"
                       updateContext (addCtxtDef (sUN "it") (Function ty' tm'))
                       ist <- getIState
-                      logLvl 3 $ "Raw: " ++ show (tm', ty')
-                      logLvl 10 $ "Debug: " ++ showEnvDbg [] tm'
+                      logParser 3 $ "Raw: " ++ show (tm', ty')
+                      logParser 10 $ "Debug: " ++ showEnvDbg [] tm'
                       let tmDoc = pprintDelab ist tm'
                           -- errReverse to make type more readable
                           tyDoc =  pprintDelab ist (errReverse ist ty')
@@ -824,7 +824,7 @@ process fn (Eval t)
                         | otherwise = tm
 
 process fn (NewDefn decls) = do
-        logLvl 3 ("Defining names using these decls: " ++ show (showDecls verbosePPOption decls))
+        logParser 3 ("Defining names using these decls: " ++ show (showDecls verbosePPOption decls))
         mapM_ defineName namedGroups where
   namedGroups = groupBy (\d1 d2 -> getName d1 == getName d2) decls
   getName :: PDecl -> Maybe Name
@@ -1253,7 +1253,7 @@ process fn (DynamicLink l)
                                   Nothing -> iPrintError $ "Could not load dynamic lib \"" ++ l ++ "\""
                                   Just x -> do let libs = idris_dynamic_libs i
                                                if x `elem` libs
-                                                  then do logLvl 1 ("Tried to load duplicate library " ++ lib_name x)
+                                                  then do logParser 1 ("Tried to load duplicate library " ++ lib_name x)
                                                           return ()
                                                   else putIState $ i { idris_dynamic_libs = x:libs }
     where trim = reverse . dropWhile isSpace . reverse . dropWhile isSpace
@@ -1524,7 +1524,7 @@ loadInputs inputs toline -- furthest line to read in input source files
 
            importlists <- getImports [] inputs
 
-           logLvl 1 (show (map (\(i,m) -> (i, map import_path m)) importlists))
+           logParser 1 (show (map (\(i,m) -> (i, map import_path m)) importlists))
 
            let ninputs = zip [1..] inputs
            ifiles <- mapWhileOK (\(num, input) ->
@@ -1534,8 +1534,8 @@ loadInputs inputs toline -- furthest line to read in input source files
                                    importlists
                                    input
                    let ifiles = getModuleFiles modTree
-                   logLvl 1 ("MODULE TREE : " ++ show modTree)
-                   logLvl 1 ("RELOAD: " ++ show ifiles)
+                   logParser 1 ("MODULE TREE : " ++ show modTree)
+                   logParser 1 ("RELOAD: " ++ show ifiles)
                    when (not (all ibc ifiles) || loadCode) $
                         tryLoad False (filter (not . ibc) ifiles)
                    -- return the files that need rechecking

--- a/src/Idris/REPLParser.hs
+++ b/src/Idris/REPLParser.hs
@@ -138,7 +138,7 @@ parserCommands =
       ":mc <line> <name> adds a case block for the definition of the metavariable on the line"
   , proofArgCmd ["ml", "makelemma"] MakeLemma "?"
   , (["log"], NumberArg, "Set logging verbosity level", cmd_log)
-  , ( ["logacts"]
+  , ( ["logcats"]
     , ManyArgs NameArg
     , "Set logging categories"
     , cmd_cats)

--- a/src/Idris/REPLParser.hs
+++ b/src/Idris/REPLParser.hs
@@ -411,6 +411,7 @@ cmd_cats name = do
            <|> try (P.symbol "elab"     >> return elabCats)
            <|> try (P.symbol "codegen"  >> return codegenCats)
            <|> try (P.symbol "coverage" >> return [ICoverage])
+           <|> try (P.symbol "ibc"      >> return [IIBC])
            <|> try (P.symbol "erasure"  >> return [IErasure])
            <|> badCat
 

--- a/src/Idris/REPLParser.hs
+++ b/src/Idris/REPLParser.hs
@@ -408,18 +408,8 @@ cmd_cats name = do
 
     pLogCats :: P.IdrisParser [LogCat]
     pLogCats = try (P.symbol "parser"     >> return parserCats)
-           <|> try (P.symbol "tychecker"  >> return checkingCats)
-           <|> try (P.symbol "backend"    >> return backendCats)
-           <|> try (P.symbol "parse"      >> return [IParse])
-           <|> try (P.symbol "elaborator" >> return [IElab])
-           <|> try (P.symbol "coverage"   >> return [ICover])
-           <|> try (P.symbol "unifyer"    >> return [IUnify])
-           <|> try (P.symbol "totality"   >> return [ITotal])
-           <|> try (P.symbol "eraser"     >> return [IErase])
-           <|> try (P.symbol "defunc"     >> return [IDefun])
-           <|> try (P.symbol "inliner"    >> return [IInline])
-           <|> try (P.symbol "resolver"   >> return [IResolve])
-           <|> try (P.symbol "codegen"    >> return [ICodeGen])
+           <|> try (P.symbol "elab"       >> return elabCats)
+           <|> try (P.symbol "codegen"    >> return codegenCats)
            <|> badCat
 
 cmd_let :: String -> P.IdrisParser (Either String Command)

--- a/src/Idris/REPLParser.hs
+++ b/src/Idris/REPLParser.hs
@@ -407,9 +407,11 @@ cmd_cats name = do
       fail $ "Category: " ++ c ++ " is not recognised."
 
     pLogCats :: P.IdrisParser [LogCat]
-    pLogCats = try (P.symbol "parser"     >> return parserCats)
-           <|> try (P.symbol "elab"       >> return elabCats)
-           <|> try (P.symbol "codegen"    >> return codegenCats)
+    pLogCats = try (P.symbol "parser"   >> return parserCats)
+           <|> try (P.symbol "elab"     >> return elabCats)
+           <|> try (P.symbol "codegen"  >> return codegenCats)
+           <|> try (P.symbol "coverage" >> return [ICoverage])
+           <|> try (P.symbol "erasure"  >> return [IErasure])
            <|> badCat
 
 cmd_let :: String -> P.IdrisParser (Either String Command)


### PR DESCRIPTION
Currently logging is based on horizontally defined levels across the
entire language infrastructure. This commit introduces vertical splits.

Logging statements record both the level the message is to be recorded
at and the categories it belongs too. No categories is an alias for
belonging to all categories.

The State record stores both the current logging level, and also the
categories to show.

Logging is decided if a given logging statement is at the right level
and if the categories specified are listed. By default all categories
are allowed, as levels will take care of logging statement visibility.

**TODO**

+ [x] Update IDE Protocol
+ [x] Finalise Logging Categories
+ [x] Implement logging helpers based on categories.
+ [x] Categorise logging statements.
+ [x] Update documentation.