### PR TITLE
No need to require bash to run tests

### DIFF
--- a/test/basic001/run
+++ b/test/basic001/run
@@ -1,4 +1,4 @@
-#!/usr/bin/env bash
+#!/usr/bin/env sh
 ${IDRIS:-idris} $@ reg005.idr -o reg005
 ${IDRIS:-idris} $@ basic001a.idr -o basic001a
 ./reg005

--- a/test/basic002/run
+++ b/test/basic002/run
@@ -1,4 +1,4 @@
-#!/usr/bin/env bash
+#!/usr/bin/env sh
 ${IDRIS:-idris} $@ --nocolour --consolewidth 80 test006.idr -o test006
 ./test006
 rm -f test006 test006.ibc

--- a/test/basic003/run
+++ b/test/basic003/run
@@ -1,4 +1,4 @@
-#!/usr/bin/env bash
+#!/usr/bin/env sh
 ${IDRIS:-idris} $@ test027.idr -o test027
 ./test027
 rm -f test027 *.ibc

--- a/test/basic004/run
+++ b/test/basic004/run
@@ -1,4 +1,4 @@
-#!/usr/bin/env bash
+#!/usr/bin/env sh
 ${IDRIS:-idris} $@ test016.idr -o test016
 ./test016
 rm -f test016 *.ibc

--- a/test/basic005/run
+++ b/test/basic005/run
@@ -1,4 +1,4 @@
-#!/usr/bin/env bash
+#!/usr/bin/env sh
 ${IDRIS:-idris} $@ test019.lidr -o test019
 ./test019
 rm -f test019 *.ibc

--- a/test/basic006/run
+++ b/test/basic006/run
@@ -1,4 +1,4 @@
-#!/usr/bin/env bash
+#!/usr/bin/env sh
 
 ${IDRIS:-idris} --consolewidth 80 $@ test020.idr -o test020
 ${IDRIS:-idris} --consolewidth 80 $@ test020a.idr --check --nocolor

--- a/test/basic007/run
+++ b/test/basic007/run
@@ -1,4 +1,4 @@
-#!/usr/bin/env bash
+#!/usr/bin/env sh
 ${IDRIS:-idris} $@ -o test033 test033.idr
 ./test033
 rm -f *.ibc test033

--- a/test/basic008/run
+++ b/test/basic008/run
@@ -1,4 +1,4 @@
-#!/usr/bin/env bash
+#!/usr/bin/env sh
 ${IDRIS:-idris} $@ test036.idr -o test036
 ./test036
 rm -f test036 *.ibc

--- a/test/basic009/run
+++ b/test/basic009/run
@@ -1,4 +1,4 @@
-#!/usr/bin/env bash
+#!/usr/bin/env sh
 
 ${IDRIS:-idris} --consolewidth 80 $@ Main.idr --nocolour --check && echo MAIN-PASS
 ${IDRIS:-idris} --consolewidth 80 $@ Faulty.idr --nocolour --check && echo FAULTY-PASS

--- a/test/basic010/run
+++ b/test/basic010/run
@@ -1,4 +1,4 @@
-#!/usr/bin/env bash
+#!/usr/bin/env sh
 
 
 declare -a extraargs

--- a/test/basic011/run
+++ b/test/basic011/run
@@ -1,4 +1,4 @@
-#!/usr/bin/env bash
+#!/usr/bin/env sh
 ${IDRIS:-idris} $@ basic011.idr -p contrib -o basic011
 ./basic011
 rm -f basic011 *.ibc

--- a/test/basic012/run
+++ b/test/basic012/run
@@ -1,4 +1,4 @@
-#!/usr/bin/env bash
+#!/usr/bin/env sh
 ${IDRIS:-idris} $@ basic012.idr -o basic012
 ./basic012
 rm -f basic012 *.ibc

--- a/test/basic013/run
+++ b/test/basic013/run
@@ -1,4 +1,4 @@
-#!/usr/bin/env bash
+#!/usr/bin/env sh
 ${IDRIS:-idris} $@ basic013.idr -o basic013
 ./basic013
 rm -f basic013 *.ibc

--- a/test/basic014/run
+++ b/test/basic014/run
@@ -1,3 +1,3 @@
-#!/usr/bin/env bash
+#!/usr/bin/env sh
 ${IDRIS:-idris} $@ basic014.idr --check
 rm -f *.ibc

--- a/test/basic015/run
+++ b/test/basic015/run
@@ -1,4 +1,4 @@
-#!/usr/bin/env bash
+#!/usr/bin/env sh
 ${IDRIS:-idris} $@ basic015.idr -o basic015
 ./basic015
 rm -f basic015 *.ibc

--- a/test/basic016/run
+++ b/test/basic016/run
@@ -1,3 +1,3 @@
-#!/usr/bin/env bash
+#!/usr/bin/env sh
 ${IDRIS:-idris} $@ CycleA.idr --consolewidth 80 --nocolour --check
 rm -f *.ibc

--- a/test/basic017/run
+++ b/test/basic017/run
@@ -1,4 +1,4 @@
-#!/usr/bin/env bash
+#!/usr/bin/env sh
 ${IDRIS:-idris} $@ basic017.idr --check --nocolor --consolewidth 80
 ${IDRIS:-idris} $@ basic017a.idr --check --nocolor --consolewidth 80
 rm -f *.ibc

--- a/test/bignum001/run
+++ b/test/bignum001/run
@@ -1,4 +1,4 @@
-#!/usr/bin/env bash
+#!/usr/bin/env sh
 ${IDRIS:-idris} $@ bignum001.idr -o bignum001
 ./bignum001
 rm -f bignum001 *.ibc

--- a/test/bignum002/run
+++ b/test/bignum002/run
@@ -1,4 +1,4 @@
-#!/usr/bin/env bash
+#!/usr/bin/env sh
 ${IDRIS:-idris} $@ bignum002.idr -o bignum002
 ./bignum002
 rm -f bignum002 *.ibc

--- a/test/bounded001/run
+++ b/test/bounded001/run
@@ -1,4 +1,4 @@
-#!/usr/bin/env bash
+#!/usr/bin/env sh
 ${IDRIS:-idris} $@ bounded001.idr -o bounded001
 ./bounded001
 rm -f bounded001 *.ibc

--- a/test/classes001/run
+++ b/test/classes001/run
@@ -1,3 +1,3 @@
-#!/usr/bin/env bash
+#!/usr/bin/env sh
 ${IDRIS:-idris} $@ --quiet --nocolour --consolewidth 70 ClassName.idr < input
 rm -f bounded001 *.ibc

--- a/test/corecords001/run
+++ b/test/corecords001/run
@@ -1,4 +1,4 @@
-#!/usr/bin/env bash
+#!/usr/bin/env sh
 ${IDRIS:-idris} $@ corecords001.idr -o corecords001
 ./corecords001
 rm -f corecords001 corecords001.ibc

--- a/test/corecords002/run
+++ b/test/corecords002/run
@@ -1,4 +1,4 @@
-#!/usr/bin/env bash
+#!/usr/bin/env sh
 ${IDRIS:-idris} $@ corecords002.idr -o corecords002
 ./corecords002
 rm -f corecords002 corecords002.ibc

--- a/test/delab001/run
+++ b/test/delab001/run
@@ -1,3 +1,3 @@
-#!/usr/bin/env bash
+#!/usr/bin/env sh
 ${IDRIS:-idris} $@ --quiet --nocolor delab001.idr < input
 rm -f *.ibc

--- a/test/disambig002/run
+++ b/test/disambig002/run
@@ -1,3 +1,3 @@
-#!/usr/bin/env bash
+#!/usr/bin/env sh
 ${IDRIS:-idris} $@ disambig002.idr --check
 rm -f *.ibc

