### PR TITLE
Use type/term pun gotten from parsing to elaborate dependent pairs

### DIFF
--- a/src/Idris/Elab/Term.hs
+++ b/src/Idris/Elab/Term.hs
@@ -413,14 +413,15 @@ elab ist info emode opts fn tm
                                                  pimp (sUN "B") Placeholder False,
                                                  pexp l, pexp r])
     elab' ina _ (PDPair fc hls p l@(PRef nfc hl n) t r)
-            = case t of
-                Placeholder ->
+            = case p of
+                IsType -> asType
+                IsTerm -> asValue
+                TypeOrTerm ->
                    do hnf_compute
                       g <- goal
                       case g of
                          TType _ -> asType
                          _ -> asValue
-                _ -> asType
          where asType = elab' ina (Just fc) (PApp fc (PRef NoFC hls sigmaTy)
                                         [pexp t,
                                          pexp (PLam fc n nfc Placeholder r)])


### PR DESCRIPTION
Instead of the current approach where this is guessed by type being placeholder.

This fixes the issue I discussed in #2636 .