### PR TITLE
Canonicalize watched files

### DIFF
--- a/idris.cabal
+++ b/idris.cabal
@@ -981,7 +981,7 @@ Library
                 , zip-archive > 0.2.3.5 && < 0.2.4
                 , safe
                 , fsnotify < 2.2
-                , async < 2.1
+                , async < 2.2
 
   -- zlib >= 0.6.1 is broken with GHC < 7.10.3
   if impl(ghc < 7.10.3)

--- a/src/Idris/REPL.hs
+++ b/src/Idris/REPL.hs
@@ -690,9 +690,9 @@ reload orig inputs = do
 
 watch :: IState -> [FilePath] -> Idris (Maybe [FilePath])
 watch orig inputs = do
-  let inputSet = S.fromList inputs
-  let dirs = nub $ map takeDirectory inputs
   resp <- runIO $ do
+    let dirs = nub $ map takeDirectory inputs
+    inputSet <- fmap S.fromList $ mapM canonicalizePath inputs
     signal <- newEmptyMVar
     withManager $ \mgr -> do
       forM_ dirs $ \dir ->


### PR DESCRIPTION
Canonicalize the set of loaded files for comparing watch events to.
Resolves `.`, `..`, and symlinks, though docs say symlink resolution doesn't
work on Windows.
For #2909
