### PR TITLE
Fix module name for Effect.Default

### DIFF
--- a/libs/effects/Effect/Default.idr
+++ b/libs/effects/Effect/Default.idr
@@ -1,4 +1,4 @@
-module Default
+module Effect.Default
 
 import Data.Vect
 
@@ -43,4 +43,3 @@ instance Default a => Default (Vect n a) where
       mkDef : (n : Nat) -> Vect n a
       mkDef Z = []
       mkDef (S k) = default :: mkDef k
-


### PR DESCRIPTION
The file name mismatch with the module name resulted in Effect.Default
not being exported by IdrisDoc. This commit fixes this issue.