### PR TITLE
Fix stack --nix on OS X

### DIFF
--- a/stack-shell.nix
+++ b/stack-shell.nix
@@ -1,0 +1,28 @@
+with (import <nixpkgs> {});
+
+let
+  # MUST match resolver in stack.yaml
+  resolver = haskell.packages.lts-4_2.ghc;
+
+  native_libs = [
+    libffi
+    zlib
+    ncurses
+    gmp
+    pkgconfig
+  ] ++ lib.optionals stdenv.isDarwin (with darwin.apple_sdk.frameworks; [
+    Cocoa
+    CoreServices
+  ]);
+
+in stdenv.mkDerivation {
+
+  name = "idrisBuildEnv";
+
+  buildInputs = [ resolver ] ++ native_libs;
+
+  STACK_IN_NIX_EXTRA_ARGS = builtins.foldl'
+    (acc: lib:
+      " --extra-lib-dirs=${lib}/lib --extra-include-dirs=${lib}/include" + acc)
+    "" native_libs;
+}

--- a/stack.yaml
+++ b/stack.yaml
@@ -13,4 +13,4 @@ extra-deps:
 - libffi-0.1
 nix:
    enable: false
-   packages: [ libffi, zlib, ncurses, gmp, pkgconfig ]
+   shell-file: stack-shell.nix


### PR DESCRIPTION
On OS X Idris depends on hfsevents which in turn depends on Cocoa and CoreServices.

I had to make a separate .nix file to conditionally depend on said frameworks.

Also, unfortunately, you need to specify the resolver in both stack.yaml and .nix shell file.