### PR TITLE
Simplify getScreenWidth

### DIFF
--- a/src/Util/ScreenSize.hs
+++ b/src/Util/ScreenSize.hs
@@ -1,14 +1,6 @@
 module Util.ScreenSize(getScreenWidth) where
 
 import System.Console.Terminal.Size (size, width)
-import System.IO (hIsTerminalDevice, stdout)
 
 getScreenWidth :: IO Int
-getScreenWidth = do term <- hIsTerminalDevice stdout
-                    sz <- size 
-                    if term
-                        then case sz of
-                                Just w  -> return $ width w
-                                Nothing -> return 80
-                        else return 80
-
+getScreenWidth = maybe 80 width `fmap` size


### PR DESCRIPTION
The extra check for a terminal device should have no effect since it is already
part of retrieving the terminal size.