### PR TITLE
Fixes #499 allowing packages to be installed to custom location.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,9 +3,11 @@
 * Improved startup performance by reducing the processing of an already imported
   module that has changed accessibility.
 
-* A limited set of command line options can be used to override package declared
-  options. Overridable options are currently, logging level and categories,
-  default totality check, warn reach, IBC output folder, and idris path.
+* A limited set of command line options can be used to override
+  package declared options. Overridable options are currently, logging
+  level and categories, default totality check, warn reach, IBC output
+  folder, and idris path. Note overriding IBC output folder, only
+  affects the installation of Idris packages.
 
 * Remove deprecated options `--ideslave` and `--ideslave-socket`. These options
   were replaced with `--ide-mode` and `--ide-mode-socket` in 0.9.17

--- a/src/Idris/REPL.hs
+++ b/src/Idris/REPL.hs
@@ -2,7 +2,8 @@
              PatternGuards, CPP #-}
 
 module Idris.REPL(getClient, getPkg, getPkgCheck, getPkgClean, getPkgMkDoc,
-                  getPkgREPL, getPkgTest, getPort, idris, idrisMain, loadInputs,
+                  getPkgREPL, getPkgTest, getPort, getIBCSubDir,
+                  idris, idrisMain, loadInputs,
                   opt, runClient, runMain, ver) where
 
 import Idris.AbsSyntax


### PR DESCRIPTION
When installing idris packages, specifying the command option
`--ibcsubdir <dir>` will install the package to `<dir>`.

This PR is to provide an option complimenting the env `TARGET` as the
option `-i <path>` compliments `IDRIS_LIBRARY_PATH`.

This option doesn't affect the other package commands, as they should
be performed locale to the package source. Aside from test that goes
to a temp directory.