### PR TITLE
Comments to Lang.hs to disambiguate the LIR.

### DIFF
--- a/src/IRTS/Lang.hs
+++ b/src/IRTS/Lang.hs
@@ -17,10 +17,11 @@ data LVar = Loc Int | Glob Name
   deriving (Show, Eq)
 
 -- ASSUMPTION: All variable bindings have unique names here
+-- Constructors commented as lifted are not present in the LIR provided to the different backends.
 data LExp = LV LVar
           | LApp Bool LExp [LExp] -- True = tail call
           | LLazyApp Name [LExp] -- True = tail call
-          | LLazyExp LExp
+          | LLazyExp LExp -- lifted out before compiling
           | LForce LExp -- make sure Exp is evaluted
           | LLet Name LExp LExp -- name just for pretty printing
           | LLam [Name] LExp -- lambda, lifted out before compiling


### PR DESCRIPTION
Currently it wasn't clear as to which LIR the backends were getting because internally we use the same data type before and after the lifting process.