### PR TITLE
Generalise help messages for Hardware Specific Options.

### DIFF
--- a/man/idris.1
+++ b/man/idris.1
@@ -93,9 +93,9 @@ should not necessarily be seen as production ready nor for industrial use.
                            ErrorReflection)
   --no-partial-eval        Switch off partial evaluation, mainly for debugging
                            purposes
-  --target TRIPLE          Select target triple (for llvm codegen)
-  --cpu CPU                Select target CPU e.g. corei7 or cortex-m3 (for LLVM
-                           codegen)
+  --target TRIPLE          If supported the codegen will target the named triple.
+  --cpu CPU                If supported the codegen will target the named CPU
+                           e.g. corei7 or cortex-m3.
   --color,--colour         Force coloured output
   --nocolor,--nocolour     Disable coloured output
   --consolewidth WIDTH     Select console width: auto, infinite, nat

--- a/src/Idris/CmdOptions.hs
+++ b/src/Idris/CmdOptions.hs
@@ -175,8 +175,8 @@ parseFlags = many $
 
   <|> (OptLevel <$> option auto (short 'O' <> long "level"))
 
-  <|> (TargetTriple <$> strOption (long "target" <> metavar "TRIPLE" <> help "Select target triple (for llvm codegen)"))
-  <|> (TargetCPU    <$> strOption (long "cpu" <> metavar "CPU" <> help "Select target CPU e.g. corei7 or cortex-m3 (for LLVM codegen)"))
+  <|> (TargetTriple <$> strOption (long "target" <> metavar "TRIPLE" <> help "If supported the codegen will target the named triple."))
+  <|> (TargetCPU    <$> strOption (long "cpu"    <> metavar "CPU"    <> help "If supported the codegen will target the named CPU e.g. corei7 or cortex-m3"))
 
   -- Colour Options
   <|> flag' (ColourREPL True)  (long "colour"   <> long "color"   <> help "Force coloured output")


### PR DESCRIPTION
The options `--target TRIPLE` and `--cpu CPU` are only really used by
the llvm-codegen, which has been spun out from the main idris project
for some time. This PR generalises and help message for these options
to be non-llvm specific, and makes reference that the backend might
not use this information during compilation.