### PR TITLE
Use ParentN for its intended purpose

### DIFF
--- a/src/Idris/AbsSyntax.hs
+++ b/src/Idris/AbsSyntax.hs
@@ -439,7 +439,7 @@ pop_estack = do i <- getIState
 -- Dodgy hack 1: Put integer instances first in the list so they are
 -- resolved by default.
 --
--- Dodgy hack 2: put constraint chasers (@@) last
+-- Dodgy hack 2: put constraint chasers (ParentN) last
 addInstance :: Bool -- ^ whether the name is an Integer instance
             -> Bool -- ^ whether to include the instance in instance search
             -> Name -- ^ the name of the class
@@ -461,8 +461,7 @@ addInstance int res n i
         insI i (n : ns) | chaser (fst n) = (i, res) : n : ns
                         | otherwise = n : insI i ns
 
-        chaser (UN nm)
-             | ('@':'@':_) <- str nm = True
+        chaser (SN (ParentN _ _)) = True
         chaser (NS n _) = chaser n
         chaser _ = False
 

--- a/src/Idris/Completion.hs
+++ b/src/Idris/Completion.hs
@@ -39,8 +39,6 @@ tactics = map fst tacticArgs
 -- | Convert a name into a string usable for completion. Filters out names
 -- that users probably don't want to see.
 nameString :: Name -> Maybe String
-nameString (UN nm)
-   | not (tnull nm) && (thead nm == '@' || thead nm == '#') = Nothing
 nameString (UN n)       = Just (str n)
 nameString (NS n _)     = nameString n
 nameString _            = Nothing

--- a/src/Idris/Core/TT.hs
+++ b/src/Idris/Core/TT.hs
@@ -598,8 +598,7 @@ mapCtxt = fmap . fmap
 
 -- |Return True if the argument 'Name' should be interpreted as the name of a
 -- typeclass.
-tcname (UN xs) | T.null xs = False
-               | otherwise = T.head xs == '@'
+tcname (UN xs) = False
 tcname (NS n _) = tcname n
 tcname (SN (InstanceN _ _)) = True
 tcname (SN (MethodN _)) = True

--- a/src/Idris/Elab/Class.hs
+++ b/src/Idris/Elab/Class.hs
@@ -237,8 +237,7 @@ elabClass info syn_in doc fc constraints tn tnfc ps pDocs fds ds mcn cd
     -- Generate a function for chasing a dictionary constraint
     cfun :: Name -> PTerm -> SyntaxInfo -> [a] -> (Name, PTerm) -> Idris [PDecl' PTerm]
     cfun cn c syn all (cnm, con)
-        = do let cfn = sUN ('@':'@':show cn ++ "#" ++ show con)
-                       -- SN (ParentN cn (show con))
+        = do let cfn = SN (ParentN cn (txt (show con)))
              let mnames = take (length all) $ map (\x -> sMN x "meth") [0..]
              let capp = PApp fc (PRef fc [] cn) (map (pexp . PRef fc []) mnames)
              let lhs = PApp fc (PRef fc [] cfn) [pconst capp]

--- a/src/Idris/Elab/Clause.hs
+++ b/src/Idris/Elab/Clause.hs
@@ -791,12 +791,9 @@ elabClause info opts (cnum, PClause fc fname lhs_in_as withs rhs_in_as wherebloc
     mkLHSapp t = t
 
     decorate (NS x ns)
-       = NS (SN (WhereN cnum fname x)) ns -- ++ [show cnum])
---        = NS (UN ('#':show x)) (ns ++ [show cnum, show fname])
+       = NS (SN (WhereN cnum fname x)) ns
     decorate x
        = SN (WhereN cnum fname x)
---        = NS (SN (WhereN cnum fname x)) [show cnum]
---        = NS (UN ('#':show x)) [show cnum, show fname]
 
     sepBlocks bs = sepBlocks' [] bs where
       sepBlocks' ns (d@(PTy _ _ _ _ _ n _ t) : bs)

--- a/src/Idris/Elab/Instance.hs
+++ b/src/Idris/Elab/Instance.hs
@@ -258,7 +258,7 @@ elabInstance info syn doc argDocs what fc cs parents acc opts n nfc ps pextra t 
              return $ any (isJust . findOverlapping i (class_determiners ci) (delab i nty)) (map fst $ class_instances ci)
 
     findOverlapping i dets t n
-     | take 2 (show n) == "@@" = Nothing
+     | SN (ParentN _ _) <- n = Nothing
      | otherwise
         = case lookupTy n (tt_ctxt i) of
             [t'] -> let tret = getRetType t

--- a/src/Idris/IdrisDoc.hs
+++ b/src/Idris/IdrisDoc.hs
@@ -180,7 +180,6 @@ removeOrphans list =
 -- | Whether a Name names something which should be documented
 filterName :: Name -- ^ Name to check
            -> Bool -- ^ Predicate result
-filterName (UN n)     | '@':'@':_ <- str n = False
 filterName (UN _)     = True
 filterName (NS n _)   = filterName n
 filterName _          = False

--- a/src/Idris/ProofSearch.hs
+++ b/src/Idris/ProofSearch.hs
@@ -451,14 +451,6 @@ resTC' tcs defaultOn openOK topholes depth topg fn elab ist
        | Constant _ <- c = not (n `elem` hs)
     notHole _ _ = True
 
-    -- HACK! Rather than giving a special name, better to have some kind
-    -- of flag in ClassInfo structure
-    chaser (UN nm)
-        | ('@':'@':_) <- str nm = True -- old way
-    chaser (SN (ParentN _ _)) = True
-    chaser (NS n _) = chaser n
-    chaser _ = False
-
     numclass = sNS (sUN "Num") ["Interfaces","Prelude"]
 
     addDefault t num@(P _ nc _) [P Bound a _] | nc == numclass && defaultOn


### PR DESCRIPTION
As far as I can tell, at least. This replaces `UN`s starting with `@@` with `ParentN`, since that’s what it seemed to be for, removing the remaining instance of `UN` being used for an internal name.

Fixes #3119.