### PR TITLE
Null terminate the returned string on eof without delimiter.

### DIFF
--- a/rts/getline.c
+++ b/rts/getline.c
@@ -38,40 +38,41 @@
 ssize_t
 getdelim(char **buf, size_t *bufsiz, int delimiter, FILE *fp)
 {
-  char *ptr, *eptr;
+    char *ptr, *eptr;
 
+    if (*buf == NULL || *bufsiz == 0) {
+        *bufsiz = BUFSIZ;
+        if ((*buf = malloc(*bufsiz)) == NULL)
+            return -1;
+    }
 
-  if (*buf == NULL || *bufsiz == 0) {
-    *bufsiz = BUFSIZ;
-    if ((*buf = malloc(*bufsiz)) == NULL)
-      return -1;
-  }
-
-  for (ptr = *buf, eptr = *buf + *bufsiz;;) {
-    int c = fgetc(fp);
-    if (c == -1) {
-      if (feof(fp))
-        return ptr == *buf ? -1 : ptr - *buf;
-      else
-        return -1;
+    for (ptr = *buf, eptr = *buf + *bufsiz;;) {
+        int c = fgetc(fp);
+        if (c == -1) {
+            if (feof(fp)) {
+                *ptr = '\0';
+                return ptr - *buf;
+            } else {
+                return -1;
+            }
+        }
+        *ptr++ = c;
+        if (c == delimiter) {
+            *ptr = '\0';
+            return ptr - *buf;
+        }
+        if (ptr + 2 >= eptr) {
+            char *nbuf;
+            size_t nbufsiz = *bufsiz * 2;
+            ssize_t d = ptr - *buf;
+            if ((nbuf = realloc(*buf, nbufsiz)) == NULL)
+                return -1;
+            *buf = nbuf;
+            *bufsiz = nbufsiz;
+            eptr = nbuf + nbufsiz;
+            ptr = nbuf + d;
+        }
     }
-    *ptr++ = c;
-    if (c == delimiter) {
-      *ptr = '\0';
-      return ptr - *buf;
-    }
-    if (ptr + 2 >= eptr) {
-      char *nbuf;
-      size_t nbufsiz = *bufsiz * 2;
-      ssize_t d = ptr - *buf;
-      if ((nbuf = realloc(*buf, nbufsiz)) == NULL)
-        return -1;
-      *buf = nbuf;
-      *bufsiz = nbufsiz;
-      eptr = nbuf + nbufsiz;
-      ptr = nbuf + d;
-    }
-  }
 }
 
 ssize_t


### PR DESCRIPTION
Also, an empty file isn't an error it's a zero-sized file, and should return an empty string.

Fixes #3021