### PR TITLE
Added more context to the no rewriting error, to include terms being rewritten with

### DIFF
--- a/libs/base/Language/Reflection/Utils.idr
+++ b/libs/base/Language/Reflection/Utils.idr
@@ -329,7 +329,7 @@ implementation Show Err where
   showPrec d (NonCollapsiblePostulate n) = showCon d "NonCollapsiblePostulate" $ showArg n
   showPrec d (AlreadyDefined n) = showCon d "AlreadyDefined" $ showArg n
   showPrec d (ProofSearchFail err) = showCon d "ProofSearchFail" $ showArg err
-  showPrec d (NoRewriting tm) = showCon d "NoRewriting" $ showArg tm
+  showPrec d (NoRewriting ltm rtm typ) = showCon d "NoRewriting" $ showArg ltm ++ showArg rtm ++ showArg typ
   showPrec d (ProviderError x) = showCon d "ProviderError" $ showArg x
   showPrec d (LoadingFailed x err) = showCon d "LoadingFailed" $ showArg x ++ showArg err
 

--- a/libs/prelude/Language/Reflection/Errors.idr
+++ b/libs/prelude/Language/Reflection/Errors.idr
@@ -43,7 +43,7 @@ data Err = Msg String
          | NonCollapsiblePostulate TTName
          | AlreadyDefined TTName
          | ProofSearchFail Err
-         | NoRewriting TT
+         | NoRewriting TT TT TT
          | ProviderError String
          | LoadingFailed String Err
 

