### PR TITLE
Remove zlib constraint for GHC >= 7.10.3

### DIFF
--- a/idris.cabal
+++ b/idris.cabal
@@ -975,8 +975,11 @@ Library
                 , vector < 0.12
                 , vector-binary-instances < 0.3
                 , zip-archive > 0.2.3.5 && < 0.2.4
-                , zlib < 0.6
                 , safe
+  -- zlib >= 0.6.1 is broken with GHC < 7.10.3
+  if impl(ghc < 7.10.3)
+     build-depends: zlib < 0.6.1
+
   Extensions:     MultiParamTypeClasses
                 , DeriveFoldable
                 , DeriveTraversable


### PR DESCRIPTION
Newer GHC versions don't have that segfault bug.
Fixes #2433

Just cribbed from the Agda version of the same thing: https://github.com/agda/agda/commit/27bf522207a240bac83838dd2711830cd38809da