### PR TITLE
Detail in docstring for zipWith on Vect and Stream

### DIFF
--- a/libs/base/Data/Vect.idr
+++ b/libs/base/Data/Vect.idr
@@ -198,8 +198,12 @@ replicate (S k) x = x :: replicate k x
 -- Zips and unzips
 --------------------------------------------------------------------------------
 
-||| Combine two equal-length vectors pairwise with some function
-zipWith : (a -> b -> c) -> Vect n a -> Vect n b -> Vect n c
+||| Combine two equal-length vectors pairwise with some function.
+|||
+||| @ f the function to combine elements with
+||| @ xs the first vector of elements
+||| @ ys the second vector of elements
+zipWith : (f : a -> b -> c) -> (xs : Vect n a) -> (ys : Vect n b) -> Vect n c
 zipWith f []      []      = []
 zipWith f (x::xs) (y::ys) = f x y :: zipWith f xs ys
 

--- a/libs/prelude/Prelude/Stream.idr
+++ b/libs/prelude/Prelude/Stream.idr
@@ -62,8 +62,12 @@ index : Nat -> Stream a -> a
 index Z     (x::xs) = x
 index (S k) (x::xs) = index k xs
 
-||| Combine two streams element-wise using a function
-zipWith : (a -> b -> c) -> Stream a -> Stream b -> Stream c
+||| Combine two streams element-wise using a function.
+|||
+||| @ f the function to combine elements with
+||| @ xs the first stream of elements
+||| @ ys the second stream of elements
+zipWith : (f : a -> b -> c) -> (xs : Stream a) -> (ys : Stream b) -> Stream c
 zipWith f (x::xs) (y::ys) = f x y :: zipWith f xs ys
 
 ||| Combine three streams by applying a function element-wise along them


### PR DESCRIPTION
Add more detailed docstrings for Vect.zipWith and Stream.zipWith,
corresponding to that found on List.zipWith.

Fixes #2956.