### PR TITLE
Make Idris build with GHC8

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -10,8 +10,10 @@ addons:
       - ghc-7.6.3
       - ghc-7.8.4
       - ghc-7.10.2
+      - ghc-8.0.1
       - cabal-install-1.20
       - cabal-install-1.22
+      - cabal-install-1.24
       # test dependencies
       - expect
       - cppcheck
@@ -35,6 +37,12 @@ matrix:
       compiler: ": #GHC 7.10.2"
     - env: CABALVER="1.22" GHCVER="7.10.2" TESTS="test_c"
       compiler: ": #GHC 7.10.2"
+    - env: CABALVER="1.24" GHCVER="8.0.1" TESTS="lib_doc doc"
+      compiler: ": #GHC 8.0.1"
+    - env: CABALVER="1.24" GHCVER="8.0.1" TESTS="test_js"
+      compiler: ": #GHC 8.0.1"
+    - env: CABALVER="1.24" GHCVER="8.0.1" TESTS="test_c"
+      compiler: ": #GHC 8.0.1"
 
 cache:
   directories:

--- a/idris.cabal
+++ b/idris.cabal
@@ -1027,7 +1027,7 @@ Library
                 , ansi-terminal < 0.7
                 , ansi-wl-pprint < 0.7
                 , base64-bytestring < 1.1
-                , binary >= 0.7 && < 0.8
+                , binary >= 0.7 && < 0.9
                 , blaze-html >= 0.6.1.3 && < 0.9
                 , blaze-markup >= 0.5.2.1 && < 0.8
                 , bytestring < 0.11
@@ -1044,14 +1044,14 @@ Library
                 , optparse-applicative >= 0.11 && < 0.13
                 , parsers >= 0.9 && < 0.13
                 , pretty < 1.2
-                , process < 1.3
+                , process < 1.5
                 , split < 0.3
                 , terminal-size < 0.4
                 , text >=1.2.1.0 && < 1.3
-                , time >= 1.4 && < 1.6
-                , transformers < 0.5
+                , time >= 1.4 && < 1.7
+                , transformers < 0.6
                 , transformers-compat >= 0.3
-                , trifecta >= 1.1 && < 1.6
+                , trifecta >= 1.6 && < 1.7
                 , uniplate >=1.6 && < 1.7
                 , unordered-containers < 0.3
                 , utf8-string < 1.1

--- a/src/Idris/Parser.hs
+++ b/src/Idris/Parser.hs
@@ -1569,7 +1569,7 @@ parseImports :: FilePath -> String -> Idris (Maybe (Docstring ()), [String], [Im
 parseImports fname input
     = do i <- getIState
          case parseString (runInnerParser (evalStateT imports i)) (Directed (UTF8.fromString fname) 0 0 0 0) input of
-              Failure err -> fail (show err)
+              Failure (ErrInfo err _) -> fail (show err)
               Success (x, annots, i) ->
                 do putIState i
                    fname' <- runIO $ Dir.makeAbsolute fname
@@ -1631,7 +1631,7 @@ parseProg :: SyntaxInfo -> FilePath -> String -> Maybe Delta ->
 parseProg syn fname input mrk
     = do i <- getIState
          case runparser mainProg i fname input of
-            Failure doc     -> do -- FIXME: Get error location from trifecta
+            Failure (ErrInfo doc _)     -> do -- FIXME: Get error location from trifecta
                                   -- this can't be the solution!
                                   -- Issue #1575 on the issue tracker.
                                   --    https://github.com/idris-lang/Idris-dev/issues/1575

--- a/src/Idris/Parser/Helpers.hs
+++ b/src/Idris/Parser/Helpers.hs
@@ -58,6 +58,21 @@ newtype IdrisInnerParser a = IdrisInnerParser { runInnerParser :: Parser a }
 
 deriving instance Parsing IdrisInnerParser
 
+#if MIN_VERSION_base(4,9,0)
+instance {-# OVERLAPPING #-} DeltaParsing IdrisParser where
+  line = lift line
+  {-# INLINE line #-}
+  position = lift position
+  {-# INLINE position #-}
+  slicedWith f (StateT m) = StateT $ \s -> slicedWith (\(a,s') b -> (f a b, s')) $ m s
+  {-# INLINE slicedWith #-}
+  rend = lift rend
+  {-# INLINE rend #-}
+  restOfLine = lift restOfLine
+  {-# INLINE restOfLine #-}
+
+#endif
+
 #if MIN_VERSION_base(4,8,0)
 instance {-# OVERLAPPING #-} TokenParsing IdrisParser where
 #else

--- a/src/Idris/Prover.hs
+++ b/src/Idris/Prover.hs
@@ -39,7 +39,7 @@ import qualified Idris.IdeMode as IdeMode
 import Idris.Output
 import Idris.TypeSearch (searchByType)
 
-import Text.Trifecta.Result(Result(..))
+import Text.Trifecta.Result(Result(..), ErrInfo(..))
 
 import System.IO (Handle, stdin, stdout, hPutStrLn)
 import System.Console.Haskeline
@@ -325,7 +325,7 @@ elabloop info fn d prompt prf e prev h env
        (d, prev', st, done, prf', env', res) <-
          idrisCatch
            (case cmd of
-              Failure err ->
+              Failure (ErrInfo err _) ->
                 return (False, prev, e, False, prf, env, Left . Msg . show . fixColour (idris_colourRepl ist) $ err)
               Success (Left cmd') ->
                 case cmd' of
@@ -440,7 +440,7 @@ ploop fn d prompt prf e h
             _ -> return ()
          (d, st, done, prf', res) <- idrisCatch
            (case cmd of
-              Failure err -> return (False, e, False, prf, Left . Msg . show . fixColour (idris_colourRepl i) $ err)
+              Failure (ErrInfo err _) -> return (False, e, False, prf, Left . Msg . show . fixColour (idris_colourRepl i) $ err)
               Success Undo -> do (_, st) <- elabStep e loadState
                                  return (True, st, False, init prf, Right $ iPrintResult "")
               Success ProofState -> return (True, e, False, prf, Right $ iPrintResult "")

--- a/stack.yaml
+++ b/stack.yaml
@@ -1,7 +1,7 @@
-resolver: lts-6.4
+resolver: lts-6.5
 
 packages:
-  - '.'
+  - location: .
 
 flags:
   idris:
@@ -10,6 +10,7 @@ flags:
 
 extra-deps:
   - libffi-0.1
+  - trifecta-1.6
 
 nix:
   enable: false


### PR DESCRIPTION
Fixes #3193. Note that I used the git version of trifecta (stack.yaml has the respective commit) to build this (due to transformers bounds).

The GHC bug in question is https://ghc.haskell.org/trac/ghc/ticket/12201 and the actual workaround is a dummy DeltaParsing IdrisParser instance (which is identical to the (StateT s m) one)