### PR TITLE
Generalize the types of mkApp and unApply

### DIFF
--- a/libs/base/Language/Reflection/Utils.idr
+++ b/libs/base/Language/Reflection/Utils.idr
@@ -40,17 +40,30 @@ getUName (UN n)    = Just n
 getUName (NS n ns) = getUName n
 getUName _         = Nothing
 
-total
-unApply : TT -> (TT, List TT)
-unApply t = unA t []
-  where unA : TT -> List TT -> (TT, List TT)
-        unA (App fn arg) args = unA fn (arg::args)
-        unA tm           args = (tm, args)
+namespace TT
+  total
+  unApply : TT -> (TT, List TT)
+  unApply t = unA t []
+    where unA : TT -> List TT -> (TT, List TT)
+          unA (App fn arg) args = unA fn (arg::args)
+          unA tm           args = (tm, args)
 
-total
-mkApp : TT -> List TT -> TT
-mkApp tm []      = tm
-mkApp tm (a::as) = mkApp (App tm a) as
+  total
+  mkApp : Foldable f => TT -> f TT -> TT
+  mkApp f args = foldl App f args
+
+namespace Raw
+  total
+  unApply : Raw -> (Raw, List Raw)
+  unApply tm = unApply' tm []
+    where unApply' : Raw -> List Raw -> (Raw, List Raw)
+          unApply' (RApp f x) xs = unApply' f (x::xs)
+          unApply' notApp xs = (notApp, xs)
+
+  total
+  mkApp : Foldable f => Raw -> f Raw -> Raw
+  mkApp f args = foldl RApp f args
+
 
 total
 binderTy : Binder t -> t

--- a/libs/pruviloj/Pruviloj/Internals.idr
+++ b/libs/pruviloj/Pruviloj/Internals.idr
@@ -26,16 +26,6 @@ updateTyConArgTy f (TyConParameter a) =
 updateTyConArgTy f (TyConIndex a) =
     TyConIndex (record {type = f (type a) } a)
 
-unApply : Raw -> (Raw, List Raw)
-unApply tm = unApply' tm []
-  where unApply' : Raw -> List Raw -> (Raw, List Raw)
-        unApply' (RApp f x) xs = unApply' f (x::xs)
-        unApply' notApp xs = (notApp, xs)
-
-mkApp : Raw -> List Raw -> Raw
-mkApp f [] = f
-mkApp f (x :: xs) = mkApp (RApp f x) xs
-
 ||| Grab the binders from around a term, alpha-converting to make
 ||| their names unique
 partial

--- a/test/meta002/AgdaStyleReflection.idr
+++ b/test/meta002/AgdaStyleReflection.idr
@@ -40,13 +40,6 @@ data Term
   | Constant Const
   | Ty
 
-unApply : Raw -> (Raw, List Raw)
-unApply tm = unApply' tm []
-  where unApply' : Raw -> List Raw -> (Raw, List Raw)
-        unApply' (RApp f x) xs = unApply' f (x::xs)
-        unApply' notApp xs = (notApp, xs)
-
-
 implementation Quotable Plicity Raw where
   quotedTy = `(Plicity)
   quote Explicit = `(Explicit)

--- a/test/meta002/expected
+++ b/test/meta002/expected
@@ -6,7 +6,7 @@ When checking right hand side of testElab3 with expected type
         DPair Ty (Tm [])
 
 Unifying ty and ARR ty t would lead to infinite value
-AgdaStyleReflection.idr:328:5:
+AgdaStyleReflection.idr:321:5:
 When checking right hand side of baz with expected type
         (Nat, Void)
 


### PR DESCRIPTION
Now, they accept any Foldable and work for both the TT and Raw
representations.