### PR TITLE
Fix alignment on 32 bits

### DIFF
--- a/libs/contrib/CFFI/Types.idr
+++ b/libs/contrib/CFFI/Types.idr
@@ -70,9 +70,9 @@ mutual
     alignOfCT I8 = 1
     alignOfCT I16 = 2
     alignOfCT I32 = 4
-    alignOfCT I64 = prim__sizeofPtr
+    alignOfCT I64 = 8
     alignOfCT FLOAT = 4
-    alignOfCT DOUBLE = prim__sizeofPtr
+    alignOfCT DOUBLE = 8
     alignOfCT PTR = prim__sizeofPtr
 
     ||| Alignment requirement of the type


### PR DESCRIPTION
Qwords and doubles are 8 byte aligned and not 4.