### PR TITLE
Relax upper bounds to allow ghc8.

### DIFF
--- a/idris.cabal
+++ b/idris.cabal
@@ -1028,7 +1028,7 @@ Library
                 , ansi-terminal < 0.7
                 , ansi-wl-pprint < 0.7
                 , base64-bytestring < 1.1
-                , binary >= 0.7 && < 0.8
+                , binary >= 0.7 && < 0.9
                 , blaze-html >= 0.6.1.3 && < 0.9
                 , blaze-markup >= 0.5.2.1 && < 0.8
                 , bytestring < 0.11
@@ -1045,12 +1045,12 @@ Library
                 , optparse-applicative >= 0.11 && < 0.13
                 , parsers >= 0.9 && < 0.13
                 , pretty < 1.2
-                , process < 1.3
+                , process < 1.5
                 , split < 0.3
                 , terminal-size < 0.4
                 , text >=1.2.1.0 && < 1.3
-                , time >= 1.4 && < 1.6
-                , transformers < 0.5
+                , time >= 1.4 && < 1.7
+                , transformers < 0.6
                 , transformers-compat >= 0.3
                 , trifecta >= 1.1 && < 1.6
                 , uniplate >=1.6 && < 1.7


### PR DESCRIPTION
This also clears up remainining newer libs available on
http://packdeps.haskellers.com/feed?needle=idris