### PR TITLE
Export intermediate representation as JSON

### DIFF
--- a/codegen/idris-codegen-c/Main.hs
+++ b/codegen/idris-codegen-c/Main.hs
@@ -40,7 +40,7 @@ c_main opts = do runIO setupBundledCC
                  mainProg <- if interface opts
                                 then liftM Just elabMain
                                 else return Nothing
-                 ir <- compile (Via "c") (output opts) mainProg
+                 ir <- compile (Via IBCFormat "c") (output opts) mainProg
                  runIO $ codegenC ir
 
 main :: IO ()

--- a/codegen/idris-codegen-javascript/Main.hs
+++ b/codegen/idris-codegen-javascript/Main.hs
@@ -34,7 +34,7 @@ jsMain :: Opts -> Idris ()
 jsMain opts = do elabPrims
                  loadInputs (inputs opts) Nothing
                  mainProg <- elabMain
-                 ir <- compile (Via "javascript") (output opts) (Just mainProg)
+                 ir <- compile (Via IBCFormat "javascript") (output opts) (Just mainProg)
                  runIO $ codegenJavaScript ir
 
 main :: IO ()

--- a/codegen/idris-codegen-node/Main.hs
+++ b/codegen/idris-codegen-node/Main.hs
@@ -33,7 +33,7 @@ jsMain :: Opts -> Idris ()
 jsMain opts = do elabPrims
                  loadInputs (inputs opts) Nothing
                  mainProg <- elabMain
-                 ir <- compile (Via "node") (output opts) (Just mainProg)
+                 ir <- compile (Via IBCFormat "node") (output opts) (Just mainProg)
                  runIO $ codegenNode ir
 
 main :: IO ()

--- a/idris.cabal
+++ b/idris.cabal
@@ -1052,7 +1052,7 @@ Library
                 , Tools_idris
 
   Build-depends:  base >=4 && <5
-                , aeson >= 0.11 && < 0.12
+                , aeson >= 0.6 && < 0.12
                 , annotated-wl-pprint >= 0.7 && < 0.8
                 , ansi-terminal < 0.7
                 , ansi-wl-pprint < 0.7

