### PR TITLE
Fixes #3075 Deprecate the `MavenProject` output option.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,7 +12,12 @@
 * Remove deprecated options `--ideslave` and `--ideslave-socket`. These options
   were replaced with `--ide-mode` and `--ide-mode-socket` in 0.9.17
 
+* The code generator output type `MavenProject` was specific to the
+  Java codegen and has now been deprecated, together with the
+  corresponding `--mvn` option.
+
 ## Reflection changes
+
 * The implicit coercion from String to TTName was removed.
 
 * Decidable equality for TTName is available.

--- a/man/idris.1
+++ b/man/idris.1
@@ -82,7 +82,6 @@ should not necessarily be seen as production ready nor for industrial use.
   --testpkg IPKG           Run tests for package
   -S,--codegenonly         Do no further compilation of code generator output
   -c,--compileonly         Compile to object files rather than an executable
-  --mvn                    Create a maven project (for Java codegen)
   --codegen TARGET         Select code generator: C, Javascript, Node and
                            bytecode are bundled with Idris
   --cg-opt ARG             Arguments to pass to code generator

--- a/src/IRTS/CodegenC.hs
+++ b/src/IRTS/CodegenC.hs
@@ -64,7 +64,6 @@ codegenC' defs out exec incs objs libs flags exports iface dbg
          let cout = headers incs ++ debug dbg ++ h ++ wrappers ++ cc ++
                      (if (exec == Executable) then mprog else hi)
          case exec of
-           MavenProject -> putStrLn ("FAILURE: output type not supported")
            Raw -> writeSource out cout
            _ -> do
              (tmpn, tmph) <- tempfile ".c"

--- a/src/IRTS/CodegenCommon.hs
+++ b/src/IRTS/CodegenCommon.hs
@@ -5,7 +5,7 @@ import IRTS.Simplified
 import IRTS.Defunctionalise
 
 data DbgLevel = NONE | DEBUG | TRACE deriving Eq
-data OutputType = Raw | Object | Executable | MavenProject deriving (Eq, Show)
+data OutputType = Raw | Object | Executable deriving (Eq, Show)
 
 -- Everything which might be needed in a code generator - a CG can choose which
 -- level of Decls to generate code from (simplified, defunctionalised or merely
@@ -26,6 +26,6 @@ data CodegenInfo = CodegenInfo { outputFile :: String,
                                  liftDecls :: [(Name, LDecl)],
                                  interfaces :: Bool,
                                  exportDecls :: [ExportIFace]
-                               } 
+                               }
 
 type CodeGenerator = CodegenInfo -> IO ()

--- a/src/Idris/CmdOptions.hs
+++ b/src/Idris/CmdOptions.hs
@@ -142,7 +142,6 @@ parseFlags = many $
 
   <|> flag' (OutputTy Raw)          (short 'S' <> long "codegenonly" <> help "Do no further compilation of code generator output")
   <|> flag' (OutputTy Object)       (short 'c' <> long "compileonly" <> help "Compile to object files rather than an executable")
-  <|> flag' (OutputTy MavenProject) (long "mvn"                      <> help "Create a maven project (for Java codegen)")
 
   <|> (DumpDefun <$> strOption (long "dumpdefuns"))
   <|> (DumpCases <$> strOption (long "dumpcases"))

--- a/src/Idris/DeepSeq.hs
+++ b/src/Idris/DeepSeq.hs
@@ -258,10 +258,9 @@ instance NFData IdrisColour where
   rnf (IdrisColour _ x2 x3 x4 x5) = rnf x2 `seq` rnf x3 `seq` rnf x4 `seq` rnf x5 `seq` ()
 
 instance NFData OutputType where
-    rnf Raw = ()
-    rnf Object = ()
+    rnf Raw        = ()
+    rnf Object     = ()
     rnf Executable = ()
-    rnf MavenProject = ()
 
 instance NFData IBCWrite where
     rnf (IBCFix fixDecl) = rnf fixDecl `seq` ()


### PR DESCRIPTION
This output was Java specific, and we should treat all codegen the
same.

This is an alternate approach to #3080 