### PR TITLE
Move Default from Effects to Prelude

### DIFF
--- a/libs/base/Data/Vect.idr
+++ b/libs/base/Data/Vect.idr
@@ -527,6 +527,16 @@ implementation Show a => Show (Vect n a) where
     show = show . toList
 
 --------------------------------------------------------------------------------
+-- Default
+--------------------------------------------------------------------------------
+
+implementation Default a => Default (Vect n a) where
+    default = mkDef _ where
+      mkDef : (n : Nat) -> Vect n a
+      mkDef Z = []
+      mkDef (S k) = default :: mkDef k
+
+--------------------------------------------------------------------------------
 -- Properties
 --------------------------------------------------------------------------------
 
@@ -584,7 +594,7 @@ noEmptyElem : {x : a} -> Elem x [] -> Void
 noEmptyElem Here impossible
 
 Uninhabited (Elem x []) where
-  uninhabited = noEmptyElem 
+  uninhabited = noEmptyElem
 
 ||| An item not in the head and not in the tail is not in the Vect at all
 neitherHereNorThere : {x, y : a} -> {xs : Vect n a} -> Not (x = y) -> Not (Elem x xs) -> Not (Elem x (y :: xs))
@@ -619,7 +629,7 @@ mapElem (There e) = There (mapElem e)
 ||| length in its type, otherwise return Nothing
 ||| @len the required length
 ||| @xs the vector with the desired length
--- Needs to be Maybe rather than Dec, because if 'n' is unequal to m, we 
+-- Needs to be Maybe rather than Dec, because if 'n' is unequal to m, we
 -- only know we don't know how to make a Vect n a, not that one can't exist.
 exactLength : {m : Nat} -> -- expected at run-time
               (len : Nat) -> (xs : Vect m a) -> Maybe (Vect len a)
@@ -639,4 +649,3 @@ overLength {m} n xs with (cmp m n)
          = Just (0 ** xs)
   overLength {m = plus n (S x)} n xs | (CmpGT x)
          = Just (S x ** rewrite plusCommutative (S x) n in xs)
-

--- a/libs/effects/Effect/Perf.idr
+++ b/libs/effects/Effect/Perf.idr
@@ -10,7 +10,6 @@ module Effect.Perf
 import System
 
 import Effects
-import Effect.Default
 
 %access public export
 

--- a/libs/effects/Effect/State.idr
+++ b/libs/effects/Effect/State.idr
@@ -37,4 +37,3 @@ locally newst prog = do st <- get
                         val <- prog
                         putM st
                         return val
-

--- a/libs/effects/Effects.idr
+++ b/libs/effects/Effects.idr
@@ -1,7 +1,6 @@
 module Effects
 
 import Language.Reflection
-import public Effect.Default
 import Data.Vect
 
 --- Effectful computations are described as algebraic data types that
@@ -273,7 +272,7 @@ pureM = Value
        EffM m b xs (\v => xs) -> EffM m b xs (\v => xs)
 a *> b = do a
             b
-     
+
 new : Handler e' m => (e : EFFECT) -> resTy ->
       {auto prf : e = MkEff resTy e'} ->
       EffM m t (e :: es) (\v => e :: es) ->

--- a/libs/effects/effects.ipkg
+++ b/libs/effects/effects.ipkg
@@ -3,7 +3,6 @@ package effects
 opts    = "--nobasepkgs -i ../prelude -i ../base"
 
 modules = Effects
-        , Effect.Default
         , Effect.Monad
 
         , Effect.Exception

--- a/libs/prelude/Prelude.idr
+++ b/libs/prelude/Prelude.idr
@@ -27,6 +27,7 @@ import public Prelude.Providers
 import public Prelude.Show
 import public Prelude.Interactive
 import public Prelude.File
+import public Prelude.Default
 import public Prelude.Doubles
 import public Decidable.Equality
 import public Language.Reflection

--- a/libs/prelude/Prelude/Default.idr
+++ b/libs/prelude/Prelude/Default.idr
@@ -1,6 +1,13 @@
-module Effect.Default
+module Prelude.Default
 
-import Data.Vect
+import Builtins
+
+import Prelude.Basics
+import Prelude.Bool
+import Prelude.Interfaces
+import Prelude.Nat
+import Prelude.Maybe
+import Prelude.List
 
 %access public export
 
@@ -39,9 +46,3 @@ implementation Default (Maybe a) where
 
 implementation Default (List a) where
     default = []
-
-implementation Default a => Default (Vect n a) where
-    default = mkDef _ where
-      mkDef : (n : Nat) -> Vect n a
-      mkDef Z = []
-      mkDef (S k) = default :: mkDef k

--- a/libs/prelude/prelude.ipkg
+++ b/libs/prelude/prelude.ipkg
@@ -3,7 +3,7 @@ package prelude
 opts = "--nobuiltins --total --no-elim-deprecation-warnings"
 modules = Builtins, Prelude, IO,
 
-          Prelude.Algebra, Prelude.Basics, Prelude.Bool, Prelude.Cast,
+          Prelude.Algebra, Prelude.Basics, Prelude.Bool, Prelude.Cast, Prelude.Default,
           Prelude.Interfaces, Prelude.Nat, Prelude.List,
           Prelude.Maybe, Prelude.Monad, Prelude.Applicative, Prelude.Either,
           Prelude.Strings, Prelude.Chars, Prelude.Show, Prelude.Functor,


### PR DESCRIPTION
The `Default` interface has uses outside of the effects library. This
commit moves the implementatation from `Effects` and redistributes it
accordingly among `Prelude` and `Base`.

I've tagged this as WIP as when I compiled this locally I get an error compiling base:

```
idris --build base.ipkg
Type checking ./System.idr
When attempting to perform error reflection, the following internal error occurred:
        No such variable Language.Reflection.UNThis is probably a bug. Please consider reporting it at https://github.com/idris-lang/Idris-dev/issues
```

I want to see if this is my issue or something else, before I think about merging this.