### PR TITLE
Do not quit the REPL on Ctrl-C

### DIFF
--- a/src/Idris/Prover.hs
+++ b/src/Idris/Prover.hs
@@ -271,6 +271,21 @@ undoElab prf env st [] = ifail "Nothing to undo"
 undoElab prf env st (h:hs) = do (prf', env', st') <- undoStep prf env st h
                                 return (prf', env', st', hs)
 
+runWithInterrupt
+  :: ElabState EState
+  -> Idris a -- ^ run with SIGINT handler
+  -> Idris b -- ^ run if mTry finished
+  -> Idris b -- ^ run if mTry was interrupted
+  -> Idris b
+runWithInterrupt elabState mTry mSuccess mFailure = do
+  ist <- getIState
+  case idris_outputmode ist of
+    RawOutput _ -> do
+      success <- runInputT (proverSettings elabState) $
+                   handleInterrupt (return False) $
+                   withInterrupt (lift mTry >> return True)
+      if success then mSuccess else mFailure
+    IdeMode _ _ -> mTry >> mSuccess
 
 elabloop :: Name -> Bool -> String -> [String] -> ElabState EState -> [ElabShellHistory] -> Maybe History -> [(Name, Type, Term)] -> Idris (Term, [String])
 elabloop fn d prompt prf e prev h env
@@ -283,7 +298,7 @@ elabloop fn d prompt prf e prev h env
                do case h of
                     Just history -> putHistory history
                     Nothing -> return ()
-                  l <- getInputLine (prompt ++ "> ")
+                  l <- handleInterrupt (return $ Just "") $ withInterrupt $ getInputLine (prompt ++ "> ")
                   h' <- getHistory
                   return (l, Just h')
            IdeMode _ handle ->
@@ -375,8 +390,9 @@ elabloop fn d prompt prf e prev h env
          Right ok ->
            if done then do (tm, _) <- elabStep st get_term
                            return (tm, prf')
-                   else do ok
-                           elabloop fn d prompt prf' st prev' h' env'
+                   else runWithInterrupt e ok
+                           (elabloop fn d prompt prf' st prev' h' env')
+                           (elabloop fn d prompt prf e prev h' env)
 
   where
     -- A bit of a hack: wrap the value up in a let binding, which will
@@ -401,7 +417,7 @@ ploop fn d prompt prf e h
                  do case h of
                       Just history -> putHistory history
                       Nothing -> return ()
-                    l <- getInputLine (prompt ++ "> ")
+                    l <- handleInterrupt (return $ Just "") $ withInterrupt $ getInputLine (prompt ++ "> ")
                     h' <- getHistory
                     return (l, Just h')
              IdeMode _ handle ->
@@ -445,8 +461,9 @@ ploop fn d prompt prf e h
            Right ok ->
              if done then do (tm, _) <- elabStep st get_term
                              return (tm, prf')
-                     else do ok
-                             ploop fn d prompt prf' st h'
+                     else runWithInterrupt e ok
+                             (ploop fn d prompt prf' st h')
+                             (ploop fn d prompt prf e h')
 
 
 envCtxt env ctxt = foldl (\c (n, b) -> addTyDecl n Bound (binderTy b) c) ctxt env

--- a/src/Idris/REPL.hs
+++ b/src/Idris/REPL.hs
@@ -122,13 +122,13 @@ repl orig mods efile
                              (if colour && not isWindows
                                 then colourisePrompt theme str
                                 else str) ++ " "
-        x <- H.catch (getInputLine prompt)
-                     (ctrlC (return Nothing))
+        x <- H.catch (H.withInterrupt $ getInputLine prompt)
+                     (ctrlC (return $ Just ""))
         case x of
             Nothing -> do lift $ when (not quiet) (iputStrLn "Bye bye")
                           return ()
             Just input -> -- H.catch
-                do ms <- H.catch (lift $ processInput input orig mods efile)
+                do ms <- H.catch (H.withInterrupt $ lift $ processInput input orig mods efile)
                                  (ctrlC (return (Just mods)))
                    case ms of
                         Just mods -> let efile' = fromMaybe efile (listToMaybe mods)


### PR DESCRIPTION
Addresses #2936 with some hacky code to get things started.

I've only tried on the main REPL loop (as opposed to `:prove` or some other subloop) and it seems to "just work" as expected:

```
Idris>           (pressing ^C)
Interrupt
Idris> 123       (pressing ^C)
Interrupt
Idris> fib 40    (pressing Enter and then ^C)
^Cuser interrupt
Idris>           (pressing ^D)
Bye bye
```