### PR TITLE
Extend iPKG files to include metadata.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -80,8 +80,24 @@
 * Added `Data.List.Views` with views on `List` and their covering functions.
 * Added `Data.Nat.Views` with views on `Nat` and their covering functions.
 * Added `Data.Primitives.Views` with views on various primitive types and their covering functions.
-* Added `System.Concurrency.Sessions` for simple management of conversations 
+* Added `System.Concurrency.Sessions` for simple management of conversations
   between processes
+
+## iPKG Updates
+
+* Taking cues from cabal, the `iPKG` format has been extended to
+  include more package metadata information.  The following fields
+  have been added:
+
+  + `brief`: Brief description of the package.
+  + `version`: Version string to associate with the package.
+  + `readme`: Location of the README file.
+  + `license`: Description of the licensing information.
+  + `author`: Author information.
+  + `maintainer`: Maintainer information.
+  + `homepage`: Website associated with the package.
+  + `sourcepage`: Location of the DVCS where the source can be found.
+
 
 ## Miscellaneous updates
 

--- a/docs/reference/packages.rst
+++ b/docs/reference/packages.rst
@@ -31,6 +31,35 @@ written as follows::
 Other examples of package files can be found in the ``libs`` directory
 of the main Idris repository, and in `third-party libraries <https://github.com/idris-lang/Idris-dev/wiki/Libraries>`_.
 
+Metadata
+--------
+
+From Idris `v0.12` the `iPKG` format supports additional metadata
+associated with the package.
+The added fields are:
+
++ ``brief = "<text>"``, a string literal containing a brief description
+  of the package.
+
++ ``version = <text>``, a version string to associate with the package.
+
++ ``readme = <file>``, location of the README file.
+
++ ``license = <text>``, a string description of the licensing
+  information.
+
++ ``author = <text>``, the author information.
+
++ ``maintainer = <text>``, Maintainer information.
+
++ ``homepage = <url>``, the website associated with the package.
+
++ ``sourceloc = <url>``, the location of the DVCS where the source
+  can be found.
+
++ ``bugtracker = <url>``, the location of the project's bug tracker.
+
+
 Common Fields
 -------------
 

--- a/src/Pkg/PParser.hs
+++ b/src/Pkg/PParser.hs
@@ -29,17 +29,32 @@ import Util.System
 type PParser = StateT PkgDesc IdrisInnerParser
 
 data PkgDesc = PkgDesc {
-    pkgname     :: String
-  , libdeps     :: [String]
-  , objs        :: [String]
-  , makefile    :: Maybe String
-  , idris_opts  :: [Opt]
-  , sourcedir   :: String
-  , modules     :: [Name]
-  , idris_main  :: Name
-  , execout     :: Maybe String
-  , idris_tests :: [Name]
+    pkgname       :: String       -- ^ Name associated with a package.
+  , pkgbrief      :: Maybe String -- ^ Brief description of the package.
+  , pkgversion    :: Maybe String -- ^ Version string to associate with the package.
+  , pkgreadme     :: Maybe String -- ^ Location of the README file.
+  , pkglicense    :: Maybe String -- ^ Description of the licensing information.
+  , pkgauthor     :: Maybe String -- ^ Author information.
+  , pkgmaintainer :: Maybe String -- ^ Maintainer information.
+  , pkghomepage   :: Maybe String -- ^ Website associated with the package.
+  , pkgsourceloc  :: Maybe String -- ^ Location of the source files.
+  , pkgbugtracker :: Maybe String -- ^ Location of the project's bug tracker.
+  , libdeps       :: [String]     -- ^ External dependencies.
+  , objs          :: [String]     -- ^ Object files required by the package.
+  , makefile      :: Maybe String -- ^ Makefile used to build external code. Used as part of the FFI process.
+  , idris_opts    :: [Opt]        -- ^ List of options to give the compiler.
+  , sourcedir     :: String       -- ^ Source directory for Idris files.
+  , modules       :: [Name]       -- ^ Modules provided by the package.
+  , idris_main    :: Name         -- ^ If an executable in which module can the Main namespace and function be found.
+  , execout       :: Maybe String -- ^ What to call the executable.
+  , idris_tests   :: [Name]       -- ^ Lists of tests to execute against the package.
   } deriving (Show)
+
+-- | Default settings for package descriptions.
+defaultPkg :: PkgDesc
+defaultPkg = PkgDesc "" Nothing Nothing Nothing Nothing
+                        Nothing Nothing Nothing Nothing
+                        Nothing [] [] Nothing [] "" [] (sUN "") Nothing []
 
 instance HasLastTokenSpan PParser where
   getLastTokenSpan = return Nothing
@@ -51,8 +66,6 @@ instance TokenParsing PParser where
 #endif
   someSpace = many (simpleWhiteSpace <|> singleLineComment <|> multiLineComment) *> pure ()
 