--- a/test/docs001/run
+++ b/test/docs001/run
@@ -1,3 +1,3 @@
-#!/usr/bin/env bash
+#!/usr/bin/env sh
 ${IDRIS:-idris} --quiet --nocolor --consolewidth 80 docs001.idr < input
 rm *.ibc

--- a/test/docs002/run
+++ b/test/docs002/run
@@ -1,3 +1,3 @@
-#!/usr/bin/env bash
+#!/usr/bin/env sh
 ${IDRIS:-idris} --consolewidth 80 --nobanner --nocolor --quiet docs002.idr < input
 rm *.ibc

--- a/test/docs003/run
+++ b/test/docs003/run
@@ -1,3 +1,3 @@
-#!/usr/bin/env bash
+#!/usr/bin/env sh
 ${IDRIS:-idris} --consolewidth 80 --quiet --nocolor docs003.idr < input
 rm *.ibc

--- a/test/docs004/run
+++ b/test/docs004/run
@@ -1,3 +1,3 @@
-#!/usr/bin/env bash
+#!/usr/bin/env sh
 ${IDRIS:-idris} --quiet --nocolor --consolewidth 80 docs004.idr < input
 rm *.ibc

--- a/test/dsl001/run
+++ b/test/dsl001/run
@@ -1,4 +1,4 @@
-#!/usr/bin/env bash
+#!/usr/bin/env sh
 ${IDRIS:-idris} $@ test001.idr -o test001
 ./test001
 rm -f test001 test001.ibc

--- a/test/dsl002/run
+++ b/test/dsl002/run
@@ -1,4 +1,4 @@
-#!/usr/bin/env bash
+#!/usr/bin/env sh
 ${IDRIS:-idris} $@ test014.idr -o test014
 ./test014
 rm -f test014 Resimp.ibc test014.ibc

--- a/test/dsl003/run
+++ b/test/dsl003/run
@@ -1,3 +1,3 @@
-#!/usr/bin/env bash
+#!/usr/bin/env sh
 ${IDRIS:-idris} $@ --nocolour --check DSLPi.idr -e test1 -e test2
 rm -f *.ibc

--- a/test/dsl004/run
+++ b/test/dsl004/run
@@ -1,4 +1,4 @@
-#!/usr/bin/env bash
+#!/usr/bin/env sh
 ${IDRIS:-idris} $@ Door0.idr --check
 ${IDRIS:-idris} $@ Door1.idr --check
 ${IDRIS:-idris} $@ Door2.idr --check

--- a/test/effects001/run
+++ b/test/effects001/run
@@ -1,4 +1,4 @@
-#!/usr/bin/env bash
+#!/usr/bin/env sh
 ${IDRIS:-idris} -p effects $@ test021.idr -o test021
 ${IDRIS:-idris} -p effects $@ test021a.idr -o test021a
 ./test021

--- a/test/effects002/run
+++ b/test/effects002/run
@@ -1,4 +1,4 @@
-#!/usr/bin/env bash
+#!/usr/bin/env sh
 ${IDRIS:-idris} -p effects $@ test025.idr -o test025
 ./test025
 rm -f test025 *.ibc

--- a/test/effects003/run
+++ b/test/effects003/run
@@ -1,4 +1,4 @@
-#!/usr/bin/env bash
+#!/usr/bin/env sh
 ${IDRIS:-idris} $@ hangman.idr --consolewidth 80 --nocolour -p effects -o hangman
 ./hangman < input
 rm -f hangman *.ibc

--- a/test/effects004/run
+++ b/test/effects004/run
@@ -1,4 +1,4 @@
-#!/usr/bin/env bash
+#!/usr/bin/env sh
 ${IDRIS:-idris} $@ effects004.idr -o effects004 -p effects
 ./effects004 < input
 rm -f effects004 *.ibc

--- a/test/effects005/run
+++ b/test/effects005/run
@@ -1,4 +1,4 @@
-#!/usr/bin/env bash
+#!/usr/bin/env sh
 ${IDRIS:-idris} $@ defaultLogger.idr -o default -p effects
 ./default
 ${IDRIS:-idris} $@ categoryLogger.idr -o category -p effects

--- a/test/error001/run
+++ b/test/error001/run
@@ -1,3 +1,3 @@
-#!/usr/bin/env bash
+#!/usr/bin/env sh
 ${IDRIS:-idris} $@ test002.idr --check --noprelude --consolewidth 70
 rm -f *.ibc

--- a/test/error002/run
+++ b/test/error002/run
@@ -1,4 +1,4 @@
-#!/usr/bin/env bash
+#!/usr/bin/env sh
 ${IDRIS:-idris} $@ test031.idr -o test031
 ./test031
 rm -f test031 *.ibc

--- a/test/error003/run
+++ b/test/error003/run
@@ -1,3 +1,3 @@
-#!/usr/bin/env bash
+#!/usr/bin/env sh
 ${IDRIS:-idris} --consolewidth 80 $@ ErrorReflection.idr --nocolour --check
 rm -f *.ibc

--- a/test/error004/run
+++ b/test/error004/run
@@ -1,3 +1,3 @@
-#!/usr/bin/env bash
+#!/usr/bin/env sh
 ${IDRIS:-idris} --consolewidth 80 $@ FunErrTest.idr --nocolour --check
 rm -f *.ibc

--- a/test/error005/run
+++ b/test/error005/run
@@ -1,3 +1,3 @@
-#!/usr/bin/env bash
+#!/usr/bin/env sh
 ${IDRIS:-idris} --consolewidth 80 $@ --check --nocolour error005.idr
 rm -f *.ibc

--- a/test/error006/run
+++ b/test/error006/run
@@ -1,3 +1,3 @@
-#!/usr/bin/env bash
+#!/usr/bin/env sh
 ${IDRIS:-idris} --consolewidth 80 $@ --check --nocolour WithPatsNoWith.idr
 rm -f *.ibc

--- a/test/ffi001/run
+++ b/test/ffi001/run
@@ -1,3 +1,3 @@
-#!/usr/bin/env bash
+#!/usr/bin/env sh
 ${IDRIS:-idris} --quiet --nocolour test022.idr --exec main
 rm -f *.ibc

--- a/test/ffi002/run
+++ b/test/ffi002/run
@@ -1,3 +1,3 @@
-#!/usr/bin/env bash
+#!/usr/bin/env sh
 ${IDRIS:-idris} --consolewidth 80 --quiet test023.idr -o test023
 rm -f test023 *.ibc

--- a/test/ffi003/run
+++ b/test/ffi003/run
@@ -1,3 +1,3 @@
-#!/usr/bin/env bash
+#!/usr/bin/env sh
 ${IDRIS:-idris} --quiet --nocolour test024.idr --exec main < input
 rm -f *.ibc

--- a/test/ffi004/run
+++ b/test/ffi004/run
@@ -1,3 +1,3 @@
-#!/usr/bin/env bash
+#!/usr/bin/env sh
 ${IDRIS:-idris} --quiet --nocolour --check test026.idr
 rm -f *.ibc

--- a/test/ffi005/run
+++ b/test/ffi005/run
@@ -1,4 +1,4 @@
-#!/usr/bin/env bash
+#!/usr/bin/env sh
 
 ${IDRIS:-idris} $@ Postulate.idr -o postulate
 ./postulate

--- a/test/ffi006/run
+++ b/test/ffi006/run
@@ -1,4 +1,4 @@
-#!/usr/bin/env bash
+#!/usr/bin/env sh
 ${IDRIS:-idris} $@ ffi006.idr --interface -o ffi006.o
 ${CC:=cc} ffi006.c ffi006.o `idris --include` `idris --link` -o ffi006
 ./ffi006

