### PR TITLE
Added compute after rewrite

### DIFF
--- a/src/Idris/Elab/Rewrite.hs
+++ b/src/Idris/Elab/Rewrite.hs
@@ -86,6 +86,7 @@ elabRewrite elab ist fc substfn_in rule sc_in newg
 --                                "GOAL: " ++ show (delab ist g)) $
                         elab rewrite
                         solve
+                        compute
                   _ -> lift $ tfail (NotEquality tmv ttrule)
       where
         mkP :: TT Name -> -- Left term, top level


### PR DESCRIPTION
This makes sure that types are normalized after using `rewrite ... in ...`, which makes them easier to read and makes it easier to progress proofs after rewriting.