### PR TITLE
Add the ability to define datatypes in Elab

### DIFF
--- a/CHANGELOG
+++ b/CHANGELOG
@@ -23,6 +23,16 @@ in a C function pointer.
 * C function pointers can be called.
 * Idris can access pointers to C globals.
 
+Elaborator reflection updates
+-----------------------------
+
+* Datatypes can now be defined from elaborator reflection:
+  - declareDatatype adds the type constructor declaration to the context
+  - defineDatatype adds the constructors to the datatype
+  - To declare an inductive-recursive family, declare the types of the
+    function and the type constructor before defining the pattern-match
+    cases and constructors.
+
 Minor language changes
 ----------------------
 

--- a/src/Idris/AbsSyntaxTree.hs
+++ b/src/Idris/AbsSyntaxTree.hs
@@ -775,6 +775,9 @@ data Directive = DLib Codegen String |
 data RDeclInstructions = RTyDeclInstrs Name FC [PArg] Type
                        | RClausesInstrs Name [([(Name, Term)], Term, Term)]
                        | RAddInstance Name Name
+                       | RDatatypeDeclInstrs Name [PArg]
+                       | RDatatypeDefnInstrs Name Type [(Name, [PArg], Type)]
+                         -- ^ Datatype, constructors
 
 -- | For elaborator state
 data EState = EState {

--- a/src/Idris/Core/ProofState.hs
+++ b/src/Idris/Core/ProofState.hs
@@ -25,7 +25,10 @@ import Util.Pretty hiding (fill)
 data ProofState = PS { thname   :: Name,
                        holes    :: [Name], -- ^ holes still to be solved
                        usedns   :: [Name], -- ^ used names, don't use again
-                       nextname :: Int,    -- ^ name supply
+                       nextname :: Int,    -- ^ name supply, for locally unique names
+                       global_nextname :: Int, -- ^ a mirror of the global name supply,
+                                               --   for generating things like type tags
+                                               --   in reflection
                        pterm    :: ProofTerm,   -- ^ current proof term
                        ptype    :: Type,   -- ^ original goal
                        dontunify :: [Name], -- ^ explicitly given by programmer, leave it
@@ -305,11 +308,16 @@ query q = do ps <- get
 addLog :: Monad m => String -> StateT TState m ()
 addLog str = action (\ps -> ps { plog = plog ps ++ str ++ "\n" })
 
-newProof :: Name -> Context -> Ctxt TypeInfo -> Type -> ProofState
-newProof n ctxt datatypes ty =
+newProof :: Name -- ^ the name of what's to be elaborated
+         -> Context -- ^ the current global context
+         -> Ctxt TypeInfo -- ^ the value of the idris_datatypes field of IState
+         -> Int -- ^ the value of the idris_name field of IState
+         -> Type -- ^ the goal type
+         -> ProofState
+newProof n ctxt datatypes globalNames ty =
   let h = holeName 0
       ty' = vToP ty
-  in PS n [h] [] 1 (mkProofTerm (Bind h (Hole ty')
+  in PS n [h] [] 1 globalNames (mkProofTerm (Bind h (Hole ty')
         (P Bound h ty'))) ty [] (h, []) [] []
         Nothing [] []
         [] [] [] []

--- a/src/Idris/Elab/Instance.hs
+++ b/src/Idris/Elab/Instance.hs
@@ -186,12 +186,14 @@ elabInstance info syn doc argDocs what fc cs acc opts n nfc ps t expn ds = do
              ty' <- implicit info syn iname ty'
              let ty = addImpl [] i ty'
              ctxt <- getContext
-             (ElabResult tyT _ _ ctxt' newDecls highlights, _) <-
-                tclift $ elaborate ctxt (idris_datatypes i) iname (TType (UVal 0)) initEState
+             (ElabResult tyT _ _ ctxt' newDecls highlights newGName, _) <-
+                tclift $ elaborate ctxt (idris_datatypes i) (idris_name i) iname (TType (UVal 0)) initEState
                          (errAt "type of " iname Nothing (erun fc (build i info ERHS [] iname ty)))
              setContext ctxt'
              processTacticDecls info newDecls
              sendHighlighting highlights
+             updateIState $ \i -> i { idris_name = newGName }
+
              ctxt <- getContext
              (cty, _) <- recheckC fc id [] tyT
              let nty = normalise ctxt [] cty

--- a/src/Idris/Elab/RunElab.hs
+++ b/src/Idris/Elab/RunElab.hs
@@ -32,18 +32,20 @@ elabRunElab info fc script' ns =
      mustBeElabScript scriptTy
      ist <- getIState
      ctxt <- getContext
-     (ElabResult tyT' defer is ctxt' newDecls highlights, log) <-
-        tclift $ elaborate ctxt (idris_datatypes ist) (sMN 0 "toplLevelElab") elabScriptTy initEState
+     (ElabResult tyT' defer is ctxt' newDecls highlights newGName, log) <-
+        tclift $ elaborate ctxt (idris_datatypes ist) (idris_name ist) (sMN 0 "toplLevelElab") elabScriptTy initEState
                  (transformErr RunningElabScript
                    (erun fc (do tm <- runElabAction ist fc [] script ns
                                 EState is _ impls highlights <- getAux
                                 ctxt <- get_context
                                 let ds = [] -- todo
                                 log <- getLog
-                                return (ElabResult tm ds (map snd is) ctxt impls highlights))))
+                                newGName <- get_global_nextname
+                                return (ElabResult tm ds (map snd is) ctxt impls highlights newGName))))
 
 
 
      setContext ctxt'
      processTacticDecls info newDecls
      sendHighlighting highlights
+     updateIState $ \i -> i { idris_name = newGName }

--- a/src/Idris/Elab/Type.hs
+++ b/src/Idris/Elab/Type.hs
@@ -67,12 +67,13 @@ buildType info syn fc opts n ty' = do
          logElab 5 $ show "with methods " ++ show (imp_methods syn)
          logElab 2 $ show n ++ " type " ++ show (using syn) ++ "\n" ++ showTmImpls ty
 
-         (ElabResult tyT' defer is ctxt' newDecls highlights, log) <-
-            tclift $ elaborate ctxt (idris_datatypes i) n (TType (UVal 0)) initEState
+         (ElabResult tyT' defer is ctxt' newDecls highlights newGName, log) <-
+            tclift $ elaborate ctxt (idris_datatypes i) (idris_name i) n (TType (UVal 0)) initEState
                      (errAt "type of " n Nothing (erun fc (build i info ETyDecl [] n ty)))
          setContext ctxt'
          processTacticDecls info newDecls
-         sendHighlighting highlights
+         sendHighlighting highlights 
+         updateIState $ \i -> i { idris_name = newGName }
 
          let tyT = patToImp tyT'
 

--- a/src/Idris/Elab/Utils.hs
+++ b/src/Idris/Elab/Utils.hs
@@ -331,4 +331,67 @@ checkVisibility fc n minAcc acc ref
                               else return ()
 
 
+-- | Find the type constructor arguments that are parameters, given a list of constructor types.
+--   Parameters are names which are unchanged across the structure,
+--   which appear exactly once in the return type of a constructor
+--   First, find all applications of the constructor, then check over
+--   them for repeated arguments
+findParams :: Name -- ^ the name of the family that we are finding parameters for
+           -> [Type] -- ^ the declared constructor types
+           -> [Int]
+findParams tyn ts =
+    let allapps = map getDataApp ts
+        -- do each constructor separately, then merge the results (names
+        -- may change between constructors)
+        conParams = map paramPos allapps
+    in inAll conParams
 
+  where
+    inAll :: [[Int]] -> [Int]
+    inAll [] = []
+    inAll (x : xs) = filter (\p -> all (\ps -> p `elem` ps) xs) x
+
+    paramPos [] = []
+    paramPos (args : rest)
+          = dropNothing $ keepSame (zip [0..] args) rest
+    dropNothing [] = []
+    dropNothing ((x, Nothing) : ts) = dropNothing ts
+    dropNothing ((x, _) : ts) = x : dropNothing ts
+    keepSame :: [(Int, Maybe Name)] -> [[Maybe Name]] ->
+                [(Int, Maybe Name)]
+    keepSame as [] = as
+    keepSame as (args : rest) = keepSame (update as args) rest
+      where
+        update [] _ = []
+        update _ [] = []
+        update ((n, Just x) : as) (Just x' : args)
+            | x == x' = (n, Just x) : update as args
+        update ((n, _) : as) (_ : args) = (n, Nothing) : update as args
+    getDataApp :: Type -> [[Maybe Name]]
+    getDataApp f@(App _ _ _)
+        | (P _ d _, args) <- unApply f
+               = if (d == tyn) then [mParam args args] else []
+    getDataApp (Bind n (Pi _ t _) sc)
+        = getDataApp t ++ getDataApp (instantiate (P Bound n t) sc)
+    getDataApp _ = []
+    -- keep the arguments which are single names, which don't appear
+    -- elsewhere
+    mParam args [] = []
+    mParam args (P Bound n _ : rest)
+           | count n args == 1
+              = Just n : mParam args rest
+        where count n [] = 0
+              count n (t : ts)
+                   | n `elem` freeNames t = 1 + count n ts
+                   | otherwise = count n ts
+    mParam args (_ : rest) = Nothing : mParam args rest
+
+-- | Mark a name as detaggable in the global state (should be called
+-- for type and constructor names of single-constructor datatypes)
+setDetaggable :: Name -> Idris ()
+setDetaggable n = do
+    ist <- getIState
+    let opt = idris_optimisation ist
+    case lookupCtxt n opt of
+        [oi] -> putIState ist { idris_optimisation = addDef n oi { detaggable = True } opt }
+        _    -> putIState ist { idris_optimisation = addDef n (Optimise [] True) opt }

--- a/src/Idris/Elab/Value.hs
+++ b/src/Idris/Elab/Value.hs
@@ -64,14 +64,15 @@ elabValBind info aspat norm tm_in
         --    * elaboration as a Type
         --    * elaboration as a function a -> b
 
-        (ElabResult tm' defer is ctxt' newDecls highlights, _) <-
-             tclift (elaborate ctxt (idris_datatypes i) (sMN 0 "val") infP initEState
+        (ElabResult tm' defer is ctxt' newDecls highlights newGName, _) <-
+             tclift (elaborate ctxt (idris_datatypes i) (idris_name i) (sMN 0 "val") infP initEState
                      (build i info aspat [Reflection] (sMN 0 "val") (infTerm tm)))
 
         -- Extend the context with new definitions created
         setContext ctxt'
         processTacticDecls info newDecls
         sendHighlighting highlights
+        updateIState $ \i -> i { idris_name = newGName }
 
         let vtm = orderPats (getInferTerm tm')
 

--- a/src/Idris/Prover.hs
+++ b/src/Idris/Prover.hs
@@ -85,7 +85,7 @@ assumptionNames e
 
 prove :: Bool -> Ctxt OptInfo -> Context -> Bool -> Name -> Type -> Idris ()
 prove mode opt ctxt lit n ty
-    = do ps <- fmap (\ist -> initElaborator n ctxt (idris_datatypes ist) ty) getIState
+    = do ps <- fmap (\ist -> initElaborator n ctxt (idris_datatypes ist) (idris_name ist) ty) getIState
          idemodePutSExp "start-proof-mode" n
          (tm, prf) <-
             if mode

--- a/test/meta002/DataDef.idr
+++ b/test/meta002/DataDef.idr
@@ -1,0 +1,73 @@
+module DataDef
+
+foo : Elab ()
+foo = do declareDatatype $ Declare `{{DataDef.N}} [MkFunArg `{{n}} `(Nat) Explicit NotErased] `(Type)
+         defineDatatype $ DefineDatatype `{{DataDef.N}} [
+                            Constructor `{{MkN}} [MkFunArg `{{x}} `(Nat) Implicit NotErased] (RApp (Var `{{DataDef.N}}) (Var `{{x}})),
+                            Constructor `{{MkN'}} [MkFunArg `{{x}} `(Nat) Explicit NotErased] (RApp (Var `{{DataDef.N}}) (RApp (Var `{S}) (Var `{{x}})))
+                          ]
+%runElab foo
+
+one : N 1
+one = MkN
+
+two : N 2
+two = MkN' 1
+
+
+-- mutual
+--   data U : Type where
+--     Base : U
+--     Pi : (code : U) -> (el code -> U) -> U
+--   el : U -> Type
+--   el Base = Bool
+--   el (Pi code body) = (x : el code) -> el (body x)
+
+
+
+mkU : Elab ()
+mkU = do let U = `{{DataDef.U}}
+         let el = `{{DataDef.el}}
+         declareDatatype $ Declare U [] `(Type)
+         declareType $ Declare el [MkFunArg `{{code}} (Var U) Explicit NotErased] `(Type)
+         defineDatatype $ DefineDatatype U [
+                            Constructor `{{Base}} [] (Var U),
+                            Constructor `{{Pi}}
+                                        [MkFunArg `{{code}} (Var U) Explicit NotErased,
+                                         MkFunArg `{{body}} `(~(RApp (Var el) (Var `{{code}})) -> ~(Var U)) Explicit NotErased]
+                                        (Var U)
+                          ]
+         defineFunction $ DefineFun el [
+                            MkFunClause (RBind `{{code}} (PVar (Var U))
+                                           (RBind `{{body}} (PVar `(~(RApp (Var el) (Var `{{code}})) -> ~(Var U)))
+                                              (RApp (Var el)
+                                                    (RApp (RApp (Var `{{DataDef.Pi}})
+                                                                (Var `{{code}}))
+                                                          (Var `{{body}})))))
+                                        (RBind `{{code}} (PVar (Var U))
+                                           (RBind `{{body}} (PVar `(~(RApp (Var el) (Var `{{code}})) -> ~(Var U)))
+                                              (RBind `{{x}} (Pi (RApp (Var el) (Var `{{code}})) `(Type))
+                                                 (RApp (Var el) (RApp (Var `{{body}}) (Var `{{x}})))))),
+                            MkFunClause (RApp (Var el) (Var `{{DataDef.Base}})) `(Bool)
+
+                          ]
+
+%runElab mkU
+
+tt : el Base
+tt = True
+
+fun : el (Pi Base (\x => if x then Base else Pi Base (const Base)))
+fun = \x => (case x of
+               False => \y => False
+               True => False)
+
+
+nope : Elab ()
+nope = defineDatatype $ DefineDatatype `{Either} [
+           Constructor `{{Middle}} [ MkFunArg `{{x}} `(Type) Implicit NotErased
+                                   , MkFunArg `{{y}} `(Type) Implicit NotErased
+                                   ] `(Either ~(Var `{{x}}) ~(Var `{{y}}))
+       ]
+%runElab nope
+ 

--- a/test/meta002/expected
+++ b/test/meta002/expected
@@ -1,3 +1,6 @@
+DataDef.idr:72:1-9:
+While running an elaboration script, the following error occurred:
+Prelude.Either.Either is already defined as a datatype.
 Tacs.idr:298:15:
 When checking right hand side of testElab3 with expected type
         DPair Ty (Tm [])

--- a/test/meta002/run
+++ b/test/meta002/run
@@ -1,4 +1,5 @@
 #!/usr/bin/env bash
+${IDRIS:-idris} $@ -p pruviloj --nocolour --check --consolewidth 70 DataDef.idr
 ${IDRIS:-idris} $@ -p pruviloj --nocolour --check --consolewidth 70 Tacs.idr
 ${IDRIS:-idris} $@ -p pruviloj --nocolour --check --consolewidth 70 AgdaStyleReflection.idr
 # Disabled due to excess memory consumption


### PR DESCRIPTION
Add two new Elab effects:
 * declareDatatype, which adds the type constructor declaration to the context
 * defineDatatype, which adds the constructors to the datatype

See test/meta002/DataDef.idr for an example.