### PR TITLE
Use bit-pattern identity for Double

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -52,6 +52,12 @@
   Java codegen and has now been deprecated, together with the
   corresponding `--mvn` option.
 
+* Definitional equality on Double is now bit-pattern identity rather
+  than IEEE's comparison operator. This prevents a bug where programs
+  could distinguish between -0.0 and 0.0, but the type theory could
+  not, leading to a contradiction. The new fine-grained equality
+  prevents this.
+
 ## Reflection changes
 
 * The implicit coercion from String to TTName was removed.

--- a/idris.cabal
+++ b/idris.cabal
@@ -328,6 +328,10 @@ Extra-source-files:
                        test/reg071/run
                        test/reg071/*.idr
                        test/reg071/expected
+                       test/reg072/run
+                       test/reg072/*.idr
+                       test/reg072/expected
+
 
                        test/basic001/run
                        test/basic001/*.idr

--- a/idris.cabal
+++ b/idris.cabal
@@ -1011,6 +1011,7 @@ Library
                 , filepath < 1.5
                 , fingertree >= 0.1 && < 0.2
                 , haskeline >= 0.7 && < 0.8
+                , ieee754 >= 0.7 && < 0.8
                 , mtl >= 2.1 && < 2.3
                 , network < 2.7
                 , optparse-applicative >= 0.11 && < 0.13

--- a/src/Idris/Core/TT.hs
+++ b/src/Idris/Core/TT.hs
@@ -73,6 +73,8 @@ import qualified Data.Binary as B
 import Data.Binary hiding (get, put)
 import Foreign.Storable (sizeOf)
 
+import Numeric.IEEE (IEEE (identicalIEEE))
+
 import Util.Pretty hiding (Str)
 
 data Option = TTypeInTType
@@ -708,7 +710,30 @@ data Const = I Int | BI Integer | Fl Double | Ch Char | Str String
            | AType ArithTy | StrType
            | WorldType | TheWorld
            | VoidType | Forgot
-  deriving (Eq, Ord, Data, Typeable)
+  deriving (Ord, Data, Typeable)
+
+-- We need to compare Double using bit-pattern identity rather than
+-- Haskell's Eq, which equates 0.0 and -0.0, leading to a
+-- contradiction in the type theory. Bit-pattern identity will also
+-- avoid similar problems for NaNs.
+instance Eq Const where
+  I i       == I j       = i == j
+  BI i      == BI j      = i == j
+  Fl i      == Fl j      = identicalIEEE i j
+  Ch i      == Ch j      = i == j
+  Str i     == Str j     = i == j
+  B8 i      == B8 j      = i == j
+  B16 i     == B16 j     = i == j
+  B32 i     == B32 j     = i == j
+  B64 i     == B64 j     = i == j
+  AType i   == AType j   = i == j
+  StrType   == StrType   = True
+  WorldType == WorldType = True
+  TheWorld  == TheWorld  = True
+  VoidType  == VoidType  = True
+  Forgot    == Forgot    = True
+  _         == _         = False
+
 {-!
 deriving instance Binary Const
 deriving instance NFData Const

--- a/test/reg072/DoubleEquality.idr
+++ b/test/reg072/DoubleEquality.idr
@@ -1,0 +1,5 @@
+module DoubleEquality
+
+oops : Void
+oops = the ((False = True) -> Void) (\Refl impossible) $ cong {f = (>0) . (1/)} $ the (-0.0 = 0.0) Refl
+

--- a/test/reg072/expected
+++ b/test/reg072/expected
@@ -1,0 +1,15 @@
+DoubleEquality.idr:4:87:
+When checking right hand side of oops with expected type
+        Void
+
+When checking argument value to function Prelude.Basics.the:
+        Type mismatch between
+                x = x (Type of Refl)
+        and
+                negate 0.0 = 0.0 (Expected type)
+        
+        Specifically:
+                Type mismatch between
+                        -0.0
+                and
+                        0.0

--- a/test/reg072/run
+++ b/test/reg072/run
@@ -1,0 +1,3 @@
+#!/usr/bin/env bash
+${IDRIS:-idris} $@ DoubleEquality.idr --check
+rm -f *.ibc


### PR DESCRIPTION
Change the conversion checker to use bit-pattern identity on Double
instead of the IEEE comparison that Haskell's Eq type class implements.
Previously, we had definitionally equal values like -0.0 and 0.0 that
could nevertheless be distinguished by programs. This breaking of
functionality allowed proving a contradiction.

Thanks to Ryan Scott (@RyanGlScott) for the tip on how to do the bit-pattern
comparison!
 
Here's the test case from #2609 now:
```
Idris> the ((False = True) -> Void) (\Refl impossible) $ cong {f = (>0) . (1/)} $ the (-0.0 = 0.0) Refl
(input):1:80:When checking argument value to function Prelude.Basics.the:
        Type mismatch between
                x = x (Type of Refl)
        and
                negate 0.0 = 0.0 (Expected type)
        
        Specifically:
                Type mismatch between
                        -0.0
                and
                        0.0
```

which is evidence that this fixes #2609.