### PR TITLE
Get more data from bigint when truncating

### DIFF
--- a/rts/idris_gmp.c
+++ b/rts/idris_gmp.c
@@ -488,3 +488,16 @@ VAL idris_castBigStr(VM* vm, VAL i) {
     return MKSTR(vm, str);
 }
 
+// Get 64 bits out of a big int with special handling
+// for systems that have 32-bit longs which needs two limbs to
+// fill that.
+uint64_t idris_truncBigB64(const mpz_t bi) {
+    if (sizeof(mp_limb_t) == 8) {
+        return mpz_get_ui(bi);
+    }
+    int64_t out = mpz_get_ui(bi);
+    if (bi->_mp_size > 1 ) {
+        out |= (uint64_t)bi->_mp_d[1] << 32;
+    }
+    return out;
+}

--- a/rts/idris_gmp.h
+++ b/rts/idris_gmp.h
@@ -43,6 +43,8 @@ VAL idris_bigOr(VM* vm, VAL x, VAL y);
 VAL idris_bigShiftLeft(VM* vm, VAL x, VAL y);
 VAL idris_bigShiftRight(VM* vm, VAL x, VAL y);
 
+uint64_t idris_truncBigB64(const mpz_t bi);
+
 #define GETMPZ(x) *((mpz_t*)((x)->info.ptr))
 
 #endif

--- a/src/IRTS/CodegenC.hs
+++ b/src/IRTS/CodegenC.hs
@@ -557,6 +557,8 @@ doOp v (LTrunc (ITFixed from) ITNative) [x]
     = v ++ "MKINT((i_int)" ++ creg x ++ "->info.bits" ++ show (nativeTyWidth from) ++ ")"
 doOp v (LTrunc (ITFixed from) ITChar) [x]
     = doOp v (LTrunc (ITFixed from) ITNative) [x]
+doOp v (LTrunc ITBig (ITFixed IT64)) [x]
+    = v ++ "idris_b64const(vm, ISINT(" ++ creg x ++ ") ? GETINT(" ++ creg x ++ ") : idris_truncBigB64(GETMPZ(" ++ creg x ++ ")))"
 doOp v (LTrunc ITBig (ITFixed to)) [x]
     = v ++ "idris_b" ++ show (nativeTyWidth to) ++ "const(vm, ISINT(" ++ creg x ++ ") ? GETINT(" ++ creg x ++ ") : mpz_get_ui(GETMPZ(" ++ creg x ++ ")))"
 doOp v (LTrunc (ITFixed from) (ITFixed to)) [x]


### PR DESCRIPTION
Systems with 32-bit longs only got 32 bits even when truncating to 64 bits.

Fixes #2967