--- a/test/ffi007/run
+++ b/test/ffi007/run
@@ -1,4 +1,4 @@
-#!/usr/bin/env bash
+#!/usr/bin/env sh
 ${IDRIS:-idris} $@ ffi007.idr -o ffi007 --cg-opt "ffi007.c"
 ./ffi007
 rm -f ffi007 *.ibc

--- a/test/folding001/run
+++ b/test/folding001/run
@@ -1,4 +1,4 @@
-#!/usr/bin/env bash
+#!/usr/bin/env sh
 ${IDRIS:-idris} $@ folding001.idr -o folding001
 ./folding001
 rm -f folding001 *.ibc

--- a/test/idrisdoc001/run
+++ b/test/idrisdoc001/run
@@ -1,4 +1,4 @@
-#!/usr/bin/env bash
+#!/usr/bin/env sh
 # Tests that no documentation is built for empty and/or private-only namespaces
 ${IDRIS:-idris} --mkdoc test_empty.ipkg
 rm -rf *.ibc *_doc

--- a/test/idrisdoc002/run
+++ b/test/idrisdoc002/run
@@ -1,4 +1,4 @@
-#!/usr/bin/env bash
+#!/usr/bin/env sh
 # Tests that documentation is generated for functions
 ${IDRIS:-idris} --mkdoc test_functions.ipkg
 [ -d test_functions_doc ] && echo "Functions are documented"

--- a/test/idrisdoc003/run
+++ b/test/idrisdoc003/run
@@ -1,4 +1,4 @@
-#!/usr/bin/env bash
+#!/usr/bin/env sh
 # Tests that documentation is generated for data types
 ${IDRIS:-idris} --mkdoc test_datatypes.ipkg
 [ -d test_datatypes_doc ] && echo "Data types are documented"

--- a/test/idrisdoc004/run
+++ b/test/idrisdoc004/run
@@ -1,4 +1,4 @@
-#!/usr/bin/env bash
+#!/usr/bin/env sh
 # Tests that documentation is generated for typeclasses
 ${IDRIS:-idris} --mkdoc test_typeclasses.ipkg
 [ -d test_typeclasses_doc ] && echo "Typeclasses are documented"

--- a/test/idrisdoc005/run
+++ b/test/idrisdoc005/run
@@ -1,4 +1,4 @@
-#!/usr/bin/env bash
+#!/usr/bin/env sh
 # Tests that references to other namespaces are traced
 ${IDRIS:-idris} --mkdoc test_tracing.ipkg
 [ -f test_tracing_doc/docs/TestTracing.html ] && echo "TestTracing: Check"

--- a/test/idrisdoc006/run
+++ b/test/idrisdoc006/run
@@ -1,4 +1,4 @@
-#!/usr/bin/env bash
+#!/usr/bin/env sh
 # Tests that documentation properly is merged with existent.
 ${IDRIS:-idris} --mkdoc package_a.ipkg
 [ -f test_merge_doc/IdrisDoc ] && echo "IdrisDoc file written"

--- a/test/idrisdoc007/run
+++ b/test/idrisdoc007/run
@@ -1,4 +1,4 @@
-#!/usr/bin/env bash
+#!/usr/bin/env sh
 # Tests that documentation only is written when safe
 mkdir do_not_delete_doc
 ${IDRIS:-idris} --mkdoc package.ipkg > nowhere

--- a/test/idrisdoc008/run
+++ b/test/idrisdoc008/run
@@ -1,4 +1,4 @@
-#!/usr/bin/env bash
+#!/usr/bin/env sh
 # Tests that documentation is generated for both public and abstract members.
 ${IDRIS:-idris} --mkdoc visibility.ipkg
 [ -f visibility_doc/docs/Abstract.html ] && echo "Abstract members are documented"

--- a/test/idrisdoc009/run
+++ b/test/idrisdoc009/run
@@ -1,3 +1,3 @@
-#!/usr/bin/env bash
+#!/usr/bin/env sh
 ${IDRIS:-idris} $@ --nocolour --quiet Test.idr < input
 rm -f *.ibc

--- a/test/interactive001/run
+++ b/test/interactive001/run
@@ -1,3 +1,3 @@
-#!/usr/bin/env bash
+#!/usr/bin/env sh
 ${IDRIS:-idris} --quiet test032.idr < input
 rm -f *.ibc

--- a/test/interactive002/run
+++ b/test/interactive002/run
@@ -1,3 +1,3 @@
-#!/usr/bin/env bash
+#!/usr/bin/env sh
 ${IDRIS:-idris} --quiet interactive002.idr < input
 rm -f *.ibc

--- a/test/interactive003/run
+++ b/test/interactive003/run
@@ -1,3 +1,3 @@
-#!/usr/bin/env bash
+#!/usr/bin/env sh
 ${IDRIS:-idris} --quiet interactive003.idr < input
 rm -f *.ibc

--- a/test/interactive004/run
+++ b/test/interactive004/run
@@ -1,3 +1,3 @@
-#!/usr/bin/env bash
+#!/usr/bin/env sh
 ${IDRIS:-idris} --quiet interactive004.idr < input
 rm -f *.ibc

--- a/test/interactive005/run
+++ b/test/interactive005/run
@@ -1,4 +1,4 @@
-#!/usr/bin/env bash
+#!/usr/bin/env sh
 ${IDRIS:-idris} --nocolour --quiet interactive005.idr --consolewidth 70 < input
 rm -f *.ibc
 rm -f hello.bytecode

--- a/test/interactive006/run
+++ b/test/interactive006/run
@@ -1,3 +1,3 @@
-#!/usr/bin/env bash
+#!/usr/bin/env sh
 ${IDRIS:-idris} --quiet --port 5000 interactive006.idr < input
 rm -f *.ibc

--- a/test/interactive007/run
+++ b/test/interactive007/run
@@ -1,2 +1,2 @@
-#!/usr/bin/env bash
+#!/usr/bin/env sh
 ${IDRIS:-idris} -p contrib --nobanner --nocolor < input

--- a/test/interactive008/run
+++ b/test/interactive008/run
@@ -1,2 +1,2 @@
-#!/usr/bin/env bash
+#!/usr/bin/env sh
 ${IDRIS:-idris} --nobanner --nocolor < input

--- a/test/interactive009/run
+++ b/test/interactive009/run
@@ -1,3 +1,3 @@
-#!/usr/bin/env bash
+#!/usr/bin/env sh
 ${IDRIS:-idris} --quiet interactive009.idr < input
 rm -f *.ibc

--- a/test/interactive010/run
+++ b/test/interactive010/run
@@ -1,2 +1,2 @@
-#!/usr/bin/env bash
+#!/usr/bin/env sh
 ${IDRIS:-idris} --quiet --nobanner --nocolor  --consolewidth 80 < input

--- a/test/interactive011/run
+++ b/test/interactive011/run
@@ -1,3 +1,3 @@
-#!/usr/bin/env bash
+#!/usr/bin/env sh
 ${IDRIS:-idris} --quiet interactive011.idr < input
 rm -f *.ibc

--- a/test/interactive012/run
+++ b/test/interactive012/run
@@ -1,3 +1,3 @@
-#!/usr/bin/env bash
+#!/usr/bin/env sh
 ${IDRIS:-idris} --nocolour --consolewidth 70 --quiet interactive012.idr < input
 rm -f *.ibc

--- a/test/io001/run
+++ b/test/io001/run
@@ -1,4 +1,4 @@
-#!/usr/bin/env bash
+#!/usr/bin/env sh
 ${IDRIS:-idris} $@ test004.idr -o test004
 ./test004
 rm -f test004 test004.ibc testfile

