### PR TITLE
Don't read so much when just changing the reexport status of a module

### DIFF
--- a/CHANGELOG
+++ b/CHANGELOG
@@ -1,3 +1,9 @@
+New in 0.12:
+============
+
+* Improved startup performance by reducing the processing of an already imported
+  module that has changed accessibility.
+
 New in 0.11:
 ============
 


### PR DESCRIPTION
I realized that the error https://github.com/idris-lang/Idris-dev/commit/c9d20273f7cb8a6e212cd61abbccf419f2d7119f fixed was probably what blocked this from working before.

It cuts the time to compile a trivial program from ~1.9s to ~1.5s on my computer