### PR TITLE
Some new C FFI features

### DIFF
--- a/CHANGELOG
+++ b/CHANGELOG
@@ -15,6 +15,14 @@ Updated export rules
 * Exported types can only refer to other exported names
 * Publicly exported definitions can only refer to publicly exported names
 
+Improved C FFI
+--------------
+
+* Idris functions can now be passed as callbacks to C functions or wrapped
+in a C function pointer.
+* C function pointers can be called.
+* Idris can access pointers to C globals.
+
 Minor language changes
 ----------------------
 

--- a/libs/prelude/Builtins.idr
+++ b/libs/prelude/Builtins.idr
@@ -192,6 +192,7 @@ export data ManagedPtr : Type
 
 -- primitives for accessing memory.
 %extern prim__asPtr : ManagedPtr -> Ptr
+%extern prim__sizeofPtr : Int
 %extern prim__peek8 : prim__WorldType -> Ptr -> Int -> Bits8
 %extern prim__peek16 : prim__WorldType -> Ptr -> Int -> Bits16
 %extern prim__peek32 : prim__WorldType -> Ptr -> Int -> Bits32
@@ -201,3 +202,6 @@ export data ManagedPtr : Type
 %extern prim__poke16 : prim__WorldType -> Ptr -> Int -> Bits16 -> Int
 %extern prim__poke32 : prim__WorldType -> Ptr -> Int -> Bits32 -> Int
 %extern prim__poke64 : prim__WorldType -> Ptr -> Int -> Bits64 -> Int
+
+%extern prim__peekPtr : prim__WorldType -> Ptr -> Int -> Ptr
+%extern prim__pokePtr : prim__WorldType -> Ptr -> Int -> Ptr -> Int

--- a/libs/prelude/IO.idr
+++ b/libs/prelude/IO.idr
@@ -319,25 +319,32 @@ prim_peek8 ptr offset = MkIO (\w => prim_io_return (prim__peek8 (world w) ptr of
 
 prim_poke8 : Ptr -> Int -> Bits8 -> IO Int
 prim_poke8 ptr offset val = MkIO (\w =>  prim_io_return (
-     prim__poke8 (world w) ptr offset val))
+    prim__poke8 (world w) ptr offset val))
 
 prim_peek16 : Ptr -> Int -> IO Bits16
 prim_peek16 ptr offset = MkIO (\w => prim_io_return (prim__peek16 (world w) ptr offset))
 
 prim_poke16 : Ptr -> Int -> Bits16 -> IO Int
 prim_poke16 ptr offset val = MkIO (\w =>  prim_io_return (
-     prim__poke16 (world w) ptr offset val))
+    prim__poke16 (world w) ptr offset val))
 
 prim_peek32 : Ptr -> Int -> IO Bits32
 prim_peek32 ptr offset = MkIO (\w => prim_io_return (prim__peek32 (world w) ptr offset))
 
 prim_poke32 : Ptr -> Int -> Bits32 -> IO Int
 prim_poke32 ptr offset val = MkIO (\w =>  prim_io_return (
-     prim__poke32 (world w) ptr offset val))
+    prim__poke32 (world w) ptr offset val))
 
 prim_peek64 : Ptr -> Int -> IO Bits64
 prim_peek64 ptr offset = MkIO (\w => prim_io_return (prim__peek64 (world w) ptr offset))
 
 prim_poke64 : Ptr -> Int -> Bits64 -> IO Int
 prim_poke64 ptr offset val = MkIO (\w =>  prim_io_return (
-     prim__poke64 (world w) ptr offset val))
+    prim__poke64 (world w) ptr offset val))
+
+prim_peekPtr : Ptr -> Int -> IO Ptr
+prim_peekPtr ptr offset = MkIO (\w => prim_io_return (prim__peekPtr (world w) ptr offset))
+
+prim_pokePtr : Ptr -> Int -> Ptr -> IO Int
+prim_pokePtr ptr offset val = MkIO (\w =>  prim_io_return (
+    prim__pokePtr (world w) ptr offset val))

--- a/rts/idris_bitstring.c
+++ b/rts/idris_bitstring.c
@@ -822,3 +822,38 @@ VAL idris_b64T32(VM *vm, VAL a) {
     return cl;
 }
 