--- a/test/io002/run
+++ b/test/io002/run
@@ -1,4 +1,4 @@
-#!/usr/bin/env bash
+#!/usr/bin/env sh
 ${IDRIS:-idris} $@ test008.idr -o test008
 ./test008
 rm -f test008 test008.ibc

--- a/test/io003/run
+++ b/test/io003/run
@@ -1,4 +1,4 @@
-#!/usr/bin/env bash
+#!/usr/bin/env sh
 ${IDRIS:-idris} $@ test018.idr -p contrib -o test018
 ${IDRIS:-idris} $@ test018a.idr -p contrib -o test018a
 ./test018

--- a/test/literate001/run
+++ b/test/literate001/run
@@ -1,4 +1,4 @@
-#!/usr/bin/env bash
+#!/usr/bin/env sh
 ${IDRIS:-idris} --consolewidth 80 $@ test003a.lidr --check
 ${IDRIS:-idris} --consolewidth 80 $@ test003.lidr -o test003
 ./test003

--- a/test/meta001/run
+++ b/test/meta001/run
@@ -1,3 +1,3 @@
-#!/usr/bin/env bash
+#!/usr/bin/env sh
 ${IDRIS:-idris} $@ --check --nocolour --consolewidth 70 Finite.idr
 rm -f *.ibc

--- a/test/meta002/run
+++ b/test/meta002/run
@@ -1,4 +1,4 @@
-#!/usr/bin/env bash
+#!/usr/bin/env sh
 ${IDRIS:-idris} $@ -p pruviloj --nocolour --check --consolewidth 70 Tacs.idr
 ${IDRIS:-idris} $@ -p pruviloj --nocolour --check --consolewidth 70 AgdaStyleReflection.idr
 # Disabled due to excess memory consumption

--- a/test/meta003/run
+++ b/test/meta003/run
@@ -1,3 +1,3 @@
-#!/usr/bin/env bash
+#!/usr/bin/env sh
 ${IDRIS:-idris} $@ --nocolour --check --consolewidth 70 BadDef.idr
 rm -f *.ibc

--- a/test/meta004/run
+++ b/test/meta004/run
@@ -1,3 +1,3 @@
-#!/usr/bin/env bash
+#!/usr/bin/env sh
 ${IDRIS:-idris} $@ -p pruviloj --nocolour --check --consolewidth 70 meta004.idr
 rm -f *.ibc

--- a/test/pkg001/run
+++ b/test/pkg001/run
@@ -1,3 +1,3 @@
-#!/usr/bin/env bash
+#!/usr/bin/env sh
 ${IDRIS:-idris} $@ --build test.ipkg
 rm -f  *.ibc

--- a/test/pkg002/run
+++ b/test/pkg002/run
@@ -1,4 +1,4 @@
-#!/usr/bin/env bash
+#!/usr/bin/env sh
 ### Test: IPKG executable names can be any namespaced identifier.
 ${IDRIS:-idris} $@ --build test.ipkg
 rm -f *.ibc

--- a/test/pkg003/run
+++ b/test/pkg003/run
@@ -1,4 +1,4 @@
-#!/usr/bin/env bash
+#!/usr/bin/env sh
 ### Test: IPKG executable names can be a quoted string
 ### containing a valid filename.
 ${IDRIS:-idris} $@ --build test.ipkg

--- a/test/pkg004/run
+++ b/test/pkg004/run
@@ -1,4 +1,4 @@
-#!/usr/bin/env bash
+#!/usr/bin/env sh
 ### Test: IPKG executable names CANNOT include a directory separator.
 # TODO: Verify that a name like "a/b\c" is rejected by both *NIX and Windows
 # (assuming these tests get run on Windows).

--- a/test/primitives001/run
+++ b/test/primitives001/run
@@ -1,4 +1,4 @@
-#!/usr/bin/env bash
+#!/usr/bin/env sh
 ${IDRIS:-idris} $@ test005.idr -o test005
 ./test005
 ${IDRIS:-idris} $@ substring.idr -o substring

--- a/test/primitives002/run
+++ b/test/primitives002/run
@@ -1,4 +1,4 @@
-#!/usr/bin/env bash
+#!/usr/bin/env sh
 
 HEAD='module Main
 

--- a/test/primitives003/run
+++ b/test/primitives003/run
@@ -1,4 +1,4 @@
-#!/usr/bin/env bash
+#!/usr/bin/env sh
 ${IDRIS:-idris} $@ -o test038 test038.idr --nocolour
 ./test038
 rm -f test038 *.ibc

--- a/test/primitives004-disabled/run
+++ b/test/primitives004-disabled/run
@@ -1,4 +1,4 @@
-#!/usr/bin/env bash
+#!/usr/bin/env sh
 ${IDRIS:-idris} $@ -o primitives004 primitives004.idr --nocolour
 ./primitives004
 rm -f primitives004 *.ibc

--- a/test/primitives005/run
+++ b/test/primitives005/run
@@ -1,4 +1,4 @@
-#!/usr/bin/env bash
+#!/usr/bin/env sh
 ${IDRIS:-idris} $@ -o p005 primitives005.idr --nocolour
 ./p005
 rm -f p005 *.ibc

--- a/test/proof001/run
+++ b/test/proof001/run
@@ -1,3 +1,3 @@
-#!/usr/bin/env bash
+#!/usr/bin/env sh
 ${IDRIS:-idris} $@ test029.idr --consolewidth 80 --nocolour --check test029
 rm -f *.ibc

--- a/test/proof002/run
+++ b/test/proof002/run
@@ -1,4 +1,4 @@
-#!/usr/bin/env bash
+#!/usr/bin/env sh
 ${IDRIS:-idris} --consolewidth 80 $@ test030.idr --check --nocolour
 ${IDRIS:-idris} --consolewidth 80 $@ test030a.idr --check --nocolour
 rm -f *.ibc

--- a/test/proof003/run
+++ b/test/proof003/run
@@ -1,4 +1,4 @@
-#!/usr/bin/env bash
+#!/usr/bin/env sh
 ${IDRIS:-idris} $@ test015.idr --nocolour --consolewidth 80 -o test015
 ./test015
 rm -f test015 Parity.ibc test015.ibc

--- a/test/proof004/run
+++ b/test/proof004/run
@@ -1,3 +1,3 @@
-#!/usr/bin/env bash
+#!/usr/bin/env sh
 ${IDRIS:-idris} --check $@ test035.idr
 rm -f *.ibc

--- a/test/proof005/run
+++ b/test/proof005/run
@@ -1,3 +1,3 @@
-#!/usr/bin/env bash
+#!/usr/bin/env sh
 ${IDRIS:-idris} --check $@ DefaultArgSubstitutionSuccess.idr
 rm -f *.ibc

--- a/test/proof006/run
+++ b/test/proof006/run
@@ -1,3 +1,3 @@
-#!/usr/bin/env bash
+#!/usr/bin/env sh
 ${IDRIS:-idris} --check $@ DefaultArgSubstitutionSyntax.idr
 rm -f *.ibc

--- a/test/proof007/run
+++ b/test/proof007/run
@@ -1,3 +1,3 @@
-#!/usr/bin/env bash
+#!/usr/bin/env sh
 ${IDRIS:-idris} --nocolour --consolewidth 80 --check $@ DefaultArgUnknownName.idr
 rm -f *.ibc

--- a/test/proof008/run
+++ b/test/proof008/run
@@ -1,3 +1,3 @@
-#!/usr/bin/env bash
+#!/usr/bin/env sh
 ${IDRIS:-idris} --nocolour --consolewidth 80 --check $@ ClaimAndUnfocus.idr
 rm -f *.ibc

