### PR TITLE
The old code doesn't work

### DIFF
--- a/docs/tutorial/typesfuns.rst
+++ b/docs/tutorial/typesfuns.rst
@@ -1045,7 +1045,7 @@ using natural numbers, the new value can be incremented using the
 .. code-block:: idris
 
     addStudent : Person -> SizedClass n -> SizedClass (S n)
-    addStudent p c = record { students = p :: students c } c
+    addStudent p c =  SizedClassInfo (p :: students c) (className c)
 
 .. _sect-more-expr:
 


### PR DESCRIPTION
The type of `SizedClass.set_students` is `Vect size Person -> SizedClass size -> SizedClass size`, so this function must use the constructor `SizedClassInfo`.