### PR TITLE
File c ptr

### DIFF
--- a/libs/prelude/Prelude/File.idr
+++ b/libs/prelude/Prelude/File.idr
@@ -17,16 +17,11 @@ import IO
 %access public export
 
 ||| A file handle
-export
 data File : Type where
   FHandle : (p : Ptr) -> File
 
 -- Usage hints for erasure analysis
 %used FHandle p
-
-||| Pointer to a C FILE structure (for passing to C routines)
-to_C : File -> Ptr
-to_C (FHandle p) = p
 
 ||| An error from a file operation
 -- This is built in idris_mkFileError() in rts/idris_stdfgn.c. Make sure

--- a/libs/prelude/Prelude/File.idr
+++ b/libs/prelude/Prelude/File.idr
@@ -24,6 +24,10 @@ data File : Type where
 -- Usage hints for erasure analysis
 %used FHandle p
 
+||| Pointer to a C FILE structure (for passing to C routines)
+to_C : File -> Ptr
+to_C (FHandle p) = p
+
 ||| An error from a file operation
 -- This is built in idris_mkFileError() in rts/idris_stdfgn.c. Make sure
 -- the values correspond!


### PR DESCRIPTION
to_C was OK but I also needed from_C, which doesn't work because of the new access rules about not leaking private features.

So i exported the constructor instead.