### PR TITLE
Add the "fmap" shortcut <$> to EffM

### DIFF
--- a/libs/effects/Effects.idr
+++ b/libs/effects/Effects.idr
@@ -256,6 +256,7 @@ return x = Value x
 -- ------------------------------------------------------ [ for idiom brackets ]
 
 infixl 2 <*>
+infixl 2 <$>
 
 pure : a -> EffM m a xs (\v => xs)
 pure = Value
@@ -268,6 +269,10 @@ pureM = Value
 (<*>) prog v = do fn <- prog
                   arg <- v
                   return (fn arg)
+                  
+(<$>) : (a -> b) ->
+        EffM m a xs (\v => xs) -> EffM m b xs (\v => xs)
+(<$>) f v = pure f <*> v
 
 (*>) : EffM m a xs (\v => xs) ->
        EffM m b xs (\v => xs) -> EffM m b xs (\v => xs)

--- a/libs/effects/Effects.idr
+++ b/libs/effects/Effects.idr
@@ -256,7 +256,6 @@ return x = Value x
 -- ------------------------------------------------------ [ for idiom brackets ]
 
 infixl 2 <*>
-infixl 2 <$>
 
 pure : a -> EffM m a xs (\v => xs)
 pure = Value


### PR DESCRIPTION
The `pure FancyConstructor <*> pure arg1 <*> hiddenlyEffectfulArg2 <*> (pure transform <*> effectfulArg3)` starts to get a little bit too noisy without the `<$>`.