--- a/test/proof009/run
+++ b/test/proof009/run
@@ -1,3 +1,3 @@
-#!/usr/bin/env bash
+#!/usr/bin/env sh
 ${IDRIS:-idris} $@ --consolewidth 70 --quiet proof009.idr < input
 rm -f *.ibc

--- a/test/proof010/run
+++ b/test/proof010/run
@@ -1,4 +1,4 @@
-#!/usr/bin/env bash
+#!/usr/bin/env sh
 ${IDRIS:-idris} $@ proof010.idr -o proof010
 ./proof010
 rm -f proof010 *.ibc

--- a/test/proofsearch001/run
+++ b/test/proofsearch001/run
@@ -1,3 +1,3 @@
-#!/usr/bin/env bash
+#!/usr/bin/env sh
 ${IDRIS:-idris} $@ --check proofsearch001.idr
 rm -f *.ibc

--- a/test/proofsearch002/run
+++ b/test/proofsearch002/run
@@ -1,3 +1,3 @@
-#!/usr/bin/env bash
+#!/usr/bin/env sh
 ${IDRIS:-idris} $@ --check proofsearch002.idr
 rm -f *.ibc

--- a/test/proofsearch003/run
+++ b/test/proofsearch003/run
@@ -1,3 +1,3 @@
-#!/usr/bin/env bash
+#!/usr/bin/env sh
 ${IDRIS:-idris} --check proofsearch003.idr 
 rm -f *.ibc

--- a/test/pruviloj001/run
+++ b/test/pruviloj001/run
@@ -1,3 +1,3 @@
-#!/usr/bin/env bash
+#!/usr/bin/env sh
 ${IDRIS:-idris} $@ -p pruviloj --check --nocolour --consolewidth 70 pruviloj001.idr
 rm -f *.ibc

--- a/test/quasiquote001/run
+++ b/test/quasiquote001/run
@@ -1,4 +1,4 @@
-#!/usr/bin/env bash
+#!/usr/bin/env sh
 ${IDRIS:-idris} $@ QuasiquoteBasics.idr -o quasiquote001
 ./quasiquote001
 rm -f quasiquote001 *.ibc

--- a/test/quasiquote002/run
+++ b/test/quasiquote002/run
@@ -1,4 +1,4 @@
-#!/usr/bin/env bash
+#!/usr/bin/env sh
 ${IDRIS:-idris} $@ GoalQQuote.idr -o quasiquote002
 ./quasiquote002
 rm -f quasiquote002 *.ibc

--- a/test/quasiquote003/run
+++ b/test/quasiquote003/run
@@ -1,3 +1,3 @@
-#!/usr/bin/env bash
+#!/usr/bin/env sh
 ${IDRIS:-idris} --consolewidth 80 $@ --check NoInfer.idr
 rm -f *.ibc

--- a/test/quasiquote004/run
+++ b/test/quasiquote004/run
@@ -1,3 +1,3 @@
-#!/usr/bin/env bash
+#!/usr/bin/env sh
 ${IDRIS:-idris} --consolewidth 80 $@ --check --nocolour Quasiquote004.idr
 rm -f *.ibc

--- a/test/quasiquote005/run
+++ b/test/quasiquote005/run
@@ -1,3 +1,3 @@
-#!/usr/bin/env bash
+#!/usr/bin/env sh
 ${IDRIS:-idris} $@ --check --nocolour Quasiquote005.idr
 rm -f *.ibc

--- a/test/quasiquote006/run
+++ b/test/quasiquote006/run
@@ -1,3 +1,3 @@
-#!/usr/bin/env bash
+#!/usr/bin/env sh
 ${IDRIS:-idris} $@ --check --nocolour --quiet --consolewidth 70 quasiquote006.idr
 rm -f *.ibc

--- a/test/records001/run
+++ b/test/records001/run
@@ -1,4 +1,4 @@
-#!/usr/bin/env bash
+#!/usr/bin/env sh
 ${IDRIS:-idris} $@ test011.idr -o test011
 ./test011
 rm -f test011 test011.ibc

--- a/test/records002/run
+++ b/test/records002/run
@@ -1,4 +1,4 @@
-#!/usr/bin/env bash
+#!/usr/bin/env sh
 ${IDRIS:-idris} $@ record002.idr -o record002
 ./record002
 rm -f record002 *.ibc

--- a/test/records003/run
+++ b/test/records003/run
@@ -1,4 +1,4 @@
-#!/usr/bin/env bash
+#!/usr/bin/env sh
 ${IDRIS:-idris} $@ records003.idr -o records003
 ./records003
 rm -f records003 *.ibc

--- a/test/records004/run
+++ b/test/records004/run
@@ -1,4 +1,4 @@
-#!/usr/bin/env bash
+#!/usr/bin/env sh
 ${IDRIS:-idris} $@ records004.idr -o records004
 ./records004
 rm -f records004 *.ibc

--- a/test/reg001/run
+++ b/test/reg001/run
@@ -1,4 +1,4 @@
-#!/usr/bin/env bash
+#!/usr/bin/env sh
 ${IDRIS:-idris} reg001.idr --check
 rm -rf reg001.ibc
 

--- a/test/reg002/run
+++ b/test/reg002/run
@@ -1,4 +1,4 @@
-#!/usr/bin/env bash
+#!/usr/bin/env sh
 ${IDRIS:-idris} reg012.idr -o reg012
 ./reg012
 rm -f reg012 *.ibc

--- a/test/reg003/run
+++ b/test/reg003/run
@@ -1,4 +1,4 @@
-#!/usr/bin/env bash
+#!/usr/bin/env sh
 ${IDRIS:-idris} --consolewidth 80 --check reg003.idr
 ${IDRIS:-idris} --consolewidth 80 --check reg003a.idr
 rm -f *.ibc

--- a/test/reg004/run
+++ b/test/reg004/run
@@ -1,4 +1,4 @@
-#!/usr/bin/env bash
+#!/usr/bin/env sh
 ${IDRIS:-idris} $@ reg004.idr -o reg004
 ./reg004
 rm -f reg004 *.ibc

--- a/test/reg005/run
+++ b/test/reg005/run
@@ -1,4 +1,4 @@
-#!/usr/bin/env bash
+#!/usr/bin/env sh
 ${IDRIS:-idris} $@ reg005.idr -o reg005
 ./reg005
 rm -f reg005 *.ibc

--- a/test/reg006/run
+++ b/test/reg006/run
@@ -1,3 +1,3 @@
-#!/usr/bin/env bash
+#!/usr/bin/env sh
 ${IDRIS:-idris} --consolewidth 80 $@ reg006.idr --check
 rm -f *.ibc

--- a/test/reg007/run
+++ b/test/reg007/run
@@ -1,3 +1,3 @@
-#!/usr/bin/env bash
+#!/usr/bin/env sh
 ${IDRIS:-idris} --consolewidth 80 --nocolour --check $@ reg007.lidr
 rm -f *.ibc

--- a/test/reg010/run
+++ b/test/reg010/run
@@ -1,2 +1,2 @@
-#!/usr/bin/env bash
+#!/usr/bin/env sh
 ${IDRIS:-idris} --consolewidth 80 $@ reg010.idr --check --nocolour

--- a/test/reg013/run
+++ b/test/reg013/run
@@ -1,4 +1,4 @@
-#!/usr/bin/env bash
+#!/usr/bin/env sh
 ${IDRIS:-idris} $@ reg013.idr -o reg013
 ./reg013
 rm -f reg013 *.ibc

--- a/test/reg016/run
+++ b/test/reg016/run
@@ -1,4 +1,4 @@
-#!/usr/bin/env bash
+#!/usr/bin/env sh
 ${IDRIS:-idris} $@ reg016.idr -o reg016
 ./reg016
 rm -f reg016 *.ibc

