### PR TITLE
Convert trifecta's pretty-printed error messages in Pkg

### DIFF
--- a/src/Pkg/PParser.hs
+++ b/src/Pkg/PParser.hs
@@ -5,7 +5,7 @@
 module Pkg.PParser where
 
 import Text.Trifecta hiding (span, charLiteral, natural, symbol, char, string, whiteSpace)
-
+import qualified Text.PrettyPrint.ANSI.Leijen as PP
 import Idris.Core.TT
 import Idris.REPL
 import Idris.AbsSyntaxTree
@@ -51,7 +51,7 @@ parseDesc :: FilePath -> IO PkgDesc
 parseDesc fp = do
     p <- readFile fp
     case runparser pPkg defaultPkg fp p of
-      Failure err -> fail (show err)
+      Failure err -> fail (show $ PP.plain err)
       Success x -> return x
 
 pPkg :: PParser PkgDesc


### PR DESCRIPTION
Because Pkg is entirely outside the mechanism that control the output
in other parts of Idris, the easiest solution is to scrub the error
messages from trifecta, which will otherwise contain ANSI escapes or not
on different systems.