--- a/idris.cabal
+++ b/idris.cabal
@@ -606,7 +606,7 @@ Extra-source-files:
                        test/interactive013/input
                        test/interactive013/run
                        test/interactive013/*.idr
-                       
+
                        test/interfaces001/*.idr
                        test/interfaces001/run
                        test/interfaces001/expected
@@ -1031,6 +1031,7 @@ Library
                 , IRTS.Inliner
                 , IRTS.Lang
                 , IRTS.LangOpts
+                , IRTS.Portable
                 , IRTS.Simplified
                 , IRTS.System
 
@@ -1051,6 +1052,7 @@ Library
                 , Tools_idris
 
   Build-depends:  base >=4 && <5
+                , aeson >= 0.11 && < 0.12
                 , annotated-wl-pprint >= 0.7 && < 0.8
                 , ansi-terminal < 0.7
                 , ansi-wl-pprint < 0.7

--- a/src/IRTS/Portable.hs
+++ b/src/IRTS/Portable.hs
@@ -1,0 +1,277 @@
+{-# LANGUAGE OverloadedStrings #-}
+
+module IRTS.Portable (writePortable) where
+
+import Data.Aeson
+import qualified Data.ByteString.Lazy as B
+import qualified Data.Text as T
+
+import Idris.Core.CaseTree
+import Idris.Core.TT
+
+import IRTS.Bytecode
+import IRTS.CodegenCommon
+import IRTS.Defunctionalise
+import IRTS.Lang
+import IRTS.Simplified
+
+import System.IO
+
+data CodegenFile = CGFile {
+    fileType :: String,
+    version :: Int,
+    cgInfo :: CodegenInfo
+}
+
+-- Update the version when the format changes
+formatVersion :: Int
+formatVersion = 1
+
+writePortable :: Handle -> CodegenInfo -> IO ()
+writePortable file ci = do
+    let json = encode $ CGFile "idris-codegen" formatVersion ci
+    B.hPut file json
+
+instance ToJSON CodegenFile where
+    toJSON (CGFile ft v ci) = object ["file-type" .= ft,
+                                      "version" .= v,
+                                      "codegen-info" .= toJSON ci]
+
+instance ToJSON CodegenInfo where
+    toJSON ci = object ["output-file" .= (outputFile ci),
+                        "includes" .= (includes ci),
+                        "import-dirs" .= (importDirs ci),
+                        "compile-objs" .= (compileObjs ci),
+                        "compile-libs" .= (compileLibs ci),
+                        "compiler-flags" .= (compilerFlags ci),
+                        "interfaces" .= (interfaces ci),
+                        "exports" .= (exportDecls ci),
+                        "lift-decls" .= (liftDecls ci),
+                        "defun-decls" .= (defunDecls ci),
+                        "simple-decls" .= (simpleDecls ci),
+                        "bytecode" .= (map toBC (simpleDecls ci))]
+
+instance ToJSON Name where
+    toJSON n = toJSON $ showCG n
+
+instance ToJSON ExportIFace where
+    toJSON (Export n f xs) = object ["ffi-desc" .= n,
+                                     "interface-file" .= f,
+                                     "exports" .= xs]
+
+instance ToJSON FDesc where
+    toJSON (FCon n) = object ["FCon" .= n]
+    toJSON (FStr s) = object ["FStr" .= s]
+    toJSON (FUnknown) = object ["FUnknown" .= Null]
+    toJSON (FIO fd) = object ["FIO" .= fd]
+    toJSON (FApp n xs) = object ["FApp" .= (n, xs)]
+
+instance ToJSON Export where
+    toJSON (ExportData fd) = object ["ExportData" .= fd]
+    toJSON (ExportFun n dsc ret args) = object ["ExportFun" .= (n, dsc, ret, args)]
+
+instance ToJSON LDecl where
+    toJSON (LFun opts name args def) = object ["LFun" .= (opts, name, args, def)]
+    toJSON (LConstructor name tag ar) = object ["LConstructor" .= (name, tag, ar)]
+
+instance ToJSON LOpt where
+    toJSON Inline = String "Inline"
+    toJSON NoInline = String "NoInline"
+
+instance ToJSON LExp where
+    toJSON (LV lv) = object ["LV" .= lv]
+    toJSON (LApp tail exp args) = object ["LApp" .= (tail, exp, args)]
+    toJSON (LLazyApp name exps) = object ["LLazyApp" .= (name, exps)]
+    toJSON (LLazyExp exp) = object ["LLazyExp" .= exp]
+    toJSON (LForce exp) = object ["LForce" .= exp]
+    toJSON (LLet name a b) = object ["LLet" .= (name, a, b)]
+    toJSON (LLam args exp) = object ["LLam" .= (args, exp)]
+    toJSON (LProj exp i) = object ["LProj" .= (exp, i)]
+    toJSON (LCon lv i n exps) = object ["LCon" .= (lv, i, n, exps)]
+    toJSON (LCase ct exp alts) = object ["LCase" .= (ct, exp, alts)]
+    toJSON (LConst c) = object ["LConst" .= c]
+    toJSON (LForeign fd ret exps) = object ["LForeign" .= (fd, ret, exps)]
+    toJSON (LOp prim exps) = object ["LOp" .= (prim, exps)]
+    toJSON LNothing = object ["LNothing" .= Null]
+    toJSON (LError s) = object ["LError" .= s]
+
+instance ToJSON LVar where
+    toJSON (Loc i) = object ["Loc" .= i]
+    toJSON (Glob n) = object ["Glob" .= n]
+
+instance ToJSON CaseType where
+    toJSON Updatable = String "Updatable"
+    toJSON Shared = String "Shared"
+
+instance ToJSON LAlt where
+    toJSON (LConCase i n ns exp) = object ["LConCase" .= (i, n, ns, exp)]
+    toJSON (LConstCase c exp) = object ["LConstCase" .= (c, exp)]
+    toJSON (LDefaultCase exp) = object ["LDefaultCase" .= exp]
+
+instance ToJSON Const where
+    toJSON (I i) = object ["int" .= i]
+    toJSON (BI i) = object ["bigint" .= (show i)]
+    toJSON (Fl d) = object ["double" .= d]
+    toJSON (Ch c) = object ["char" .= (show c)]
+    toJSON (Str s) = object ["string" .= s]
+    toJSON (B8 b) = object ["bits8" .= b]
+    toJSON (B16 b) = object ["bits16" .= b]
+    toJSON (B32 b) = object ["bits32" .= b]
+    toJSON (B64 b) = object ["bits64" .= b]
+    toJSON (AType at) = object ["atype" .= at]
+    toJSON StrType = object ["strtype" .= Null]
+    toJSON WorldType = object ["worldtype" .= Null]
+    toJSON TheWorld = object ["theworld" .= Null]
+    toJSON VoidType = object ["voidtype" .= Null]
+    toJSON Forgot = object ["forgot" .= Null]
+
+instance ToJSON ArithTy where
+    toJSON (ATInt it) = object ["ATInt" .= it]
+    toJSON ATFloat = object ["ATFloat" .= Null]
+
+instance ToJSON IntTy where
+    toJSON it = toJSON $ intTyName it
+
+instance ToJSON PrimFn where
+    toJSON (LPlus aty) = object ["LPlus" .= aty]
+    toJSON (LMinus aty) = object ["LMinus" .= aty]
+    toJSON (LTimes aty) = object ["LTimes" .= aty]
+    toJSON (LUDiv aty) = object ["LUDiv" .= aty]
+    toJSON (LSDiv aty) = object ["LSDiv" .= aty]
+    toJSON (LAnd ity) = object ["LAnd" .= ity]
+    toJSON (LOr ity) = object ["LOr" .= ity]
+    toJSON (LXOr ity) = object ["LXOr" .= ity]
+    toJSON (LCompl ity) = object ["LCompl" .= ity]
+    toJSON (LSHL ity) = object ["LSHL" .= ity]
+    toJSON (LLSHR ity) = object ["LLSHR" .= ity]
+    toJSON (LASHR ity) = object ["LASHR" .= ity]
+    toJSON (LEq aty) = object ["LEq" .= aty]
+    toJSON (LLt ity) = object ["LLt" .= ity]
+    toJSON (LLe ity) = object ["LLe" .= ity]
+    toJSON (LGt ity) = object ["LGt" .= ity]
+    toJSON (LGe ity) = object ["LGe" .= ity]
+    toJSON (LSLt aty) = object ["LSLt" .= aty]
+    toJSON (LSLe aty) = object ["LSLe" .= aty]
+    toJSON (LSGt aty) = object ["LSGt" .= aty]
+    toJSON (LSGe aty) = object ["LSGe" .= aty]
+    toJSON (LZExt from to) = object ["LZExt" .= (from, to)]
+    toJSON (LSExt from to) = object ["LSExt" .= (from, to)]
+    toJSON (LTrunc from to) = object ["LTrunc" .= (from, to)]
+    toJSON LStrConcat = object ["LStrConcat" .= Null]
+    toJSON LStrLt = object ["LStrLt" .= Null]
+    toJSON LStrEq = object ["LStrEq" .= Null]
+    toJSON LStrLen = object ["LStrLen" .= Null]
+    toJSON (LIntFloat ity) = object ["LIntFloat" .= ity]
+    toJSON (LFloatInt ity) = object ["LFloatInt" .= ity]
+    toJSON (LIntStr ity) = object ["LIntStr" .= ity]
+    toJSON (LStrInt ity) = object ["LStrInt" .= ity]
+    toJSON (LIntCh ity) = object ["LIntCh" .= ity]
+    toJSON (LChInt ity) = object ["LChInt" .= ity]
+    toJSON LFloatStr = object ["LFloatStr" .= Null]
+    toJSON LStrFloat = object ["LStrFloat" .= Null]
+    toJSON (LBitCast from to) = object ["LBitCast" .= (from, to)]
+    toJSON LFExp = object ["LFExp" .= Null]
+    toJSON LFLog = object ["LFLog" .= Null]
+    toJSON LFSin = object ["LFSin" .= Null]
+    toJSON LFCos = object ["LFCos" .= Null]
+    toJSON LFTan = object ["LFTan" .= Null]
+    toJSON LFASin = object ["LFASin" .= Null]
+    toJSON LFACos = object ["LFACos" .= Null]
+    toJSON LFATan = object ["LFATan" .= Null]
+    toJSON LFSqrt = object ["LFSqrt" .= Null]
+    toJSON LFFloor = object ["LFFloor" .= Null]
+    toJSON LFCeil = object ["LFCeil" .= Null]
+    toJSON LFNegate = object ["LFNegate" .= Null]
+    toJSON LStrHead = object ["LStrHead" .= Null]
+    toJSON LStrTail = object ["LStrTail" .= Null]
+    toJSON LStrCons = object ["LStrCons" .= Null]
+    toJSON LStrIndex = object ["LStrIndex" .= Null]
+    toJSON LStrRev = object ["LStrRev" .= Null]
+    toJSON LStrSubstr = object ["LStrSubstr" .= Null]
+    toJSON LReadStr = object ["LReadStr" .= Null]
+    toJSON LWriteStr = object ["LWriteStr" .= Null]
+    toJSON LSystemInfo = object ["LSystemInfo" .= Null]
+    toJSON LFork = object ["LFork" .= Null]
+    toJSON LPar = object ["LPar" .= Null]
+    toJSON (LExternal name) = object ["LExternal" .= name]
+    toJSON LNoOp = object ["LNoOp" .= Null]
+
+
+
+
+
+instance ToJSON DDecl where
+    toJSON (DFun name args exp) = object ["DFun" .= (name, args, exp)]
+    toJSON (DConstructor name tag arity) = object ["DConstructor" .= (name, tag, arity)]
+
+instance ToJSON DExp where
+    toJSON (DV lv) = object ["DV" .= lv]
+    toJSON (DApp tail name exps) = object ["DApp" .= (tail, name, exps)]
+    toJSON (DLet name a b) = object ["DLet" .= (name, a, b)]
+    toJSON (DUpdate name exp) = object ["DUpdate" .= (name,exp)]
+    toJSON (DProj exp i) = object ["DProj" .= (exp, i)]
+    toJSON (DC lv i name exp) = object ["DC" .= (lv, i, name, exp)]
+    toJSON (DCase ct exp alts) = object ["DCase" .= (ct, exp, alts)]
+    toJSON (DChkCase exp alts) = object ["DChkCase" .= (exp, alts)]
+    toJSON (DConst c) = object ["DConst" .= c]
+    toJSON (DForeign fd ret exps) = object ["DForeign" .= (fd, ret, exps)]
+    toJSON (DOp prim exps) = object ["DOp" .= (prim, exps)]
+    toJSON DNothing = object ["DNothing" .= Null]
+    toJSON (DError s) = object ["DError" .= s]
+
+instance ToJSON DAlt where
+    toJSON (DConCase i n ns exp) = object ["DConCase" .= (i, n, ns, exp)]
+    toJSON (DConstCase c exp) = object ["DConstCase" .= (c, exp)]
+    toJSON (DDefaultCase exp) = object ["DDefaultCase" .= exp]
+
+instance ToJSON SDecl where
+    toJSON (SFun name args i exp) = object ["SFun" .= (name, args, i, exp)]
+
+instance ToJSON SExp where
+    toJSON (SV lv) = object ["SV" .= lv]
+    toJSON (SApp tail name exps) = object ["SApp" .= (tail, name, exps)]
+    toJSON (SLet lv a b) = object ["SLet" .= (lv, a, b)]
+    toJSON (SUpdate lv exp) = object ["SUpdate" .= (lv, exp)]
+    toJSON (SProj lv i) = object ["DProj" .= (lv, i)]
+    toJSON (SCon lv i name vars) = object ["SCon" .= (lv, i, name, vars)]
+    toJSON (SCase ct lv alts) = object ["SCase" .= (ct, lv, alts)]
+    toJSON (SChkCase lv alts) = object ["DChkCase" .= (lv, alts)]
+    toJSON (SConst c) = object ["SConst" .= c]
+    toJSON (SForeign fd ret exps) = object ["SForeign" .= (fd, ret, exps)]
+    toJSON (SOp prim vars) = object ["DOp" .= (prim, vars)]
+    toJSON SNothing = object ["SNothing" .= Null]
+    toJSON (SError s) = object ["SError" .= s]
+
+instance ToJSON SAlt where
+    toJSON (SConCase i j n ns exp) = object ["SConCase" .= (i, j, n, ns, exp)]
+    toJSON (SConstCase c exp) = object ["SConstCase" .= (c, exp)]
+    toJSON (SDefaultCase exp) = object ["SDefaultCase" .= exp]
+
+instance ToJSON BC where
+    toJSON (ASSIGN r1 r2) = object ["ASSIGN" .= (r1, r2)]
+    toJSON (ASSIGNCONST r c) = object ["ASSIGNCONST" .= (r, c)]
+    toJSON (UPDATE r1 r2) = object ["UPDATE" .= (r1, r2)]
+    toJSON (MKCON con mr i regs) = object ["MKCON" .= (con, mr, i, regs)]
+    toJSON (CASE b r alts def) = object ["CASE" .= (b, r, alts, def)]
+    toJSON (PROJECT r loc arity) = object ["PROJECT" .= (r, loc, arity)]
+    toJSON (PROJECTINTO r1 r2 loc) = object ["PROJECTINTO" .= (r1, r2, loc)]
+    toJSON (CONSTCASE r alts def) = object ["CONSTCASE" .= (r, alts, def)]
+    toJSON (CALL name) = object ["CALL" .= name]
+    toJSON (TAILCALL name) = object ["TAILCALL" .= name]
+    toJSON (FOREIGNCALL r fd ret exps) = object ["FOREIGNCALL" .= (r, fd, ret, exps)]
+    toJSON (SLIDE i) = object ["SLIDE" .= i]
+    toJSON (RESERVE i) = object ["RESERVE" .= i]
+    toJSON (ADDTOP i) = object ["ADDTOP" .= i]
+    toJSON (TOPBASE i) = object ["TOPBASE" .= i]
+    toJSON (BASETOP i) = object ["BASETOP" .= i]
+    toJSON REBASE = object ["REBASE" .= Null]
+    toJSON STOREOLD = object ["STOREOLD" .= Null]
+    toJSON (OP r prim args) = object ["OP" .= (r, prim, args)]
+    toJSON (NULL r) = object ["NULL" .= r]
+    toJSON (ERROR s) = object ["ERROR" .= s]
+
+instance ToJSON Reg where
+    toJSON RVal = object ["RVal" .= Null]
+    toJSON (T i) = object ["T" .= i]
+    toJSON (L i) = object ["L" .= i]
+    toJSON Tmp = object ["Tmp" .= Null]

--- a/src/Idris/AbsSyntax.hs
+++ b/src/Idris/AbsSyntax.hs
@@ -45,7 +45,11 @@ getContext :: Idris Context
 getContext = do i <- getIState; return (tt_ctxt i)
 
 forCodegen :: Codegen -> [(Codegen, a)] -> [a]
-forCodegen tgt xs = [x | (tgt', x) <- xs, tgt == tgt']
+forCodegen tgt xs = [x | (tgt', x) <- xs, eqLang tgt tgt']
+    where
+        eqLang (Via _ x) (Via _ y) = x == y
+        eqLang Bytecode Bytecode = True
+        eqLang _ _ = False
 
 getObjectFiles :: Codegen -> Idris [FilePath]
 getObjectFiles tgt = do i <- getIState; return (forCodegen tgt $ idris_objs i)
@@ -946,16 +950,6 @@ codegen :: Idris Codegen
 codegen = do i <- getIState
              return (opt_codegen (idris_options i))
 
-setPortableCodegen :: Bool -> Idris ()
-setPortableCodegen p = do i <- getIState
-                          let opts = idris_options i
-                          let opt' = opts { opt_portableCG = p }
-                          putIState $ i { idris_options = opt' }
-
-getPortableCodegen :: Idris Bool
-getPortableCodegen = do i <- getIState
-                        let opts = idris_options i
-                        return (opt_portableCG opts)
 
 setOutputTy :: OutputType -> Idris ()
 setOutputTy t = do i <- getIState

--- a/src/Idris/AbsSyntax.hs
+++ b/src/Idris/AbsSyntax.hs
@@ -459,13 +459,13 @@ addInstance int res n i
 -- Returns the old list, so we can revert easily at the end of a block
 
 addOpenImpl :: [Name] -> Idris [Name]
-addOpenImpl ns = do ist <- getIState 
+addOpenImpl ns = do ist <- getIState
                     ns' <- mapM (checkValid ist) ns
                     let open = idris_openimpls ist
                     putIState $ ist { idris_openimpls = nub (ns' ++ open) }
                     return open
   where
-    checkValid ist n 
+    checkValid ist n
       = case lookupCtxtName n (idris_implicits ist) of
              [(n', _)] -> return n'
              []        -> throwError (NoSuchVariable n)
@@ -945,6 +945,17 @@ setCodegen t = do i <- getIState
 codegen :: Idris Codegen
 codegen = do i <- getIState
              return (opt_codegen (idris_options i))
+
+setPortableCodegen :: Bool -> Idris ()
+setPortableCodegen p = do i <- getIState
+                          let opts = idris_options i
+                          let opt' = opts { opt_portableCG = p }
+                          putIState $ i { idris_options = opt' }
+
+getPortableCodegen :: Idris Bool
+getPortableCodegen = do i <- getIState
+                        let opts = idris_options i
+                        return (opt_portableCG opts)
 
 setOutputTy :: OutputType -> Idris ()
 setOutputTy t = do i <- getIState
@@ -2329,7 +2340,7 @@ shadow n n' t = sm 0 t where
     sm 0 (PTyped x y) = PTyped (sm 0 x) (sm 0 y)
     sm 0 (PPair f hls p x y) = PPair f hls p (sm 0 x) (sm 0 y)
     sm 0 (PDPair f hls p x t y) = PDPair f hls p (sm 0 x) (sm 0 t) (sm 0 y)
-    sm 0 (PAlternative ms a as) 
+    sm 0 (PAlternative ms a as)
           = PAlternative (map shadowAlt ms) a (map (sm 0) as)
     sm 0 (PTactics ts) = PTactics (map (fmap (sm 0)) ts)
     sm 0 (PProof ts) = PProof (map (fmap (sm 0)) ts)

--- a/src/Idris/AbsSyntaxTree.hs
+++ b/src/Idris/AbsSyntaxTree.hs
@@ -85,6 +85,7 @@ data IOption = IOption {
   , opt_nobanner     :: Bool
   , opt_quiet        :: Bool
   , opt_codegen      :: Codegen
+  , opt_portableCG   :: Bool
   , opt_outputTy     :: OutputType
   , opt_ibcsubdir    :: FilePath
   , opt_importdirs   :: [FilePath]
@@ -113,6 +114,7 @@ defaultOpts = IOption { opt_logLevel   = 0
                       , opt_nobanner   = False
                       , opt_quiet      = False
                       , opt_codegen    = Via "c"
+                      , opt_portableCG = False
                       , opt_outputTy   = Executable
                       , opt_ibcsubdir  = ""
                       , opt_importdirs = []
@@ -186,7 +188,7 @@ data DefaultTotality = DefaultCheckingTotal    -- ^ Total
                      | DefaultCheckingPartial  -- ^ Partial
                      | DefaultCheckingCovering -- ^Total coverage, but may diverge
   deriving (Show, Eq)
-  
+
 -- | The global state used in the Idris monad
 data IState = IState {
     tt_ctxt :: Context, -- ^ All the currently defined names and their terms
@@ -558,6 +560,7 @@ data Opt = Filename String
          | DumpDefun String
          | DumpCases String
          | UseCodegen Codegen
+         | PortableCodegen
          | CodegenArgs String
          | OutputTy OutputType
          | Extension LanguageExt

--- a/src/Idris/AbsSyntaxTree.hs
+++ b/src/Idris/AbsSyntaxTree.hs
@@ -85,7 +85,6 @@ data IOption = IOption {
   , opt_nobanner     :: Bool
   , opt_quiet        :: Bool
   , opt_codegen      :: Codegen
-  , opt_portableCG   :: Bool
   , opt_outputTy     :: OutputType
   , opt_ibcsubdir    :: FilePath
   , opt_importdirs   :: [FilePath]
@@ -113,8 +112,7 @@ defaultOpts = IOption { opt_logLevel   = 0
                       , opt_verbose    = True
                       , opt_nobanner   = False
                       , opt_quiet      = False
-                      , opt_codegen    = Via "c"
-                      , opt_portableCG = False
+                      , opt_codegen    = Via IBCFormat "c"
                       , opt_outputTy   = Executable
                       , opt_ibcsubdir  = ""
                       , opt_importdirs = []
@@ -388,17 +386,14 @@ throwError = Trans.lift . throwE
 
 -- Commands in the REPL
 
-data Codegen = Via String
---              | ViaC
---              | ViaJava
---              | ViaNode
---              | ViaJavaScript
---              | ViaLLVM
+data Codegen = Via IRFormat String
              | Bytecode
     deriving (Show, Eq)
 {-!
 deriving instance NFData Codegen
 !-}
+
+data IRFormat = IBCFormat | JSONFormat deriving (Show, Eq)
 
 data HowMuchDocs = FullDocs | OverviewDocs
 
@@ -560,7 +555,6 @@ data Opt = Filename String
          | DumpDefun String
          | DumpCases String
          | UseCodegen Codegen
-         | PortableCodegen
          | CodegenArgs String
          | OutputTy OutputType
          | Extension LanguageExt

--- a/src/Idris/CmdOptions.hs
+++ b/src/Idris/CmdOptions.hs
@@ -149,6 +149,7 @@ parseFlags = many $
   <|> ((\s -> UseCodegen $ parseCodegen s) <$> strOption (long "codegen"
                                                        <> metavar "TARGET"
                                                        <> help "Select code generator: C, Javascript, Node and bytecode are bundled with Idris"))
+  <|> flag' PortableCodegen (long "portable" <> help "Call codegen with json-formatted codegen info")
   <|> (CodegenArgs <$> strOption (long "cg-opt"
                                <> metavar "ARG"
                                <> help "Arguments to pass to code generator"))

--- a/src/Idris/CmdOptions.hs
+++ b/src/Idris/CmdOptions.hs
@@ -149,7 +149,12 @@ parseFlags = many $
   <|> ((\s -> UseCodegen $ parseCodegen s) <$> strOption (long "codegen"
                                                        <> metavar "TARGET"
                                                        <> help "Select code generator: C, Javascript, Node and bytecode are bundled with Idris"))
-  <|> flag' PortableCodegen (long "portable" <> help "Call codegen with json-formatted codegen info")
+
+
+  <|> ((\s -> UseCodegen $ Via JSONFormat s) <$> strOption (long "portable-codegen"
+                                                         <> metavar "TARGET"
+                                                         <> help "Pass the name of the code generator. This option is for codegens that take JSON formatted IR."))
+
   <|> (CodegenArgs <$> strOption (long "cg-opt"
                                <> metavar "ARG"
                                <> help "Arguments to pass to code generator"))
@@ -207,7 +212,8 @@ preProcOpts (x:xs)          ys = preProcOpts xs (x:ys)
 
 parseCodegen :: String -> Codegen
 parseCodegen "bytecode" = Bytecode
-parseCodegen cg         = Via (map toLower cg)
+parseCodegen cg         = Via IBCFormat (map toLower cg)
+
 
 parseLogCats :: Monad m => String -> m [LogCat]
 parseLogCats s =

--- a/src/Idris/DeepSeq.hs
+++ b/src/Idris/DeepSeq.hs
@@ -149,7 +149,6 @@ instance NFData Opt where
     rnf (DumpDefun str) = rnf  str `seq` ()
     rnf (DumpCases str) = rnf  str `seq` ()
     rnf (UseCodegen cg) = rnf  cg `seq` ()
-    rnf (PortableCodegen) = ()
     rnf (CodegenArgs str) = rnf  str `seq` ()
     rnf (OutputTy ot) = rnf  ot `seq` ()
     rnf (Extension le) = rnf  le `seq` ()
@@ -188,7 +187,6 @@ instance NFData IOption where
          opt_nobanner
          opt_quiet
          opt_codegen
-         opt_portableCG
          opt_outputTy
          opt_ibcsubdir
          opt_importdirs
@@ -363,8 +361,11 @@ instance NFData FnInfo where
         rnf (FnInfo x1) = rnf x1 `seq` ()
 
 instance NFData Codegen where
-        rnf (Via x1) = rnf x1 `seq` ()
+        rnf (Via x1 x2) = rnf x1 `seq` rnf x2 `seq` ()
         rnf Bytecode = ()
+
+instance NFData IRFormat where
+        rnf _ = ()
 
 instance NFData LogCat where
        rnf _ = ()

--- a/src/Idris/DeepSeq.hs
+++ b/src/Idris/DeepSeq.hs
@@ -149,6 +149,7 @@ instance NFData Opt where
     rnf (DumpDefun str) = rnf  str `seq` ()
     rnf (DumpCases str) = rnf  str `seq` ()
     rnf (UseCodegen cg) = rnf  cg `seq` ()
+    rnf (PortableCodegen) = ()
     rnf (CodegenArgs str) = rnf  str `seq` ()
     rnf (OutputTy ot) = rnf  ot `seq` ()
     rnf (Extension le) = rnf  le `seq` ()
@@ -187,6 +188,7 @@ instance NFData IOption where
          opt_nobanner
          opt_quiet
          opt_codegen
+         opt_portableCG
          opt_outputTy
          opt_ibcsubdir
          opt_importdirs
@@ -700,7 +702,7 @@ instance NFData DefaultTotality where
   rnf DefaultCheckingTotal = ()
   rnf DefaultCheckingPartial = ()
   rnf DefaultCheckingCovering = ()
-  
+
 instance NFData IState where
   rnf (IState x1 x2 x3 x4 x5 x6 x7 x8 x9 x10 x11 x12 x13 x14 x15 x16 x17 x18 x19 x20
               x21 x22 x23 x24 x25 x26 x27 x28 x29 x30 x31 x32 x33 x34 x35 x36 x37 x38 x39 x40

--- a/src/Idris/IBC.hs
+++ b/src/Idris/IBC.hs
@@ -40,7 +40,7 @@ import System.Directory
 import Codec.Archive.Zip
 
 ibcVersion :: Word16
-ibcVersion = 142
+ibcVersion = 143
 
 -- When IBC is being loaded - we'll load different things (and omit different
 -- structures/definitions) depending on which phase we're in
@@ -2461,13 +2461,25 @@ instance Binary SSymbol where
 instance Binary Codegen where
         put x
           = case x of
-                Via str -> do putWord8 0
-                              put str
+                Via ir str -> do putWord8 0
+                                 put ir
+                                 put str
                 Bytecode -> putWord8 1
         get
           = do i <- getWord8
                case i of
                   0 -> do x1 <- get
-                          return (Via x1)
+                          x2 <- get
+                          return (Via x1 x2)
                   1 -> return Bytecode
                   _ -> error  "Corrupted binary data for Codegen"
+
+instance Binary IRFormat where
+    put x = case x of
+                IBCFormat -> putWord8 0
+                JSONFormat -> putWord8 1
+    get = do i <- getWord8
+             case i of
+                0 -> return IBCFormat
+                1 -> return JSONFormat
+                _ -> error  "Corrupted binary data for IRFormat"

--- a/src/Idris/Parser.hs
+++ b/src/Idris/Parser.hs
@@ -781,7 +781,7 @@ params syn =
        return [PParams fc ns' (concat ds)]
     <?> "parameters declaration"
 
-{- | Parses an open block 
+{- | Parses an open block
 
 -}
 
@@ -790,7 +790,7 @@ openInterface syn =
     do reservedHL "using"
        reservedHL "implementation"
        fc <- getFC
-       ns <- sepBy1 fnName (lchar ',') 
+       ns <- sepBy1 fnName (lchar ',')
 
        openBlock
        ds <- many (decl syn)
@@ -799,7 +799,7 @@ openInterface syn =
     <?> "open interface declaration"
 
 
-       
+
 
 {- | Parses a mutual declaration (for mutually recursive functions)
 
@@ -877,7 +877,7 @@ classBlock syn = do reservedHL "where"
                     ist <- get
                     let cd' = annotate syn ist cd
 
-                    ds <- many (notEndBlock >> try (instance_ True syn) 
+                    ds <- many (notEndBlock >> try (instance_ True syn)
                                                <|> do x <- data_ syn
                                                       return [x]
                                                <|> fnDecl syn)
@@ -1324,7 +1324,7 @@ Codegen ::= 'C'
 -}
 codegen_ :: IdrisParser Codegen
 codegen_ = do n <- fst <$> identifier
-              return (Via (map toLower n))
+              return (Via IBCFormat (map toLower n))
        <|> do reserved "Bytecode"; return Bytecode
        <?> "code generation language"
 
@@ -1812,7 +1812,7 @@ loadSource lidr f toline
                   logLvl 2 $ "Totality checking " ++ show deftots
                   mapM_ (\x -> do tot <- getTotality x
                                   case tot of
-                                       Total _ -> 
+                                       Total _ ->
                                          do let opts = case lookupCtxtExact x (idris_flags i) of
                                                           Just os -> os
                                                           Nothing -> []

--- a/src/Idris/REPL.hs
+++ b/src/Idris/REPL.hs
@@ -1228,8 +1228,7 @@ process fn (Execute tm)
                            -- gcc adds .exe when it builds windows programs
                            progName <- return $ if isWindows then tmpn ++ ".exe" else tmpn
                            ir <- compile t tmpn (Just m)
-                           port <- getPortableCodegen
-                           runIO $ generate t (fst (head (idris_imported ist))) port ir
+                           runIO $ generate t (fst (head (idris_imported ist))) ir
                            case idris_outputmode ist of
                              RawOutput h -> do runIO $ rawSystem progName []
                                                return ()
@@ -1250,9 +1249,8 @@ process fn (Compile codegen f)
                                             [pexp $ PRef fc [] mainname])
                                return (Just m')
                        ir <- compile codegen f m
-                       port <- getPortableCodegen
                        i <- getIState
-                       runIO $ generate codegen (fst (head (idris_imported i))) port ir
+                       runIO $ generate codegen (fst (head (idris_imported i))) ir
   where fc = fileFC "main"
 process fn (LogLvl i) = setLogLevel i
 process fn (LogCategory cs) = setLogCats cs
@@ -1689,9 +1687,8 @@ idrisMain opts =
                               Object else Executable
                      xs -> last xs
        let cgn = case opt getCodegen opts of
-                   [] -> Via "c"
+                   [] -> Via IBCFormat "c"
                    xs -> last xs
-       let portable = PortableCodegen `elem` opts
        let cgFlags = opt getCodegenArgs opts
 
        -- Now set/unset specifically chosen optimisations
@@ -1719,7 +1716,6 @@ idrisMain opts =
        setOutputTy outty
        setNoBanner nobanner
        setCodegen cgn
-       setPortableCodegen portable
        mapM_ (addFlag cgn) cgFlags
        mapM_ makeOption opts
        -- if we have the --bytecode flag, drop into the bytecode assembler

--- a/src/Idris/REPL/Parser.hs
+++ b/src/Idris/REPL/Parser.hs
@@ -358,13 +358,13 @@ cmd_pprint name = do
 
 cmd_compile :: String -> P.IdrisParser (Either String Command)
 cmd_compile name = do
-    let defaultCodegen = Via "c"
+    let defaultCodegen = Via IBCFormat "c"
 
     let codegenOption :: P.IdrisParser Codegen
         codegenOption = do
             let bytecodeCodegen = discard (P.symbol "bytecode") *> return Bytecode
                 viaCodegen = do x <- fst <$> P.identifier
-                                return (Via (map toLower x))
+                                return (Via IBCFormat (map toLower x))
             bytecodeCodegen <|> viaCodegen
 
     let hasOneArg = do


### PR DESCRIPTION
This adds an option to pass the intermediate representations JSON-encoded to the backend. This makes it possible to build backends in other languages than Haskell.