### PR TITLE
Syntax hygiene for quoted names

### DIFF
--- a/libs/base/Language/Reflection/Utils.idr
+++ b/libs/base/Language/Reflection/Utils.idr
@@ -145,6 +145,8 @@ implementation Show Const where
   showPrec d StrType    = "StrType"
   showPrec d VoidType   = "VoidType"
   showPrec d Forgot     = "Forgot"
+  showPrec d WorldType  = "WorldType"
+  showPrec d TheWorld   = "TheWorld"
 
 implementation Eq NativeTy where
   IT8  == IT8  = True

--- a/src/Idris/Parser.hs
+++ b/src/Idris/Parser.hs
@@ -502,7 +502,9 @@ syntaxRule syn
                body' <- fixBind ((n,n'):rens) body
                return $ PLam fc n' nfc ty' body'
         fixBind rens (PPi plic n nfc argTy body)
-          | n `elem` userNames = liftM2 (PPi plic n nfc) (fixBind rens argTy) (fixBind rens body)
+          | n `elem` userNames = liftM2 (PPi plic n nfc)
+                                        (fixBind rens argTy)
+                                        (fixBind rens body)
           | otherwise =
             do ty' <- fixBind rens argTy
                n' <- gensym n
@@ -521,6 +523,10 @@ syntaxRule syn
                return $ PLet fc n' nfc ty' val' body'
         fixBind rens (PMatchApp fc n) | Just n' <- lookup n rens =
           return $ PMatchApp fc n'
+        -- Also rename resolved quotations, to allow syntax rules to
+        -- have quoted references to their own bindings.
+        fixBind rens (PQuoteName n True fc) | Just n' <- lookup n rens =
+          return $ PQuoteName n' True fc
         fixBind rens x = descendM (fixBind rens) x
 
         gensym :: Name -> IdrisParser Name

--- a/test/meta002/AgdaStyleReflection.idr
+++ b/test/meta002/AgdaStyleReflection.idr
@@ -2,6 +2,10 @@
 ||| Idris's reflected elaboration. Requires handling type class
 ||| resolution and implicit arguments - some of the same features as
 ||| the Idris elaborator itself.
+|||
+||| Since this test was put together, Agda has adopted an Idris-style
+||| elaborator reflection mechanism. The module name is preserved for
+||| historical interest.
 module AgdaStyleReflection
 
 
@@ -9,6 +13,7 @@ import Language.Reflection.Utils
 import Pruviloj
 
 %default total
+
 
 
 ||| Function arguments as provided at the application site
@@ -19,6 +24,10 @@ record Arg a where
 
 implementation Functor Arg where
   map f (MkArg plic x) = MkArg plic (f x)
+
+implementation Show a => Show (Arg a) where
+  showPrec d (MkArg plic x) = showCon d "MkArg" $ showArg plic ++ showArg x
+
 
 ||| Reflected terms, in the tradition of Agda's reflection library
 data Term
@@ -36,6 +45,41 @@ unApply tm = unApply' tm []
   where unApply' : Raw -> List Raw -> (Raw, List Raw)
         unApply' (RApp f x) xs = unApply' f (x::xs)
         unApply' notApp xs = (notApp, xs)
