### PR TITLE
Relax naming rules for packages.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -16,14 +16,14 @@
   ```
   [PlusNatSemi] Semigroup Nat where
     (<+>) x y = x + y
-  
+
   [MultNatSemi] Semigroup Nat where
     (<+>) x y = x * y
-  
+
   -- use PlusNatSemi as the parent implementation
   [PlusNatMonoid] Monoid Nat using PlusNatSemi where
     neutral = 0
-  
+
   -- use MultNatSemi as the parent implementation
   [MultNatMonoid] Monoid Nat using MultNatSemi where
     neutral = 1
@@ -106,6 +106,12 @@
   could distinguish between -0.0 and 0.0, but the type theory could
   not, leading to a contradiction. The new fine-grained equality
   prevents this.
+
+* Naming conventions for Idris packages in an iPKG file now follow the
+  same rules for executables.  Unquoted names must be valid namespaced
+  Idris identifiers e.g. ``package my.first.package``. Quoted package
+  names allow for packages to be given valid file names, for example,
+  ``package "my-first-package"``.
 
 ## Reflection changes
 
@@ -278,7 +284,7 @@
   package names that the idris project depends on. This reduces bloat in the
   `opts` option with multiple package declarations.
 * iPKG files now allow `executable = "your filename here"` in addition to the
-  existing `executable = yourFilenameHere` style. While the unquoted version is
+  Existing `Executable = yourFilenameHere` style. While the unquoted version is
   limited to filenames that look like namespaced Idris identifiers
   (`your.filename.here`), the quoted version accepts any valid filename.
 * Add definition command (`\d` in Vim, `Ctrl-Alt-A` in Atom, `C-c C-s` in Emacs)

--- a/docs/reference/packages.rst
+++ b/docs/reference/packages.rst
@@ -15,7 +15,8 @@ Package Descriptions
 A package description includes the following:
 
 + A header, consisting of the keyword package followed by the package
-  name. Package names can be any valid Idris identifier.
+  name. Package names can be any valid Idris identifier. The iPKG
+  format also takes a quoted version that accepts any valid filename.
 + Fields describing package contents, ``<field> = <value>``
 
 At least one field must be the modules field, where the value is a

--- a/docs/tutorial/packages.rst
+++ b/docs/tutorial/packages.rst
@@ -4,7 +4,7 @@ Packages
 
 
 Idris includes a simple build system for building packages and executables from a named package description file.
-These files can be used with the Idris compiler to manage the development process.
+These files can be used with the Idris compiler to manage the development process .
 
 Package Descriptions
 ====================
@@ -12,7 +12,8 @@ Package Descriptions
 A package description includes the following:
 
 + A header, consisting of the keyword package followed by the package
-  name.  Package names can be any valid Idris identifier.
+  name. Package names can be any valid Idris identifier. The iPKG
+  format also takes a quoted version that accepts any valid filename.
 + Fields describing package contents, ``<field> = <value>``
 
 At least one field must be the modules field, where the value is a

--- a/idris.cabal
+++ b/idris.cabal
@@ -671,7 +671,7 @@ Extra-source-files:
                        test/primitives006/expected
 
                        test/pkg001/run
-                       test/pkg001/test.ipkg
+                       test/pkg001/test-pkg.ipkg
                        test/pkg001/*.idr
                        test/pkg001/expected
 

--- a/src/Pkg/PParser.hs
+++ b/src/Pkg/PParser.hs
@@ -56,7 +56,8 @@ parseDesc fp = do
 
 pPkg :: PParser PkgDesc
 pPkg = do
-    reserved "package"; p <- fst <$> identifier
+    reserved "package"
+    p <- filename
     st <- get
     put (st { pkgname = p })
     some pClause

--- a/test/pkg001/run
+++ b/test/pkg001/run
@@ -1,5 +1,5 @@
 #!/usr/bin/env bash
-${IDRIS:-idris} $@ --build test.ipkg
+${IDRIS:-idris} $@ --build test-pkg.ipkg
 rm -f  *.ibc
-${IDRIS:-idris} $@ --build test.ipkg --quiet
-${IDRIS:-idris} $@ --build test.ipkg --logging-categories "elab" --log 1
+${IDRIS:-idris} $@ --build test-pkg.ipkg --quiet
+${IDRIS:-idris} $@ --build test-pkg.ipkg --logging-categories "elab" --log 1

--- a/test/pkg001/test-pkg.ipkg
+++ b/test/pkg001/test-pkg.ipkg
@@ -1,4 +1,4 @@
-package test
+package "test-pkg"
 
 pkgs = effects
 


### PR DESCRIPTION
Naming conventions for Idris packages in an iPKG file now follow the
same rules for executables.  Unquoted names must be valid namespaced
Idris identifiers e.g. ``package my.first.package``. Quoted package
names allow for packages to be given valid file names, for example,
``package "my-first-package"``.