### PR TITLE
Building with stack works on OSX El Capitan + gmp/libffi

### DIFF
--- a/idris.cabal
+++ b/idris.cabal
@@ -1080,6 +1080,12 @@ Library
      build-depends: unix < 2.8
   if os(darwin)
      build-depends: unix < 2.8
+     if flag(GMP)
+        include-dirs: /usr/local/opt/gmp/include/gmp
+        extra-lib-dirs: /usr/local/opt/gmp/lib
+     if flag(FFI)
+        pkgconfig-depends: libffi
+      -- /usr/local/opt/libffi/lib/pkgconfig
   if os(windows)
      build-depends: Win32 < 2.4
   if flag(FFI)

--- a/stack.yaml
+++ b/stack.yaml
@@ -8,12 +8,6 @@ flags:
     FFI: true
     GMP: true
 
-extra-include-dirs:
-  - /usr/local/opt/gmp/include/gmp
-
-extra-lib-dirs:
-  - /usr/local/opt/gmp/lib
-
 extra-deps:
   - libffi-0.1
 

--- a/stack.yaml
+++ b/stack.yaml
@@ -1,4 +1,4 @@
-resolver: lts-5.11
+resolver: lts-6.2
 
 packages:
   - '.'

--- a/stack.yaml
+++ b/stack.yaml
@@ -8,6 +8,12 @@ flags:
     FFI: true
     GMP: true
 
+extra-include-dirs:
+  - /usr/local/opt/gmp/include/gmp
+
+extra-lib-dirs:
+  - /usr/local/opt/gmp/lib
+
 extra-deps:
   - libffi-0.1
 


### PR DESCRIPTION
These are the steps:
```
brew install libffi
brew install gmp

PKG_CONFIG_PATH=$(brew --prefix libffi)/lib/pkgconfig stack build
```