### PR TITLE
Fixes #1448, Fix cli and pkg options

### DIFF
--- a/CHANGELOG
+++ b/CHANGELOG
@@ -4,6 +4,12 @@ New in 0.12:
 * Improved startup performance by reducing the processing of an already imported
   module that has changed accessibility.
 
+* A limited set of command line options can be used to override
+  package declared options. Overridable options are currently,
+  logging level and categories, default totality check, warn reach,
+  IBC output folder, and idris path.
+
+
 New in 0.11:
 ============
 

--- a/main/Main.hs
+++ b/main/Main.hs
@@ -56,26 +56,26 @@ runIdris opts = do
                    runIO exitSuccess
     case opt getPkgCheck opts of
        [] -> return ()
-       fs -> do runIO $ mapM_ (checkPkg (WarnOnly `elem` opts) True) fs
+       fs -> do runIO $ mapM_ (checkPkg opts (WarnOnly `elem` opts) True) fs
                 runIO exitSuccess
     case opt getPkgClean opts of
        [] -> return ()
-       fs -> do runIO $ mapM_ cleanPkg fs
+       fs -> do runIO $ mapM_ (cleanPkg opts) fs
                 runIO exitSuccess
     case opt getPkgMkDoc opts of                -- IdrisDoc
        [] -> return ()
-       fs -> do runIO $ mapM_ documentPkg fs
+       fs -> do runIO $ mapM_ (documentPkg opts) fs
                 runIO exitSuccess
     case opt getPkgTest opts of
        [] -> return ()
-       fs -> do runIO $ mapM_ testPkg fs
+       fs -> do runIO $ mapM_ (testPkg opts) fs
                 runIO exitSuccess
     case opt getPkg opts of
        [] -> case opt getPkgREPL opts of
                   [] -> idrisMain opts
-                  [f] -> replPkg f
+                  [f] -> replPkg opts f
                   _ -> ifail "Too many packages"
-       fs -> runIO $ mapM_ (buildPkg (WarnOnly `elem` opts)) fs
+       fs -> runIO $ mapM_ (buildPkg opts (WarnOnly `elem` opts)) fs
 
 showver :: IO b
 showver = do putStrLn $ "Idris version " ++ ver

--- a/test/pkg001/expected
+++ b/test/pkg001/expected
@@ -1,0 +1,19 @@
+Not all command line options can be used to override package options.
+
+The only changeable options are:
+	--log <lvl>, --total, --warnpartial, --warnreach
+	--ibcsubdir <path>, -i --idrispath <path>
+	--logging-categories <cats>
+
+The options need removing are:
+	 Quiet 
+
+
+
+Elaborating {__Infer0}
+builtin
+Elaborating =
+builtin
+Elaborating type decl Main.main[]
+Elaborating clause Main.main
+Rechecking for positivity []

--- a/test/pkg001/run
+++ b/test/pkg001/run
@@ -1,3 +1,5 @@
 #!/usr/bin/env bash
 ${IDRIS:-idris} $@ --build test.ipkg
 rm -f  *.ibc
+${IDRIS:-idris} $@ --build test.ipkg --quiet
+${IDRIS:-idris} $@ --build test.ipkg --logging-categories "elab" --log 1


### PR DESCRIPTION
When building packages a preapproved command line options (if
specified) will be merged into the options list generated from the
iPKG file. The allowed options are placed at the head of the options
list such that they. The allowed options are:

+ Logging levels and categories
+ Default total, default partial
+ Warn partial
+ Warn reach
+ Location of IBC subdir
+ Location of import dir.

Idris also reports an error if invalid command lines options are
specified when used to override package specified options. This error
message detaisl the offending flag.