--- a/test/reg017/run
+++ b/test/reg017/run
@@ -1,4 +1,4 @@
-#!/usr/bin/env bash
+#!/usr/bin/env sh
 ${IDRIS:-idris} $@ --nocolour --consolewidth 80 reg017.idr -o reg017
 ./reg017
 rm -f reg017 *.ibc

--- a/test/reg018/run
+++ b/test/reg018/run
@@ -1,4 +1,4 @@
-#!/usr/bin/env bash
+#!/usr/bin/env sh
 ${IDRIS:-idris} --consolewidth 80 $@ reg018a.idr --check
 ${IDRIS:-idris} --consolewidth 80 $@ reg018b.idr --check
 ${IDRIS:-idris} --consolewidth 80 $@ reg018c.idr --check

--- a/test/reg020/run
+++ b/test/reg020/run
@@ -1,4 +1,4 @@
-#!/usr/bin/env bash
+#!/usr/bin/env sh
 ${IDRIS:-idris} $@ reg020.idr -o reg020
 ./reg020
 rm -f reg020 *.ibc

--- a/test/reg023/run
+++ b/test/reg023/run
@@ -1,3 +1,3 @@
-#!/usr/bin/env bash
+#!/usr/bin/env sh
 ${IDRIS:-idris} --nocolour --consolewidth 80 $@ reg023.idr --check
 rm -f *.ibc

--- a/test/reg024/run
+++ b/test/reg024/run
@@ -1,4 +1,4 @@
-#!/usr/bin/env bash
+#!/usr/bin/env sh
 ${IDRIS:-idris} $@ reg024.idr -o reg024
 ./reg024
 rm -f reg024 *.ibc

--- a/test/reg025/run
+++ b/test/reg025/run
@@ -1,4 +1,4 @@
-#!/usr/bin/env bash
+#!/usr/bin/env sh
 ${IDRIS:-idris} $@ reg025.idr -o reg025
 ./reg025
 rm -f reg025 *.ibc

--- a/test/reg027/run
+++ b/test/reg027/run
@@ -1,4 +1,4 @@
-#!/usr/bin/env bash
+#!/usr/bin/env sh
 ${IDRIS:-idris} --consolewidth 80 $@ reg027.idr -o reg027
 ./reg027
 ${IDRIS:-idris} --consolewidth 80 $@ reg027a.idr --check

--- a/test/reg028/run
+++ b/test/reg028/run
@@ -1,4 +1,4 @@
-#!/usr/bin/env bash
+#!/usr/bin/env sh
 ${IDRIS:-idris} --consolewidth 80 $@ reg028.idr --check
 ${IDRIS:-idris} --consolewidth 80 $@ reg028a.idr --check
 rm -f *.ibc

--- a/test/reg029/run
+++ b/test/reg029/run
@@ -1,4 +1,4 @@
-#!/usr/bin/env bash
+#!/usr/bin/env sh
 
 ${IDRIS:-idris} $@ reg029.idr -o reg029
 unset IDRIS_REG029_NONEXISTENT_VAR

--- a/test/reg031/run
+++ b/test/reg031/run
@@ -1,4 +1,4 @@
-#!/usr/bin/env bash
+#!/usr/bin/env sh
 ${IDRIS:-idris} $@ reg031.idr -o reg031
 ./reg031
 rm -f *.ibc reg031

--- a/test/reg032/run
+++ b/test/reg032/run
@@ -1,4 +1,4 @@
-#!/usr/bin/env bash
+#!/usr/bin/env sh
 ${IDRIS:-idris} $@ test028.idr -o test028
 ./test028
 rm -f test028 test028.ibc

--- a/test/reg034/run
+++ b/test/reg034/run
@@ -1,3 +1,3 @@
-#!/usr/bin/env bash
+#!/usr/bin/env sh
 ${IDRIS:-idris} --nocolour --consolewidth 80 --check reg034.idr
 rm -f reg034 *.ibc

--- a/test/reg035/run
+++ b/test/reg035/run
@@ -1,4 +1,4 @@
-#!/usr/bin/env bash
+#!/usr/bin/env sh
 ${IDRIS:-idris} --nocolour --consolewidth 80 --check reg035.idr
 ${IDRIS:-idris} --nocolour --consolewidth 80 --check reg035a.lidr
 ${IDRIS:-idris} --nocolour --consolewidth 80 --check reg035b.idr

--- a/test/reg036/run
+++ b/test/reg036/run
@@ -1,3 +1,3 @@
-#!/usr/bin/env bash
+#!/usr/bin/env sh
 ${IDRIS:-idris} --check reg036.idr
 rm -f reg036 *.ibc

--- a/test/reg037/run
+++ b/test/reg037/run
@@ -1,3 +1,3 @@
-#!/usr/bin/env bash
+#!/usr/bin/env sh
 ${IDRIS:-idris} --check reg037.idr
 rm -f reg037 *.ibc

--- a/test/reg038/run
+++ b/test/reg038/run
@@ -1,3 +1,3 @@
-#!/usr/bin/env bash
+#!/usr/bin/env sh
 ${IDRIS:-idris} --check reg038.idr
 rm -f *.ibc

--- a/test/reg039/run
+++ b/test/reg039/run
@@ -1,4 +1,4 @@
-#!/usr/bin/env bash
+#!/usr/bin/env sh
 
 
 declare -a extraargs

--- a/test/reg040/run
+++ b/test/reg040/run
@@ -1,4 +1,4 @@
-#!/usr/bin/env bash
+#!/usr/bin/env sh
 
 ${IDRIS:-idris} --warnreach reg040.idr -o reg040
 ./reg040

--- a/test/reg041/run
+++ b/test/reg041/run
@@ -1,4 +1,4 @@
-#!/usr/bin/env bash
+#!/usr/bin/env sh
 ${IDRIS:-idris} $@ --quiet ott.idr -e example
 ${IDRIS:-idris} $@ showu.idr -o reg040
 ./reg040

--- a/test/reg042/run
+++ b/test/reg042/run
@@ -1,4 +1,4 @@
-#!/usr/bin/env bash
+#!/usr/bin/env sh
 ${IDRIS:-idris} $@ reg042 -o reg042 --warnreach
 ./reg042
 rm -f reg042 *.ibc

--- a/test/reg044/run
+++ b/test/reg044/run
@@ -1,3 +1,3 @@
-#!/usr/bin/env bash
+#!/usr/bin/env sh
 ${IDRIS:-idris} --nocolour --consolewidth 80 reg044.idr --check
 rm -f *.ibc

--- a/test/reg045/run
+++ b/test/reg045/run
@@ -1,4 +1,4 @@
-#!/usr/bin/env bash
+#!/usr/bin/env sh
 ${IDRIS:-idris} $@ reg045.idr -o reg045
 ./reg045
 rm -f reg045 *.ibc

--- a/test/reg046/run
+++ b/test/reg046/run
@@ -1,3 +1,3 @@
-#!/usr/bin/env bash
+#!/usr/bin/env sh
 ${IDRIS:-idris} $@ reg046.idr --check
 rm -f reg046 *.ibc

--- a/test/reg047/run
+++ b/test/reg047/run
@@ -1,4 +1,4 @@
-#!/usr/bin/env bash
+#!/usr/bin/env sh
 ${IDRIS:-idris} $@ reg047.idr --check --nobuiltins
 ${IDRIS:-idris} $@ reg047a.idr --check
 rm -f *.ibc

--- a/test/reg048/run
+++ b/test/reg048/run
@@ -1,4 +1,4 @@
-#!/usr/bin/env bash
+#!/usr/bin/env sh
 ${IDRIS:-idris} $@ reg048.idr -p contrib -o reg048
 ./reg048
 rm -f reg048 *.ibc

