### PR TITLE
Fragile directive

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -26,6 +26,10 @@
     be called directly, so the recursive structure of `SnocList` can direct the
     recursion structure of `my_reverse`.
 
+* Added `%fragile` directive, which gives a warning and a message when a
+  fragile name is referenced. For use in detailing fragile APIs.
+
+
 ## Library updates
 
 * `Control.WellFounded` module removed, and added to the Prelude as

--- a/idris.cabal
+++ b/idris.cabal
@@ -91,7 +91,7 @@ Extra-source-files:
                        config.mk
                        stack.yaml
                        man/idris.1
-		       
+
                        rts/*.c
                        rts/*.h
                        rts/arduino/*.c
@@ -408,6 +408,10 @@ Extra-source-files:
                        test/corecords002/*.idr
                        test/corecords002/run
                        test/corecords002/expected
+
+                       test/directives001/*.idr
+                       test/directives001/run
+                       test/directives001/expected
 
                        test/delab001/*.idr
                        test/delab001/run

--- a/src/Idris/AbsSyntaxTree.hs
+++ b/src/Idris/AbsSyntaxTree.hs
@@ -760,23 +760,23 @@ deriving instance NFData PDecl'
 !-}
 
 -- | The set of source directives
-data Directive = DLib Codegen String |
-                 DLink Codegen String |
-                 DFlag Codegen String |
-                 DInclude Codegen String |
-                 DHide Name |
-                 DFreeze Name |
-                 DAccess Accessibility |
-                 DDefault Bool |
-                 DLogging Integer |
-                 DDynamicLibs [String] |
-                 DNameHint Name FC [(Name, FC)] |
-                 DErrorHandlers Name FC Name FC [(Name, FC)] |
-                 DLanguage LanguageExt |
-                 DDeprecate Name String |
-                 DFragile Name String |
-                 DAutoImplicits Bool |
-                 DUsed FC Name Name
+data Directive = DLib Codegen String
+               | DLink Codegen String
+               | DFlag Codegen String
+               | DInclude Codegen String
+               | DHide Name
+               | DFreeze Name
+               | DAccess Accessibility
+               | DDefault Bool
+               | DLogging Integer
+               | DDynamicLibs [String]
+               | DNameHint Name FC [(Name, FC)]
+               | DErrorHandlers Name FC Name FC [(Name, FC)]
+               | DLanguage LanguageExt
+               | DDeprecate Name String
+               | DFragile Name String
+               | DAutoImplicits Bool
+               | DUsed FC Name Name
 
 -- | A set of instructions for things that need to happen in IState
 -- after a term elaboration when there's been reflected elaboration.

--- a/src/Idris/DeepSeq.hs
+++ b/src/Idris/DeepSeq.hs
@@ -306,6 +306,7 @@ instance NFData IBCWrite where
     rnf (IBCAutoHint n1 n2) = rnf n1 `seq` rnf n2 `seq` ()
     rnf (IBCDeprecate n1 n2) = rnf n1 `seq` rnf n2 `seq` ()
     rnf (IBCRecord x) = rnf x `seq` ()
+    rnf (IBCFragile n1 n2) = rnf n1 `seq` rnf n2 `seq` ()
 
 
 instance NFData a => NFData (D.Block a) where
@@ -698,8 +699,8 @@ instance NFData IState where
   rnf (IState x1 x2 x3 x4 x5 x6 x7 x8 x9 x10 x11 x12 x13 x14 x15 x16 x17 x18 x19 x20
               x21 x22 x23 x24 x25 x26 x27 x28 x29 x30 x31 x32 x33 x34 x35 x36 x37 x38 x39 x40
               x41 x42 x43 x44 x45 x46 x47 x48 x49 x50 x51 x52 x53 x54 x55 x56 x57 x58 x59 x60
-              x61 x62 x63 x64 x65 x66 x67 x68 x69 x70 x71 x72 x73 x74 x75)
+              x61 x62 x63 x64 x65 x66 x67 x68 x69 x70 x71 x72 x73 x74 x75 x76)
      = rnf x1 `seq` rnf x2 `seq` rnf x3 `seq` rnf x4 `seq` rnf x5 `seq` rnf x6 `seq` rnf x7 `seq` rnf x8 `seq` rnf x9 `seq` rnf x10 `seq` () `seq` rnf x11 `seq` rnf x12 `seq` rnf x13 `seq` rnf x14 `seq` rnf x15 `seq` rnf x16 `seq` rnf x17 `seq` rnf x18 `seq` rnf x19 `seq` rnf x20 `seq`
        rnf x21 `seq` rnf x22 `seq` rnf x23 `seq` rnf x24 `seq` rnf x25 `seq` rnf x26 `seq` rnf x27 `seq` rnf x28 `seq` rnf x29 `seq` rnf x30 `seq` rnf x31 `seq` rnf x32 `seq` rnf x33 `seq` rnf x34 `seq` rnf x35 `seq` rnf x36 `seq` rnf x37 `seq` rnf x38 `seq` rnf x39 `seq` rnf x40 `seq`
        rnf x41 `seq` rnf x42 `seq` rnf x43 `seq` rnf x44 `seq` rnf x45 `seq` rnf x46 `seq` rnf x47 `seq` rnf x48 `seq` rnf x49 `seq` rnf x50 `seq` rnf x51 `seq` rnf x52 `seq` rnf x53 `seq` rnf x54 `seq` rnf x55 `seq` rnf x56 `seq` rnf x57 `seq` rnf x58 `seq` rnf x59 `seq` rnf x60 `seq`
-       rnf x61 `seq` rnf x62 `seq` rnf x63 `seq` rnf x64 `seq` rnf x65 `seq` rnf x66 `seq` rnf x67 `seq` rnf x68 `seq` rnf x69 `seq` rnf x70 `seq` rnf x71 `seq` rnf x72 `seq` rnf x73 `seq` rnf x74 `seq` rnf x75 `seq` ()
+       rnf x61 `seq` rnf x62 `seq` rnf x63 `seq` rnf x64 `seq` rnf x65 `seq` rnf x66 `seq` rnf x67 `seq` rnf x68 `seq` rnf x69 `seq` rnf x70 `seq` rnf x71 `seq` rnf x72 `seq` rnf x73 `seq` rnf x74 `seq` rnf x75 `seq` rnf x76 `seq` ()

--- a/src/Idris/Directives.hs
+++ b/src/Idris/Directives.hs
@@ -59,8 +59,7 @@ directiveAction (DNameHint ty tyFC ns) = do
   ty' <- disambiguate ty
   mapM_ (addNameHint ty' . fst) ns
   mapM_ (\n -> addIBC (IBCNameHint (ty', fst n))) ns
-  sendHighlighting $
-  [(tyFC, AnnName ty' Nothing Nothing Nothing)] ++ map (\(n, fc) -> (fc, AnnBoundName n False)) ns
+  sendHighlighting $ [(tyFC, AnnName ty' Nothing Nothing Nothing)] ++ map (\(n, fc) -> (fc, AnnBoundName n False)) ns
 
 directiveAction (DErrorHandlers fn nfc arg afc ns) = do
   fn' <- disambiguate fn
@@ -80,6 +79,11 @@ directiveAction (DDeprecate n reason) = do
   n' <- disambiguate n
   addDeprecated n' reason
   addIBC (IBCDeprecate n' reason)
+
+directiveAction (DFragile n reason) = do
+  n' <- disambiguate n
+  addFragile n' reason
+  addIBC (IBCFragile n' reason)
 
 directiveAction (DAutoImplicits b) = setAutoImpls b
 directiveAction (DUsed fc fn arg)  = addUsedName fc fn arg

--- a/src/Idris/Directives.hs
+++ b/src/Idris/Directives.hs
@@ -13,28 +13,35 @@ import Util.DynamicLinker
 
 -- | Run the action corresponding to a directive
 directiveAction :: Directive -> Idris ()
-directiveAction (DLib cgn lib) = do addLib cgn lib
-                                    addIBC (IBCLib cgn lib)
+directiveAction (DLib cgn lib) = do
+  addLib cgn lib
+  addIBC (IBCLib cgn lib)
 
-directiveAction (DLink cgn obj) = do dirs <- allImportDirs
-                                     o <- runIO $ findInPath dirs obj
-                                     addIBC (IBCObj cgn obj) -- just name, search on loading ibc
-                                     addObjectFile cgn o
+directiveAction (DLink cgn obj) = do
+  dirs <- allImportDirs
+  o <- runIO $ findInPath dirs obj
+  addIBC (IBCObj cgn obj) -- just name, search on loading ibc
+  addObjectFile cgn o
 
 directiveAction (DFlag cgn flag) = do
-                                      let flags = words flag
-                                      mapM_ (\f -> addIBC (IBCCGFlag cgn f)) flags
-                                      mapM_ (addFlag cgn) flags
+  let flags = words flag
+  mapM_ (\f -> addIBC (IBCCGFlag cgn f)) flags
+  mapM_ (addFlag cgn) flags
 
-directiveAction (DInclude cgn hdr) = do addHdr cgn hdr
-                                        addIBC (IBCHeader cgn hdr)
+directiveAction (DInclude cgn hdr) = do
+  addHdr cgn hdr
+  addIBC (IBCHeader cgn hdr)
 
-directiveAction (DHide n') = do ns <- allNamespaces n'
-                                mapM_ (\n -> do setAccessibility n Hidden
-                                                addIBC (IBCAccess n Hidden)) ns
-directiveAction (DFreeze n') = do ns <- allNamespaces n'
-                                  mapM_ (\n -> do setAccessibility n Frozen
-                                                  addIBC (IBCAccess n Frozen)) ns
+directiveAction (DHide n') = do
+  ns <- allNamespaces n'
+  mapM_ (\n -> do
+            setAccessibility n Hidden
+            addIBC (IBCAccess n Hidden)) ns
+directiveAction (DFreeze n') = do
+  ns <- allNamespaces n'
+  mapM_ (\n -> do
+            setAccessibility n Frozen
+            addIBC (IBCAccess n Frozen)) ns
 
 directiveAction (DAccess acc) = do updateIState (\i -> i { default_access = acc })
 
@@ -42,49 +49,54 @@ directiveAction (DDefault tot) =  do updateIState (\i -> i { default_total = tot
 
 directiveAction (DLogging lvl) = setLogLevel (fromInteger lvl)
 
-directiveAction (DDynamicLibs libs) = do added <- addDyLib libs
-                                         case added of
-                                             Left lib -> addIBC (IBCDyLib (lib_name lib))
-                                             Right msg -> fail $ msg
+directiveAction (DDynamicLibs libs) = do
+  added <- addDyLib libs
+  case added of
+    Left lib  -> addIBC (IBCDyLib (lib_name lib))
+    Right msg -> fail $ msg
 
-directiveAction (DNameHint ty tyFC ns) = do ty' <- disambiguate ty
-                                            mapM_ (addNameHint ty' . fst) ns
-                                            mapM_ (\n -> addIBC (IBCNameHint (ty', fst n))) ns
-                                            sendHighlighting $
-                                              [(tyFC, AnnName ty' Nothing Nothing Nothing)] ++
-                                              map (\(n, fc) -> (fc, AnnBoundName n False)) ns
+directiveAction (DNameHint ty tyFC ns) = do
+  ty' <- disambiguate ty
+  mapM_ (addNameHint ty' . fst) ns
+  mapM_ (\n -> addIBC (IBCNameHint (ty', fst n))) ns
+  sendHighlighting $
+  [(tyFC, AnnName ty' Nothing Nothing Nothing)] ++ map (\(n, fc) -> (fc, AnnBoundName n False)) ns
 
-directiveAction (DErrorHandlers fn nfc arg afc ns) =
-  do fn' <- disambiguate fn
-     ns' <- mapM (\(n, fc) -> do n' <- disambiguate n
-                                 return (n', fc)) ns
-     addFunctionErrorHandlers fn' arg (map fst ns')
-     mapM_ (addIBC .
-         IBCFunctionErrorHandler fn' arg . fst) ns'
-     sendHighlighting $
-       [(nfc, AnnName fn' Nothing Nothing Nothing),
-        (afc, AnnBoundName arg False)] ++
-       map (\(n, fc) -> (fc, AnnName n Nothing Nothing Nothing)) ns'
+directiveAction (DErrorHandlers fn nfc arg afc ns) = do
+  fn' <- disambiguate fn
+  ns' <- mapM (\(n, fc) -> do
+                  n' <- disambiguate n
+                  return (n', fc)) ns
+  addFunctionErrorHandlers fn' arg (map fst ns')
+  mapM_ (addIBC . IBCFunctionErrorHandler fn' arg . fst) ns'
+  sendHighlighting $
+       [ (nfc, AnnName fn' Nothing Nothing Nothing)
+       , (afc, AnnBoundName arg False)
+       ] ++ map (\(n, fc) -> (fc, AnnName n Nothing Nothing Nothing)) ns'
 
 directiveAction (DLanguage ext) = addLangExt ext
-directiveAction (DDeprecate n reason) 
-    = do n' <- disambiguate n
-         addDeprecated n' reason
-         addIBC (IBCDeprecate n' reason)
-directiveAction (DAutoImplicits b)
-    = setAutoImpls b
-directiveAction (DUsed fc fn arg) = addUsedName fc fn arg
+
+directiveAction (DDeprecate n reason) = do
+  n' <- disambiguate n
+  addDeprecated n' reason
+  addIBC (IBCDeprecate n' reason)
+
+directiveAction (DAutoImplicits b) = setAutoImpls b
+directiveAction (DUsed fc fn arg)  = addUsedName fc fn arg
 
 disambiguate :: Name -> Idris Name
-disambiguate n = do i <- getIState
-                    case lookupCtxtName n (idris_implicits i) of
-                              [(n', _)] -> return n'
-                              []        -> throwError (NoSuchVariable n)
-                              more      -> throwError (CantResolveAlts (map fst more))
+disambiguate n = do
+  i <- getIState
+  case lookupCtxtName n (idris_implicits i) of
+    [(n', _)] -> return n'
+    []        -> throwError (NoSuchVariable n)
+    more      -> throwError (CantResolveAlts (map fst more))
+
 
 allNamespaces :: Name -> Idris [Name]
-allNamespaces n = do i <- getIState
-                     case lookupCtxtName n (idris_implicits i) of
-                              [(n', _)] -> return [n']
-                              []        -> throwError (NoSuchVariable n)
-                              more      -> return (map fst more)
+allNamespaces n = do
+  i <- getIState
+  case lookupCtxtName n (idris_implicits i) of
+    [(n', _)] -> return [n']
+    []        -> throwError (NoSuchVariable n)
+    more      -> return (map fst more)

--- a/src/Idris/Parser.hs
+++ b/src/Idris/Parser.hs
@@ -535,7 +535,7 @@ syntaxRule syn
           flip PQuasiquote goal <$> fixBind (q + 1) rens tm
         fixBind q rens (PUnquote tm) =
           PUnquote <$> fixBind (q - 1) rens tm
-          
+
         fixBind q rens x = descendM (fixBind q rens) x
 
         gensym :: Name -> IdrisParser Name
@@ -923,11 +923,11 @@ instance_ kwopt syn
                                           then [TotalFn]
                                           else []
 
-                   (doc, argDocs) <- docstring syn 
+                   (doc, argDocs) <- docstring syn
                    opts <- fnOpts initOpts
                    acc <- accessibility
                    opts' <- fnOpts opts
-         
+
                    if kwopt then optional instanceKeyword
                             else do instanceKeyword
                                     return (Just ())
@@ -1319,6 +1319,8 @@ Directive' ::= 'lib'            CodeGen String_t
            |   'error_handlers' Name NameList
            |   'language'       'TypeProviders'
            |   'language'       'ErrorReflection'
+           |   'deprecated' Name String
+           |   'fragile'    Name Reason
            ;
 @
 -}
@@ -1371,6 +1373,10 @@ directive syn = do try (lchar '%' *> reserved "lib")
                     n <- fst <$> fnName
                     alt <- option "" (fst <$> stringLiteral)
                     return [PDirective (DDeprecate n alt)]
+             <|> do try (lchar '%' *> reserved "fragile")
+                    n <- fst <$> fnName
+                    alt <- option "" (fst <$> stringLiteral)
+                    return [PDirective (DFragile n alt)]
              <|> do fc <- getFC
                     try (lchar '%' *> reserved "used")
                     fn <- fst <$> fnName

--- a/test/directives001/directives001.idr
+++ b/test/directives001/directives001.idr
@@ -1,0 +1,28 @@
+module directives001
+
+%access export
+
+
+data Foo = MkFoo String
+
+%deprecate Foo "To be replaced with `Bar`."
+
+data Bar : Type where
+    MkBar : Nat -> Nat -> Bar
+
+
+mkFoo : String -> Foo
+mkFoo = MkFoo
+
+%deprecate mkFoo "To be replaced with `mkBar`."
+
+mkBar : Nat -> Bar
+mkBar a = MkBar a a
+
+%fragile mkBar "How `Bar`s are to be created is still being discussed, `mkBar` is subject to change."
+
+namespace Main
+  main : IO ()
+  main = do
+    let b = mkBar 1
+    putStrLn $ "Hello World"

--- a/test/directives001/expected
+++ b/test/directives001/expected
@@ -1,0 +1,14 @@
+directives001.idr:14:7:Use of deprecated name directives001.Foo
+To be replaced with `Bar`.
+directives001.idr:14:7:Use of deprecated name directives001.Foo
+To be replaced with `Bar`.
+directives001.idr:15:7:Use of deprecated name directives001.Foo
+To be replaced with `Bar`.
+directives001.idr:15:7:Use of deprecated name directives001.Foo
+To be replaced with `Bar`.
+directives001.idr:26:8:
+Use of a fragile construct directives001.mkBar
+How `Bar`s are to be created is still being discussed, `mkBar` is subject to change.
+directives001.idr:26:8:
+Use of a fragile construct directives001.mkBar
+How `Bar`s are to be created is still being discussed, `mkBar` is subject to change.

--- a/test/directives001/run
+++ b/test/directives001/run
@@ -1,0 +1,4 @@
+#!/usr/bin/env bash
+${IDRIS:-idris} $@ directives001.idr --check --nocolour
+
+rm -f directives001 *.ibc


### PR DESCRIPTION
When building packages new features may be added for testing. The
`fragile` directive provides support for marking such fragile
constructs and providing compilation warnings.

This commit also adds a directives test to check the operation of the
deprecate and fragile directives.