-defaultPkg :: PkgDesc
-defaultPkg = PkgDesc "" [] [] Nothing [] "" [] (sUN "") Nothing []
 
 parseDesc :: FilePath -> IO PkgDesc
 parseDesc fp = do
@@ -121,41 +134,118 @@ pClause = do reserved "executable"; lchar '=';
              exec <- filename
              st <- get
              put (st { execout = Just exec })
+
       <|> do reserved "main"; lchar '=';
              main <- fst <$> iName []
              st <- get
              put (st { idris_main = main })
+
       <|> do reserved "sourcedir"; lchar '=';
              src <- fst <$> identifier
              st <- get
              put (st { sourcedir = src })
+
       <|> do reserved "opts"; lchar '=';
              opts <- stringLiteral
              st <- get
              let args = pureArgParser (words opts)
              put (st { idris_opts = args ++ idris_opts st })
+
       <|> do reserved "pkgs"; lchar '=';
              ps <- sepBy1 (fst <$> identifier) (lchar ',')
              st <- get
              let pkgs = pureArgParser $ concatMap (\x -> ["-p", x]) ps
              put (st {idris_opts = pkgs ++ idris_opts st})
+
       <|> do reserved "modules"; lchar '=';
              ms <- sepBy1 (fst <$> iName []) (lchar ',')
              st <- get
              put (st { modules = modules st ++ ms })
+
       <|> do reserved "libs"; lchar '=';
              ls <- sepBy1 (fst <$> identifier) (lchar ',')
              st <- get
              put (st { libdeps = libdeps st ++ ls })
+
       <|> do reserved "objs"; lchar '=';
              ls <- sepBy1 (fst <$> identifier) (lchar ',')
              st <- get
              put (st { objs = libdeps st ++ ls })
+
       <|> do reserved "makefile"; lchar '=';
              mk <- fst <$> iName []
              st <- get
              put (st { makefile = Just (show mk) })
+
       <|> do reserved "tests"; lchar '=';
              ts <- sepBy1 (fst <$> iName []) (lchar ',')
              st <- get
              put st { idris_tests = idris_tests st ++ ts }
+
+      <|> do reserved "version"
+             lchar '='
+             vStr <- many (satisfy (not . isEol))
+             eol
+             someSpace
+             st <- get
+             put st {pkgversion = Just vStr}
+
+      <|> do reserved "readme"
+             lchar '='
+             rme <- many (satisfy (not . isEol))
+             eol
+             someSpace
+             st <- get
+             put (st { pkgreadme = Just rme })
+
+      <|> do reserved "license"
+             lchar '='
+             lStr <- many (satisfy (not . isEol))
+             eol
+             st <- get
+             put st {pkglicense = Just lStr}
+
+      <|> do reserved "homepage"
+             lchar '='
+             www <- many (satisfy (not . isEol))
+             eol
+             someSpace
+             st <- get
+             put st {pkghomepage = Just www}
+
+      <|> do reserved "sourceloc"
+             lchar '='
+             srcpage <- many (satisfy (not . isEol))
+             eol
+             someSpace
+             st <- get
+             put st {pkgsourceloc = Just srcpage}
+
+      <|> do reserved "bugtracker"
+             lchar '='
+             src <- many (satisfy (not . isEol))
+             eol
+             someSpace
+             st <- get
+             put st {pkgbugtracker = Just src}
+
+      <|> do reserved "brief"
+             lchar '='
+             brief <- stringLiteral
+             st <- get
+             someSpace
+             put st {pkgbrief = Just brief}
+
+      <|> do reserved "author"; lchar '=';
+             author <- many (satisfy (not . isEol))
+             eol
+             someSpace
+             st <- get
+             put st {pkgauthor = Just author}
+
+      <|> do reserved "maintainer"; lchar '=';
+             maintainer <- many (satisfy (not . isEol))
+             eol
+             someSpace
+             st <- get
+             put st {pkgmaintainer = Just maintainer}

--- a/test/pkg001/test-pkg.ipkg
+++ b/test/pkg001/test-pkg.ipkg
@@ -5,3 +5,13 @@ pkgs = effects
 opts = "--warnpartial --warnreach --nocolour --quiet --consolewidth 80"
 
 modules = Main
+
+author = Anne Author
+maintainer = Anne Maintainer
+license = BSD3 but see LICENSE for more information
+brief = "This is a test package."
+readme = README.md
+version = 1234
+homepage = http://www.idris-lang.org
+sourceloc = http://ww.github.com/idris-lang/Idris-Dev
+bugtracker = http://ww.github.com/idris-lang/Idris-Dev/issues


### PR DESCRIPTION
Taking cues from cabal, the iPKG format has been extended to include more package metadata information.
The following fields have been added:

+ brief: Brief description of the package.
+ version: Version string to associate with the package.
+ readme: Location of the README file.
+ license: Description of the licensing information.
+ author: Author information.
+ maintainer: Maintainer information.
+ homepage: Website associated with the package.
+ sourcepage: Location of the DCVS where the source can be found.