--- a/test/reg049/run
+++ b/test/reg049/run
@@ -1,3 +1,3 @@
-#!/usr/bin/env bash
+#!/usr/bin/env sh
 ${IDRIS:-idris} --consolewidth 80 --nocolour --check $@ reg049.idr
 rm -f *.ibc

--- a/test/reg050/run
+++ b/test/reg050/run
@@ -1,4 +1,4 @@
-#!/usr/bin/env bash
+#!/usr/bin/env sh
 ${IDRIS:-idris} --nocolour --check $@ working.idr
 ${IDRIS:-idris} --nocolour --check $@ badbangop.idr
 ${IDRIS:-idris} --nocolour --check $@ baddoublebang.idr

--- a/test/reg051-disabled/run
+++ b/test/reg051-disabled/run
@@ -1,3 +1,3 @@
-#!/usr/bin/env bash
+#!/usr/bin/env sh
 ${IDRIS:-idris} $@ reg051.idr --check
 rm -f *.ibc

--- a/test/reg052/run
+++ b/test/reg052/run
@@ -1,4 +1,4 @@
-#!/usr/bin/env bash
+#!/usr/bin/env sh
 ${IDRIS:-idris} $@ -o reg052 reg052.idr
 ./reg052
 rm -f reg052 *.ibc

--- a/test/reg053/run
+++ b/test/reg053/run
@@ -1,3 +1,3 @@
-#!/usr/bin/env bash
+#!/usr/bin/env sh
 ${IDRIS:-idris} $@ --check four.idr 
 rm -f *.ibc

--- a/test/reg054/run
+++ b/test/reg054/run
@@ -1,2 +1,2 @@
-#!/usr/bin/env bash
+#!/usr/bin/env sh
 ${IDRIS:-idris} --nocolour --consolewidth 80 $@ reg054.idr --check

--- a/test/reg055/run
+++ b/test/reg055/run
@@ -1,4 +1,4 @@
-#!/usr/bin/env bash
+#!/usr/bin/env sh
 ${IDRIS:-idris} --nocolour --consolewidth 80 $@ reg055.idr --check
 ${IDRIS:-idris} --nocolour --consolewidth 80 $@ reg055a.idr --check
 rm -f *.ibc

--- a/test/reg056/run
+++ b/test/reg056/run
@@ -1,3 +1,3 @@
-#!/usr/bin/env bash
+#!/usr/bin/env sh
 ${IDRIS:-idris} --consolewidth 80 $@ reg056.idr -o reg056
 rm -f *.ibc

--- a/test/reg057/run
+++ b/test/reg057/run
@@ -1,3 +1,3 @@
-#!/usr/bin/env bash
+#!/usr/bin/env sh
 ${IDRIS:-idris} $@ reg057.idr --check
 rm -f *.ibc

--- a/test/reg058/run
+++ b/test/reg058/run
@@ -1,4 +1,4 @@
-#!/usr/bin/env bash
+#!/usr/bin/env sh
 ${IDRIS:-idris} $@ implicits.idr --check
 ${IDRIS:-idris} $@ implicits2.idr --check
 

--- a/test/reg059/run
+++ b/test/reg059/run
@@ -1,3 +1,3 @@
-#!/usr/bin/env bash
+#!/usr/bin/env sh
 ${IDRIS:-idris} $@ reg059.idr --check
 rm -f *.ibc

--- a/test/reg060/run
+++ b/test/reg060/run
@@ -1,3 +1,3 @@
-#!/usr/bin/env bash
+#!/usr/bin/env sh
 ${IDRIS:-idris} $@ reg060.idr --check
 rm -f *.ibc

--- a/test/reg061/run
+++ b/test/reg061/run
@@ -1,3 +1,3 @@
-#!/usr/bin/env bash
+#!/usr/bin/env sh
 ${IDRIS:-idris} $@ Capture.idr --check
 rm -f *.ibc

--- a/test/reg062/run
+++ b/test/reg062/run
@@ -1,4 +1,4 @@
-#!/usr/bin/env bash
+#!/usr/bin/env sh
 ${IDRIS:-idris} $@ reg062.idr --check --nocolour
 ${IDRIS:-idris} $@ reg062.lidr --check --nocolour
 rm -f *.ibc

--- a/test/reg063/run
+++ b/test/reg063/run
@@ -1,3 +1,3 @@
-#!/usr/bin/env bash
+#!/usr/bin/env sh
 ${IDRIS:-idris} $@ Cmp.idr --check --nocolour --quiet
 rm *.ibc

--- a/test/reg064/run
+++ b/test/reg064/run
@@ -1,3 +1,3 @@
-#!/usr/bin/env bash
+#!/usr/bin/env sh
 ${IDRIS:-idris} $@ reg064.idr --check
 rm -f *.ibc

--- a/test/reg065/run
+++ b/test/reg065/run
@@ -1,3 +1,3 @@
-#!/usr/bin/env bash
+#!/usr/bin/env sh
 ${IDRIS:-idris} $@ reg065.idr --check
 rm -f *.ibc

--- a/test/reg066/run
+++ b/test/reg066/run
@@ -1,3 +1,3 @@
-#!/usr/bin/env bash
+#!/usr/bin/env sh
 ${IDRIS:-idris} $@ reg066.idr --check --nocolor
 rm -f *.ibc

--- a/test/reg067/run
+++ b/test/reg067/run
@@ -1,4 +1,4 @@
-#!/usr/bin/env bash
+#!/usr/bin/env sh
 rm -f *.ibc reg067
 ${IDRIS:-idris} $@ reg067.idr -o reg067 --warnreach
 ./reg067

--- a/test/sourceLocation001/run
+++ b/test/sourceLocation001/run
@@ -1,4 +1,4 @@
-#!/usr/bin/env bash
+#!/usr/bin/env sh
 ${IDRIS:-idris} $@ --nocolour --consolewidth 80 SourceLoc.idr -o sourceLocation001
 ./sourceLocation001
 rm -f sourceLocation001 *.ibc

--- a/test/sugar001/run
+++ b/test/sugar001/run
@@ -1,4 +1,4 @@
-#!/usr/bin/env bash
+#!/usr/bin/env sh
 ${IDRIS:-idris} $@ test007.idr -o test007
 ./test007
 rm -f test007 test007.ibc

--- a/test/sugar002/run
+++ b/test/sugar002/run
@@ -1,4 +1,4 @@
-#!/usr/bin/env bash
+#!/usr/bin/env sh
 ${IDRIS:-idris} $@ test009.idr -o test009
 ./test009
 rm -f test009 test009.ibc

--- a/test/sugar003/run
+++ b/test/sugar003/run
@@ -1,4 +1,4 @@
-#!/usr/bin/env bash
+#!/usr/bin/env sh
 ${IDRIS:-idris} $@ test013.idr -o test013
 ./test013
 rm -f test013 test013.ibc

--- a/test/sugar004/run
+++ b/test/sugar004/run
@@ -1,4 +1,4 @@
-#!/usr/bin/env bash
+#!/usr/bin/env sh
 ${IDRIS:-idris} $@ sugar004.idr -o sugar004
 ./sugar004
 ./sugar004 42

--- a/test/sugar005/run
+++ b/test/sugar005/run
@@ -1,4 +1,4 @@
-#!/usr/bin/env bash
+#!/usr/bin/env sh
 ${IDRIS:-idris} $@ As.idr -o sugar005
 ./sugar005
 rm -f sugar005 *.ibc

