### PR TITLE
Add :watch files for changes command to REPL.

### DIFF
--- a/idris.cabal
+++ b/idris.cabal
@@ -979,6 +979,8 @@ Library
                 , vector-binary-instances < 0.3
                 , zip-archive > 0.2.3.5 && < 0.2.4
                 , safe
+                , fsnotify < 2.2
+                , async < 2.1
   -- zlib >= 0.6.1 is broken with GHC < 7.10.3
   if impl(ghc < 7.10.3)
      build-depends: zlib < 0.6.1

--- a/src/IRTS/System.hs
+++ b/src/IRTS/System.hs
@@ -21,10 +21,7 @@ getCC :: IO String
 getCC = fromMaybe "gcc" <$> environment "IDRIS_CC"
 
 getEnvFlags :: IO [String]
-getEnvFlags = do flags <- environment "IDRIS_CFLAGS"
-                 case flags of
-                     Nothing -> return $ []
-                     Just s -> return $ splitOn " " s
+getEnvFlags = maybe [] (splitOn " ") <$> environment "IDRIS_CFLAGS"
 
 mvnCommand :: String
 #ifdef mingw32_HOST_OS
@@ -37,9 +34,8 @@ getMvn :: IO String
 getMvn = fromMaybe mvnCommand <$> environment "IDRIS_MVN"
 
 environment :: String -> IO (Maybe String)
-environment x = catchIO (do e <- getEnv x
-                            return (Just e))
-                      (\_ -> return Nothing)
+environment x = catchIO (Just <$> getEnv x)
+                        (\_ -> return Nothing)
 
 getTargetDir :: IO String
 getTargetDir = environment "TARGET" >>= maybe getDataDir return

--- a/src/Idris/AbsSyntaxTree.hs
+++ b/src/Idris/AbsSyntaxTree.hs
@@ -391,6 +391,7 @@ data Command = Quit
              | DocStr (Either Name Const) HowMuchDocs
              | TotCheck Name
              | Reload
+             | Watch
              | Load FilePath (Maybe Int) -- up to maximum line number
              | ChangeDirectory FilePath
              | ModImport String

--- a/src/Idris/ProofSearch.hs
+++ b/src/Idris/ProofSearch.hs
@@ -478,8 +478,7 @@ resTC' tcs defaultOn topholes depth topg fn elab ist
                                                      return (num + 1)
                         _ -> return 0
 
-    solven 0 = return ()
-    solven n = do solve; solven (n - 1)
+    solven n = replicateM_ n solve
 
     resolve n depth
        | depth == 0 = fail $ "Can't resolve type class"

--- a/src/Idris/REPLParser.hs
+++ b/src/Idris/REPLParser.hs
@@ -67,6 +67,7 @@ parserCommandsForHelp =
   , namespaceArgCmd ["browse"] Browse "List the contents of some namespace"
   , nameArgCmd ["total"] TotCheck "Check the totality of a name"
   , noArgCmd ["r", "reload"] Reload "Reload current file"
+  , noArgCmd ["w", "watch"] Watch "Watch the current file for changes"
   , (["l", "load"], FileArg, "Load a new file"
     , strArg (\f -> Load f Nothing))
   , (["cd"], FileArg, "Change working directory"
@@ -98,7 +99,7 @@ parserCommandsForHelp =
   , (["consolewidth"], ConsoleWidthArg, "Set the width of the console", cmd_consolewidth)
   , (["printerdepth"], OptionalArg NumberArg, "Set the maximum pretty-printer depth (no arg for infinite)", cmd_printdepth)
   , noArgCmd ["q", "quit"] Quit "Exit the Idris system"
-  , noArgCmd ["w", "warranty"] Warranty "Displays warranty information"
+  , noArgCmd ["warranty"] Warranty "Displays warranty information"
   , (["let"], ManyArgs DeclArg
     , "Evaluate a declaration, such as a function definition, instance implementation, or fixity declaration"
     , cmd_let)


### PR DESCRIPTION
While reading through the upcoming Idris book, I came across the following paragraph:
> Note that the REPL does not reload files automatically, as it runs independently of the
> interactive editing in Atom. Therefore, you will need to reload explicitly using the :r command.

That had me thinking, "well, we can automate that".
fsnotify is a cross-platform lib - uses whatever is appropriate for each platform (inotify on Linux, etc).
Was thinking along the lines of SBT's "~compile" command it has in its REPL. Could add support for running other commands on file changes in the future, but I can't think of any others you'd want to do (test?).

If people think this is a good idea, could add this as a configure flag, so as to not require those two extra Haskell libs, and possibly complicate the build for some people.