+VAL idris_peekB8(VM* vm, VAL ptr, VAL offset) {
+    return MKB8(vm, *(uint8_t*)(GETPTR(ptr) + GETINT(offset)));
+}
+
+VAL idris_pokeB8(VAL ptr, VAL offset, VAL data) {
+    *(uint8_t*)(GETPTR(ptr) + GETINT(offset)) = GETBITS8(data);
+    return MKINT(0);
+}
+
+VAL idris_peekB16(VM* vm, VAL ptr, VAL offset) {
+    return MKB16(vm, *(uint16_t*)(GETPTR(ptr) + GETINT(offset)));
+}
+
+VAL idris_pokeB16(VAL ptr, VAL offset, VAL data) {
+    *(uint16_t*)(GETPTR(ptr) + GETINT(offset)) = GETBITS16(data);
+    return MKINT(0);
+}
+
+VAL idris_peekB32(VM* vm, VAL ptr, VAL offset) {
+    return MKB32(vm, *(uint32_t*)(GETPTR(ptr) + GETINT(offset)));
+}
+
+VAL idris_pokeB32(VAL ptr, VAL offset, VAL data) {
+    *(uint32_t*)(GETPTR(ptr) + GETINT(offset)) = GETBITS32(data);
+    return MKINT(0);
+}
+
+VAL idris_peekB64(VM* vm, VAL ptr, VAL offset) {
+    return MKB64(vm, *(uint64_t*)(GETPTR(ptr) + GETINT(offset)));
+}
+
+VAL idris_pokeB64(VAL ptr, VAL offset, VAL data) {
+    *(uint64_t*)(GETPTR(ptr) + GETINT(offset)) = GETBITS64(data);
+    return MKINT(0);
+}

--- a/rts/idris_bitstring.h
+++ b/rts/idris_bitstring.h
@@ -126,4 +126,14 @@ VAL idris_b64T8(VM *vm, VAL a);
 VAL idris_b64T16(VM *vm, VAL a);
 VAL idris_b64T32(VM *vm, VAL a);
 
+// memory access
+VAL idris_peekB8(VM* vm, VAL ptr, VAL offset);
+VAL idris_pokeB8(VAL ptr, VAL offset, VAL data);
+VAL idris_peekB16(VM* vm, VAL ptr, VAL offset);
+VAL idris_pokeB16(VAL ptr, VAL offset, VAL data);
+VAL idris_peekB32(VM* vm, VAL ptr, VAL offset);
+VAL idris_pokeB32(VAL ptr, VAL offset, VAL data);
+VAL idris_peekB64(VM* vm, VAL ptr, VAL offset);
+VAL idris_pokeB64(VAL ptr, VAL offset, VAL data);
+
 #endif

--- a/rts/idris_rts.c
+++ b/rts/idris_rts.c
@@ -422,39 +422,15 @@ void idris_poke(void* ptr, i_int offset, uint8_t data) {
     *(((uint8_t*)ptr) + offset) = data;
 }
 