--- a/test/syntax001/run
+++ b/test/syntax001/run
@@ -1,4 +1,4 @@
-#!/usr/bin/env bash
+#!/usr/bin/env sh
 ${IDRIS:-idris} $@ Syntax.idr --nocolour --consolewidth 80 --check
 ${IDRIS:-idris} $@ SyntaxTest.idr --nocolour --consolewidth 80 --check
 rm -f *.ibc

--- a/test/syntax002/run
+++ b/test/syntax002/run
@@ -1,4 +1,4 @@
-#!/usr/bin/env bash
+#!/usr/bin/env sh
 ${IDRIS:-idris} $@ syntax002.idr -o syntax002
 ./syntax002
 rm -f syntax002 *.ibc

--- a/test/tactics001/run
+++ b/test/tactics001/run
@@ -1,3 +1,3 @@
-#!/usr/bin/env bash
+#!/usr/bin/env sh
 ${IDRIS:-idris} $@ --check Tactics.idr
 rm -f *.ibc

--- a/test/totality001/run
+++ b/test/totality001/run
@@ -1,4 +1,4 @@
-#!/usr/bin/env bash
+#!/usr/bin/env sh
 ${IDRIS:-idris} --consolewidth 80 $@ --check test010.idr
 ${IDRIS:-idris} --consolewidth 80 $@ --check test010a.idr
 ${IDRIS:-idris} --consolewidth 80 $@ --check test010b.idr

--- a/test/totality002/run
+++ b/test/totality002/run
@@ -1,4 +1,4 @@
-#!/usr/bin/env bash
+#!/usr/bin/env sh
 ${IDRIS:-idris} --consolewidth 80 $@ --check test017.idr
 ${IDRIS:-idris} --consolewidth 80 $@ --check test017a.idr
 ${IDRIS:-idris} --consolewidth 80 $@ --check test017b.idr

--- a/test/totality003/run
+++ b/test/totality003/run
@@ -1,4 +1,4 @@
-#!/usr/bin/env bash
+#!/usr/bin/env sh
 ${IDRIS:-idris} --nocolour --consolewidth 80 $@ totality003.idr --check
 ${IDRIS:-idris} --nocolour --consolewidth 80 $@ totality003a.idr --check
 rm -f *.ibc

--- a/test/totality004/run
+++ b/test/totality004/run
@@ -1,4 +1,4 @@
-#!/usr/bin/env bash
+#!/usr/bin/env sh
 ${IDRIS:-idris} --consolewidth 80 $@ totality004.idr -o totality004
 ./totality004
 ${IDRIS:-idris} --consolewidth 80 $@ --check totality004a.idr 

--- a/test/totality005/run
+++ b/test/totality005/run
@@ -1,4 +1,4 @@
-#!/usr/bin/env bash
+#!/usr/bin/env sh
 ${IDRIS:-idris} $@ totality005.idr --total --check
 ${IDRIS:-idris} $@ totality005.idr -o totality005
 ./totality005

--- a/test/totality006/run
+++ b/test/totality006/run
@@ -1,4 +1,4 @@
-#!/usr/bin/env bash
+#!/usr/bin/env sh
 ${IDRIS:-idris} --consolewidth 80 $@ totality006.idr --check
 ${IDRIS:-idris} --consolewidth 80 $@ totality006a.idr --check
 ${IDRIS:-idris} --consolewidth 80 $@ totality006b.idr --check

--- a/test/totality007/run
+++ b/test/totality007/run
@@ -1,3 +1,3 @@
-#!/usr/bin/env bash
+#!/usr/bin/env sh
 ${IDRIS:-idris} $@ --build totality.ipkg
 rm -f src/*.ibc

--- a/test/totality008/run
+++ b/test/totality008/run
@@ -1,3 +1,3 @@
-#!/usr/bin/env bash
+#!/usr/bin/env sh
 ${IDRIS:-idris} --consolewidth 80 $@ totality008.idr --check
 rm -f *.ibc

--- a/test/totality009/run
+++ b/test/totality009/run
@@ -1,4 +1,4 @@
-#!/usr/bin/env bash
+#!/usr/bin/env sh
 OPTS="--consolewidth infinite --nocolour"
 ${IDRIS:-idris} "$@" $OPTS --check TestLambdaImpossible
 ${IDRIS:-idris} "$@" $OPTS --check --warnpartial TestLambdaPossible

--- a/test/totality010/run
+++ b/test/totality010/run
@@ -1,3 +1,3 @@
-#!/usr/bin/env bash
+#!/usr/bin/env sh
 ${IDRIS:-idris} $@ totality010.idr --nocolour --consolewidth 80 --check
 rm -f *.ibc

--- a/test/tutorial001/run
+++ b/test/tutorial001/run
@@ -1,3 +1,3 @@
-#!/usr/bin/env bash
+#!/usr/bin/env sh
 ${IDRIS:-idris} --check tutorial001.idr
 rm -f *.ibc

--- a/test/tutorial002/run
+++ b/test/tutorial002/run
@@ -1,3 +1,3 @@
-#!/usr/bin/env bash
+#!/usr/bin/env sh
 ${IDRIS:-idris} $@ --nocolour --consolewidth 80 tutorial002.idr --check
 rm -f *.ibc

--- a/test/tutorial003/run
+++ b/test/tutorial003/run
@@ -1,3 +1,3 @@
-#!/usr/bin/env bash
+#!/usr/bin/env sh
 ${IDRIS:-idris} $@ tutorial003.idr --check 
 rm -f *.ibc

--- a/test/tutorial004/run
+++ b/test/tutorial004/run
@@ -1,3 +1,3 @@
-#!/usr/bin/env bash
+#!/usr/bin/env sh
 ${IDRIS:-idris} $@ tutorial004.idr --check --nocolour --consolewidth 80
 rm -f *.ibc

--- a/test/tutorial005/run
+++ b/test/tutorial005/run
@@ -1,3 +1,3 @@
-#!/usr/bin/env bash
+#!/usr/bin/env sh
 ${IDRIS:-idris} $@ tutorial005.idr --check
 rm -f *.ibc

--- a/test/tutorial006/run
+++ b/test/tutorial006/run
@@ -1,4 +1,4 @@
-#!/usr/bin/env bash
+#!/usr/bin/env sh
 ${IDRIS:-idris} --nocolour --consolewidth 80 $@ tutorial006a.idr --check
 ${IDRIS:-idris} --nocolour --consolewidth 80 $@ tutorial006b.idr --check
 ${IDRIS:-idris} --nocolour --consolewidth 80 $@ tutorial006c.idr -p effects --check

--- a/test/unique001/run
+++ b/test/unique001/run
@@ -1,4 +1,4 @@
-#!/usr/bin/env bash
+#!/usr/bin/env sh
 ${IDRIS:-idris} --nocolour --consolewidth 80 $@ unique001.idr -o unique001
 ./unique001
 ${IDRIS:-idris} --nocolour --consolewidth 80 $@ unique001a.idr --check

--- a/test/unique002/run
+++ b/test/unique002/run
@@ -1,4 +1,4 @@
-#!/usr/bin/env bash
+#!/usr/bin/env sh
 ${IDRIS:-idris} --nocolour --consolewidth 80 $@ unique002.idr --check
 ${IDRIS:-idris} --nocolour --consolewidth 80 $@ unique002a.idr --check
 rm -f *.ibc

--- a/test/unique003/run
+++ b/test/unique003/run
@@ -1,3 +1,3 @@
-#!/usr/bin/env bash
+#!/usr/bin/env sh
 ${IDRIS:-idris} --nocolour --consolewidth 80 $@ unique003.idr --check
 rm -f *.ibc


### PR DESCRIPTION
I had to install bash on my FreeBSD server to run the tests, and that felt unnecessary, it's not like it's actually using any bash feature.