### PR TITLE
Fixes #2049

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -35,6 +35,8 @@ matrix:
       compiler: ": #GHC 7.10.2"
     - env: CABALVER="1.22" GHCVER="7.10.2" TESTS="test_c"
       compiler: ": #GHC 7.10.2"
+    - env: CABALVER="1.22" GHCVER="7.10.2" TESTS="user_doc_test"
+      compiler: ": #GHC 7.10.2"
 
 cache:
   directories:
@@ -48,6 +50,7 @@ before_cache:
 before_install:
   - unset CC
   - export PATH=/opt/ghc/$GHCVER/bin:/opt/cabal/$CABALVER/bin:$HOME/.cabal/bin:$PATH
+  - export PATH=$HOME/.local/bin:$PATH
   - env
 
 install:
@@ -88,6 +91,10 @@ install:
       mkdir $HOME/.cabsnap;
       cp -a $HOME/.ghc $HOME/.cabsnap/ghc;
       cp -a $HOME/.cabal/lib $HOME/.cabal/share $HOME/.cabal/bin installplan.txt $HOME/.cabsnap/;
+    fi
+  - if [[ "$TESTS" == "user_doc_test" ]];
+    then
+      pip install --user Sphinx sphinx-rtd-theme;
     fi
 
 before_script:

--- a/Makefile
+++ b/Makefile
@@ -1,4 +1,4 @@
-.PHONY: build configure doc install linecount nodefault pinstall lib_clean relib fast test_c test lib_doc lib_doc_clean user_doc_html user_doc_pdf user_docs
+.PHONY: build configure doc install linecount nodefault pinstall lib_clean relib fast test_c test lib_doc lib_doc_clean user_doc_html user_doc_pdf user_docs user_doc_test
 
 include config.mk
 -include custom.mk
@@ -57,6 +57,11 @@ user_doc_html:
 
 user_doc_pdf:
 	$(MAKE) -C docs latexpdf
+
+user_doc_test:
+	(cd docs; bash checkdocs.sh)
+	@echo
+	@echo "Checking of Sphinx HTML docs finished."
 
 fast:
 	$(CABAL) install $(CABALFLAGS) --ghc-option=-O0

--- a/docs/checkdocs.sh
+++ b/docs/checkdocs.sh
@@ -1,0 +1,13 @@
+#  ------------------------------------------------------------ [ checkdocs.sh ]
+#  Module    : checkdocs.sh
+#  Copyright : (c) The Idris Community
+#  License   : see LICENSE
+#  --------------------------------------------------------------------- [ EOH ]
+
+# A numpty test to determine if the sphinx docs can be built or not.
+#
+# Adapted in part from [PyMSQL project](https://github.com/pymssql/pymssql)
+
+test -z "$(make SPHINXOPTS='-q' html 2>&1 | egrep -w 'SEVERE:|ERROR:')"
+
+#  --------------------------------------------------------------------- [ EOF ]


### PR DESCRIPTION
These changes augments the build setup to check the sphinx documentation.

The changes are based upon the configuration used by [PyMSQL
project](https://github.com/pymssql/pymssql).

A problem with this approach is that the matrix for checking the docs
requires Idris to be built. The travis build could be made more modal
so that only the sphinx docs are built.