-VAL idris_peekB8(VM* vm, VAL ptr, VAL offset) {
-    return MKB8(vm, *(uint8_t*)(GETPTR(ptr) + GETINT(offset)));
+
+VAL idris_peekPtr(VM* vm, VAL ptr, VAL offset) {
+    void** addr = GETPTR(ptr) + GETINT(offset);
+    return MKPTR(vm, *addr);
 }
 
-VAL idris_pokeB8(VAL ptr, VAL offset, VAL data) {
-    *(uint8_t*)(GETPTR(ptr) + GETINT(offset)) = GETBITS8(data);
-    return MKINT(0);
-}
-
-VAL idris_peekB16(VM* vm, VAL ptr, VAL offset) {
-    return MKB16(vm, *(uint16_t*)(GETPTR(ptr) + GETINT(offset)));
-}
-
-VAL idris_pokeB16(VAL ptr, VAL offset, VAL data) {
-    *(uint16_t*)(GETPTR(ptr) + GETINT(offset)) = GETBITS16(data);
-    return MKINT(0);
-}
-
-VAL idris_peekB32(VM* vm, VAL ptr, VAL offset) {
-    return MKB32(vm, *(uint32_t*)(GETPTR(ptr) + GETINT(offset)));
-}
-
-VAL idris_pokeB32(VAL ptr, VAL offset, VAL data) {
-    *(uint32_t*)(GETPTR(ptr) + GETINT(offset)) = GETBITS32(data);
-    return MKINT(0);
-}
-
-VAL idris_peekB64(VM* vm, VAL ptr, VAL offset) {
-    return MKB64(vm, *(uint64_t*)(GETPTR(ptr) + GETINT(offset)));
-}
-
-VAL idris_pokeB64(VAL ptr, VAL offset, VAL data) {
-    *(uint64_t*)(GETPTR(ptr) + GETINT(offset)) = GETBITS64(data);
+VAL idris_pokePtr(VAL ptr, VAL offset, VAL data) {
+    void** addr = GETPTR(ptr) + GETINT(offset);
+    *addr = GETPTR(data);
     return MKINT(0);
 }
 

--- a/rts/idris_rts.h
+++ b/rts/idris_rts.h
@@ -311,16 +311,8 @@ void idris_memmove(void* dest, void* src, i_int dest_offset, i_int src_offset, i
 uint8_t idris_peek(void* ptr, i_int offset);
 void idris_poke(void* ptr, i_int offset, uint8_t data);
 
-
-// memory access
-VAL idris_peekB8(VM* vm, VAL ptr, VAL offset);
-VAL idris_pokeB8(VAL ptr, VAL offset, VAL data);
-VAL idris_peekB16(VM* vm, VAL ptr, VAL offset);
-VAL idris_pokeB16(VAL ptr, VAL offset, VAL data);
-VAL idris_peekB32(VM* vm, VAL ptr, VAL offset);
-VAL idris_pokeB32(VAL ptr, VAL offset, VAL data);
-VAL idris_peekB64(VM* vm, VAL ptr, VAL offset);
-VAL idris_pokeB64(VAL ptr, VAL offset, VAL data);
+VAL idris_peekPtr(VM* vm, VAL ptr, VAL offset);
+VAL idris_pokePtr(VAL ptr, VAL offset, VAL data);
 
 // String primitives
 VAL idris_concat(VM* vm, VAL l, VAL r);

--- a/test/ffi007/expected
+++ b/test/ffi007/expected
@@ -3,3 +3,6 @@
 Before calling callback
 In an Idris callback
 After calling callback
+00000377
+I'm dynamic 3
+6

--- a/test/ffi007/ffi007.c
+++ b/test/ffi007/ffi007.c
@@ -19,3 +19,12 @@ void test_ffi3(void (*cb)(void))
     cb();
     printf("After calling callback\n");
 }
+
+int dynamic_fn(int i) {
+    printf("I'm dynamic %d\n", i);
+    return i*2;
+}
+
+callback test_ffi6(void) {
+    return &dynamic_fn;
+}

--- a/test/ffi007/ffi007.h
+++ b/test/ffi007/ffi007.h
@@ -1,4 +1,11 @@
+#include <stdint.h>
+typedef int (*callback)(int);
+
+int32_t testvar = 887;
+
 void test_ffi(int (*cb)(int));
 
 void test_ffi2(int (*cb)(char*));
 void test_ffi3(void (*cb)(void));
+
+callback test_ffi6(void);

--- a/test/ffi007/ffi007.idr
+++ b/test/ffi007/ffi007.idr
@@ -23,8 +23,16 @@ test3 : IO ()
 test3 = foreign FFI_C "test_ffi3" (CFnPtr (() -> ()) -> IO ()) (MkCFnPtr printIt)
 
 test4 : IO Ptr
-test4 = foreign FFI_C "_idris_get_wrapper" (CFnPtr (() -> ()) -> IO Ptr) (MkCFnPtr printIt)
+test4 = foreign FFI_C "%wrapper" (CFnPtr (() -> ()) -> IO Ptr) (MkCFnPtr printIt)
 
+test5 : IO Ptr
+test5 = foreign FFI_C "&testvar" (IO Ptr)
+
+test6 : IO Ptr
+test6 = foreign FFI_C "test_ffi6" (IO Ptr)
+
+test7 : Ptr -> Int -> IO Int
+test7 fnptr i = foreign FFI_C "%dynamic" (Ptr -> Int -> IO Int) fnptr i
 
 main : IO ()
 main = do
@@ -32,4 +40,10 @@ main = do
             test2
             test3
             ptr <- test4
+            tv <- test5
+            val <- prim_peek32 tv 0
+            printLn val
+            fptr <- test6
+            i <- test7 fptr 3
+            printLn i
             return ()


### PR DESCRIPTION
This adds some new features to the C FFI that match what's in the Haskell FFI.

Prefixing the name with `&` gives a pointer to a C global. 

```
errno : IO Ptr
errno = foreign FFI_C "&__errno" (IO Ptr)
```

Putting `%wrapper` in the name argument gives a function pointer to a wrapped Idris function (useful for APIs that take a struct with a bunch of functions). It's functionality matches "wrapper" in Haskell, but the illegal C name makes name clashes go away.

Putting `%dynamic` in the name argument calls a C function from a function pointer. This is useful for APIs that provide structures with C functions (popular in object oriented C) or otherwise returns C function pointers. ~~There is an ugliness here, as there is no great way to generate temp names in the pure codegen, this thing allows a name after `%dynamic`, like `"%dynamic example"`, so that it can be used without name clashes if used several times in a declaration.~~ The type signature in dynamic should take an extra Ptr up front for the function pointer.