### PR TITLE
Publish functions needed to compute the index of Bits

### DIFF
--- a/libs/base/Data/Bits.idr
+++ b/libs/base/Data/Bits.idr
@@ -4,6 +4,7 @@ import Data.Fin
 
 %default total
 
+public
 nextPow2 : Nat -> Nat
 nextPow2 Z = Z
 nextPow2 (S x) = if (S x) == (2 `power` l2x)
@@ -12,9 +13,11 @@ nextPow2 (S x) = if (S x) == (2 `power` l2x)
     where
       l2x = log2NZ (S x) SIsNotZ
 
+public
 nextBytes : Nat -> Nat
 nextBytes bits = (nextPow2 (divCeilNZ bits 8 SIsNotZ))
 
+public
 machineTy : Nat -> Type
 machineTy Z = Bits8
 machineTy (S Z) = Bits16


### PR DESCRIPTION
These functions are necessary for type signatures to work properly because the constructor of `Bits` refers to them, which breaks my `UTF8` module.

Also, I don't think there's reason to hide them — they define part of the interface.