### PR TITLE
Do not split arguments indiscriminately on spaces

### DIFF
--- a/src/IRTS/CodegenC.hs
+++ b/src/IRTS/CodegenC.hs
@@ -81,10 +81,10 @@ codegenC' defs out exec incs objs libs flags exports iface dbg
                          "-I."] ++ objs ++ envFlags ++
                         (if (exec == Executable) then [] else ["-c"]) ++
                         [tmpn] ++
-                        (if not iface then concatMap words libFlags else []) ++
-                        concatMap words incFlags ++
-                        (if not iface then concatMap words libs else []) ++
-                        concatMap words flags ++
+                        (if not iface then libFlags else []) ++
+                        incFlags ++
+                        (if not iface then libs else []) ++
+                        flags ++
                         ["-o", out]
 --              putStrLn (show args)
              exit <- rawSystem comp args

--- a/src/Idris/Directives.hs
+++ b/src/Idris/Directives.hs
@@ -21,8 +21,10 @@ directiveAction (DLink cgn obj) = do dirs <- allImportDirs
                                      addIBC (IBCObj cgn obj) -- just name, search on loading ibc
                                      addObjectFile cgn o
 
-directiveAction (DFlag cgn flag) = do addIBC (IBCCGFlag cgn flag)
-                                      addFlag cgn flag
+directiveAction (DFlag cgn flag) = do
+                                      let flags = words flag
+                                      mapM_ (\f -> addIBC (IBCCGFlag cgn f)) flags
+                                      mapM_ (addFlag cgn) flags
 
 directiveAction (DInclude cgn hdr) = do addHdr cgn hdr
                                         addIBC (IBCHeader cgn hdr)


### PR DESCRIPTION
Fixes #2934

The arguments given in the flag directive are now split when that
directive is handled.