### PR TITLE
Util cleanup

### DIFF
--- a/src/IRTS/CodegenCommon.hs
+++ b/src/IRTS/CodegenCommon.hs
@@ -5,17 +5,10 @@ import IRTS.Simplified
 import IRTS.Defunctionalise
 import IRTS.Lang
 
-import Control.Exception
 import Data.Word
-import System.Environment
 
 data DbgLevel = NONE | DEBUG | TRACE deriving Eq
 data OutputType = Raw | Object | Executable | MavenProject deriving (Eq, Show)
-
-environment :: String -> IO (Maybe String)
-environment x = Control.Exception.catch (do e <- getEnv x
-                                            return (Just e))
-                          (\y-> do return (y::SomeException);  return Nothing)
 
 -- Everything which might be needed in a code generator - a CG can choose which
 -- level of Decls to generate code from (simplified, defunctionalised or merely

--- a/src/IRTS/CodegenCommon.hs
+++ b/src/IRTS/CodegenCommon.hs
@@ -3,9 +3,6 @@ module IRTS.CodegenCommon where
 import Idris.Core.TT
 import IRTS.Simplified
 import IRTS.Defunctionalise
-import IRTS.Lang
-
-import Data.Word
 
 data DbgLevel = NONE | DEBUG | TRACE deriving Eq
 data OutputType = Raw | Object | Executable | MavenProject deriving (Eq, Show)

--- a/src/IRTS/System.hs
+++ b/src/IRTS/System.hs
@@ -1,8 +1,7 @@
 {-# LANGUAGE CPP #-}
 module IRTS.System(getDataFileName, getDataDir, getTargetDir,getCC,getLibFlags,getIdrisLibDir,
-                   getIncFlags, getEnvFlags, getMvn,getExecutablePom, version) where
+                   getIncFlags, getEnvFlags, version) where
 
-import Util.System
 import Data.List.Split
 
 import Control.Applicative ((<$>))
@@ -17,27 +16,18 @@ import Paths_idris (version)
 import Paths_idris
 #endif
 
+overrideDataDirWith :: String -> IO FilePath
+overrideDataDirWith envVar = do envValue <- lookupEnv envVar
+                                maybe getDataDir return envValue
+
 getCC :: IO String
-getCC = fromMaybe "gcc" <$> environment "IDRIS_CC"
+getCC = fromMaybe "gcc" <$> lookupEnv "IDRIS_CC"
 
 getEnvFlags :: IO [String]
-getEnvFlags = maybe [] (splitOn " ") <$> environment "IDRIS_CFLAGS"
-
-mvnCommand :: String
-#ifdef mingw32_HOST_OS
-mvnCommand = "mvn.bat"
-#else
-mvnCommand = "mvn"
-#endif
-
-getMvn :: IO String
-getMvn = fromMaybe mvnCommand <$> environment "IDRIS_MVN"
-
-environment :: String -> IO (Maybe String)
-environment = lookupEnv
+getEnvFlags = maybe [] (splitOn " ") <$> lookupEnv "IDRIS_CFLAGS"
 
 getTargetDir :: IO String
-getTargetDir = environment "TARGET" >>= maybe getDataDir return
+getTargetDir = overrideDataDirWith "TARGET"
 
 #if defined(FREEBSD) || defined(DRAGONFLY)
 extraLib = ["-L/usr/local/lib"]
@@ -55,9 +45,7 @@ getLibFlags = do dir <- getDataDir
                  return $ ["-L" ++ (dir </> "rts"),
                            "-lidris_rts"] ++ extraLib ++ gmpLib ++ ["-lpthread"]
 
-getIdrisLibDir = do libPath <- environment "IDRIS_LIBRARY_PATH"
-                    dir <- maybe getDataDir return libPath
-                    return $ addTrailingPathSeparator dir
+getIdrisLibDir = addTrailingPathSeparator <$> overrideDataDirWith "IDRIS_LIBRARY_PATH"
 
 #if defined(FREEBSD) || defined(DRAGONFLY)
 extraInclude = ["-I/usr/local/include"]
@@ -66,6 +54,3 @@ extraInclude = []
 #endif
 getIncFlags = do dir <- getDataDir
                  return $ ("-I" ++ dir </> "rts") : extraInclude
-
-getExecutablePom = do dir <- getDataDir
-                      return $ dir </> "java" </> "executable_pom.xml"

--- a/src/IRTS/System.hs
+++ b/src/IRTS/System.hs
@@ -34,8 +34,7 @@ getMvn :: IO String
 getMvn = fromMaybe mvnCommand <$> environment "IDRIS_MVN"
 
 environment :: String -> IO (Maybe String)
-environment x = catchIO (Just <$> getEnv x)
-                        (\_ -> return Nothing)
+environment = lookupEnv
 
 getTargetDir :: IO String
 getTargetDir = environment "TARGET" >>= maybe getDataDir return

--- a/src/Util/System.hs
+++ b/src/Util/System.hs
@@ -2,7 +2,6 @@
 module Util.System(tempfile,withTempdir,rmFile,catchIO, isWindows,
                    writeSource, writeSourceText, readSource,
                    setupBundledCC, isATTY) where
-
 -- System helper functions.
 
 import Control.Exception as CE
@@ -31,9 +30,6 @@ import System.Environment (getEnv, setEnv, getExecutablePath)
 
 catchIO :: IO a -> (IOError -> IO a) -> IO a
 catchIO = CE.catch
-
-throwIO :: IOError -> IO a
-throwIO = CE.throw
 
 isWindows :: Bool
 isWindows = os `elem` ["win32", "mingw32", "cygwin32"]


### PR DESCRIPTION
Remove some stuff related to looking up env vars for overriding Idris's libdir.

Also removed some java backend (maven) stuff. The Java backend currently uses the `getMvn` function exported from here; will submit a PR against the Java backend adding it to there.