--- a/src/Idris/Core/Binary.hs
+++ b/src/Idris/Core/Binary.hs
@@ -146,8 +146,10 @@ instance Binary a => Binary (Err' a) where
                               put n
   put (ProofSearchFail e) = do putWord8 25
                                put e
-  put (NoRewriting t) = do putWord8 26
-                           put t
+  put (NoRewriting l r t) = do putWord8 26
+                               put l
+                               put r
+                               put t
   put (At fc e) = do putWord8 27
                      put fc
                      put e
@@ -237,7 +239,8 @@ instance Binary a => Binary (Err' a) where
              23 -> fmap NonCollapsiblePostulate get
              24 -> fmap AlreadyDefined get
              25 -> fmap ProofSearchFail get
-             26 -> fmap NoRewriting get
+             26 -> do l <- get; r <- get; t <- get
+                      return $ NoRewriting l r t
              27 -> do x <- get ; y <- get
                       return $ At x y
              28 -> do w <- get; x <- get ; y <- get ; z <- get

--- a/src/Idris/Core/DeepSeq.hs
+++ b/src/Idris/Core/DeepSeq.hs
@@ -154,7 +154,7 @@ instance NFData Err where
         rnf (NonCollapsiblePostulate x1) = rnf x1 `seq` ()
         rnf (AlreadyDefined x1) = rnf x1 `seq` ()
         rnf (ProofSearchFail x1) = rnf x1 `seq` ()
-        rnf (NoRewriting x1) = rnf x1 `seq` ()
+        rnf (NoRewriting x1 x2 x3) = rnf x1 `seq` rnf x2 `seq` rnf x3 `seq` ()
         rnf (At x1 x2) = rnf x1 `seq` rnf x2 `seq` ()
         rnf (Elaborating x1 x2 x3 x4)
           = rnf x1 `seq` rnf x2 `seq` rnf x3 `seq` rnf x4 `seq` ()

--- a/src/Idris/Core/TT.hs
+++ b/src/Idris/Core/TT.hs
@@ -295,7 +295,7 @@ data Err' t
           | NonCollapsiblePostulate Name
           | AlreadyDefined Name
           | ProofSearchFail (Err' t)
-          | NoRewriting t
+          | NoRewriting t t t
           | At FC (Err' t)
           | Elaborating String Name (Maybe t) (Err' t)
           | ElaboratingArg Name Name [(Name, Name)] (Err' t)
@@ -365,7 +365,7 @@ instance Sized Err where
   size (NoTypeDecl name) = size name
   size (NotInjective l c r) = size l + size c + size r
   size (CantResolve _ trm _) = size trm
-  size (NoRewriting trm) = size trm
+  size (NoRewriting l r t) = size l + size r + size t
   size (CantResolveAlts _) = 1
   size (IncompleteTerm trm) = size trm
   size ProgramLineComment = 1

--- a/src/Idris/Delaborate.hs
+++ b/src/Idris/Delaborate.hs
@@ -452,7 +452,7 @@ pprintErr' i (NonCollapsiblePostulate n) = text "The return type of postulate" <
 pprintErr' i (AlreadyDefined n) = annName n<+>
                                   text "is already defined"
 pprintErr' i (ProofSearchFail e) = pprintErr' i e
-pprintErr' i (NoRewriting tm) = text "rewrite did not change type" <+> annTm tm (pprintTerm i (delabSugared i tm))
+pprintErr' i (NoRewriting l r tm) = text "rewriting" <+> annTm l (pprintTerm i (delabSugared i l)) <+> text "to" <+> annTm r (pprintTerm i (delabSugared i r)) <+> text "did not change type" <+> annTm tm (pprintTerm i (delabSugared i tm))
 pprintErr' i (At f e) = annotate (AnnFC f) (text (show f)) <> colon <> pprintErr' i e
 pprintErr' i (Elaborating s n ty e) = text "When checking" <+> text s <>
                                       annName' n (showqual i n) <>

--- a/src/Idris/Elab/Rewrite.hs
+++ b/src/Idris/Elab/Rewrite.hs
@@ -74,7 +74,7 @@ elabRewrite elab ist fc substfn_in rule sc_in newg
                   (P _ (UN q) _, [lt, rt, l, r]) | q == txt "=" ->
                      do substfn <- findSubstFn substfn_in ist lt rt
                         let pred_tt = mkP (P Bound rname rt) l r g
-                        when (g == pred_tt) $ lift $ tfail (NoRewriting g)
+                        when (g == pred_tt) $ lift $ tfail (NoRewriting l r g)
                         let pred = PLam fc rname fc Placeholder
                                         (delab ist pred_tt)
                         let rewrite = stripImpls $

--- a/src/Idris/IBC.hs
+++ b/src/Idris/IBC.hs
@@ -47,7 +47,7 @@ import System.Directory
 import Codec.Archive.Zip
 
 ibcVersion :: Word16
-ibcVersion = 143
+ibcVersion = 144
 
 -- | When IBC is being loaded - we'll load different things (and omit
 -- different structures/definitions) depending on which phase we're in.

--- a/src/Idris/Reflection.hs
+++ b/src/Idris/Reflection.hs
@@ -924,7 +924,7 @@ reflectErr (UnknownImplicit n f) = raw_apply (Var $ reflErrName "UnknownImplicit
 reflectErr (NonCollapsiblePostulate n) = raw_apply (Var $ reflErrName "NonCollabsiblePostulate") [reflectName n]
 reflectErr (AlreadyDefined n) = raw_apply (Var $ reflErrName "AlreadyDefined") [reflectName n]
 reflectErr (ProofSearchFail e) = raw_apply (Var $ reflErrName "ProofSearchFail") [reflectErr e]
-reflectErr (NoRewriting tm) = raw_apply (Var $ reflErrName "NoRewriting") [reflect tm]
+reflectErr (NoRewriting l r tm) = raw_apply (Var $ reflErrName "NoRewriting") [reflect l, reflect r, reflect tm]
 reflectErr (ProviderError str) =
   raw_apply (Var $ reflErrName "ProviderError") [RConstant (Str str)]
 reflectErr (LoadingFailed str err) =

--- a/test/proof011/expected
+++ b/test/proof011/expected
@@ -2,11 +2,13 @@ proof011.idr:19:9:
 When checking right hand side of vassoc' with expected type
         (x :: xs) ++ ys ++ zs = ((x :: xs) ++ ys) ++ zs
 
-rewrite did not change type x :: xs ++ ys ++ zs =
-                            x :: (xs ++ ys) ++ zs
+rewriting xs ++ ys ++ xs to (xs ++ ys) ++
+                            xs did not change type x :: xs ++ ys ++ zs =
+                                                   x :: (xs ++ ys) ++ zs
 proof011a.idr:13:9:
 When checking right hand side of vassoc' with expected type
         (x :: xs) ++ ys ++ zs = ((x :: xs) ++ ys) ++ zs
 
-rewrite did not change type x :: xs ++ ys ++ zs =
-                            x :: (xs ++ ys) ++ zs
+rewriting xs ++ ys ++ xs to (xs ++ ys) ++
+                            xs did not change type x :: xs ++ ys ++ zs =
+                                                   x :: (xs ++ ys) ++ zs


### PR DESCRIPTION
So now instead of displaying

```
rewrite did not change type <<ty>>
```

it will display

```
rewriting <<tm>> to <<tm>> did not chcange type <<ty>>
```


This fixes #3052 .