### PR TITLE
Addition of a HLint configuration.

### DIFF
--- a/HLint.hs
+++ b/HLint.hs
@@ -1,0 +1,3 @@
+-- HLint File
+
+import "hint" HLint.HLint

--- a/idris.cabal
+++ b/idris.cabal
@@ -91,6 +91,7 @@ Extra-source-files:
                        Makefile
                        config.mk
                        stack.yaml
+                       HLint.hs
                        man/idris.1
 
                        rts/*.c


### PR DESCRIPTION
This commit helps address #3205 by adding a default HLint configuration file to the repository. This file allows for fine grained specification of rule usage at both project and module level. It has been left empty at the moment. Once rules have been decided upon then they can be added here.