### PR TITLE
cabal: Remove redundant ghc-options

### DIFF
--- a/idris.cabal
+++ b/idris.cabal
@@ -1010,7 +1010,6 @@ Library
                 , TemplateHaskell
 
   ghc-prof-options: -auto-all -caf-all
-  ghc-options:      -threaded -rtsopts
 
   if os(linux)
      cpp-options:   -DLINUX


### PR DESCRIPTION
-rtsopts and -threaded only apply to executables yet they were applied
to a library.