### PR TITLE
Fix the "stack build" for the current NixOS unstable

### DIFF
--- a/INSTALL.md
+++ b/INSTALL.md
@@ -63,9 +63,9 @@ contribute.
 [Stack](https://github.com/commercialhaskell/stack) is a new
 cross-platform program for developing Haskell projects, that enhances
 the functionality provided by Cabal. There is experimental support for
-building Idris from source using with stack, that uses the LTS 3.16
-resolver.  This installation has been tested on Ubuntu 14.04.2 LTS,
-only.
+building Idris from source with stack.  
+This installation has been tested on Ubuntu 14.04.2 LTS, and the current 
+NixOS unstable.
 
 To build Idris with stack the following commands are recommended:
 
@@ -76,6 +76,11 @@ on Unix based systems and an appropriate place on Windows. If you
 haven't used stack before this will also setup the related
 infrastructure. For more information about Stack please visit the
 [Stack website](https://github.com/commercialhaskell/stack).
+
+On NixOS, please use the following command instead, to make sure
+the required libraries and header files are available:
+
+* `stack build --nix`
 
 ### System GHC
 

--- a/stack.yaml
+++ b/stack.yaml
@@ -1,4 +1,4 @@
-resolver: lts-3.16
+resolver: lts-4.1
 packages:
 - '.'
 flags:

--- a/stack.yaml
+++ b/stack.yaml
@@ -1,4 +1,4 @@
-resolver: lts-4.1
+resolver: lts-4.2
 packages:
 - '.'
 flags:

--- a/stack.yaml
+++ b/stack.yaml
@@ -11,3 +11,6 @@ extra-deps:
 - cheapskate-0.1.0.4
 - hscurses-1.4.2.0
 - libffi-0.1
+nix:
+   enable: false
+   packages: [ libffi, zlib, ncurses, gmp, pkgconfig ]


### PR DESCRIPTION
The "stack build" command does not currently work on NixOS, since the library & header paths are all weird.
The current version of stack supports Nix integration, which allows the build process to locate the libraries.
Added the required Nix package dependencies, and updated the INSTALL.md with the new instructions.
Bumped up the stack resolver version, since I somehow had issues building with 3.16, and also, why not?