### PR TITLE
Namespace the ClosureType enums.

### DIFF
--- a/rts/idris_bitstring.c
+++ b/rts/idris_bitstring.c
@@ -5,7 +5,7 @@
 VAL idris_b8CopyForGC(VM *vm, VAL a) {
     uint8_t A = a->info.bits8;
     VAL cl = allocate(sizeof(Closure), 1);
-    SETTY(cl, BITS8);
+    SETTY(cl, CT_BITS8);
     cl->info.bits8 = A;
     return cl;
 }
@@ -13,7 +13,7 @@ VAL idris_b8CopyForGC(VM *vm, VAL a) {
 VAL idris_b16CopyForGC(VM *vm, VAL a) {
     uint16_t A = a->info.bits16;
     VAL cl = allocate(sizeof(Closure), 1);
-    SETTY(cl, BITS16);
+    SETTY(cl, CT_BITS16);
     cl->info.bits16 = A;
     return cl;
 }
@@ -21,7 +21,7 @@ VAL idris_b16CopyForGC(VM *vm, VAL a) {
 VAL idris_b32CopyForGC(VM *vm, VAL a) {
     uint32_t A = a->info.bits32;
     VAL cl = allocate(sizeof(Closure), 1);
-    SETTY(cl, BITS32);
+    SETTY(cl, CT_BITS32);
     cl->info.bits32 = A;
     return cl;
 }
@@ -29,7 +29,7 @@ VAL idris_b32CopyForGC(VM *vm, VAL a) {
 VAL idris_b64CopyForGC(VM *vm, VAL a) {
     uint64_t A = a->info.bits64;
     VAL cl = allocate(sizeof(Closure), 1);
-    SETTY(cl, BITS64);
+    SETTY(cl, CT_BITS64);
     cl->info.bits64 = A;
     return cl;
 }
@@ -37,7 +37,7 @@ VAL idris_b64CopyForGC(VM *vm, VAL a) {
 VAL idris_b8(VM *vm, VAL a) {
     uint8_t A = GETINT(a);
     VAL cl = allocate(sizeof(Closure), 0);
-    SETTY(cl, BITS8);
+    SETTY(cl, CT_BITS8);
     cl->info.bits8 = (uint8_t) A;
     return cl;
 }
@@ -45,7 +45,7 @@ VAL idris_b8(VM *vm, VAL a) {
 VAL idris_b16(VM *vm, VAL a) {
     uint16_t A = GETINT(a);
     VAL cl = allocate(sizeof(Closure), 0);
-    SETTY(cl, BITS16);
+    SETTY(cl, CT_BITS16);
     cl->info.bits16 = (uint16_t) A;
     return cl;
 }
@@ -53,7 +53,7 @@ VAL idris_b16(VM *vm, VAL a) {
 VAL idris_b32(VM *vm, VAL a) {
     uint32_t A = GETINT(a);
     VAL cl = allocate(sizeof(Closure), 0);
-    SETTY(cl, BITS32);
+    SETTY(cl, CT_BITS32);
     cl->info.bits32 = (uint32_t) A;
     return cl;
 }
@@ -61,7 +61,7 @@ VAL idris_b32(VM *vm, VAL a) {
 VAL idris_b64(VM *vm, VAL a) {
     uint64_t A = GETINT(a);
     VAL cl = allocate(sizeof(Closure), 0);
-    SETTY(cl, BITS64);
+    SETTY(cl, CT_BITS64);
     cl->info.bits64 = (uint64_t) A;
     return cl;
 }
@@ -72,28 +72,28 @@ VAL idris_castB32Int(VM *vm, VAL a) {
 
 VAL idris_b8const(VM *vm, uint8_t a) {
     VAL cl = allocate(sizeof(Closure), 0);
-    SETTY(cl, BITS8);
+    SETTY(cl, CT_BITS8);
     cl->info.bits8 = a;
     return cl;
 }
 
 VAL idris_b16const(VM *vm, uint16_t a) {
     VAL cl = allocate(sizeof(Closure), 0);
-    SETTY(cl, BITS16);
+    SETTY(cl, CT_BITS16);
     cl->info.bits16 = a;
     return cl;
 }
 
 VAL idris_b32const(VM *vm, uint32_t a) {
     VAL cl = allocate(sizeof(Closure), 0);
-    SETTY(cl, BITS32);
+    SETTY(cl, CT_BITS32);
     cl->info.bits32 = a;
     return cl;
 }
 
 VAL idris_b64const(VM *vm, uint64_t a) {
     VAL cl = allocate(sizeof(Closure), 0);
-    SETTY(cl, BITS64);
+    SETTY(cl, CT_BITS64);
     cl->info.bits64 = a;
     return cl;
 }
@@ -102,7 +102,7 @@ VAL idris_b8Plus(VM *vm, VAL a, VAL b) {
     uint8_t A = a->info.bits8;
     uint8_t B = b->info.bits8;
     VAL cl = allocate(sizeof(Closure), 0);
-    SETTY(cl, BITS8);
+    SETTY(cl, CT_BITS8);
     cl->info.bits8 = A + B;
     return cl;
 }
@@ -111,7 +111,7 @@ VAL idris_b8Minus(VM *vm, VAL a, VAL b) {
     uint8_t A = a->info.bits8;
     uint8_t B = b->info.bits8;
     VAL cl = allocate(sizeof(Closure), 0);
-    SETTY(cl, BITS8);
+    SETTY(cl, CT_BITS8);
     cl->info.bits8 = A - B;
     return cl;
 }
@@ -120,7 +120,7 @@ VAL idris_b8Times(VM *vm, VAL a, VAL b) {
     uint8_t A = a->info.bits8;
     uint8_t B = b->info.bits8;
     VAL cl = allocate(sizeof(Closure), 0);
-    SETTY(cl, BITS8);
+    SETTY(cl, CT_BITS8);
     cl->info.bits8 = A * B;
     return cl;
 }
@@ -129,7 +129,7 @@ VAL idris_b8UDiv(VM *vm, VAL a, VAL b) {
     uint8_t A = a->info.bits8;
     uint8_t B = b->info.bits8;
     VAL cl = allocate(sizeof(Closure), 0);
-    SETTY(cl, BITS8);
+    SETTY(cl, CT_BITS8);
     cl->info.bits8 = A / B;
     return cl;
 }
@@ -138,7 +138,7 @@ VAL idris_b8SDiv(VM *vm, VAL a, VAL b) {
     uint8_t A = a->info.bits8;
     uint8_t B = b->info.bits8;
     VAL cl = allocate(sizeof(Closure), 0);
-    SETTY(cl, BITS8);
+    SETTY(cl, CT_BITS8);
     cl->info.bits8 = (uint8_t) (((int8_t) A) / ((int8_t) B));
     return cl;
 }
@@ -147,7 +147,7 @@ VAL idris_b8URem(VM *vm, VAL a, VAL b) {
     uint8_t A = a->info.bits8;
     uint8_t B = b->info.bits8;
     VAL cl = allocate(sizeof(Closure), 0);
-    SETTY(cl, BITS8);
+    SETTY(cl, CT_BITS8);
     cl->info.bits8 = A % B;
     return cl;
 }
@@ -156,7 +156,7 @@ VAL idris_b8SRem(VM *vm, VAL a, VAL b) {
     uint8_t A = a->info.bits8;
     uint8_t B = b->info.bits8;
     VAL cl = allocate(sizeof(Closure), 0);
-    SETTY(cl, BITS8);
+    SETTY(cl, CT_BITS8);
     cl->info.bits8 = (uint8_t) (((int8_t) A) % ((int8_t) B));
     return cl;
 }
@@ -184,7 +184,7 @@ VAL idris_b8Gte(VM *vm, VAL a, VAL b) {
 VAL idris_b8Compl(VM *vm, VAL a) {
     uint8_t A = a->info.bits8;
     VAL cl = allocate(sizeof(Closure), 0);
-    SETTY(cl, BITS8);
+    SETTY(cl, CT_BITS8);
     cl->info.bits8 = ~ A;
     return cl;
 }
@@ -193,7 +193,7 @@ VAL idris_b8And(VM *vm, VAL a, VAL b) {
     uint8_t A = a->info.bits8;
     uint8_t B = b->info.bits8;
     VAL cl = allocate(sizeof(Closure), 0);
-    SETTY(cl, BITS8);
+    SETTY(cl, CT_BITS8);
     cl->info.bits8 = A & B;
     return cl;
 }
@@ -202,7 +202,7 @@ VAL idris_b8Or(VM *vm, VAL a, VAL b) {
     uint8_t A = a->info.bits8;
     uint8_t B = b->info.bits8;
     VAL cl = allocate(sizeof(Closure), 0);
-    SETTY(cl, BITS8);
+    SETTY(cl, CT_BITS8);
     cl->info.bits8 = A | B;
     return cl;
 }
@@ -211,7 +211,7 @@ VAL idris_b8Xor(VM *vm, VAL a, VAL b) {
     uint8_t A = a->info.bits8;
     uint8_t B = b->info.bits8;
     VAL cl = allocate(sizeof(Closure), 0);
-    SETTY(cl, BITS8);
+    SETTY(cl, CT_BITS8);
     cl->info.bits8 = A ^ B;
     return cl;
 }
@@ -220,7 +220,7 @@ VAL idris_b8Shl(VM *vm, VAL a, VAL b) {
     uint8_t A = a->info.bits8;
     uint8_t B = b->info.bits8;
     VAL cl = allocate(sizeof(Closure), 0);
-    SETTY(cl, BITS8);
+    SETTY(cl, CT_BITS8);
     cl->info.bits8 = A << B;
     return cl;
 }
@@ -229,7 +229,7 @@ VAL idris_b8LShr(VM *vm, VAL a, VAL b) {
     uint8_t A = a->info.bits8;
     uint8_t B = b->info.bits8;
     VAL cl = allocate(sizeof(Closure), 0);
-    SETTY(cl, BITS8);
+    SETTY(cl, CT_BITS8);
     cl->info.bits8 = A >> B;
     return cl;
 }
@@ -238,7 +238,7 @@ VAL idris_b8AShr(VM *vm, VAL a, VAL b) {
     uint8_t A = a->info.bits8;
     uint8_t B = b->info.bits8;
     VAL cl = allocate(sizeof(Closure), 0);
-    SETTY(cl, BITS8);
+    SETTY(cl, CT_BITS8);
     cl->info.bits8 = (uint8_t) (((int8_t) A) >> ((int8_t) B));
     return cl;
 }
@@ -247,7 +247,7 @@ VAL idris_b16Plus(VM *vm, VAL a, VAL b) {
     uint16_t A = a->info.bits16;
     uint16_t B = b->info.bits16;
     VAL cl = allocate(sizeof(Closure), 0);
-    SETTY(cl, BITS16);
+    SETTY(cl, CT_BITS16);
     cl->info.bits16 = A + B;
     return cl;
 }
@@ -256,7 +256,7 @@ VAL idris_b16Minus(VM *vm, VAL a, VAL b) {
     uint16_t A = a->info.bits16;
     uint16_t B = b->info.bits16;
     VAL cl = allocate(sizeof(Closure), 0);
-    SETTY(cl, BITS16);
+    SETTY(cl, CT_BITS16);
     cl->info.bits16 = A - B;
     return cl;
 }
@@ -265,7 +265,7 @@ VAL idris_b16Times(VM *vm, VAL a, VAL b) {
     uint16_t A = a->info.bits16;
     uint16_t B = b->info.bits16;
     VAL cl = allocate(sizeof(Closure), 0);
-    SETTY(cl, BITS16);
+    SETTY(cl, CT_BITS16);
     cl->info.bits16 = A * B;
     return cl;
 }
@@ -274,7 +274,7 @@ VAL idris_b16UDiv(VM *vm, VAL a, VAL b) {
     uint16_t A = a->info.bits16;
     uint16_t B = b->info.bits16;
     VAL cl = allocate(sizeof(Closure), 0);
-    SETTY(cl, BITS16);
+    SETTY(cl, CT_BITS16);
     cl->info.bits16 = A / B;
     return cl;
 }
@@ -283,7 +283,7 @@ VAL idris_b16SDiv(VM *vm, VAL a, VAL b) {
     uint16_t A = a->info.bits16;
     uint16_t B = b->info.bits16;
     VAL cl = allocate(sizeof(Closure), 0);
-    SETTY(cl, BITS16);
+    SETTY(cl, CT_BITS16);
     cl->info.bits16 = (uint16_t) (((int16_t) A) / ((int16_t) B));
     return cl;
 }
@@ -292,7 +292,7 @@ VAL idris_b16URem(VM *vm, VAL a, VAL b) {
     uint16_t A = a->info.bits16;
     uint16_t B = b->info.bits16;
     VAL cl = allocate(sizeof(Closure), 0);
-    SETTY(cl, BITS16);
+    SETTY(cl, CT_BITS16);
     cl->info.bits16 = A % B;
     return cl;
 }
@@ -301,7 +301,7 @@ VAL idris_b16SRem(VM *vm, VAL a, VAL b) {
     uint16_t A = a->info.bits16;
     uint16_t B = b->info.bits16;
     VAL cl = allocate(sizeof(Closure), 0);
-    SETTY(cl, BITS16);
+    SETTY(cl, CT_BITS16);
     cl->info.bits16 = (uint16_t) (((int16_t) A) % ((int16_t) B));
     return cl;
 }
@@ -329,7 +329,7 @@ VAL idris_b16Gte(VM *vm, VAL a, VAL b) {
 VAL idris_b16Compl(VM *vm, VAL a) {
     uint16_t A = a->info.bits16;
     VAL cl = allocate(sizeof(Closure), 0);
-    SETTY(cl, BITS16);
+    SETTY(cl, CT_BITS16);
     cl->info.bits16 = ~ A;
     return cl;
 }
@@ -338,7 +338,7 @@ VAL idris_b16And(VM *vm, VAL a, VAL b) {
     uint16_t A = a->info.bits16;
     uint16_t B = b->info.bits16;
     VAL cl = allocate(sizeof(Closure), 0);
-    SETTY(cl, BITS16);
+    SETTY(cl, CT_BITS16);
     cl->info.bits16 = A & B;
     return cl;
 }
@@ -347,7 +347,7 @@ VAL idris_b16Or(VM *vm, VAL a, VAL b) {
     uint16_t A = a->info.bits16;
     uint16_t B = b->info.bits16;
     VAL cl = allocate(sizeof(Closure), 0);
-    SETTY(cl, BITS16);
+    SETTY(cl, CT_BITS16);
     cl->info.bits16 = A | B;
     return cl;
 }
@@ -356,7 +356,7 @@ VAL idris_b16Xor(VM *vm, VAL a, VAL b) {
     uint16_t A = a->info.bits16;
     uint16_t B = b->info.bits16;
     VAL cl = allocate(sizeof(Closure), 0);
-    SETTY(cl, BITS16);
+    SETTY(cl, CT_BITS16);
     cl->info.bits16 = A ^ B;
     return cl;
 }
@@ -365,7 +365,7 @@ VAL idris_b16Shl(VM *vm, VAL a, VAL b) {
     uint16_t A = a->info.bits16;
     uint16_t B = b->info.bits16;
     VAL cl = allocate(sizeof(Closure), 0);
-    SETTY(cl, BITS16);
+    SETTY(cl, CT_BITS16);
     cl->info.bits16 = A << B;
     return cl;
 }
@@ -374,7 +374,7 @@ VAL idris_b16LShr(VM *vm, VAL a, VAL b) {
     uint16_t A = a->info.bits16;
     uint16_t B = b->info.bits16;
     VAL cl = allocate(sizeof(Closure), 0);
-    SETTY(cl, BITS16);
+    SETTY(cl, CT_BITS16);
     cl->info.bits16 = A >> B;
     return cl;
 }
@@ -383,7 +383,7 @@ VAL idris_b16AShr(VM *vm, VAL a, VAL b) {
     uint16_t A = a->info.bits16;
     uint16_t B = b->info.bits16;
     VAL cl = allocate(sizeof(Closure), 0);
-    SETTY(cl, BITS16);
+    SETTY(cl, CT_BITS16);
     cl->info.bits16 = (uint16_t) (((int16_t) A) >> ((int16_t) B));
     return cl;
 }
@@ -392,7 +392,7 @@ VAL idris_b32Plus(VM *vm, VAL a, VAL b) {
     uint32_t A = a->info.bits32;
     uint32_t B = b->info.bits32;
     VAL cl = allocate(sizeof(Closure), 0);
-    SETTY(cl, BITS32);
+    SETTY(cl, CT_BITS32);
     cl->info.bits32 = A + B;
     return cl;
 }
@@ -401,7 +401,7 @@ VAL idris_b32Minus(VM *vm, VAL a, VAL b) {
     uint32_t A = a->info.bits32;
     uint32_t B = b->info.bits32;
     VAL cl = allocate(sizeof(Closure), 0);
-    SETTY(cl, BITS32);
+    SETTY(cl, CT_BITS32);
     cl->info.bits32 = A - B;
     return cl;
 }
@@ -410,7 +410,7 @@ VAL idris_b32Times(VM *vm, VAL a, VAL b) {
     uint32_t A = a->info.bits32;
     uint32_t B = b->info.bits32;
     VAL cl = allocate(sizeof(Closure), 0);
-    SETTY(cl, BITS32);
+    SETTY(cl, CT_BITS32);
     cl->info.bits32 = A * B;
     return cl;
 }
@@ -419,7 +419,7 @@ VAL idris_b32UDiv(VM *vm, VAL a, VAL b) {
     uint32_t A = a->info.bits32;
     uint32_t B = b->info.bits32;
     VAL cl = allocate(sizeof(Closure), 0);
-    SETTY(cl, BITS32);
+    SETTY(cl, CT_BITS32);
     cl->info.bits32 = A / B;
     return cl;
 }
@@ -428,7 +428,7 @@ VAL idris_b32SDiv(VM *vm, VAL a, VAL b) {
     uint32_t A = a->info.bits32;
     uint32_t B = b->info.bits32;
     VAL cl = allocate(sizeof(Closure), 0);
-    SETTY(cl, BITS32);
+    SETTY(cl, CT_BITS32);
     cl->info.bits32 = (uint32_t) (((int32_t) A) / ((int32_t) B));
     return cl;
 }
@@ -437,7 +437,7 @@ VAL idris_b32URem(VM *vm, VAL a, VAL b) {
     uint32_t A = a->info.bits32;
     uint32_t B = b->info.bits32;
     VAL cl = allocate(sizeof(Closure), 0);
-    SETTY(cl, BITS32);
+    SETTY(cl, CT_BITS32);
     cl->info.bits32 = A % B;
     return cl;
 }
@@ -446,7 +446,7 @@ VAL idris_b32SRem(VM *vm, VAL a, VAL b) {
     uint32_t A = a->info.bits32;
     uint32_t B = b->info.bits32;
     VAL cl = allocate(sizeof(Closure), 0);
-    SETTY(cl, BITS32);
+    SETTY(cl, CT_BITS32);
     cl->info.bits32 = (uint32_t) (((int32_t) A) % ((int32_t) B));
     return cl;
 }
@@ -474,7 +474,7 @@ VAL idris_b32Gte(VM *vm, VAL a, VAL b) {
 VAL idris_b32Compl(VM *vm, VAL a) {
     uint32_t A = a->info.bits32;
     VAL cl = allocate(sizeof(Closure), 0);
-    SETTY(cl, BITS32);
+    SETTY(cl, CT_BITS32);
     cl->info.bits32 = ~ A;
     return cl;
 }
@@ -483,7 +483,7 @@ VAL idris_b32And(VM *vm, VAL a, VAL b) {
     uint32_t A = a->info.bits32;
     uint32_t B = b->info.bits32;
     VAL cl = allocate(sizeof(Closure), 0);
-    SETTY(cl, BITS32);
+    SETTY(cl, CT_BITS32);
     cl->info.bits32 = A & B;
     return cl;
 }
@@ -492,7 +492,7 @@ VAL idris_b32Or(VM *vm, VAL a, VAL b) {
     uint32_t A = a->info.bits32;
     uint32_t B = b->info.bits32;
     VAL cl = allocate(sizeof(Closure), 0);
-    SETTY(cl, BITS32);
+    SETTY(cl, CT_BITS32);
     cl->info.bits32 = A | B;
     return cl;
 }
@@ -501,7 +501,7 @@ VAL idris_b32Xor(VM *vm, VAL a, VAL b) {
     uint32_t A = a->info.bits32;
     uint32_t B = b->info.bits32;
     VAL cl = allocate(sizeof(Closure), 0);
-    SETTY(cl, BITS32);
+    SETTY(cl, CT_BITS32);
     cl->info.bits32 = A ^ B;
     return cl;
 }
@@ -510,7 +510,7 @@ VAL idris_b32Shl(VM *vm, VAL a, VAL b) {
     uint32_t A = a->info.bits32;
     uint32_t B = b->info.bits32;
     VAL cl = allocate(sizeof(Closure), 0);
-    SETTY(cl, BITS32);
+    SETTY(cl, CT_BITS32);
     cl->info.bits32 = A << B;
     return cl;
 }
@@ -519,7 +519,7 @@ VAL idris_b32LShr(VM *vm, VAL a, VAL b) {
     uint32_t A = a->info.bits32;
     uint32_t B = b->info.bits32;
     VAL cl = allocate(sizeof(Closure), 0);
-    SETTY(cl, BITS32);
+    SETTY(cl, CT_BITS32);
     cl->info.bits32 = A >> B;
     return cl;
 }
@@ -528,7 +528,7 @@ VAL idris_b32AShr(VM *vm, VAL a, VAL b) {
     uint32_t A = a->info.bits32;
     uint32_t B = b->info.bits32;
     VAL cl = allocate(sizeof(Closure), 0);
-    SETTY(cl, BITS32);
+    SETTY(cl, CT_BITS32);
     cl->info.bits32 = (uint32_t) (((int32_t)A) >> ((int32_t)B));
     return cl;
 }
@@ -537,7 +537,7 @@ VAL idris_b64Plus(VM *vm, VAL a, VAL b) {
     uint64_t A = a->info.bits64;
     uint64_t B = b->info.bits64;
     VAL cl = allocate(sizeof(Closure), 0);
-    SETTY(cl, BITS64);
+    SETTY(cl, CT_BITS64);
     cl->info.bits64 = A + B;
     return cl;
 }
@@ -546,7 +546,7 @@ VAL idris_b64Minus(VM *vm, VAL a, VAL b) {
     uint64_t A = a->info.bits64;
     uint64_t B = b->info.bits64;
     VAL cl = allocate(sizeof(Closure), 0);
-    SETTY(cl, BITS64);
+    SETTY(cl, CT_BITS64);
     cl->info.bits64 = A - B;
     return cl;
 }
@@ -555,7 +555,7 @@ VAL idris_b64Times(VM *vm, VAL a, VAL b) {
     uint64_t A = a->info.bits64;
     uint64_t B = b->info.bits64;
     VAL cl = allocate(sizeof(Closure), 0);
-    SETTY(cl, BITS64);
+    SETTY(cl, CT_BITS64);
     cl->info.bits64 = A * B;
     return cl;
 }
@@ -564,7 +564,7 @@ VAL idris_b64UDiv(VM *vm, VAL a, VAL b) {
     uint64_t A = a->info.bits64;
     uint64_t B = b->info.bits64;
     VAL cl = allocate(sizeof(Closure), 0);
-    SETTY(cl, BITS64);
+    SETTY(cl, CT_BITS64);
     cl->info.bits64 = A / B;
     return cl;
 }
@@ -573,7 +573,7 @@ VAL idris_b64SDiv(VM *vm, VAL a, VAL b) {
     uint64_t A = a->info.bits64;
     uint64_t B = b->info.bits64;
     VAL cl = allocate(sizeof(Closure), 0);
-    SETTY(cl, BITS64);
+    SETTY(cl, CT_BITS64);
     cl->info.bits64 = (uint64_t) (((int64_t) A) / ((int64_t) B));
     return cl;
 }
@@ -582,7 +582,7 @@ VAL idris_b64URem(VM *vm, VAL a, VAL b) {
     uint64_t A = a->info.bits64;
     uint64_t B = b->info.bits64;
     VAL cl = allocate(sizeof(Closure), 0);
-    SETTY(cl, BITS64);
+    SETTY(cl, CT_BITS64);
     cl->info.bits64 = A % B;
     return cl;
 }
@@ -591,7 +591,7 @@ VAL idris_b64SRem(VM *vm, VAL a, VAL b) {
     uint64_t A = a->info.bits64;
     uint64_t B = b->info.bits64;
     VAL cl = allocate(sizeof(Closure), 0);
-    SETTY(cl, BITS64);
+    SETTY(cl, CT_BITS64);
     cl->info.bits64 = (uint64_t) (((int64_t) A) % ((int64_t) B));
     return cl;
 }
@@ -619,7 +619,7 @@ VAL idris_b64Gte(VM *vm, VAL a, VAL b) {
 VAL idris_b64Compl(VM *vm, VAL a) {
     uint64_t A = a->info.bits64;
     VAL cl = allocate(sizeof(Closure), 0);
-    SETTY(cl, BITS64);
+    SETTY(cl, CT_BITS64);
     cl->info.bits64 = ~ A;
     return cl;
 }
@@ -628,7 +628,7 @@ VAL idris_b64And(VM *vm, VAL a, VAL b) {
     uint64_t A = a->info.bits64;
     uint64_t B = b->info.bits64;
     VAL cl = allocate(sizeof(Closure), 0);
-    SETTY(cl, BITS64);
+    SETTY(cl, CT_BITS64);
     cl->info.bits64 = A & B;
     return cl;
 }
@@ -637,7 +637,7 @@ VAL idris_b64Or(VM *vm, VAL a, VAL b) {
     uint64_t A = a->info.bits64;
     uint64_t B = b->info.bits64;
     VAL cl = allocate(sizeof(Closure), 0);
-    SETTY(cl, BITS64);
+    SETTY(cl, CT_BITS64);
     cl->info.bits64 = A | B;
     return cl;
 }
@@ -646,7 +646,7 @@ VAL idris_b64Xor(VM *vm, VAL a, VAL b) {
     uint64_t A = a->info.bits64;
     uint64_t B = b->info.bits64;
     VAL cl = allocate(sizeof(Closure), 0);
-    SETTY(cl, BITS64);
+    SETTY(cl, CT_BITS64);
     cl->info.bits64 = A ^ B;
     return cl;
 }
@@ -655,7 +655,7 @@ VAL idris_b64Shl(VM *vm, VAL a, VAL b) {
     uint64_t A = a->info.bits64;
     uint64_t B = b->info.bits64;
     VAL cl = allocate(sizeof(Closure), 0);
-    SETTY(cl, BITS64);
+    SETTY(cl, CT_BITS64);
     cl->info.bits64 = A << B;
     return cl;
 }
@@ -664,7 +664,7 @@ VAL idris_b64LShr(VM *vm, VAL a, VAL b) {
     uint64_t A = a->info.bits64;
     uint64_t B = b->info.bits64;
     VAL cl = allocate(sizeof(Closure), 0);
-    SETTY(cl, BITS64);
+    SETTY(cl, CT_BITS64);
     cl->info.bits64 = A >> B;
     return cl;
 }
@@ -673,7 +673,7 @@ VAL idris_b64AShr(VM *vm, VAL a, VAL b) {
     uint64_t A = a->info.bits64;
     uint64_t B = b->info.bits64;
     VAL cl = allocate(sizeof(Closure), 0);
-    SETTY(cl, BITS64);
+    SETTY(cl, CT_BITS64);
     cl->info.bits64 = (uint64_t) (((int64_t) A) >> ((int64_t) B));
     return cl;
 }
@@ -681,7 +681,7 @@ VAL idris_b64AShr(VM *vm, VAL a, VAL b) {
 VAL idris_b8Z16(VM *vm, VAL a) {
     uint8_t A = a->info.bits8;
     VAL cl = allocate(sizeof(Closure), 0);
-    SETTY(cl, BITS16);
+    SETTY(cl, CT_BITS16);
     cl->info.bits16 = (uint16_t) A;
     return cl;
 }
@@ -689,7 +689,7 @@ VAL idris_b8Z16(VM *vm, VAL a) {
 VAL idris_b8Z32(VM *vm, VAL a) {
     uint8_t A = a->info.bits8;
     VAL cl = allocate(sizeof(Closure), 0);
-    SETTY(cl, BITS32);
+    SETTY(cl, CT_BITS32);
     cl->info.bits32 = (uint32_t) A;
     return cl;
 }
@@ -697,7 +697,7 @@ VAL idris_b8Z32(VM *vm, VAL a) {
 VAL idris_b8Z64(VM *vm, VAL a) {
     uint8_t A = a->info.bits8;
     VAL cl = allocate(sizeof(Closure), 0);
-    SETTY(cl, BITS64);
+    SETTY(cl, CT_BITS64);
     cl->info.bits64 = (uint64_t) A;
     return cl;
 }
@@ -705,7 +705,7 @@ VAL idris_b8Z64(VM *vm, VAL a) {
 VAL idris_b8S16(VM *vm, VAL a) {
     uint8_t A = a->info.bits8;
     VAL cl = allocate(sizeof(Closure), 0);
-    SETTY(cl, BITS16);
+    SETTY(cl, CT_BITS16);
     cl->info.bits16 = (uint16_t) (int16_t) (int8_t) A;
     return cl;
 }
@@ -713,7 +713,7 @@ VAL idris_b8S16(VM *vm, VAL a) {
 VAL idris_b8S32(VM *vm, VAL a) {
     uint8_t A = a->info.bits8;
     VAL cl = allocate(sizeof(Closure), 0);
-    SETTY(cl, BITS32);
+    SETTY(cl, CT_BITS32);
     cl->info.bits32 = (uint32_t) (int32_t) (int8_t) A;
     return cl;
 }
@@ -721,7 +721,7 @@ VAL idris_b8S32(VM *vm, VAL a) {
 VAL idris_b8S64(VM *vm, VAL a) {
     uint8_t A = a->info.bits8;
     VAL cl = allocate(sizeof(Closure), 0);
-    SETTY(cl, BITS64);
+    SETTY(cl, CT_BITS64);
     cl->info.bits64 = (uint64_t) (int64_t) (int8_t) A;
     return cl;
 }
@@ -729,7 +729,7 @@ VAL idris_b8S64(VM *vm, VAL a) {
 VAL idris_b16Z32(VM *vm, VAL a) {
     uint16_t A = a->info.bits16;
     VAL cl = allocate(sizeof(Closure), 0);
-    SETTY(cl, BITS32);
+    SETTY(cl, CT_BITS32);
     cl->info.bits32 = (uint32_t) A;
     return cl;
 }
@@ -737,7 +737,7 @@ VAL idris_b16Z32(VM *vm, VAL a) {
 VAL idris_b16Z64(VM *vm, VAL a) {
     uint16_t A = a->info.bits16;
     VAL cl = allocate(sizeof(Closure), 0);
-    SETTY(cl, BITS64);
+    SETTY(cl, CT_BITS64);
     cl->info.bits64 = (uint64_t) A;
     return cl;
 }
@@ -745,7 +745,7 @@ VAL idris_b16Z64(VM *vm, VAL a) {
 VAL idris_b16S32(VM *vm, VAL a) {
     uint16_t A = a->info.bits16;
     VAL cl = allocate(sizeof(Closure), 0);
-    SETTY(cl, BITS32);
+    SETTY(cl, CT_BITS32);
     cl->info.bits32 = (uint32_t) (int32_t) (int16_t) A;
     return cl;
 }
@@ -753,7 +753,7 @@ VAL idris_b16S32(VM *vm, VAL a) {
 VAL idris_b16S64(VM *vm, VAL a) {
     uint16_t A = a->info.bits16;
     VAL cl = allocate(sizeof(Closure), 0);
-    SETTY(cl, BITS64);
+    SETTY(cl, CT_BITS64);
     cl->info.bits64 = (uint64_t) (int64_t) (int16_t) A;
     return cl;
 }
@@ -761,7 +761,7 @@ VAL idris_b16S64(VM *vm, VAL a) {
 VAL idris_b16T8(VM *vm, VAL a) {
     uint16_t A = a->info.bits16;
     VAL cl = allocate(sizeof(Closure), 0);
-    SETTY(cl, BITS8);
+    SETTY(cl, CT_BITS8);
     cl->info.bits8 = (uint8_t) A;
     return cl;
 }
@@ -769,7 +769,7 @@ VAL idris_b16T8(VM *vm, VAL a) {
 VAL idris_b32Z64(VM *vm, VAL a) {
     uint32_t A = a->info.bits32;
     VAL cl = allocate(sizeof(Closure), 0);
-    SETTY(cl, BITS64);
+    SETTY(cl, CT_BITS64);
     cl->info.bits64 = (uint64_t) A;
     return cl;
 }
@@ -777,7 +777,7 @@ VAL idris_b32Z64(VM *vm, VAL a) {
 VAL idris_b32S64(VM *vm, VAL a) {
     uint32_t A = a->info.bits32;
     VAL cl = allocate(sizeof(Closure), 0);
-    SETTY(cl, BITS64);
+    SETTY(cl, CT_BITS64);
     cl->info.bits64 = (uint64_t) (int64_t) (int32_t) A;
     return cl;
 }
@@ -785,7 +785,7 @@ VAL idris_b32S64(VM *vm, VAL a) {
 VAL idris_b32T8(VM *vm, VAL a) {
     uint32_t A = a->info.bits32;
     VAL cl = allocate(sizeof(Closure), 0);
-    SETTY(cl, BITS8);
+    SETTY(cl, CT_BITS8);
     cl->info.bits8 = (uint8_t) A;
     return cl;
 }
@@ -793,7 +793,7 @@ VAL idris_b32T8(VM *vm, VAL a) {
 VAL idris_b32T16(VM *vm, VAL a) {
     uint32_t A = a->info.bits32;
     VAL cl = allocate(sizeof(Closure), 0);
-    SETTY(cl, BITS16);
+    SETTY(cl, CT_BITS16);
     cl->info.bits16 = (uint16_t) A;
     return cl;
 }
@@ -801,7 +801,7 @@ VAL idris_b32T16(VM *vm, VAL a) {
 VAL idris_b64T8(VM *vm, VAL a) {
     uint64_t A = a->info.bits64;
     VAL cl = allocate(sizeof(Closure), 0);
-    SETTY(cl, BITS8);
+    SETTY(cl, CT_BITS8);
     cl->info.bits8 = (uint8_t) A;
     return cl;
 }
@@ -809,7 +809,7 @@ VAL idris_b64T8(VM *vm, VAL a) {
 VAL idris_b64T16(VM *vm, VAL a) {
     uint64_t A = a->info.bits64;
     VAL cl = allocate(sizeof(Closure), 0);
-    SETTY(cl, BITS16);
+    SETTY(cl, CT_BITS16);
     cl->info.bits16 = (uint16_t) A;
     return cl;
 }
@@ -817,7 +817,7 @@ VAL idris_b64T16(VM *vm, VAL a) {
 VAL idris_b64T32(VM *vm, VAL a) {
     uint64_t A = a->info.bits64;
     VAL cl = allocate(sizeof(Closure), 0);
-    SETTY(cl, BITS32);
+    SETTY(cl, CT_BITS32);
     cl->info.bits32 = (uint32_t) A;
     return cl;
 }

--- a/rts/idris_gc.c
+++ b/rts/idris_gc.c
@@ -10,7 +10,7 @@ VAL copy(VM* vm, VAL x) {
         return x;
     }
     switch(GETTY(x)) {
-    case CON:
+    case CT_CON:
         ar = CARITY(x);
         if (ar == 0 && CTAG(x) < 256) {
             return x;
@@ -21,53 +21,53 @@ VAL copy(VM* vm, VAL x) {
             }
         }
         break;
-    case FLOAT:
+    case CT_FLOAT:
         cl = MKFLOATc(vm, x->info.f);
         break;
-    case STRING:
+    case CT_STRING:
         cl = MKSTRc(vm, x->info.str);
         break;
-    case STROFFSET:
+    case CT_STROFFSET:
         cl = MKSTROFFc(vm, x->info.str_offset);
         break;
-    case BIGINT:
+    case CT_BIGINT:
         cl = MKBIGMc(vm, x->info.ptr);
         break;
-    case PTR:
+    case CT_PTR:
         cl = MKPTRc(vm, x->info.ptr);
         break;
-    case MANAGEDPTR:
+    case CT_MANAGEDPTR:
         cl = MKMPTRc(vm, x->info.mptr->data, x->info.mptr->size);
         break;
-    case BITS8:
+    case CT_BITS8:
         cl = idris_b8CopyForGC(vm, x);
         break;
-    case BITS16:
+    case CT_BITS16:
         cl = idris_b16CopyForGC(vm, x);
         break;
-    case BITS32:
+    case CT_BITS32:
         cl = idris_b32CopyForGC(vm, x);
         break;
-    case BITS64:
+    case CT_BITS64:
         cl = idris_b64CopyForGC(vm, x);
         break;
-    case FWD:
+    case CT_FWD:
         return x->info.ptr;
-    case RAWDATA:
+    case CT_RAWDATA:
         {
             size_t size = x->info.size + sizeof(Closure);
             cl = allocate(size, 0);
             memcpy(cl, x, size);
         }
         break;
-    case CDATA:
+    case CT_CDATA:
         cl = MKCDATAc(vm, x->info.c_heap_item);
         c_heap_mark_item(x->info.c_heap_item);
         break;
     default:
         break;
     }
-    SETTY(x, FWD);
+    SETTY(x, CT_FWD);
     x->info.ptr = cl;
     return cl;
 }
@@ -80,16 +80,16 @@ void cheney(VM *vm) {
     while(scan < vm->heap.next) {
        size_t inc = *((size_t*)scan);
        VAL heap_item = (VAL)(scan+sizeof(size_t));
-       // If it's a CON or STROFFSET, copy its arguments
+       // If it's a CT_CON or CT_STROFFSET, copy its arguments
        switch(GETTY(heap_item)) {
-       case CON:
+       case CT_CON:
            ar = ARITY(heap_item);
            for(i = 0; i < ar; ++i) {
                VAL newptr = copy(vm, heap_item->info.c.args[i]);
                heap_item->info.c.args[i] = newptr;
            }
            break;
-       case STROFFSET:
+       case CT_STROFFSET:
            heap_item->info.str_offset->str
                = copy(vm, heap_item->info.str_offset->str);
            break;

--- a/rts/idris_gmp.c
+++ b/rts/idris_gmp.c
@@ -33,7 +33,7 @@ VAL MKBIGC(VM* vm, char* val) {
     mpz_init(*bigint);
     mpz_set_str(*bigint, val, 10);
 
-    SETTY(cl, BIGINT);
+    SETTY(cl, CT_BIGINT);
     cl -> info.ptr = (void*)bigint;
 
     return cl;
@@ -50,7 +50,7 @@ VAL MKBIGM(VM* vm, void* big) {
     mpz_init(*bigint);
     mpz_set(*bigint, *((mpz_t*)big));
 
-    SETTY(cl, BIGINT);
+    SETTY(cl, CT_BIGINT);
     cl -> info.ptr = (void*)bigint;
 
     return cl;
@@ -66,7 +66,7 @@ VAL MKBIGMc(VM* vm, void* big) {
 
     mpz_init_set(*bigint, *((mpz_t*)big));
 
-    SETTY(cl, BIGINT);
+    SETTY(cl, CT_BIGINT);
     cl -> info.ptr = (void*)bigint;
 
     return cl;
@@ -82,7 +82,7 @@ VAL MKBIGUI(VM* vm, unsigned long val) {
 
     mpz_init_set_ui(*bigint, val);
 
-    SETTY(cl, BIGINT);
+    SETTY(cl, CT_BIGINT);
     cl -> info.ptr = (void*)bigint;
 
     return cl;
@@ -98,7 +98,7 @@ VAL MKBIGSI(VM* vm, signed long val) {
 
     mpz_init_set_si(*bigint, val);
 
-    SETTY(cl, BIGINT);
+    SETTY(cl, CT_BIGINT);
     cl -> info.ptr = (void*)bigint;
 
     return cl;
@@ -116,14 +116,14 @@ VAL GETBIG(VM * vm, VAL x) {
         mpz_init(*bigint);
         mpz_set_si(*bigint, GETINT(x));
 
-        SETTY(cl, BIGINT);
+        SETTY(cl, CT_BIGINT);
         cl -> info.ptr = (void*)bigint;
 
         return cl;
     } else {
         idris_doneAlloc();
         switch(GETTY(x)) {
-        case FWD:
+        case CT_FWD:
             return GETBIG(vm, x->info.ptr);
         default:
             return x;
@@ -139,7 +139,7 @@ VAL bigAdd(VM* vm, VAL x, VAL y) {
     idris_doneAlloc();
     bigint = (mpz_t*)(((char*)cl) + sizeof(Closure));
     mpz_add(*bigint, GETMPZ(GETBIG(vm,x)), GETMPZ(GETBIG(vm,y)));
-    SETTY(cl, BIGINT);
+    SETTY(cl, CT_BIGINT);
     cl -> info.ptr = (void*)bigint;
     return cl;
 }
@@ -152,7 +152,7 @@ VAL bigSub(VM* vm, VAL x, VAL y) {
     idris_doneAlloc();
     bigint = (mpz_t*)(((char*)cl) + sizeof(Closure));
     mpz_sub(*bigint, GETMPZ(GETBIG(vm,x)), GETMPZ(GETBIG(vm,y)));
-    SETTY(cl, BIGINT);
+    SETTY(cl, CT_BIGINT);
     cl -> info.ptr = (void*)bigint;
     return cl;
 }
@@ -165,7 +165,7 @@ VAL bigMul(VM* vm, VAL x, VAL y) {
     idris_doneAlloc();
     bigint = (mpz_t*)(((char*)cl) + sizeof(Closure));
     mpz_mul(*bigint, GETMPZ(GETBIG(vm,x)), GETMPZ(GETBIG(vm,y)));
-    SETTY(cl, BIGINT);
+    SETTY(cl, CT_BIGINT);
     cl -> info.ptr = (void*)bigint;
     return cl;
 }
@@ -178,7 +178,7 @@ VAL bigDiv(VM* vm, VAL x, VAL y) {
     idris_doneAlloc();
     bigint = (mpz_t*)(((char*)cl) + sizeof(Closure));
     mpz_tdiv_q(*bigint, GETMPZ(GETBIG(vm,x)), GETMPZ(GETBIG(vm,y)));
-    SETTY(cl, BIGINT);
+    SETTY(cl, CT_BIGINT);
     cl -> info.ptr = (void*)bigint;
     return cl;
 }
@@ -191,7 +191,7 @@ VAL bigMod(VM* vm, VAL x, VAL y) {
     idris_doneAlloc();
     bigint = (mpz_t*)(((char*)cl) + sizeof(Closure));
     mpz_mod(*bigint, GETMPZ(GETBIG(vm,x)), GETMPZ(GETBIG(vm,y)));
-    SETTY(cl, BIGINT);
+    SETTY(cl, CT_BIGINT);
     cl -> info.ptr = (void*)bigint;
     return cl;
 }
@@ -204,7 +204,7 @@ VAL bigAnd(VM* vm, VAL x, VAL y) {
     idris_doneAlloc();
     bigint = (mpz_t*)(((char*)cl) + sizeof(Closure));
     mpz_and(*bigint, GETMPZ(GETBIG(vm,x)), GETMPZ(GETBIG(vm,y)));
-    SETTY(cl, BIGINT);
+    SETTY(cl, CT_BIGINT);
     cl -> info.ptr = (void*)bigint;
     return cl;
 }
@@ -217,7 +217,7 @@ VAL bigOr(VM* vm, VAL x, VAL y) {
     idris_doneAlloc();
     bigint = (mpz_t*)(((char*)cl) + sizeof(Closure));
     mpz_ior(*bigint, GETMPZ(GETBIG(vm,x)), GETMPZ(GETBIG(vm,y)));
-    SETTY(cl, BIGINT);
+    SETTY(cl, CT_BIGINT);
     cl -> info.ptr = (void*)bigint;
     return cl;
 }
@@ -230,7 +230,7 @@ VAL bigShiftLeft(VM* vm, VAL x, VAL y) {
     idris_doneAlloc();
     bigint = (mpz_t*)(((char*)cl) + sizeof(Closure));
     mpz_mul_2exp(*bigint, GETMPZ(GETBIG(vm,x)), GETINT(y));
-    SETTY(cl, BIGINT);
+    SETTY(cl, CT_BIGINT);
     cl -> info.ptr = (void*)bigint;
     return cl;
 }
@@ -244,7 +244,7 @@ VAL bigLShiftRight(VM* vm, VAL x, VAL y) {
     idris_doneAlloc();
     bigint = (mpz_t*)(((char*)cl) + sizeof(Closure));
     mpz_fdiv_q_2exp(*bigint, GETMPZ(GETBIG(vm,x)), GETINT(y));
-    SETTY(cl, BIGINT);
+    SETTY(cl, CT_BIGINT);
     cl -> info.ptr = (void*)bigint;
     return cl;
 }
@@ -257,7 +257,7 @@ VAL bigAShiftRight(VM* vm, VAL x, VAL y) {
     idris_doneAlloc();
     bigint = (mpz_t*)(((char*)cl) + sizeof(Closure));
     mpz_fdiv_q_2exp(*bigint, GETMPZ(GETBIG(vm,x)), GETINT(y));
-    SETTY(cl, BIGINT);
+    SETTY(cl, CT_BIGINT);
     cl -> info.ptr = (void*)bigint;
     return cl;
 }
@@ -473,7 +473,7 @@ VAL idris_castFloatBig(VM* vm, VAL f) {
 
     mpz_init_set_d(*bigint, val);
 
-    SETTY(cl, BIGINT);
+    SETTY(cl, CT_BIGINT);
     cl -> info.ptr = (void*)bigint;
 
     return cl;

--- a/rts/idris_heap.c
+++ b/rts/idris_heap.c
@@ -186,7 +186,7 @@ void heap_check_pointers(Heap * heap) {
        VAL heap_item = (VAL)(scan + sizeof(size_t));
 
        switch(GETTY(heap_item)) {
-       case CON:
+       case CT_CON:
            {
              int ar = ARITY(heap_item);
              int i = 0;
@@ -207,7 +207,7 @@ void heap_check_pointers(Heap * heap) {
                      if (!(ptr < heap_item)) {
                          fprintf(stderr,
                                  "RTS ERROR: heap unidirectionality broken:" \
-                                 "<CON %p> <FIELD %p>\n",
+                                 "<CT_CON %p> <FIELD %p>\n",
                                  heap_item, ptr);
                          exit(EXIT_FAILURE);
                      }
@@ -216,9 +216,9 @@ void heap_check_pointers(Heap * heap) {
              }
              break;
            }
-       case FWD:
+       case CT_FWD:
            // Check for artifacts after cheney gc.
-           fprintf(stderr, "RTS ERROR: FWD in working heap.\n");
+           fprintf(stderr, "RTS ERROR: CT_FWD in working heap.\n");
            exit(EXIT_FAILURE);
            break;
        default:

--- a/rts/idris_rts.c
+++ b/rts/idris_rts.c
@@ -180,7 +180,7 @@ int space(VM* vm, size_t size) {
 
 void* idris_alloc(size_t size) {
     Closure* cl = (Closure*) allocate(sizeof(Closure)+size, 0);
-    SETTY(cl, RAWDATA);
+    SETTY(cl, CT_RAWDATA);
     cl->info.size = size;
     return (void*)cl+sizeof(Closure);
 }
@@ -245,7 +245,7 @@ void* allocate(size_t size, int outerlock) {
 void* allocCon(VM* vm, int arity, int outer) {
     Closure* cl = allocate(vm, sizeof(Closure) + sizeof(VAL)*arity,
                                outer);
-    SETTY(cl, CON);
+    SETTY(cl, CT_CON);
 
     cl -> info.c.arity = arity;
 //    cl -> info.c.tag = 42424242;
@@ -256,7 +256,7 @@ void* allocCon(VM* vm, int arity, int outer) {
 
 VAL MKFLOAT(VM* vm, double val) {
     Closure* cl = allocate(sizeof(Closure), 0);
-    SETTY(cl, FLOAT);
+    SETTY(cl, CT_FLOAT);
     cl -> info.f = val;
     return cl;
 }
@@ -270,7 +270,7 @@ VAL MKSTR(VM* vm, const char* str) {
     }
     Closure* cl = allocate(sizeof(Closure) + // Type) + sizeof(char*) +
                            sizeof(char)*len, 0);
-    SETTY(cl, STRING);
+    SETTY(cl, CT_STRING);
     cl -> info.str = (char*)cl + sizeof(Closure);
     if (str == NULL) {
         cl->info.str = NULL;
@@ -289,7 +289,7 @@ char* GETSTROFF(VAL stroff) {
 VAL MKCDATA(VM* vm, CHeapItem * item) {
     c_heap_insert_if_needed(vm, &vm->c_heap, item);
     Closure* cl = allocate(sizeof(Closure), 0);
-    SETTY(cl, CDATA);
+    SETTY(cl, CT_CDATA);
     cl->info.c_heap_item = item;
     return cl;
 }
@@ -297,14 +297,14 @@ VAL MKCDATA(VM* vm, CHeapItem * item) {
 VAL MKCDATAc(VM* vm, CHeapItem * item) {
     c_heap_insert_if_needed(vm, &vm->c_heap, item);
     Closure* cl = allocate(sizeof(Closure), 1);
-    SETTY(cl, CDATA);
+    SETTY(cl, CT_CDATA);
     cl->info.c_heap_item = item;
     return cl;
 }
 
 VAL MKPTR(VM* vm, void* ptr) {
     Closure* cl = allocate(sizeof(Closure), 0);
-    SETTY(cl, PTR);
+    SETTY(cl, CT_PTR);
     cl -> info.ptr = ptr;
     return cl;
 }
@@ -312,7 +312,7 @@ VAL MKPTR(VM* vm, void* ptr) {
 VAL MKMPTR(VM* vm, void* ptr, size_t size) {
     Closure* cl = allocate(sizeof(Closure) +
                            sizeof(ManagedPtr) + size, 0);
-    SETTY(cl, MANAGEDPTR);
+    SETTY(cl, CT_MANAGEDPTR);
     cl->info.mptr = (ManagedPtr*)((char*)cl + sizeof(Closure));
     cl->info.mptr->data = (char*)cl + sizeof(Closure) + sizeof(ManagedPtr);
     memcpy(cl->info.mptr->data, ptr, size);
@@ -322,7 +322,7 @@ VAL MKMPTR(VM* vm, void* ptr, size_t size) {
 
 VAL MKFLOATc(VM* vm, double val) {
     Closure* cl = allocate(sizeof(Closure), 1);
-    SETTY(cl, FLOAT);
+    SETTY(cl, CT_FLOAT);
     cl -> info.f = val;
     return cl;
 }
@@ -330,7 +330,7 @@ VAL MKFLOATc(VM* vm, double val) {
 VAL MKSTRc(VM* vm, char* str) {
     Closure* cl = allocate(sizeof(Closure) + // Type) + sizeof(char*) +
                            sizeof(char)*strlen(str)+1, 1);
-    SETTY(cl, STRING);
+    SETTY(cl, CT_STRING);
     cl -> info.str = (char*)cl + sizeof(Closure);
 
     strcpy(cl -> info.str, str);
@@ -339,7 +339,7 @@ VAL MKSTRc(VM* vm, char* str) {
 
 VAL MKPTRc(VM* vm, void* ptr) {
     Closure* cl = allocate(sizeof(Closure), 1);
-    SETTY(cl, PTR);
+    SETTY(cl, CT_PTR);
     cl -> info.ptr = ptr;
     return cl;
 }
@@ -347,7 +347,7 @@ VAL MKPTRc(VM* vm, void* ptr) {
 VAL MKMPTRc(VM* vm, void* ptr, size_t size) {
     Closure* cl = allocate(sizeof(Closure) +
                            sizeof(ManagedPtr) + size, 1);
-    SETTY(cl, MANAGEDPTR);
+    SETTY(cl, CT_MANAGEDPTR);
     cl->info.mptr = (ManagedPtr*)((char*)cl + sizeof(Closure));
     cl->info.mptr->data = (char*)cl + sizeof(Closure) + sizeof(ManagedPtr);
     memcpy(cl->info.mptr->data, ptr, size);
@@ -357,28 +357,28 @@ VAL MKMPTRc(VM* vm, void* ptr, size_t size) {
 
 VAL MKB8(VM* vm, uint8_t bits8) {
     Closure* cl = allocate(sizeof(Closure), 1);
-    SETTY(cl, BITS8);
+    SETTY(cl, CT_BITS8);
     cl -> info.bits8 = bits8;
     return cl;
 }
 
 VAL MKB16(VM* vm, uint16_t bits16) {
     Closure* cl = allocate(sizeof(Closure), 1);
-    SETTY(cl, BITS16);
+    SETTY(cl, CT_BITS16);
     cl -> info.bits16 = bits16;
     return cl;
 }
 
 VAL MKB32(VM* vm, uint32_t bits32) {
     Closure* cl = allocate(sizeof(Closure), 1);
-    SETTY(cl, BITS32);
+    SETTY(cl, CT_BITS32);
     cl -> info.bits32 = bits32;
     return cl;
 }
 
 VAL MKB64(VM* vm, uint64_t bits64) {
     Closure* cl = allocate(sizeof(Closure), 1);
-    SETTY(cl, BITS64);
+    SETTY(cl, CT_BITS64);
     cl -> info.bits64 = bits64;
     return cl;
 }
@@ -420,18 +420,18 @@ void dumpVal(VAL v) {
         return;
     }
     switch(GETTY(v)) {
-    case CON:
+    case CT_CON:
         printf("%d[", TAG(v));
         for(i = 0; i < ARITY(v); ++i) {
             dumpVal(v->info.c.args[i]);
         }
         printf("] ");
         break;
-    case STRING:
+    case CT_STRING:
         printf("STR[%s]", v->info.str);
         break;
-    case FWD:
-        printf("FWD ");
+    case CT_FWD:
+        printf("CT_FWD ");
         dumpVal((VAL)(v->info.ptr));
         break;
     default:
@@ -489,7 +489,7 @@ void idris_memmove(void* dest, void* src, i_int dest_offset, i_int src_offset, i
 VAL idris_castIntStr(VM* vm, VAL i) {
     int x = (int) GETINT(i);
     Closure* cl = allocate(sizeof(Closure) + sizeof(char)*16, 0);
-    SETTY(cl, STRING);
+    SETTY(cl, CT_STRING);
     cl -> info.str = (char*)cl + sizeof(Closure);
     sprintf(cl -> info.str, "%d", x);
     return cl;
@@ -500,25 +500,25 @@ VAL idris_castBitsStr(VM* vm, VAL i) {
     ClosureType ty = i->ty;
 
     switch (ty) {
-    case BITS8:
+    case CT_BITS8:
         // max length 8 bit unsigned int str 3 chars (256)
         cl = allocate(sizeof(Closure) + sizeof(char)*4, 0);
         cl->info.str = (char*)cl + sizeof(Closure);
         sprintf(cl->info.str, "%" PRIu8, (uint8_t)i->info.bits8);
         break;
-    case BITS16:
+    case CT_BITS16:
         // max length 16 bit unsigned int str 5 chars (65,535)
         cl = allocate(sizeof(Closure) + sizeof(char)*6, 0);
         cl->info.str = (char*)cl + sizeof(Closure);
         sprintf(cl->info.str, "%" PRIu16, (uint16_t)i->info.bits16);
         break;
-    case BITS32:
+    case CT_BITS32:
         // max length 32 bit unsigned int str 10 chars (4,294,967,295)
         cl = allocate(sizeof(Closure) + sizeof(char)*11, 0);
         cl->info.str = (char*)cl + sizeof(Closure);
         sprintf(cl->info.str, "%" PRIu32, (uint32_t)i->info.bits32);
         break;
-    case BITS64:
+    case CT_BITS64:
         // max length 64 bit unsigned int str 20 chars (18,446,744,073,709,551,615)
         cl = allocate(sizeof(Closure) + sizeof(char)*21, 0);
         cl->info.str = (char*)cl + sizeof(Closure);
@@ -529,7 +529,7 @@ VAL idris_castBitsStr(VM* vm, VAL i) {
         exit(EXIT_FAILURE);
     }
 
-    SETTY(cl, STRING);
+    SETTY(cl, CT_STRING);
     return cl;
 }
 
@@ -544,7 +544,7 @@ VAL idris_castStrInt(VM* vm, VAL i) {
 
 VAL idris_castFloatStr(VM* vm, VAL i) {
     Closure* cl = allocate(sizeof(Closure) + sizeof(char)*32, 0);
-    SETTY(cl, STRING);
+    SETTY(cl, CT_STRING);
     cl -> info.str = (char*)cl + sizeof(Closure);
     snprintf(cl -> info.str, 32, "%.16g", GETFLOAT(i));
     return cl;
@@ -560,7 +560,7 @@ VAL idris_concat(VM* vm, VAL l, VAL r) {
     // dumpVal(l);
     // printf("\n");
     Closure* cl = allocate(sizeof(Closure) + strlen(ls) + strlen(rs) + 1, 0);
-    SETTY(cl, STRING);
+    SETTY(cl, CT_STRING);
     cl -> info.str = (char*)cl + sizeof(Closure);
     strcpy(cl -> info.str, ls);
     strcat(cl -> info.str, rs);
@@ -606,7 +606,7 @@ VAL idris_strHead(VM* vm, VAL str) {
 
 VAL MKSTROFFc(VM* vm, StrOffset* off) {
     Closure* cl = allocate(sizeof(Closure) + sizeof(StrOffset), 1);
-    SETTY(cl, STROFFSET);
+    SETTY(cl, CT_STROFFSET);
     cl->info.str_offset = (StrOffset*)((char*)cl + sizeof(Closure));
 
     cl->info.str_offset->str = off->str;
@@ -620,7 +620,7 @@ VAL idris_strTail(VM* vm, VAL str) {
     // gc moves str
     if (space(vm, sizeof(Closure) + sizeof(StrOffset))) {
         Closure* cl = allocate(sizeof(Closure) + sizeof(StrOffset), 0);
-        SETTY(cl, STROFFSET);
+        SETTY(cl, CT_STROFFSET);
         cl->info.str_offset = (StrOffset*)((char*)cl + sizeof(Closure));
 
         int offset = 0;
@@ -648,7 +648,7 @@ VAL idris_strCons(VM* vm, VAL x, VAL xs) {
     if ((xval & 0x80) == 0) { // ASCII char
         Closure* cl = allocate(sizeof(Closure) +
                                strlen(xstr) + 2, 0);
-        SETTY(cl, STRING);
+        SETTY(cl, CT_STRING);
         cl -> info.str = (char*)cl + sizeof(Closure);
         cl -> info.str[0] = (char)(GETINT(x));
         strcpy(cl -> info.str+1, xstr);
@@ -656,7 +656,7 @@ VAL idris_strCons(VM* vm, VAL x, VAL xs) {
     } else {
         char *init = idris_utf8_fromChar(xval);
         Closure* cl = allocate(sizeof(Closure) + strlen(init) + strlen(xstr) + 1, 0);
-        SETTY(cl, STRING);
+        SETTY(cl, CT_STRING);
         cl -> info.str = (char*)cl + sizeof(Closure);
         strcpy(cl -> info.str, init);
         strcat(cl -> info.str, xstr);
@@ -674,7 +674,7 @@ VAL idris_substr(VM* vm, VAL offset, VAL length, VAL str) {
     char *start = idris_utf8_advance(GETSTR(str), GETINT(offset));
     char *end = idris_utf8_advance(start, GETINT(length));
     Closure* newstr = allocate(sizeof(Closure) + (end - start) +1, 0);
-    SETTY(newstr, STRING);
+    SETTY(newstr, CT_STRING);
     newstr -> info.str = (char*)newstr + sizeof(Closure);
     memcpy(newstr -> info.str, start, end - start);
     *(newstr -> info.str + (end - start) + 1) = '\0';
@@ -685,7 +685,7 @@ VAL idris_strRev(VM* vm, VAL str) {
     char *xstr = GETSTR(str);
     Closure* cl = allocate(sizeof(Closure) +
                            strlen(xstr) + 1, 0);
-    SETTY(cl, STRING);
+    SETTY(cl, CT_STRING);
     cl->info.str = (char*)cl + sizeof(Closure);
     idris_utf8_rev(xstr, cl->info.str);
     return cl;
@@ -768,7 +768,7 @@ VAL doCopyTo(VM* vm, VAL x) {
         return x;
     }
     switch(GETTY(x)) {
-    case CON:
+    case CT_CON:
         ar = CARITY(x);
         if (ar == 0 && CTAG(x) < 256) { // globally allocated
             cl = x;
@@ -782,34 +782,34 @@ VAL doCopyTo(VM* vm, VAL x) {
             }
         }
         break;
-    case FLOAT:
+    case CT_FLOAT:
         cl = MKFLOATc(vm, x->info.f);
         break;
-    case STRING:
+    case CT_STRING:
         cl = MKSTRc(vm, x->info.str);
         break;
-    case BIGINT:
+    case CT_BIGINT:
         cl = MKBIGMc(vm, x->info.ptr);
         break;
-    case PTR:
+    case CT_PTR:
         cl = MKPTRc(vm, x->info.ptr);
         break;
-    case MANAGEDPTR:
+    case CT_MANAGEDPTR:
         cl = MKMPTRc(vm, x->info.mptr->data, x->info.mptr->size);
         break;
-    case BITS8:
+    case CT_BITS8:
         cl = idris_b8CopyForGC(vm, x);
         break;
-    case BITS16:
+    case CT_BITS16:
         cl = idris_b16CopyForGC(vm, x);
         break;
-    case BITS32:
+    case CT_BITS32:
         cl = idris_b32CopyForGC(vm, x);
         break;
-    case BITS64:
+    case CT_BITS64:
         cl = idris_b64CopyForGC(vm, x);
         break;
-    case RAWDATA:
+    case CT_RAWDATA:
         {
             size_t size = x->info.size + sizeof(Closure);
             cl = allocate(size, 0);
@@ -1019,7 +1019,7 @@ void init_nullaries() {
     nullary_cons = malloc(256 * sizeof(VAL));
     for(i = 0; i < 256; ++i) {
         cl = malloc(sizeof(Closure));
-        SETTY(cl, CON);
+        SETTY(cl, CT_CON);
         cl->info.c.tag_arity = i << 8;
         nullary_cons[i] = cl;
     }

--- a/rts/idris_rts.h
+++ b/rts/idris_rts.h
@@ -25,9 +25,9 @@
 
 // Closures
 typedef enum {
-    CON, INT, BIGINT, FLOAT, STRING, STROFFSET,
-    BITS8, BITS16, BITS32, BITS64, UNIT, PTR, FWD,
-    MANAGEDPTR, RAWDATA, CDATA
+    CT_CON, CT_INT, CT_BIGINT, CT_FLOAT, CT_STRING, CT_STROFFSET,
+    CT_BITS8, CT_BITS16, CT_BITS32, CT_BITS64, CT_UNIT, CT_PTR, CT_FWD,
+    CT_MANAGEDPTR, CT_RAWDATA, CT_CDATA
 } ClosureType;
 
 typedef struct Closure *VAL;
@@ -189,10 +189,10 @@ typedef void(*func)(VM*, VAL*);
 #define GETBITS32(x) (((VAL)(x))->info.bits32)
 #define GETBITS64(x) (((VAL)(x))->info.bits64)
 
-#define TAG(x) (ISINT(x) || x == NULL ? (-1) : ( GETTY(x) == CON ? (x)->info.c.tag_arity >> 8 : (-1)) )
-#define ARITY(x) (ISINT(x) || x == NULL ? (-1) : ( GETTY(x) == CON ? (x)->info.c.tag_arity & 0x000000ff : (-1)) )
+#define TAG(x) (ISINT(x) || x == NULL ? (-1) : ( GETTY(x) == CT_CON ? (x)->info.c.tag_arity >> 8 : (-1)) )
+#define ARITY(x) (ISINT(x) || x == NULL ? (-1) : ( GETTY(x) == CT_CON ? (x)->info.c.tag_arity & 0x000000ff : (-1)) )
 
-// Already checked it's a CON
+// Already checked it's a CT_CON
 #define CTAG(x) (((x)->info.c.tag_arity) >> 8)
 #define CARITY(x) ((x)->info.c.tag_arity & 0x000000ff)
 
@@ -212,7 +212,7 @@ typedef intptr_t i_int;
 #define MKINT(x) ((void*)((x)<<1)+1)
 #define GETINT(x) ((i_int)(x)>>1)
 #define ISINT(x) ((((i_int)x)&1) == 1)
-#define ISSTR(x) (GETTY(x) == STRING)
+#define ISSTR(x) (GETTY(x) == CT_STRING)
 
 #define INTOP(op,x,y) MKINT((i_int)((((i_int)x)>>1) op (((i_int)y)>>1)))
 #define UINTOP(op,x,y) MKINT((i_int)((((uintptr_t)x)>>1) op (((uintptr_t)y)>>1)))
@@ -283,12 +283,12 @@ void idris_free(void* ptr, size_t size);
 
 #define allocCon(cl, vm, t, a, o) \
   cl = allocate(sizeof(Closure) + sizeof(VAL)*a, o); \
-  SETTY(cl, CON); \
+  SETTY(cl, CT_CON); \
   cl->info.c.tag_arity = ((t) << 8) | (a);
 
 #define updateCon(cl, old, t, a) \
   cl = old; \
-  SETTY(cl, CON); \
+  SETTY(cl, CT_CON); \
   cl->info.c.tag_arity = ((t) << 8) | (a);
 
 #define NULL_CON(x) nullary_cons[x]


### PR DESCRIPTION
Some had generic names like INT and FLOAT that caused collisions.