### PR TITLE
Fixes to some library issues under nix and stack.

### DIFF
--- a/stack-shell.nix
+++ b/stack-shell.nix
@@ -25,4 +25,7 @@ in stdenv.mkDerivation {
     (acc: lib:
       " --extra-lib-dirs=${lib}/lib --extra-include-dirs=${lib}/include" + acc)
     "" native_libs;
+
+  # Needed if one wants to use ghci, due to https://ghc.haskell.org/trac/ghc/ticket/11042
+  LD_LIBRARY_PATH = builtins.concatStringsSep ":" (map (lib: lib.out + "/lib") native_libs);
 }

--- a/stack-shell.nix
+++ b/stack-shell.nix
@@ -7,6 +7,7 @@ let
   native_libs = [
     libffi
     zlib
+    ncurses
     gmp
     pkgconfig
   ] ++ lib.optionals stdenv.isDarwin (with darwin.apple_sdk.frameworks; [


### PR DESCRIPTION
A couple of modifications to stack-shell.nix:

Ghci has an [issue](https://ghc.haskell.org/trac/ghc/ticket/11042) such that it doesn't recognize --extra-lib-dirs, which causes problems on systems like Nixos which use unusual locations for libraries. The workaround is to add locations for compiled libraries to LD_LIBRARY_PATH.

Also, dependencies don't seem to compile without ncurses being available, so I added that as well.