### PR TITLE
Fix #1957 Make man page installable.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,7 +5,7 @@
 * `rewrite` can now be used to rewrite equalities on functions over
   dependent types
 * `rewrite` can now be given an optional rewriting lemma, with the syntax
-  `rewrite [rule] using [rewrite_lemma] in [scope]`. 
+  `rewrite [rule] using [rewrite_lemma] in [scope]`.
 * Experimental extended `with` syntax, which allows calling functions defined
   in a with block directly. For example:
 
@@ -13,9 +13,9 @@
   data SnocList : List a -> Type where
        Empty : SnocList []
        Snoc : SnocList xs -> SnocList (xs ++ [x])
-    
+
   snocList : (xs : List a) -> SnocList a
-    
+
   my_reverse : List a -> List a
   my_reverse xs with (snocList xs)
     my_reverse [] | Empty = []
@@ -27,6 +27,8 @@
     recursion structure of `my_reverse`.
 
 ## Miscellaneous updates
+
+* The Idris man page is now installed as part of the cabal/stack build  process.
 
 * Improved startup performance by reducing the processing of an already imported
   module that has changed accessibility.

--- a/Setup.hs
+++ b/Setup.hs
@@ -9,7 +9,7 @@ import Distribution.Simple.InstallDirs as I
 import Distribution.Simple.LocalBuildInfo as L
 import qualified Distribution.Simple.Setup as S
 import qualified Distribution.Simple.Program as P
-import Distribution.Simple.Utils (createDirectoryIfMissingVerbose, rewriteFile)
+import Distribution.Simple.Utils (createDirectoryIfMissingVerbose, rewriteFile, notice, installOrdinaryFiles)
 import Distribution.Compiler
 import Distribution.PackageDescription
 import Distribution.Text
@@ -228,7 +228,7 @@ idrisBuild _ flags _ local = unless (execOnly (configFlags local)) $ do
          where
             makeBuild dir = make verbosity [ "-C", dir, "build" , "IDRIS=" ++ idrisCmd local]
 
-      buildRTS = make verbosity (["-C", "rts", "build"] ++ 
+      buildRTS = make verbosity (["-C", "rts", "build"] ++
                                    gmpflag (usesGMP (configFlags local)))
 
       gmpflag False = []
@@ -242,6 +242,7 @@ idrisBuild _ flags _ local = unless (execOnly (configFlags local)) $ do
 idrisInstall verbosity copy pkg local = unless (execOnly (configFlags local)) $ do
       installStdLib
       installRTS
+      installManPage
    where
       target = datadir $ L.absoluteInstallDirs pkg local copy
 
@@ -253,6 +254,12 @@ idrisInstall verbosity copy pkg local = unless (execOnly (configFlags local)) $ 
          let target' = target </> "rts"
          putStrLn $ "Installing run time system in " ++ target'
          makeInstall "rts" target'
+
+      installManPage = do
+         let mandest = (mandir $ L.absoluteInstallDirs pkg local copy) ++ "/man1"
+         notice verbosity $ unwords ["Copying man page to", mandest]
+         installOrdinaryFiles verbosity mandest [("man", "idris.1")]
+
 
       makeInstall src target =
          make verbosity [ "-C", src, "install" , "TARGET=" ++ target, "IDRIS=" ++ idrisCmd local]

--- a/idris.cabal
+++ b/idris.cabal
@@ -81,7 +81,6 @@ Extra-doc-files:
                        CONTRIBUTORS
                        README.md
                        idris-tutorial.pdf
-                       man/idris.1
                        samples/effects/*.idr
                        samples/misc/*.idr
                        samples/misc/*.lidr
@@ -91,7 +90,8 @@ Extra-source-files:
                        Makefile
                        config.mk
                        stack.yaml
-
+                       man/idris.1
+		       
                        rts/*.c
                        rts/*.h
                        rts/arduino/*.c


### PR DESCRIPTION
Idris comes with a man page, this commit uses cabal (or stack) to
install it to an appropriate place.  Once installed you may need to
add the location to `$MANPATH` if you haven't done so already.