### PR TITLE
Reenabled '[static]' with a deprecation warning

### DIFF
--- a/src/Idris/ParseData.hs
+++ b/src/Idris/ParseData.hs
@@ -167,11 +167,7 @@ dataOpts opts
   <|> return opts
   <?> "data options"
   where warnElim fc =
-          do ist <- get
-             let cmdline = opt_cmdline (idris_options ist)
-             unless (NoElimDeprecationWarnings `elem` cmdline) $
-               put ist { parserWarnings =
-                           (fc, Msg "Eliminator generation is deprecated. Use an eliminator generator in a library instead.") : parserWarnings ist }
+          parserWarning fc (Just NoElimDeprecationWarnings) (Msg "The 'class' keyword is deprecated. Use 'interface' instead.")
 
 {- | Parses a data type declaration
 Data ::= DocComment? Accessibility? DataI DefaultEliminator FnName TypeSig ExplicitTypeDataRest?

--- a/src/Idris/ParseExpr.hs
+++ b/src/Idris/ParseExpr.hs
@@ -333,11 +333,7 @@ caseOption syn = do lhs <- expr (syn { inPattern = True })
 
 warnTacticDeprecation :: FC -> IdrisParser ()
 warnTacticDeprecation fc =
-    do ist <- get
-       let cmdline = opt_cmdline (idris_options ist)
-       unless (NoOldTacticDeprecationWarnings `elem` cmdline) $
-         put ist { parserWarnings =
-                     (fc, Msg "This style of tactic proof is deprecated. See %runElab for the replacement.") : parserWarnings ist }
+ parserWarning fc (Just NoOldTacticDeprecationWarnings) (Msg "This style of tactic proof is deprecated. See %runElab for the replacement.")
 
 {- | Parses a proof block
 @
@@ -1390,6 +1386,10 @@ Static ::=
 -}
 static :: IdrisParser Static
 static =     do reserved "%static"; return Static
+         <|> do reserved "[static]"
+                fc <- getFC
+                parserWarning fc Nothing (Msg "The use of [static] is deprecated, use %static instead.")
+                return Static
          <|> return Dynamic
          <?> "static modifier"
 

--- a/src/Idris/ParseHelpers.hs
+++ b/src/Idris/ParseHelpers.hs
@@ -666,3 +666,10 @@ collect (PInstance doc argDocs f s cs n nfc ps t en ds : ds')
     = PInstance doc argDocs f s cs n nfc ps t en (collect ds) : collect ds'
 collect (d : ds) = d : collect ds
 collect [] = []
+
+parserWarning :: FC -> Maybe Opt -> Err -> IdrisParser ()
+parserWarning fc warnOpt warnErr = do
+  is <- get
+  let cmdline = opt_cmdline (idris_options ist)
+  unless (maybe False (`elem` cmdline) warnOpt) $
+    put ist { parserWarnings = (fc, warnErr) : parserWarnings ist }

--- a/src/Idris/ParseHelpers.hs
+++ b/src/Idris/ParseHelpers.hs
@@ -7,7 +7,7 @@ module Idris.ParseHelpers where
 import Prelude hiding (pi)
 
 import Text.Trifecta.Delta
-import Text.Trifecta hiding (span, stringLiteral, charLiteral, natural, symbol, char, string, whiteSpace)
+import Text.Trifecta hiding (span, stringLiteral, charLiteral, natural, symbol, char, string, whiteSpace, Err)
 import Text.Parser.LookAhead
 import Text.Parser.Expression
 import qualified Text.Parser.Token as Tok
@@ -104,6 +104,14 @@ reportParserWarnings = do ist <- getIState
                                          FC' fc == FC' fc' && err == err') $
                                  parserWarnings ist)
                           clearParserWarnings
+
+
+parserWarning :: FC -> Maybe Opt -> Err -> IdrisParser ()
+parserWarning fc warnOpt warnErr = do
+  ist <- get
+  let cmdline = opt_cmdline (idris_options ist)
+  unless (maybe False (`elem` cmdline) warnOpt) $
+    put ist { parserWarnings = (fc, warnErr) : parserWarnings ist }
 
 {- * Space, comments and literals (token/lexing like parsers) -}
 
@@ -666,10 +674,3 @@ collect (PInstance doc argDocs f s cs n nfc ps t en ds : ds')
     = PInstance doc argDocs f s cs n nfc ps t en (collect ds) : collect ds'
 collect (d : ds) = d : collect ds
 collect [] = []
-
-parserWarning :: FC -> Maybe Opt -> Err -> IdrisParser ()
-parserWarning fc warnOpt warnErr = do
-  is <- get
-  let cmdline = opt_cmdline (idris_options ist)
-  unless (maybe False (`elem` cmdline) warnOpt) $
-    put ist { parserWarnings = (fc, warnErr) : parserWarnings ist }

--- a/src/Idris/Parser.hs
+++ b/src/Idris/Parser.hs
@@ -878,10 +878,7 @@ class_ syn = do (doc, argDocs, acc)
     classKeyword = reservedHL "interface"
                <|> do reservedHL "class"
                       fc <- getFC
-                      ist <- get
-                      put ist { parserWarnings = 
-                         (fc, Msg "The 'class' keyword is deprecated. Use 'interface' instead.")
-                              : parserWarnings ist }
+                      parserWarning fc Nothing (Msg "The 'class' keyword is deprecated. Use 'interface' instead.")
 
     carg :: IdrisParser (Name, FC, PTerm)
     carg = do lchar '('; (i, ifc) <- name; lchar ':'; ty <- expr syn; lchar ')'
@@ -928,11 +925,7 @@ instance_ kwopt syn
         instanceKeyword = reservedHL "implementation"
                       <|> do reservedHL "instance"
                              fc <- getFC
-                             ist <- get
-                             put ist { parserWarnings = 
-                                (fc, Msg "The 'instance' keyword is deprecated. Use 'implementation' (or omit it) instead.")
-                                     : parserWarnings ist }
-
+                             parserWarning fc Nothing (Msg "The 'instance' keyword is deprecated. Use 'implementation' (or omit it) instead.")
 
 -- | Parse a docstring
 docstring :: SyntaxInfo


### PR DESCRIPTION
Also, smaller cleanup of parser warnings