### PR TITLE
Changed IOExcept to IOExcept' (with an FFI param) to work with the new FFI

### DIFF
--- a/libs/base/Control/IOExcept.idr
+++ b/libs/base/Control/IOExcept.idr
@@ -2,25 +2,28 @@ module Control.IOExcept
 
 -- An IO monad with exception handling
 
-record IOExcept err a where
+record IOExcept' (f:FFI) err a where
      constructor IOM
-     runIOExcept : IO (Either err a)
+     runIOExcept : IO' f (Either err a)
 
-instance Functor (IOExcept e) where
+instance Functor (IOExcept' f e) where
      map f (IOM fn) = IOM (map (map f) fn)
 
-instance Applicative (IOExcept e) where
+instance Applicative (IOExcept' f e) where
      pure x = IOM (pure (pure x))
      (IOM f) <*> (IOM a) = IOM [| f <*> a |]
 
-instance Monad (IOExcept e) where
+instance Monad (IOExcept' f e) where
      (IOM x) >>= f = IOM $ x >>= either (pure . Left) (runIOExcept . f)
 
-ioe_lift : IO a -> IOExcept err a
+ioe_lift : IO' f a -> IOExcept' f err a
 ioe_lift op = IOM $ map Right op
 
-ioe_fail : err -> IOExcept err a
+ioe_fail : err -> IOExcept' f err a
 ioe_fail e = IOM $ pure (Left e)
 
-ioe_run : IOExcept err a -> (err -> IO b) -> (a -> IO b) -> IO b
+ioe_run : IOExcept' f err a -> (err -> IO' f b) -> (a -> IO' f b) -> IO' f b
 ioe_run (IOM act) err ok = either err ok !act
+
+IOExcept : Type -> Type -> Type
+IOExcept = IOExcept' FFI_C


### PR DESCRIPTION
I've been using this with Java and JS and it works for me without a problem.