### PR TITLE
HLint Directed Code Cleanup

### DIFF
--- a/src/IRTS/CodegenC.hs
+++ b/src/IRTS/CodegenC.hs
@@ -808,7 +808,7 @@ genDispatcher tags = "void* _idris_get_wrapper(VAL con)\n" ++
 
 genWrapper :: (FDesc, Int) -> String
 genWrapper (desc, tag) | (toFType desc) == FFunctionIO =
-    error $ "Cannot create C callbacks for IO functions, wrap them with unsafePerformIO.\n"
+    error "Cannot create C callbacks for IO functions, wrap them with unsafePerformIO.\n"
 genWrapper (desc, tag) =  ret ++ " " ++ wrapperName tag ++ "(" ++
                           renderArgs argList ++")\n"  ++
                           "{\n" ++

--- a/src/IRTS/Compiler.hs
+++ b/src/IRTS/Compiler.hs
@@ -483,11 +483,11 @@ irTerm top vs env (Proj t (-1)) = do
                  [t', LConst (BI 1)]
 
 irTerm top vs env (Proj t i)   = LProj <$> irTerm top vs env t <*> pure i
-irTerm top vs env (Constant TheWorld) = return $ LNothing
-irTerm top vs env (Constant c) = return $ LConst c
-irTerm top vs env (TType _)    = return $ LNothing
-irTerm top vs env Erased       = return $ LNothing
-irTerm top vs env Impossible   = return $ LNothing
+irTerm top vs env (Constant TheWorld) = return LNothing
+irTerm top vs env (Constant c)        = return (LConst c)
+irTerm top vs env (TType _)           = return LNothing
+irTerm top vs env Erased              = return LNothing
+irTerm top vs env Impossible          = return LNothing
 
 doForeign :: Vars -> [Name] -> [Term] -> Idris LExp
 doForeign vs env (ret : fname : world : args)
@@ -500,7 +500,7 @@ doForeign vs env (ret : fname : world : args)
         = do let l' = toFDesc l
              r' <- irTerm (sMN 0 "__foreignCall") vs env r
              return (l', r')
-    splitArg _ = ifail $ "Badly formed foreign function call"
+    splitArg _ = ifail "Badly formed foreign function call"
 
     toFDesc (Constant (Str str)) = FStr str
     toFDesc tm

--- a/src/IRTS/JavaScript/AST.hs
+++ b/src/IRTS/JavaScript/AST.hs
@@ -99,7 +99,7 @@ ffi code args = let parsed = ffiParse code in
   where
     ffiParse :: String -> [FFI]
     ffiParse ""           = []
-    ffiParse ['%']        = [FFIError $ "FFI - Invalid positional argument"]
+    ffiParse ['%']        = [FFIError "FFI - Invalid positional argument"]
     ffiParse ('%':'%':ss) = FFICode '%' : ffiParse ss
     ffiParse ('%':s:ss)
       | isDigit s =

--- a/src/IRTS/Lang.hs
+++ b/src/IRTS/Lang.hs
@@ -213,7 +213,7 @@ lift env (LForeign t s args) = do args' <- mapM (liftF env) args
 lift env (LOp f args) = do args' <- mapM (lift env) args
                            return (LOp f args')
 lift env (LError str) = return $ LError str
-lift env LNothing = return $ LNothing
+lift env LNothing = return LNothing
 
 allocUnique :: LDefs -> (Name, LDecl) -> (Name, LDecl)
 allocUnique defs p@(n, LConstructor _ _ _) = p

--- a/src/IRTS/Simplified.hs
+++ b/src/IRTS/Simplified.hs
@@ -214,7 +214,7 @@ scopecheck fn ctxt envTop tm = sc envTop tm where
               Just i -> do lvar i; return (Loc i)
               Nothing -> case lookupCtxtExact n ctxt of
                               Just (DConstructor _ i ar) ->
-                                  failsc $ "can't pass constructor here"
+                                  failsc "can't pass constructor here"
                               Just _ -> return (Glob n)
                               Nothing -> failsc $ "No such variable " ++ show n ++
                                                " in " ++ show tm ++ " " ++ show envTop

--- a/src/Idris/AbsSyntax.hs
+++ b/src/Idris/AbsSyntax.hs
@@ -583,7 +583,7 @@ getSO = do i <- getIState
 
 setSO :: Maybe String -> Idris ()
 setSO s = do i <- getIState
-             putIState $ (i { compiled_so = s })
+             putIState (i { compiled_so = s })
 
 getIState :: Idris IState
 getIState = get
@@ -617,7 +617,7 @@ runIO x = liftIO (tryIOError x) >>= either (throwError . Msg . show) return
 getName :: Idris Int
 getName = do i <- getIState;
              let idx = idris_name i;
-             putIState $ (i { idris_name = idx + 1 })
+             putIState (i { idris_name = idx + 1 })
              return idx
 
 -- | InternalApp keeps track of the real function application for
@@ -686,10 +686,10 @@ isUndefined fc n
              _ -> return True
 
 setContext :: Context -> Idris ()
-setContext ctxt = do i <- getIState; putIState $ (i { tt_ctxt = ctxt } )
+setContext ctxt = do i <- getIState; putIState (i { tt_ctxt = ctxt } )
 
 updateContext :: (Context -> Context) -> Idris ()
-updateContext f = do i <- getIState; putIState $ (i { tt_ctxt = f (tt_ctxt i) } )
+updateContext f = do i <- getIState; putIState (i { tt_ctxt = f (tt_ctxt i) } )
 
 addConstraints :: FC -> (Int, [UConstraint]) -> Idris ()
 addConstraints fc (v, cs)
@@ -1741,7 +1741,7 @@ implicitise auto syn ignore ist tm = -- trace ("INCOMING " ++ showImp True tm) $
       = case lookup n using of
             Just ty -> PPi impl_gen
                            n NoFC ty (pibind using ns sc)
-            Nothing -> PPi (impl_gen { pargopts = [InaccessibleArg] }) 
+            Nothing -> PPi (impl_gen { pargopts = [InaccessibleArg] })
                            n NoFC Placeholder (pibind using ns sc)
 
 -- | Add implicit arguments in function calls

--- a/src/Idris/AbsSyntaxTree.hs
+++ b/src/Idris/AbsSyntaxTree.hs
@@ -1870,7 +1870,7 @@ pprintPTerm ppo bnd docArgs infixes = prettySe (ppopt_depth ppo) startPrec bnd
         text "![" <> pretty r <> text "]"
     prettySe d p bnd (PPatvar fc n) = pretty n
     prettySe d p bnd e
-      | Just str <- slist d p bnd e = depth d $ str
+      | Just str <- slist d p bnd e = depth d str
       | Just n <- snat ppo d p e = depth d $ annotate (AnnData "Nat" "") (text (show n))
     prettySe d p bnd (PRef fc _ n) = prettyName True (ppopt_impl ppo) bnd n
     prettySe d p bnd (PLam fc n nfc ty sc) =

--- a/src/Idris/Chaser.hs
+++ b/src/Idris/Chaser.hs
@@ -143,8 +143,8 @@ buildTree built importlists fp = evalStateT (btree [] fp) []
        let file = extractFileName f
        lift $ logLvl 1 $ "CHASING " ++ show file ++ " (" ++ show fp ++ ")"
        ibcsd <- lift $ valIBCSubDir i
-       ids <- lift $ allImportDirs
-       fp <- lift $ findImport ids ibcsd file
+       ids   <- lift allImportDirs
+       fp   <- lift $ findImport ids ibcsd file
        lift $ logLvl 1 $ "Found " ++ show fp
        mt <- lift $ runIO $ getIModTime fp
        if (file `elem` built)

--- a/src/Idris/CmdOptions.hs
+++ b/src/Idris/CmdOptions.hs
@@ -226,7 +226,7 @@ parseLogCats :: Monad m => String -> m [LogCat]
 parseLogCats s =
     case lastMay (readP_to_S (doParse) s) of
       Just (xs, _) -> return xs
-      _            -> fail $ "Incorrect categories specified"
+      _            -> fail "Incorrect categories specified"
   where
     doParse :: ReadP [LogCat]
     doParse = do

--- a/src/Idris/Completion.hs
+++ b/src/Idris/Completion.hs
@@ -148,7 +148,7 @@ completeCmd cmd (prev, next) = fromMaybe completeCmdName $ fmap completeArg $ lo
           completeArg (OptionalArg a) = completeArg a
           completeArg (SeqArgs a b) = completeArg a
           completeArg _ = noCompletion (prev, next)
-          completeCmdName = return $ ("", completeWith commands cmd)
+          completeCmdName = return ("", completeWith commands cmd)
 
 -- | Complete REPL commands and defined identifiers
 replCompletion :: CompletionFunc Idris
@@ -168,7 +168,7 @@ completePkg = completeWord Nothing " \t()" completeP
 completeTactic :: [String] -> String -> CompletionFunc Idris
 completeTactic as tac (prev, next) = fromMaybe completeTacName . fmap completeArg $
                                      lookup tac tacticArgs
-    where completeTacName = return $ ("", completeWith tactics tac)
+    where completeTacName = return ("", completeWith tactics tac)
           completeArg Nothing              = noCompletion (prev, next)
           completeArg (Just NameTArg)      = noCompletion (prev, next) -- this is for binding new names!
           completeArg (Just ExprTArg)      = completeExpr as (prev, next)

--- a/src/Idris/Core/Elaborate.hs
+++ b/src/Idris/Core/Elaborate.hs
@@ -654,8 +654,9 @@ apply' fillt fn imps =
        fillt (raw_apply fn (map (Var . snd) args))
        ulog <- getUnifyLog
        g <- goal
-       traceWhen ulog ("Goal " ++ show g ++ " -- when elaborating " ++ show fn) $
-        end_unify
+       traceWhen ulog
+                 ("Goal " ++ show g ++ " -- when elaborating " ++ show fn)
+                 end_unify
        return $! (map (\(argName, argHole) -> (argName, updateUnify unify argHole)) args)
   where updateUnify us n = case lookup n us of
                                 Just (P _ t _) -> t

--- a/src/Idris/Core/Evaluate.hs
+++ b/src/Idris/Core/Evaluate.hs
@@ -182,7 +182,7 @@ bindEnv ((n, b):bs)       tm = Bind n b (bindEnv bs tm)
 unbindEnv :: EnvTT n -> TT n -> TT n
 unbindEnv [] tm = tm
 unbindEnv (_:bs) (Bind n b sc) = unbindEnv bs sc
-unbindEnv env tm = error $ "Impossible case occurred: couldn't unbind env."
+unbindEnv env tm = error "Impossible case occurred: couldn't unbind env."
 
 usable :: Bool -- specialising
           -> Int -- Reduction depth limit (when simplifying/at REPL)
@@ -558,8 +558,8 @@ class Quote a where
     quote :: Int -> a -> Eval (TT Name)
 
 instance Quote Value where
-    quote i (VP nt n v)    = liftM (P nt n) (quote i v)
-    quote i (VV x)         = return $ V x
+    quote i (VP nt n v)      = liftM (P nt n) (quote i v)
+    quote i (VV x)           = return $ V x
     quote i (VBind _ n b sc) = do sc' <- sc (VTmp i)
                                   b' <- quoteB b
                                   liftM (Bind n b') (quote (i+1) sc')
@@ -571,10 +571,10 @@ instance Quote Value where
                                 let sc'' = pToV (sMN vd "vlet") (addBinder sc')
                                 return (Bind n (Let t' v') sc'')
     quote i (VApp f a)     = liftM2 (App MaybeHoles) (quote i f) (quote i a)
-    quote i (VType u)       = return $ TType u
-    quote i (VUType u)      = return $ UType u
-    quote i VErased        = return $ Erased
-    quote i VImpossible    = return $ Impossible
+    quote i (VType u)      = return (TType u)
+    quote i (VUType u)     = return (UType u)
+    quote i VErased        = return Erased
+    quote i VImpossible    = return Impossible
     quote i (VProj v j)    = do v' <- quote i v
                                 return (Proj v' j)
     quote i (VConstant c)  = return $ Constant c

--- a/src/Idris/Core/ProofState.hs
+++ b/src/Idris/Core/ProofState.hs
@@ -765,8 +765,8 @@ casetac tm induction ctxt env (Bind x (Hole t) (P _ x' _)) | x == x' = do
         case lookupTy (SN (tacn tnm)) ctxt of
           [elimTy] -> do
              param_pos <- case lookupMetaInformation tnm ctxt of
-                               [DataMI param_pos] -> return param_pos
-                               m | length tyargs > 0 -> fail $ "Invalid meta information for " ++ show tnm ++ " where the metainformation is " ++ show m ++ " and definition is" ++ show (lookupDef tnm ctxt)
+                               [DataMI param_pos]    -> return param_pos
+                               m | not (null tyargs) -> fail $ "Invalid meta information for " ++ show tnm ++ " where the metainformation is " ++ show m ++ " and definition is" ++ show (lookupDef tnm ctxt)
                                _ -> return []
              let (params, indicies) = splitTyArgs param_pos tyargs
              let args     = getArgTys elimTy
@@ -774,8 +774,8 @@ casetac tm induction ctxt env (Bind x (Hole t) (P _ x' _)) | x == x' = do
              let args'    = drop (length params) args
              let propTy   = head args'
              let restargs = init $ tail args'
-             let consargs = take (length restargs - length indicies) $ restargs
-             let indxargs = drop (length restargs - length indicies) $ restargs
+             let consargs = take (length restargs - length indicies) restargs
+             let indxargs = drop (length restargs - length indicies) restargs
              let scr      = last $ tail args'
              let indxnames = makeIndexNames indicies
              currentNames <- query $ allTTNames . getProofTerm . pterm
@@ -790,7 +790,7 @@ casetac tm induction ctxt env (Bind x (Hole t) (P _ x' _)) | x == x' = do
              action (\ps -> ps {holes = holes ps \\ [x],
                                 recents = x : recents ps })
              mapM_ addConsHole (reverse consargs')
-             let res' = forget $ res
+             let res' = forget res
              (scv, sct) <- lift $ check ctxt env res'
              let (scv', _) = specialise ctxt env [] scv
              return scv'

--- a/src/Idris/Coverage.hs
+++ b/src/Idris/Coverage.hs
@@ -758,8 +758,7 @@ type MultiPath = [SCGEntry]
 
 mkMultiPaths :: IState -> MultiPath -> [SCGEntry] -> [MultiPath]
 mkMultiPaths ist path [] = [reverse path]
-mkMultiPaths ist path cg
-    = concat (map extend cg)
+mkMultiPaths ist path cg = concatMap extend cg
   where extend (nextf, args)
            | (nextf, args) `elem` path = [ reverse ((nextf, args) : path) ]
            | [Unchecked] <- lookupTotal nextf (tt_ctxt ist)

--- a/src/Idris/Directives.hs
+++ b/src/Idris/Directives.hs
@@ -54,7 +54,7 @@ directiveAction (DThaw n') = do
             ctxt <- getContext
             case lookupDefAccExact n False ctxt of
                  Just (_, Frozen) -> do setAccessibility n Public
-                                        addIBC (IBCAccess n Public) 
+                                        addIBC (IBCAccess n Public)
                  _ -> throwError (Msg (show n ++ " is not frozen"))) ns
 directiveAction (DInjective n') = do
   ns <- allNamespaces n'
@@ -77,7 +77,7 @@ directiveAction (DDynamicLibs libs) = do
   added <- addDyLib libs
   case added of
     Left lib  -> addIBC (IBCDyLib (lib_name lib))
-    Right msg -> fail $ msg
+    Right msg -> fail msg
 
 directiveAction (DNameHint ty tyFC ns) = do
   ty' <- disambiguate ty

--- a/src/Idris/Elab/Class.hs
+++ b/src/Idris/Elab/Class.hs
@@ -138,7 +138,7 @@ elabClass info syn_in doc fc constraints tn tnfc ps pDocs fds ds mcn cd
                (map fst (filter (\(_, (inj, _, _, _, _)) -> inj) imethods))
 
          -- add the default definitions
-         mapM_ (rec_elabDecl info EAll info) (concat (map (snd.snd) defs))
+         mapM_ (rec_elabDecl info EAll info) (concatMap (snd.snd) defs)
          addIBC (IBCClass tn)
 
          sendHighlighting $
@@ -164,12 +164,12 @@ elabClass info syn_in doc fc constraints tn tnfc ps pDocs fds ds mcn cd
     checkDefaultSuperclassInstance :: PDecl -> Idris ()
     checkDefaultSuperclassInstance (PInstance _ _ _ fc cs _ _ _ n _ ps _ _ _ _)
         = do when (not $ null cs) . tclift
-                $ tfail (At fc (Msg $ "Default superclass instances can't have constraints."))
+                $ tfail (At fc (Msg "Default superclass instances can't have constraints."))
              i <- getIState
              let t = PApp fc (PRef fc [] n) (map pexp ps)
              let isConstrained = any (== t) (map snd constraints)
              when (not isConstrained) . tclift
-                $ tfail (At fc (Msg $ "Default instances must be for a superclass constraint on the containing class."))
+                $ tfail (At fc (Msg "Default instances must be for a superclass constraint on the containing class."))
              return ()
 
     checkConstraintName :: [Name] -> Name -> Idris ()

--- a/src/Idris/Elab/Clause.hs
+++ b/src/Idris/Elab/Clause.hs
@@ -421,7 +421,7 @@ elabPE info fc caller r =
                                   PClause fc newnm lhs' [] rhs [])
                               (pe_clauses specdecl)
                 trans <- elabTransform info fc False rhs lhs
-                elabClauses (info {pe_depth = pe_depth info + 1}) fc 
+                elabClauses (info {pe_depth = pe_depth info + 1}) fc
                             (PEGenerated:opts) newnm def
                 return [trans]
              else return [])
@@ -555,8 +555,8 @@ elabClause info opts (cnum, PClause fc fname lhs_in_as withs rhs_in_as wherebloc
 
         -- Check if we have "with" patterns outside of "with" block
         when (isOutsideWith lhs_in && (not $ null withs)) $
-            ierror $ (At fc (Elaborating "left hand side of " fname Nothing
-                             (Msg "unexpected patterns outside of \"with\" block")))
+            ierror (At fc (Elaborating "left hand side of " fname Nothing
+                          (Msg "unexpected patterns outside of \"with\" block")))
 
         -- get the parameters first, to pass through to any where block
         let fn_ty = case lookupTy fname ctxt of
@@ -713,7 +713,7 @@ elabClause info opts (cnum, PClause fc fname lhs_in_as withs rhs_in_as wherebloc
         mapM_ (elabCaseBlock winfo opts) is
 
         ctxt <- getContext
-        logElab 5 $ "Rechecking"
+        logElab 5 "Rechecking"
         logElab 6 $ " ==> " ++ show (forget rhs')
 
         (crhs, crhsty) -- if there's holes && deferred things, it's okay
@@ -760,7 +760,7 @@ elabClause info opts (cnum, PClause fc fname lhs_in_as withs rhs_in_as wherebloc
            addIBC (IBCErrRev (crhs, clhs))
            addErrRev (crhs, clhs)
         pop_estack
-        return $ (Right (clhs, crhs), lhs)
+        return (Right (clhs, crhs), lhs)
   where
     pinfo :: ElabInfo -> [(Name, PTerm)] -> [Name] -> Int -> ElabInfo
     pinfo info ns ds i
@@ -903,7 +903,7 @@ elabClause info opts (_, PWith fc fname lhs_in withs wval_in pn_in withblock)
                        Just (n, nfc) -> Just (uniqueName n (map fst bargs))
 
         -- Highlight explicit proofs
-        sendHighlighting $ [(fc, AnnBoundName n False) | (n, fc) <- maybeToList pn_in]
+        sendHighlighting [(fc, AnnBoundName n False) | (n, fc) <- maybeToList pn_in]
 
         logElab 10 ("With type " ++ show (getRetTy cwvaltyN) ++
                   " depends on " ++ show pdeps ++ " from " ++ show pvars)
@@ -991,7 +991,7 @@ elabClause info opts (_, PWith fc fname lhs_in withs wval_in pn_in withblock)
         mapM_ (elabCaseBlock info opts) is
         logElab 5 ("Checked RHS " ++ show rhs')
         (crhs, crhsty) <- recheckC (constraintNS info) fc id [] rhs'
-        return $ (Right (clhs, crhs), lhs)
+        return (Right (clhs, crhs), lhs)
   where
     getImps (Bind n (Pi _ _ _) t) = pexp Placeholder : getImps t
     getImps _ = []
@@ -999,7 +999,7 @@ elabClause info opts (_, PWith fc fname lhs_in withs wval_in pn_in withblock)
     mkAuxC pn wname lhs ns ns' (PClauses fc o n cs)
                 = do cs' <- mapM (mkAux pn wname lhs ns ns') cs
                      return $ PClauses fc o wname cs'
-    mkAuxC pn wname lhs ns ns' d = return $ d
+    mkAuxC pn wname lhs ns ns' d = return d
 
     mkAux pn wname toplhs ns ns' (PClause fc n tm_in (w:ws) rhs wheres)
         = do i <- getIState

--- a/src/Idris/Elab/Data.hs
+++ b/src/Idris/Elab/Data.hs
@@ -258,11 +258,11 @@ elabCon info syn tn codata expkind dkind (doc, argDocs, n, nfc, t_in, fc, forcen
     checkUniqueKind (UType AllTypes) _
         = tclift $ tfail (At fc (UniqueKindError AllTypes n))
     checkUniqueKind _ _ = return ()
-        
+
 addParamConstraints :: FC -> [Int] -> Type -> [(Name, Type)] -> Idris ()
 addParamConstraints fc ps cty cons
    = case getRetTy cty of
-          TType cvar -> mapM_ (addConConstraint ps cvar) 
+          TType cvar -> mapM_ (addConConstraint ps cvar)
                               (map getParamNames cons)
           _ -> return ()
   where
@@ -277,7 +277,7 @@ addParamConstraints fc ps cty cons
     paramArgs i (_ : args) = paramArgs (i + 1) args
     paramArgs i [] = []
 
-    addConConstraint ps cvar (ty, pnames) = constraintTy ty 
+    addConConstraint ps cvar (ty, pnames) = constraintTy ty
       where
         constraintTy (Bind n (Pi _ ty _) sc)
            = case getRetTy ty of
@@ -305,7 +305,7 @@ elabCaseFun :: Bool -> [Int] -> Name -> PTerm ->
                   [(Docstring (Either Err PTerm), [(Name, Docstring (Either Err PTerm))], Name, FC, PTerm, FC, [Name])] ->
                   ElabInfo -> EliminatorState ()
 elabCaseFun ind paramPos n ty cons info = do
-  elimLog $ "Elaborating case function"
+  elimLog "Elaborating case function"
   put (Map.fromList $ zip (concatMap (\(_, p, _, _, ty, _, _) -> (map show $ boundNamesIn ty) ++ map (show . fst) p) cons ++ (map show $ boundNamesIn ty)) (repeat 0))
   let (cnstrs, _) = splitPi ty
   let (splittedTy@(pms, idxs)) = splitPms cnstrs

--- a/src/Idris/Elab/Instance.hs
+++ b/src/Idris/Elab/Instance.hs
@@ -147,7 +147,7 @@ elabInstance info syn doc argDocs what fc cs parents acc opts n nfc ps pextra t 
          logElab 5 ("Before defaults: " ++ show ds ++ "\n" ++ show (map fst (class_methods ci)))
          let ds_defs = insertDefaults ist iname (class_defaults ci) ns ds
          logElab 3 ("After defaults: " ++ show ds_defs ++ "\n")
-         let ds' = reorderDefs (map fst (class_methods ci)) $ ds_defs
+         let ds' = reorderDefs (map fst (class_methods ci)) ds_defs
          logElab 1 ("Reordered: " ++ show ds' ++ "\n")
 
          mapM_ (warnMissing ds' ns iname) (map fst (class_methods ci))

--- a/src/Idris/Elab/Type.hs
+++ b/src/Idris/Elab/Type.hs
@@ -104,8 +104,8 @@ buildType info syn fc opts n ty' = do
 
          mapM_ (elabCaseBlock info opts) is
          ctxt <- getContext
-         logElab 5 $ "Rechecking"
-         logElab 6 $ show tyT
+         logElab 5 "Rechecking"
+         logElab 6 (show tyT)
          logElab 10 $ "Elaborated to " ++ showEnvDbg [] tyT
          (cty, ckind)   <- recheckC (constraintNS info) fc id [] tyT
 
@@ -224,7 +224,7 @@ elabType' norm info syn doc argDocs fc opts n nfc ty' = {- let ty' = piBind (par
              case fam of
                 P _ tyn _ -> do addAutoHint tyn n
                                 addIBC (IBCAutoHint tyn n)
-                t -> ifail $ "Hints must return a data or record type"
+                t -> ifail "Hints must return a data or record type"
 
          -- If the function is declared as an error handler and the language
          -- extension is enabled, then add it to the list of error handlers.

--- a/src/Idris/IBC.hs
+++ b/src/Idris/IBC.hs
@@ -150,7 +150,7 @@ loadIBC reexport phase fp
 
 -- | Load an entire package from its index file
 loadPkgIndex :: String -> Idris ()
-loadPkgIndex pkg = do ddir <- runIO $ getIdrisLibDir
+loadPkgIndex pkg = do ddir <- runIO getIdrisLibDir
                       addImportDir (ddir </> pkg)
                       fp <- findPkgIndex pkg
                       loadIBC True IBC_Building fp

--- a/src/Idris/IdeMode.hs
+++ b/src/Idris/IdeMode.hs
@@ -258,18 +258,18 @@ data IdeModeCommand = REPLCompletions String
                     | GetIdrisVersion
 
 sexpToCommand :: SExp -> Maybe IdeModeCommand
-sexpToCommand (SexpList (x:[]))                                                         = sexpToCommand x
-sexpToCommand (SexpList [SymbolAtom "interpret", StringAtom cmd])                       = Just (Interpret cmd)
-sexpToCommand (SexpList [SymbolAtom "repl-completions", StringAtom prefix])             = Just (REPLCompletions prefix)
-sexpToCommand (SexpList [SymbolAtom "load-file", StringAtom filename, IntegerAtom line])                  = Just (LoadFile filename (Just (fromInteger line)))
-sexpToCommand (SexpList [SymbolAtom "load-file", StringAtom filename])                  = Just (LoadFile filename Nothing)
-sexpToCommand (SexpList [SymbolAtom "type-of", StringAtom name])                        = Just (TypeOf name)
-sexpToCommand (SexpList [SymbolAtom "case-split", IntegerAtom line, StringAtom name])   = Just (CaseSplit (fromInteger line) name)
-sexpToCommand (SexpList [SymbolAtom "add-clause", IntegerAtom line, StringAtom name])   = Just (AddClause (fromInteger line) name)
-sexpToCommand (SexpList [SymbolAtom "add-proof-clause", IntegerAtom line, StringAtom name])   = Just (AddProofClause (fromInteger line) name)
-sexpToCommand (SexpList [SymbolAtom "add-missing", IntegerAtom line, StringAtom name])  = Just (AddMissing (fromInteger line) name)
-sexpToCommand (SexpList [SymbolAtom "make-with", IntegerAtom line, StringAtom name])    = Just (MakeWithBlock (fromInteger line) name)
-sexpToCommand (SexpList [SymbolAtom "make-case", IntegerAtom line, StringAtom name])    = Just (MakeCaseBlock (fromInteger line) name)
+sexpToCommand (SexpList ([x]))                                                              = sexpToCommand x
+sexpToCommand (SexpList [SymbolAtom "interpret", StringAtom cmd])                           = Just (Interpret cmd)
+sexpToCommand (SexpList [SymbolAtom "repl-completions", StringAtom prefix])                 = Just (REPLCompletions prefix)
+sexpToCommand (SexpList [SymbolAtom "load-file", StringAtom filename, IntegerAtom line])    = Just (LoadFile filename (Just (fromInteger line)))
+sexpToCommand (SexpList [SymbolAtom "load-file", StringAtom filename])                      = Just (LoadFile filename Nothing)
+sexpToCommand (SexpList [SymbolAtom "type-of", StringAtom name])                            = Just (TypeOf name)
+sexpToCommand (SexpList [SymbolAtom "case-split", IntegerAtom line, StringAtom name])       = Just (CaseSplit (fromInteger line) name)
+sexpToCommand (SexpList [SymbolAtom "add-clause", IntegerAtom line, StringAtom name])       = Just (AddClause (fromInteger line) name)
+sexpToCommand (SexpList [SymbolAtom "add-proof-clause", IntegerAtom line, StringAtom name]) = Just (AddProofClause (fromInteger line) name)
+sexpToCommand (SexpList [SymbolAtom "add-missing", IntegerAtom line, StringAtom name])      = Just (AddMissing (fromInteger line) name)
+sexpToCommand (SexpList [SymbolAtom "make-with", IntegerAtom line, StringAtom name])        = Just (MakeWithBlock (fromInteger line) name)
+sexpToCommand (SexpList [SymbolAtom "make-case", IntegerAtom line, StringAtom name])        = Just (MakeCaseBlock (fromInteger line) name)
 -- The Boolean in ProofSearch means "search recursively"
 -- If it's False, that means "refine", i.e. apply the name and fill in any
 -- arguments which can be done by unification.

--- a/src/Idris/IdrisDoc.hs
+++ b/src/Idris/IdrisDoc.hs
@@ -423,7 +423,7 @@ createIndex :: S.Set NsName -- ^ Set of namespace names to
 createIndex nss out =
   do (path, h) <- openTempFile out "index.html"
      BS2.hPut h $ renderHtml $ wrapper Nothing $ do
-       H.h1 $ "Namespaces"
+       H.h1 "Namespaces"
        H.ul ! class_ "names" $ do
          let path ns  = "docs" ++ "/" ++ genRelNsPath ns "html"
              item ns  = do let n    = toHtml $ nsName2Str ns
@@ -523,7 +523,7 @@ genTypeHeader ist (FD n _ args ftype _) = do
         docExtractor (_, _, _, Nothing) = Nothing
         docExtractor (n, _, _, Just d)  = Just (n, doc2Str d)
                          -- TODO: Remove <p> tags more robustly
-        doc2Str d      = let dirty = renderMarkup $ contents $ Docstrings.renderHtml $ d
+        doc2Str d      = let dirty = renderMarkup $ contents $ Docstrings.renderHtml d
                          in  take (length dirty - 8) $ drop 3 dirty
 
         name (NS n ns) = show (NS (sUN $ name n) ns)

--- a/src/Idris/Interactive.hs
+++ b/src/Idris/Interactive.hs
@@ -380,7 +380,7 @@ makeLemma fn updatefile l n
                   runIO $ writeSource fb (addProv before tyline lem_app later)
                   runIO $ copyFile fb fn
                else case idris_outputmode i of
-                      RawOutput _  -> iPrintResult $ lem_app
+                      RawOutput _  -> iPrintResult lem_app
                       IdeMode n h ->
                         let good = SexpList [SymbolAtom "ok",
                                              SexpList [SymbolAtom "provisional-definition-lemma",
@@ -495,7 +495,7 @@ makeLemma fn updatefile l n
         addLem before tyline lem lem_app later
             = let (bef_end, blankline : bef_start)
                        = case span (not . blank) (reverse before) of
-                              (bef, []) -> (bef, "" : [])
+                              (bef, []) -> (bef, [""])
                               x -> x
                   mvline = updateMeta tyline (show n) lem_app in
                 unlines $ reverse bef_start ++
@@ -505,7 +505,7 @@ makeLemma fn updatefile l n
         addProv before tyline lem_app later
             = let (later_bef, blankline : later_end)
                       = case span (not . blank) later of
-                             (bef, []) -> (bef, "" : [])
+                             (bef, []) -> (bef, [""])
                              x -> x in
                   unlines $ before ++ tyline :
                             (later_bef ++ [blankline, lem_app, blankline] ++

--- a/src/Idris/Parser/Data.hs
+++ b/src/Idris/Parser/Data.hs
@@ -232,7 +232,7 @@ data_ syn = do (doc, argDocs, acc, dataOpts) <- try (do
                                              let kw = (if DefaultEliminator `elem` dataOpts then "%elim" else "") ++ (if Codata `elem` dataOpts then "co" else "") ++ "data "
                                              let n  = show tyn_in ++ " "
                                              let s  = kw ++ n
-                                             let as = concat (intersperse " " $ map show args) ++ " "
+                                             let as = unwords (map show args) ++ " "
                                              let ns = concat (intersperse " -> " $ map ((\x -> "(" ++ x ++ " : Type)") . show) args)
                                              let ss = concat (intersperse " -> " $ map (const "Type") args)
                                              let fix1 = s ++ as ++ " = ..."

--- a/src/Idris/Parser/Expr.hs
+++ b/src/Idris/Parser/Expr.hs
@@ -499,7 +499,7 @@ bracketed' open syn =
 {-| Parses the rest of a dependent pair after '(' or '(Expr **' -}
 dependentPair :: PunInfo -> [(PTerm, Maybe (FC, PTerm), FC)] -> FC -> SyntaxInfo -> IdrisParser PTerm
 dependentPair pun prev openFC syn =
-  if prev == [] then
+  if null prev then
       nametypePart <|> namePart
   else
     case pun of

--- a/src/Idris/ProofSearch.hs
+++ b/src/Idris/ProofSearch.hs
@@ -364,7 +364,7 @@ resolveTC def openOK depth top fn elab ist
   = do hs <- get_holes
        resTC' [] def openOK hs depth top fn elab ist
 
-resTC' tcs def openOK topholes 0 topg fn elab ist = fail $ "Can't resolve interface"
+resTC' tcs def openOK topholes 0 topg fn elab ist = fail "Can't resolve interface"
 resTC' tcs def openOK topholes 1 topg fn elab ist = try' (trivial elab ist) (resolveTC def False 0 topg fn elab ist) True
 resTC' tcs defaultOn openOK topholes depth topg fn elab ist
   = do compute
@@ -484,7 +484,7 @@ resTC' tcs defaultOn openOK topholes depth topg fn elab ist
     solven n = replicateM_ n solve
 
     resolve n depth
-       | depth == 0 = fail $ "Can't resolve interface"
+       | depth == 0 = fail "Can't resolve interface"
        | otherwise
            = do lams <- introImps
                 t <- goal

--- a/src/Idris/REPL.hs
+++ b/src/Idris/REPL.hs
@@ -782,7 +782,7 @@ edit :: FilePath -> IState -> Idris ()
 edit "" orig = iputStrLn "Nothing to edit"
 edit f orig
     = do i <- getIState
-         env <- runIO $ getEnvironment
+         env <- runIO getEnvironment
          let editor = getEditor env
          let line = case errSpan i of
                         Just l -> ['+' : show (fst (fc_start l))]
@@ -915,7 +915,7 @@ process fn (NewDefn decls) = do
   fixClauses (PInstance doc argDocs syn fc constraints pnames acc opts cls nfc parms pextra ty instName decls) =
     PInstance doc argDocs syn fc constraints pnames acc opts cls nfc parms pextra ty instName (map fixClauses decls)
   fixClauses decl = decl
-    
+
   info = recinfo (fileFC "toplevel")
 
 process fn (Undefine names) = undefine names
@@ -1205,8 +1205,8 @@ process fn (Prove mode n')
           n <- case metavars of
               [] -> ierror (Msg $ "Cannot find metavariable " ++ show n')
               [(n, (_,_,_,False,_))] -> return n
-              [(_, (_,_,_,_,False))]  -> ierror (Msg $ "Can't prove this hole as it depends on other holes")
-              [(_, (_,_,_,True,_))]  -> ierror (Msg $ "Declarations not solvable using prover")
+              [(_, (_,_,_,_,False))]  -> ierror (Msg "Can't prove this hole as it depends on other holes")
+              [(_, (_,_,_,True,_))]  -> ierror (Msg "Declarations not solvable using prover")
               ns -> ierror (CantResolveAlts (map fst ns))
           prover (toplevelWith fn) mode (lit fn) n
           -- recheck totality
@@ -1280,7 +1280,7 @@ process fn (Missing n)
                                                    []
                                                    (idris_infixes i))
                                       tms))
-           _ -> iPrintError $ "Ambiguous name"
+           _ -> iPrintError "Ambiguous name"
 process fn (DynamicLink l)
                            = do i <- getIState
                                 let importdirs = opt_importdirs (idris_options i)
@@ -1404,7 +1404,7 @@ process fn (MakeDoc s) =
              parse n    | Success x <- runparser (fmap fst name) istate fn n = Right x
              parse n    = Left n
              (bad, nss) = partitionEithers $ map parse names
-         cd            <- runIO $ getCurrentDirectory
+         cd            <- runIO getCurrentDirectory
          let outputDir  = cd </> "doc"
          result        <- if null bad then runIO $ generateDocs istate nss outputDir
                                       else return . Left $ "Illegal name: " ++ head bad
@@ -1588,7 +1588,7 @@ loadInputs inputs toline -- furthest line to read in input source files
            case errSpan inew of
               Nothing ->
                 do putIState $!! ist { idris_tyinfodata = tidata }
-                   ibcfiles <- mapM findNewIBC (nub (concat (map snd ifiles)))
+                   ibcfiles <- mapM findNewIBC (nub (concatMap snd ifiles))
 --                    logLvl 0 $ "Loading from " ++ show ibcfiles
                    tryLoad True (IBC_REPL True) (mapMaybe id ibcfiles)
               _ -> return ()
@@ -1717,7 +1717,7 @@ idrisMain opts =
 
        when (DefaultTotal `elem` opts) $ do i <- getIState
                                             putIState (i { default_total = DefaultCheckingTotal })
-       tty <- runIO $ isATTY
+       tty <- runIO isATTY
        setColourise $ not quiet && last (tty : opt getColour opts)
 
 
@@ -1791,7 +1791,7 @@ idrisMain opts =
                                                            runIO $ exitWith (ExitFailure 1)
                                          Success e -> process "" (Eval e))
                            exprs
-                     runIO $ exitWith ExitSuccess
+                     runIO exitSuccess
 
 
        case script of
@@ -1829,7 +1829,7 @@ idrisMain opts =
     makeOption _             = return ()
 
     addPkgDir :: String -> Idris ()
-    addPkgDir p = do ddir <- runIO $ getIdrisLibDir
+    addPkgDir p = do ddir <- runIO getIdrisLibDir
                      addImportDir (ddir </> p)
                      addIBC (IBCImportDir (ddir </> p))
 
@@ -1848,7 +1848,7 @@ execScript expr = do i <- getIState
                           Success term -> do ctxt <- getContext
                                              (tm, _) <- elabVal (recinfo (fileFC "toplevel")) ERHS term
                                              res <- execute tm
-                                             runIO $ exitWith ExitSuccess
+                                             runIO $ exitSuccess
 
 -- | Get the platform-specific, user-specific Idris dir
 getIdrisUserDataDir :: Idris FilePath

--- a/src/Pkg/Package.hs
+++ b/src/Pkg/Package.hs
@@ -139,7 +139,7 @@ replPkg copts fp = do
         let mod = idris_main pkgdesc
         let f = toPath (showCG mod)
         putIState orig
-        dir <- runIO $ getCurrentDirectory
+        dir <- runIO getCurrentDirectory
         runIO $ setCurrentDirectory $ dir </> sourcedir pkgdesc
 
         if (f /= "")


### PR DESCRIPTION
HLint suggestions were applied  when code readability (and performance) would not be affected.

+ Removed redundant `$`
+ Reformatted some code.
+ Used pattern matching and application of single item lists `[x]` rather than `(x : [])`
+ Used `null` for list length checking.
+ Use `unwords`
+ Use `concatMap` over `concat $ map...`
+ Use `exitSuccess`