### PR TITLE
Disable views001 for javascript

### DIFF
--- a/test/Makefile
+++ b/test/Makefile
@@ -12,7 +12,7 @@ info: runtest
 	@./runtest $(patsubst %.test,%,$@) -q
 
 test_js: runtest
-	@./runtest without tutorial007 sugar004 reg029 reg052 io001 dsl002 io003 effects001 effects002 basic007 basic011 ffi006 ffi007 ffi008 primitives005 primitives006 opts --codegen node
+	@./runtest without tutorial007 sugar004 reg029 reg052 io001 dsl002 io003 effects001 effects002 basic007 basic011 ffi006 ffi007 ffi008 primitives005 primitives006 views001 opts --codegen node
 
 update: runtest
 	@./runtest all -u


### PR DESCRIPTION
It gives different results. There is probably no reason that it couldn't be made to work, but we can't have travis broken while we fiddle with js math.