+
+
+implementation Quotable Plicity Raw where
+  quotedTy = `(Plicity)
+  quote Explicit = `(Explicit)
+  quote Implicit = `(Implicit)
+  quote Constraint = `(Constraint)
+
+implementation (Quotable a Raw) => Quotable (Arg a) Raw where
+  quotedTy = `(Arg ~(quotedTy {a=a}))
+  quote (MkArg plicity argValue) =
+    `(MkArg {a=~(quotedTy {a=a})} ~(quote plicity) ~(quote argValue))
+
+
+implementation Quotable Term Raw where
+  quotedTy = `(Term)
+  quote (Var k xs) = `(AgdaStyleReflection.Var ~(quote k) ~(assert_total $ quote xs))
+  quote (Ctor n xs) = `(AgdaStyleReflection.Ctor ~(quote n) ~(assert_total $ quote xs))
+  quote (TyCtor n xs) = `(AgdaStyleReflection.TyCtor ~(quote n) ~(assert_total $ quote xs))
+  quote (Def n xs) = `(Def ~(quote n) ~(assert_total $ quote xs))
+  quote (Lam x) = `(AgdaStyleReflection.Lam ~(quote x))
+  quote (Pi x y) = `(AgdaStyleReflection.Pi ~(quote x) ~(quote y))
+  quote (Constant c) = `(Constant ~(quote c))
+  quote Ty = `(Ty)
+
+
+implementation Show Term where
+  showPrec d (Var k xs) = showCon d "Var" $ showArg k ++ showArg xs
+  showPrec d (Ctor n xs) = showCon d "Ctor" $ showArg n ++ showArg xs
+  showPrec d (TyCtor n xs) = showCon d "TyCtor" $ showArg n ++ showArg xs
+  showPrec d (Def n xs) = showCon d "Def" $ showArg n ++ showArg xs
+  showPrec d (Lam x) = showCon d "Lam" $ showArg x
+  showPrec d (Pi x y) = showCon d "Pi" $ showArg x ++ showArg y
+  showPrec d (Constant c) = showCon d "Constant" $ showArg c
+  showPrec d Ty = "Ty"
 
 ||| Quote a reflected Idris term to a Term in some induced local context
 covering
@@ -183,16 +227,39 @@ covering
 spliceTerm : Term -> Elab ()
 spliceTerm = spliceTerm' []
 
-||| Lift an Agda-style tactic into an Idris-style tactic
+syntax "splice" [tm] = %runElab (spliceTerm tm)
+
 covering
-quoteGoalImpl : (Term -> Term) -> Elab ()
-quoteGoalImpl f = do compute
-                     g <- goalType >>= quoteTerm
-                     spliceTerm (f g)
+quoteGoalImpl : TTName -> Elab ()
+quoteGoalImpl f =
+    do g <- goalType >>= quoteTerm
+       fill (RApp (Var f) (quote g))
+       solve
 
-syntax "quoteGoal" {x} "in" [expr] = %runElab (quoteGoalImpl (\x => expr))
+syntax "quoteGoal" {g} "in" [e] =
+  let f = \g : Term => e in %runElab (quoteGoalImpl `{f})
 
-syntax "tactic" [expr] = %runElab (quoteGoalImpl expr)
+
+-- Note: this definition would seem to be the right thing, but it's not:
+--   syntax "tactic" [tac] = quoteGoal g in splice tac g
+-- This is because it would make
+--   tactic foo
+-- expand to
+--   let f = \g : Term => %runElab (spliceTerm (tac g))
+--   in %runElab (quoteGoalImpl `{f})
+-- which confuses the meta-level at which the body of the lambda should be
+-- run. It must be sequenced into the same monadic action as quoting the goal,
+-- yielding the following implementation:
+
+covering
+tacticImpl : (tac : Term -> Term) -> Elab ()
+tacticImpl tac = do g <- goalType >>= quoteTerm
+                    AgdaStyleReflection.spliceTerm (tac g)
+
+syntax "tactic" [tacticCode] =
+    %runElab (tacticImpl tacticCode)
+
+
 
 
 
@@ -231,11 +298,29 @@ covering
 trivial : (goal : Term) -> Term
 trivial = perhaps . trivial'
 
-foo : (Nat, (), Nat, Either (() -> ()) Void)
-foo = quoteGoal x in trivial x
+-- DOESN'T WORK because reflection operations are not pure - they have
+-- side effects in the elaborator! Also due to metalevel confusion in
+-- underlying syntax
+--foo : (Nat, (), Either Void Nat, Nat -> ())
+--foo = quoteGoal g in splice (trivial g)
 
+
+-- WORKS because "tactic" takes care of the sequencing of operations
 bar : (Nat, (), Either Void Nat, Nat -> ())
 bar = tactic trivial
+
+someTerm : Term
+someTerm = quoteGoal g in g
+
+ok : AgdaStyleReflection.someTerm = TyCtor (NS (UN "Term") ["AgdaStyleReflection"]) []
+ok = Refl
+
+-- assert_total needed due to partial Show implementations
+stringly : String -> String
+stringly = quoteGoal g in \x => assert_total $ show g
+
+ok2 : stringly "fnord" = "Pi (Constant StrType) (Constant StrType)"
+ok2 = Refl
 
 --     When checking right hand side of baz:
 --     PROOF SEARCH FAILURE is not defined.

--- a/test/meta002/expected
+++ b/test/meta002/expected
@@ -3,7 +3,7 @@ When checking right hand side of testElab3 with expected type
         Sigma Ty (Tm [])
 
 Unifying ty and ARR ty t would lead to infinite value
-AgdaStyleReflection.idr:243:5:
+AgdaStyleReflection.idr:328:5:
 When checking right hand side of baz with expected type
         (Nat, Void)
 


### PR DESCRIPTION
Now, when doing hygiene for bindings introduced by syntax rules, definite quoted names (the ones that look like `` `{n} ``) that point to variables bound by the expansion of the syntax rule are renamed along with the new bound variable. This lets syntax rules reflect on the actual names of the bindings they produce, enabling Agda's `quoteGoal` construct to be expressible in Idris.

I haven't been able to get the test suite to run, so I hope that Travis will catch any mistakes I've made!