### PR TITLE
Fixes #3075 by adding generalised 'Project' output type.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,13 @@
 * Remove deprecated options `--ideslave` and `--ideslave-socket`. These options
   were replaced with `--ide-mode` and `--ide-mode-socket` in 0.9.17
 
+* The code generator output type `MavenProject` was specific to the
+  Java codegen. This output type has been generalised to `Project`
+  such that if a codegen wants to output a 'project' it can do so. An
+  activation flag `--projectonly` has been added. The existing `--mvn`
+  flag still exists for backwards compatibility, and will be
+  deprecated in a future release.
+
 # New in 0.11
 
 ## Updated export rules

--- a/man/idris.1
+++ b/man/idris.1
@@ -82,6 +82,10 @@ should not necessarily be seen as production ready nor for industrial use.
   --testpkg IPKG           Run tests for package
   -S,--codegenonly         Do no further compilation of code generator output
   -c,--compileonly         Compile to object files rather than an executable
+  --projectonly            Do no further compilation of code generator and
+                           create a project.
+  --mvn                    Create a maven project (for Java codegen), To be
+                           deprecated in 0.12, use --projectonly instead.
   --mvn                    Create a maven project (for Java codegen)
   --codegen TARGET         Select code generator: C, Javascript, Node and
                            bytecode are bundled with Idris

--- a/src/IRTS/CodegenC.hs
+++ b/src/IRTS/CodegenC.hs
@@ -64,7 +64,7 @@ codegenC' defs out exec incs objs libs flags exports iface dbg
          let cout = headers incs ++ debug dbg ++ h ++ wrappers ++ cc ++
                      (if (exec == Executable) then mprog else hi)
          case exec of
-           MavenProject -> putStrLn ("FAILURE: output type not supported")
+           Project -> putStrLn ("FAILURE: output type not supported")
            Raw -> writeSource out cout
            _ -> do
              (tmpn, tmph) <- tempfile ".c"

--- a/src/IRTS/CodegenCommon.hs
+++ b/src/IRTS/CodegenCommon.hs
@@ -5,7 +5,7 @@ import IRTS.Simplified
 import IRTS.Defunctionalise
 
 data DbgLevel = NONE | DEBUG | TRACE deriving Eq
-data OutputType = Raw | Object | Executable | MavenProject deriving (Eq, Show)
+data OutputType = Raw | Object | Executable | Project deriving (Eq, Show)
 
 -- Everything which might be needed in a code generator - a CG can choose which
 -- level of Decls to generate code from (simplified, defunctionalised or merely
@@ -26,6 +26,6 @@ data CodegenInfo = CodegenInfo { outputFile :: String,
                                  liftDecls :: [(Name, LDecl)],
                                  interfaces :: Bool,
                                  exportDecls :: [ExportIFace]
-                               } 
+                               }
 
 type CodeGenerator = CodegenInfo -> IO ()

--- a/src/Idris/CmdOptions.hs
+++ b/src/Idris/CmdOptions.hs
@@ -140,9 +140,10 @@ parseFlags = many $
   -- Misc options
   <|> (BCAsm <$> strOption (long "bytecode"))
 
-  <|> flag' (OutputTy Raw)          (short 'S' <> long "codegenonly" <> help "Do no further compilation of code generator output")
-  <|> flag' (OutputTy Object)       (short 'c' <> long "compileonly" <> help "Compile to object files rather than an executable")
-  <|> flag' (OutputTy MavenProject) (long "mvn"                      <> help "Create a maven project (for Java codegen)")
+  <|> flag' (OutputTy Raw)     (short 'S' <> long "codegenonly" <> help "Do no further compilation of code generator output")
+  <|> flag' (OutputTy Object)  (short 'c' <> long "compileonly" <> help "Compile to object files rather than an executable")
+  <|> flag' (OutputTy Project)              (long "projectonly" <> help "Do no further compilation of code generator and create a project.")
+  <|> flag' (OutputTy Project) (long "mvn"                      <> help "Create a maven project (for Java codegen), To be deprecated in 0.12, use --projectonly instead.")
 
   <|> (DumpDefun <$> strOption (long "dumpdefuns"))
   <|> (DumpCases <$> strOption (long "dumpcases"))

--- a/src/Idris/DeepSeq.hs
+++ b/src/Idris/DeepSeq.hs
@@ -261,7 +261,7 @@ instance NFData OutputType where
     rnf Raw = ()
     rnf Object = ()
     rnf Executable = ()
-    rnf MavenProject = ()
+    rnf Project = ()
 
 instance NFData IBCWrite where
     rnf (IBCFix fixDecl) = rnf fixDecl `seq` ()


### PR DESCRIPTION
The code generator output type `MavenProject` was specific to the Java
codegen. This output type has been generalised to `Project` such that
if a codegen wants to output a 'project' it can do so. An activation
flag `--projectonly` has been added. The existing `--mvn` flag still
exists for backwards compatibility, and will be deprecated in a future
release.