### PR TITLE
Enum for bits

### DIFF
--- a/docs/reference/ffi.rst
+++ b/docs/reference/ffi.rst
@@ -179,7 +179,8 @@ compilation error:
     example f = foreign FFI_C "callbacker" (CFnPtr (Int -> ()) -> IO ()) f
 
 The other big limitation is that it doesn't support IO functions. Use
-``unsafePerformIO`` to wrap them.
+``unsafePerformIO`` to wrap them (i.e. to make an IO function usable as a callback, change the return type
+from IOr to r, and change the = do to = unsafePerformIO $ do).
 
 There are two special function names:
 ``%wrapper`` returns the function pointer that wraps an Idris function. This
@@ -215,6 +216,9 @@ global variable with the following name. The type must be just ``IO Ptr``.
     -- access the global variable errno
     errno : IO Ptr
     errno = foreign FFI_C "&errno" (IO Ptr)
+
+For more complicated interactions with C (such as reading and setting fields of a C struct), there is
+a module CFFI available in the contrib package.
 
 FFI implementation
 ------------------

--- a/docs/tutorial/miscellany.rst
+++ b/docs/tutorial/miscellany.rst
@@ -276,7 +276,7 @@ type ``Int`` will be provided. Otherwise, it will provide the type
     strToType _ = Nat
 
     fromFile : String -> IO (Provider Type)
-    fromFile fname = do str <- readFile fname
+    fromFile fname = do Right str <- readFile fname
                         return (Provide (strToType (trim str)))
 
 We then use the ``%provide`` directive:

--- a/docs/tutorial/typesfuns.rst
+++ b/docs/tutorial/typesfuns.rst
@@ -860,12 +860,12 @@ Dependent Pairs
 
 Dependent pairs allow the type of the second element of a pair to depend
 on the value of the first element. Traditionally, these are referred to
-as “sigma types”:
+as “sigma types”, so in older code you might see Sigma rather than DPair:
 
 .. code-block:: idris
 
-    data Sigma : (a : Type) -> (P : a -> Type) -> Type where
-       MkSigma : {P : a -> Type} -> (x : a) -> P x -> Sigma a P
+    data DPair : (a : Type) -> (P : a -> Type) -> Type where
+       MkDPair : {P : a -> Type} -> (x : a) -> P x -> DPair a P
 
 Again, there is syntactic sugar for this. ``(a : A ** P)`` is the type
 of a pair of A and P, where the name ``a`` can occur inside ``P``.
@@ -882,8 +882,8 @@ equivalent.
 
 .. code-block:: idris
 
-    vec : Sigma Nat (\n => Vect n Int)
-    vec = MkSigma 2 [3, 4]
+    vec : DPair Nat (\n => Vect n Int)
+    vec = MkDPair 2 [3, 4]
 
 The type checker could of course infer the value of the first element
 from the length of the vector. We can write an underscore ``_`` in

--- a/libs/prelude/Prelude.idr
+++ b/libs/prelude/Prelude.idr
@@ -214,6 +214,30 @@ Enum Char where
 
   pred c = fromNat (pred (toNat c))
 
+Enum Bits8 where
+  toNat b   = fromIntegerNat (prim__zextB8_BigInt b)
+  fromNat n = prim__truncBigInt_B8 (toIntegerNat n)
+  
+  pred b = fromNat (pred (toNat b))
+
+Enum Bits16 where
+  toNat b   = fromIntegerNat (prim__zextB16_BigInt b)
+  fromNat n = prim__truncBigInt_B16 (toIntegerNat n)
+  
+  pred b = fromNat (pred (toNat b))
+
+Enum Bits32 where
+  toNat b   = fromIntegerNat (prim__zextB32_BigInt b)
+  fromNat n = prim__truncBigInt_B32 (toIntegerNat n)
+  
+  pred b = fromNat (pred (toNat b))
+
+Enum Bits64 where
+  toNat b   = fromIntegerNat (prim__zextB64_BigInt b)
+  fromNat n = prim__truncBigInt_B64 (toIntegerNat n)
+  
+  pred b = fromNat (pred (toNat b))
+  
 syntax "[" [start] ".." [end] "]"
      = enumFromTo start end
 syntax "[" [start] "," [next] ".." [end] "]"


### PR DESCRIPTION
I encountered an error message in code that I was writing that there was no Enum implementation for Bits8. It seemed easier to implement this than rewrite the code, so ...