### PR TITLE
Use GHC generics for NFData instances

### DIFF
--- a/src/IRTS/CodegenCommon.hs
+++ b/src/IRTS/CodegenCommon.hs
@@ -1,3 +1,4 @@
+{-# LANGUAGE DeriveGeneric #-}
 {-|
 Module      : IRTS.CodegenCommon
 Description : Common data structures required for all code generators.
@@ -7,12 +8,14 @@ Maintainer  : The Idris Community.
 -}
 module IRTS.CodegenCommon where
 
+import GHC.Generics (Generic)
+
 import Idris.Core.TT
 import IRTS.Simplified
 import IRTS.Defunctionalise
 
 data DbgLevel = NONE | DEBUG | TRACE deriving Eq
-data OutputType = Raw | Object | Executable deriving (Eq, Show)
+data OutputType = Raw | Object | Executable deriving (Eq, Show, Generic)
 
 -- | Everything which might be needed in a code generator.
 --

--- a/src/IRTS/Lang.hs
+++ b/src/IRTS/Lang.hs
@@ -5,7 +5,7 @@ Copyright   :
 License     : BSD3
 Maintainer  : The Idris Community.
 -}
-{-# LANGUAGE PatternGuards, DeriveFunctor #-}
+{-# LANGUAGE PatternGuards, DeriveFunctor, DeriveGeneric #-}
 
 module IRTS.Lang where
 
@@ -17,6 +17,7 @@ import Idris.Core.CaseTree
 
 import Data.List
 import Debug.Trace
+import GHC.Generics (Generic)
 
 data Endianness = Native | BE | LE deriving (Show, Eq)
 
@@ -93,7 +94,7 @@ data PrimFn = LPlus ArithTy | LMinus ArithTy | LTimes ArithTy
                    -- core or another machine. 'id' is a valid implementation
             | LExternal Name
             | LNoOp
-  deriving (Show, Eq)
+  deriving (Show, Eq, Generic)
 
 -- Supported target languages for foreign calls
 

--- a/src/Idris/Colours.hs
+++ b/src/Idris/Colours.hs
@@ -1,3 +1,4 @@
+{-# LANGUAGE DeriveGeneric #-}
 {-|
 Module      : Idris.Colours
 Description : Support for colours within Idris.
@@ -14,6 +15,7 @@ module Idris.Colours (
   , colourisePrompt, colourise, ColourType(..), hStartColourise, hEndColourise
   ) where
 
+import GHC.Generics (Generic)
 import System.Console.ANSI
 import System.IO (Handle)
 
@@ -37,7 +39,7 @@ data ColourTheme = ColourTheme { keywordColour   :: IdrisColour
                                , promptColour    :: IdrisColour
                                , postulateColour :: IdrisColour
                                }
-                   deriving (Eq, Show)
+                   deriving (Eq, Show, Generic)
 
 -- | Idris's default console colour theme
 defaultTheme :: ColourTheme

--- a/src/Idris/Core/CaseTree.hs
+++ b/src/Idris/Core/CaseTree.hs
@@ -18,7 +18,8 @@ allows casing on arbitrary terms, here we choose to maintain the distinction
 in order to allow for better optimisation opportunities.
 
 -}
-{-# LANGUAGE PatternGuards, DeriveFunctor, TypeSynonymInstances #-}
+{-# LANGUAGE PatternGuards, DeriveFunctor, TypeSynonymInstances,
+    DeriveGeneric #-}
 
 module Idris.Core.CaseTree (
     CaseDef(..), SC, SC'(..), CaseAlt, CaseAlt'(..), ErasureInfo
@@ -36,6 +37,7 @@ import Data.Maybe
 import Data.List hiding (partition)
 import qualified Data.List(partition)
 import Debug.Trace
+import GHC.Generics (Generic)
 
 data CaseDef = CaseDef [Name] !SC [Term]
     deriving Show
@@ -45,14 +47,14 @@ data SC' t = Case CaseType Name [CaseAlt' t]  -- ^ invariant: lowest tags first
            | STerm !t
            | UnmatchedCase String -- ^ error message
            | ImpossibleCase -- ^ already checked to be impossible
-    deriving (Eq, Ord, Functor)
+    deriving (Eq, Ord, Functor, Generic)
 {-!
 deriving instance Binary SC'
 deriving instance NFData SC'
 !-}
 
 data CaseType = Updatable | Shared
-   deriving (Eq, Ord, Show)
+   deriving (Eq, Ord, Show, Generic)
 
 type SC = SC' Term
 
@@ -61,7 +63,7 @@ data CaseAlt' t = ConCase Name Int [Name] !(SC' t)
                 | ConstCase Const         !(SC' t)
                 | SucCase Name            !(SC' t)
                 | DefaultCase             !(SC' t)
-    deriving (Show, Eq, Ord, Functor)
+    deriving (Show, Eq, Ord, Functor, Generic)
 {-!
 deriving instance Binary CaseAlt'
 deriving instance NFData CaseAlt'

--- a/src/Idris/Core/DeepSeq.hs
+++ b/src/Idris/Core/DeepSeq.hs
@@ -1,6 +1,6 @@
 {-|
 Module      : Idris.Core.DeepSeq
-Description : Marshalling information for TT.
+Description : NFData instances for TT.
 Copyright   :
 License     : BSD3
 Maintainer  : The Idris Community.
@@ -16,287 +16,46 @@ import Idris.Core.Evaluate
 
 import Control.DeepSeq
 
-instance NFData Name where
-        rnf (UN x1) = rnf x1 `seq` ()
-        rnf (NS x1 x2) = rnf x1 `seq` rnf x2 `seq` ()
-        rnf (MN x1 x2) = rnf x1 `seq` rnf x2 `seq` ()
-        rnf (SN x1) = rnf x1 `seq` ()
-        rnf (SymRef x1) = rnf x1 `seq` ()
+instance NFData Name
 
-instance NFData Context where
-  rnf ctxt = rnf (next_tvar ctxt) `seq` rnf (definitions ctxt) `seq` ()
+instance NFData Context
 
 -- | Forcing the contents of a context, for diagnosing and working
 -- around space leaks
 forceDefCtxt :: Context -> Context
 forceDefCtxt (force -> !ctxt) = ctxt
 
-instance NFData NameOutput where
-    rnf TypeOutput = ()
-    rnf FunOutput = ()
-    rnf DataOutput = ()
-    rnf MetavarOutput = ()
-    rnf PostulateOutput = ()
-
-instance NFData TextFormatting where
-  rnf BoldText = ()
-  rnf ItalicText = ()
-  rnf UnderlineText = ()
-
-instance NFData Ordering where
-  rnf LT = ()
-  rnf EQ = ()
-  rnf GT = ()
-
-instance NFData OutputAnnotation where
-  rnf (AnnName x1 x2 x3 x4) = rnf x1 `seq` rnf x2 `seq` rnf x3 `seq` rnf x4 `seq` ()
-  rnf (AnnBoundName x1 x2) = rnf x1 `seq` rnf x2 `seq` ()
-  rnf (AnnConst x1) = rnf x1 `seq` ()
-  rnf (AnnData x1 x2) = rnf x1 `seq` rnf x2 `seq` ()
-  rnf (AnnType x1 x2) = rnf x1 `seq` rnf x2 `seq` ()
-  rnf (AnnKeyword) = ()
-  rnf (AnnFC x) = rnf x `seq` ()
-  rnf (AnnTextFmt x) = rnf x `seq` ()
-  rnf (AnnLink x) = rnf x `seq` ()
-  rnf (AnnTerm x1 x2) = rnf x1 `seq` rnf x2 `seq` ()
-  rnf (AnnSearchResult  x1) = rnf x1 `seq` ()
-  rnf (AnnErr x1) = rnf x1 `seq` ()
-  rnf (AnnNamespace x1 x2) = rnf x1 `seq` rnf x2 `seq` ()
-  rnf (AnnQuasiquote) = ()
-  rnf (AnnAntiquote) = ()
-
-instance NFData SpecialName where
-        rnf (WhereN x1 x2 x3) = rnf x1 `seq` rnf x2 `seq` rnf x3 `seq` ()
-        rnf (WithN x1 x2) = rnf x1 `seq` rnf x2 `seq` ()
-        rnf (InstanceN x1 x2) = rnf x1 `seq` rnf x2 `seq` ()
-        rnf (ParentN x1 x2) = rnf x1 `seq` rnf x2 `seq` ()
-        rnf (MethodN x1) = rnf x1 `seq` ()
-        rnf (CaseN x1 x2) = rnf x1 `seq` rnf x2 `seq` ()
-        rnf (ElimN x1) = rnf x1 `seq` ()
-        rnf (InstanceCtorN x1) = rnf x1 `seq` ()
-        rnf (MetaN x1 x2) = rnf x1 `seq` rnf x2 `seq` ()
-
-instance NFData Universe where
-        rnf NullType = ()
-        rnf UniqueType = ()
-        rnf AllTypes = ()
-
-instance NFData Raw where
-        rnf (Var x1) = rnf x1 `seq` ()
-        rnf (RBind x1 x2 x3) = rnf x1 `seq` rnf x2 `seq` rnf x3 `seq` ()
-        rnf (RApp x1 x2) = rnf x1 `seq` rnf x2 `seq` ()
-        rnf RType = ()
-        rnf (RUType x1) = rnf x1 `seq` ()
-        rnf (RConstant x1) = x1 `seq` ()
-
-instance NFData FC where
-        rnf (FC x1 x2 x3) = rnf x1 `seq` rnf x2 `seq` rnf x3 `seq` ()
-        rnf NoFC = ()
-        rnf (FileFC f) = rnf f `seq` ()
-
-instance NFData FC' where
-        rnf (FC' fc) = rnf fc `seq` ()
-
-instance NFData Provenance where
-        rnf ExpectedType = ()
-        rnf InferredVal = ()
-        rnf GivenVal = ()
-        rnf (SourceTerm x1) = rnf x1 `seq` ()
-        rnf (TooManyArgs x1) = rnf x1 `seq` ()
-
-instance NFData UConstraint where
-  rnf (ULT x1 x2) = rnf x1 `seq` rnf x2 `seq` ()
-  rnf (ULE x1 x2) = rnf x1 `seq` rnf x2 `seq` ()
-
-instance NFData ConstraintFC where
-  rnf (ConstraintFC x1 x2) = rnf x1 `seq` rnf x2 `seq` ()
-
-instance NFData Err where
-        rnf (Msg x1) = rnf x1 `seq` ()
-        rnf (InternalMsg x1) = rnf x1 `seq` ()
-        rnf (CantUnify x1 x2 x3 x4 x5 x6)
-          = rnf x1 `seq`
-              rnf x2 `seq` rnf x3 `seq` rnf x4 `seq` rnf x5 `seq` rnf x6 `seq` ()
-        rnf (InfiniteUnify x1 x2 x3)
-          = rnf x1 `seq` rnf x2 `seq` rnf x3 `seq` ()
-        rnf (CantConvert x1 x2 x3)
-          = rnf x1 `seq` rnf x2 `seq` rnf x3 `seq` ()
-        rnf (UnifyScope x1 x2 x3 x4)
-          = rnf x1 `seq` rnf x2 `seq` rnf x3 `seq` rnf x4 `seq` ()
-        rnf (ElaboratingArg x1 x2 x3 x4)
-          = rnf x1 `seq` rnf x2 `seq` rnf x3 `seq` rnf x4 `seq` ()
-        rnf (CantInferType x1) = rnf x1 `seq` ()
-        rnf (CantMatch x1) = rnf x1 `seq` ()
-        rnf (ReflectionError x1 x2) = rnf x1 `seq` rnf x2 `seq` ()
-        rnf (ReflectionFailed x1 x2) = rnf x1 `seq` rnf x2 `seq` ()
-        rnf (CantSolveGoal x1 x2) = rnf x1 `seq` rnf x2 `seq` ()
-        rnf (UniqueError x1 x2) = rnf x1 `seq` rnf x2 `seq` ()
-        rnf (UniqueKindError x1 x2) = rnf x1 `seq` rnf x2 `seq` ()
-        rnf (NotEquality x1 x2) = rnf x1 `seq` rnf x2 `seq` ()
-        rnf (NonFunctionType x1 x2) = rnf x1 `seq` rnf x2 `seq` ()
-        rnf (CantIntroduce x1) = rnf x1 `seq` ()
-        rnf (TooManyArguments x1) = rnf x1 `seq` ()
-        rnf (WithFnType x1) = rnf x1 `seq` ()
-        rnf (NoSuchVariable x1) = rnf x1 `seq` ()
-        rnf (NoTypeDecl x1) = rnf x1 `seq` ()
-        rnf (NotInjective x1 x2 x3)
-          = rnf x1 `seq` rnf x2 `seq` rnf x3 `seq` ()
-        rnf (CantResolve x1 x2 x3) = rnf x1 `seq` rnf x2 `seq` rnf x3 `seq` ()
-        rnf (InvalidTCArg x1 x2) = rnf x1 `seq` rnf x2 `seq` ()
-        rnf (CantResolveAlts x1) = rnf x1 `seq` ()
-        rnf (NoValidAlts x1) = rnf x1 `seq` ()
-        rnf (IncompleteTerm x1) = rnf x1 `seq` ()
-        rnf (NoEliminator x1 x2) = rnf x1 `seq` rnf x2 `seq` ()
-        rnf (UniverseError x1 x2 x3 x4 x5) = rnf x1 `seq` rnf x2 `seq` rnf x3 `seq` rnf x4 `seq` rnf x5 `seq` ()
-        rnf ProgramLineComment = ()
-        rnf (Inaccessible x1) = rnf x1 `seq` ()
-        rnf (UnknownImplicit x1 x2) = rnf x1 `seq` rnf x2 `seq` ()
-        rnf (NonCollapsiblePostulate x1) = rnf x1 `seq` ()
-        rnf (AlreadyDefined x1) = rnf x1 `seq` ()
-        rnf (ProofSearchFail x1) = rnf x1 `seq` ()
-        rnf (NoRewriting x1 x2 x3) = rnf x1 `seq` rnf x2 `seq` rnf x3 `seq` ()
-        rnf (At x1 x2) = rnf x1 `seq` rnf x2 `seq` ()
-        rnf (Elaborating x1 x2 x3 x4)
-          = rnf x1 `seq` rnf x2 `seq` rnf x3 `seq` rnf x4 `seq` ()
-        rnf (ProviderError x1) = rnf x1 `seq` ()
-        rnf (LoadingFailed x1 x2) = rnf x1 `seq` rnf x2 `seq` ()
-        rnf (ElabScriptDebug x1 x2 x3) = rnf x1 `seq` rnf x2 `seq` rnf x3 `seq` ()
-        rnf (ElabScriptStuck x1) = rnf x1 `seq` ()
-        rnf (RunningElabScript x1) = rnf x1 `seq` ()
-        rnf (ElabScriptStaging x1) = rnf x1 `seq` ()
-        rnf (FancyMsg x1) = rnf x1 `seq` ()
-
-instance NFData ErrorReportPart where
-  rnf (TextPart x1) = rnf x1 `seq` ()
-  rnf (TermPart x1) = rnf x1 `seq` ()
-  rnf (RawPart x1) = rnf x1 `seq` ()
-  rnf (NamePart x1) = rnf x1 `seq` ()
-  rnf (SubReport x1) = rnf x1 `seq` ()
-
-instance NFData ImplicitInfo where
-        rnf (Impl x1 x2 x3) = rnf x1 `seq` rnf x2 `seq` rnf x3 `seq` ()
-
-instance (NFData b) => NFData (Binder b) where
-        rnf (Lam x1) = rnf x1 `seq` ()
-        rnf (Pi x1 x2 x3) = rnf x1 `seq` rnf x2 `seq` rnf x3 `seq` ()
-        rnf (Let x1 x2) = rnf x1 `seq` rnf x2 `seq` ()
-        rnf (NLet x1 x2) = rnf x1 `seq` rnf x2 `seq` ()
-        rnf (Hole x1) = rnf x1 `seq` ()
-        rnf (GHole x1 x2 x3) = rnf x1 `seq` rnf x2 `seq` rnf x3 `seq` ()
-        rnf (Guess x1 x2) = rnf x1 `seq` rnf x2 `seq` ()
-        rnf (PVar x1) = rnf x1 `seq` ()
-        rnf (PVTy x1) = rnf x1 `seq` ()
-
-instance NFData UExp where
-        rnf (UVar x1 x2) = rnf x1 `seq` rnf x2 `seq` ()
-        rnf (UVal x1) = rnf x1 `seq` ()
-
-instance NFData NameType where
-        rnf Bound = ()
-        rnf Ref = ()
-        rnf (DCon x1 x2 x3) = rnf x1 `seq` rnf x2 `seq` rnf x3 `seq` ()
-        rnf (TCon x1 x2) = rnf x1 `seq` rnf x2 `seq` ()
-
-instance NFData NativeTy where
-        rnf IT8 = ()
-        rnf IT16 = ()
-        rnf IT32 = ()
-        rnf IT64 = ()
-
-instance NFData IntTy where
-        rnf (ITFixed x1) = rnf x1 `seq` ()
-        rnf ITNative = ()
-        rnf ITBig = ()
-        rnf ITChar = ()
-
-instance NFData ArithTy where
-        rnf (ATInt x1) = rnf x1 `seq` ()
-        rnf ATFloat = ()
-
-instance NFData Const where
-        rnf (I x1) = rnf x1 `seq` ()
-        rnf (BI x1) = rnf x1 `seq` ()
-        rnf (Fl x1) = rnf x1 `seq` ()
-        rnf (Ch x1) = rnf x1 `seq` ()
-        rnf (Str x1) = rnf x1 `seq` ()
-        rnf (B8 x1) = rnf x1 `seq` ()
-        rnf (B16 x1) = rnf x1 `seq` ()
-        rnf (B32 x1) = rnf x1 `seq` ()
-        rnf (B64 x1) = rnf x1 `seq` ()
-        rnf (AType x1) = rnf x1 `seq` ()
-        rnf WorldType = ()
-        rnf TheWorld = ()
-        rnf StrType = ()
-        rnf VoidType = ()
-        rnf Forgot = ()
-
-instance (NFData n) => NFData (TT n) where
-        rnf (P x1 x2 x3) = rnf x1 `seq` rnf x2 `seq` rnf x3 `seq` ()
-        rnf (V x1) = rnf x1 `seq` ()
-        rnf (Bind x1 x2 x3) = rnf x1 `seq` rnf x2 `seq` rnf x3 `seq` ()
-        rnf (App x1 x2 x3) = rnf x2 `seq` rnf x3 `seq` ()
-        rnf (Constant x1) = rnf x1 `seq` ()
-        rnf (Proj x1 x2) = rnf x1 `seq` rnf x2 `seq` ()
-        rnf Erased = ()
-        rnf Impossible = ()
-        rnf (TType x1) = rnf x1 `seq` ()
-        rnf (UType _) = ()
-
-instance NFData Accessibility where
-        rnf Public = ()
-        rnf Frozen = ()
-        rnf Hidden = ()
-        rnf Private = ()
-
-
-instance NFData Totality where
-        rnf (Total x1) = rnf x1 `seq` ()
-        rnf Productive = ()
-        rnf (Partial x1) = rnf x1 `seq` ()
-        rnf Unchecked = ()
-        rnf Generated = ()
-
-instance NFData PReason where
-        rnf (Other x1) = rnf x1 `seq` ()
-        rnf Itself = ()
-        rnf NotCovering = ()
-        rnf NotPositive = ()
-        rnf (UseUndef x1) = rnf x1 `seq` ()
-        rnf ExternalIO = ()
-        rnf BelieveMe = ()
-        rnf (Mutual x1) = rnf x1 `seq` ()
-        rnf NotProductive = ()
-
-instance NFData MetaInformation where
-        rnf EmptyMI = ()
-        rnf (DataMI x1) = rnf x1 `seq` ()
-
-instance NFData Def where
-        rnf (Function x1 x2) = rnf x1 `seq` rnf x2 `seq` ()
-        rnf (TyDecl x1 x2) = rnf x1 `seq` rnf x2 `seq` ()
-        rnf (Operator x1 x2 x3) = rnf x1 `seq` rnf x2 `seq` rnf x3 `seq` ()
-        rnf (CaseOp x1 x2 x3 x4 x5 x6)
-          = rnf x1 `seq`
-              rnf x2 `seq` rnf x3 `seq` rnf x4 `seq` rnf x5 `seq` rnf x6 `seq` ()
-
-instance NFData CaseInfo where
-        rnf (CaseInfo x1 x2 x3) = rnf x1 `seq` rnf x2 `seq` rnf x3 `seq` ()
-
-instance NFData CaseDefs where
-        rnf (CaseDefs x1 x2 x3 x4)
-          = rnf x1 `seq` rnf x2 `seq` rnf x3 `seq` rnf x4 `seq` ()
-
-instance (NFData t) => NFData (SC' t) where
-        rnf (Case _ x1 x2) = rnf x1 `seq` rnf x2 `seq` ()
-        rnf (ProjCase x1 x2) = rnf x1 `seq` rnf x2 `seq` ()
-        rnf (STerm x1) = rnf x1 `seq` ()
-        rnf (UnmatchedCase x1) = rnf x1 `seq` ()
-        rnf ImpossibleCase = ()
-
-instance (NFData t) => NFData (CaseAlt' t) where
-        rnf (ConCase x1 x2 x3 x4)
-          = x1 `seq` x2 `seq` x3 `seq` rnf x4 `seq` ()
-        rnf (FnCase x1 x2 x3) = x1 `seq` x2 `seq` rnf x3 `seq` ()
-        rnf (ConstCase x1 x2) = x1 `seq` rnf x2 `seq` ()
-        rnf (SucCase x1 x2) = x1 `seq` rnf x2 `seq` ()
-        rnf (DefaultCase x1) = rnf x1 `seq` ()
+instance NFData NameOutput
+instance NFData TextFormatting
+instance NFData Ordering
+instance NFData OutputAnnotation
+instance NFData SpecialName
+instance NFData Universe
+instance NFData Raw
+instance NFData FC
+instance NFData FC'
+instance NFData Provenance
+instance NFData UConstraint
+instance NFData ConstraintFC
+instance NFData Err
+instance NFData ErrorReportPart
+instance NFData ImplicitInfo
+instance (NFData b) => NFData (Binder b)
+instance NFData UExp
+instance NFData NameType
+instance NFData NativeTy
+instance NFData IntTy
+instance NFData ArithTy
+instance NFData Const
+instance (NFData a) => NFData (AppStatus a)
+instance (NFData n) => NFData (TT n)
+instance NFData Accessibility
+instance NFData Totality
+instance NFData PReason
+instance NFData MetaInformation
+instance NFData Def
+instance NFData CaseInfo
+instance NFData CaseDefs
+instance NFData CaseType
+instance (NFData t) => NFData (SC' t)
+instance (NFData t) => NFData (CaseAlt' t)

--- a/src/Idris/Core/Evaluate.hs
+++ b/src/Idris/Core/Evaluate.hs
@@ -6,7 +6,7 @@ License     : BSD3
 Maintainer  : The Idris Community.
 -}
 {-# LANGUAGE MultiParamTypeClasses, FlexibleInstances, BangPatterns,
-             PatternGuards #-}
+             PatternGuards, DeriveGeneric #-}
 {-# OPTIONS_GHC -fwarn-incomplete-patterns #-}
 
 module Idris.Core.Evaluate(normalise, normaliseTrace, normaliseC,
@@ -31,6 +31,7 @@ import Control.Monad.State -- not Strict!
 import qualified Data.Binary as B
 import Data.Binary hiding (get, put)
 import Data.Maybe (listToMaybe)
+import GHC.Generics (Generic)
 
 import Idris.Core.TT
 import Idris.Core.CaseTree
@@ -700,6 +701,7 @@ data Def = Function !Type !Term
                   ![Either Term (Term, Term)] -- original definition
                   ![([Name], Term, Term)] -- simplified for totality check definition
                   !CaseDefs
+  deriving Generic
 --                   [Name] SC -- Compile time case definition
 --                   [Name] SC -- Run time cae definitions
 
@@ -709,12 +711,14 @@ data CaseDefs = CaseDefs {
                   cases_inlined :: !([Name], SC),
                   cases_runtime :: !([Name], SC)
                 }
+  deriving Generic
 
 data CaseInfo = CaseInfo {
                   case_inlinable :: Bool, -- decided by machine
                   case_alwaysinline :: Bool, -- decided by %inline flag
                   tc_dictionary :: Bool
                 }
+  deriving Generic
 
 {-!
 deriving instance Binary Def
@@ -761,7 +765,7 @@ instance Show Def where
 -- Private => Programs can't access the name, doesn't reduce internally
 
 data Accessibility = Hidden | Public | Frozen | Private
-    deriving (Eq, Ord)
+    deriving (Eq, Ord, Generic)
 {-!
 deriving instance NFData Accessibility
 !-}
@@ -780,7 +784,7 @@ data Totality = Total [Int] -- ^ well-founded arguments
               | Partial PReason
               | Unchecked
               | Generated
-    deriving Eq
+    deriving (Eq, Generic)
 {-!
 deriving instance NFData Totality
 !-}
@@ -788,7 +792,7 @@ deriving instance NFData Totality
 -- | Reasons why a function may not be total
 data PReason = Other [Name] | Itself | NotCovering | NotPositive | UseUndef Name
              | ExternalIO | BelieveMe | Mutual [Name] | NotProductive
-    deriving (Show, Eq)
+    deriving (Show, Eq, Generic)
 {-!
 deriving instance NFData PReason
 !-}
@@ -825,14 +829,14 @@ deriving instance Binary PReason
 data MetaInformation =
       EmptyMI -- ^ No meta-information
     | DataMI [Int] -- ^ Meta information for a data declaration with position of parameters
-  deriving (Eq, Show)
+  deriving (Eq, Show, Generic)
 
 -- | Contexts used for global definitions and for proof state. They contain
 -- universe constraints and existing definitions.
 data Context = MkContext {
                   next_tvar       :: Int,
                   definitions     :: Ctxt (Def, Injectivity, Accessibility, Totality, MetaInformation)
-                } deriving Show
+                } deriving (Show, Generic)
 
 
 -- | The initial empty context

--- a/src/Idris/DeepSeq.hs
+++ b/src/Idris/DeepSeq.hs
@@ -1,6 +1,6 @@
 {-|
 Module      : Idris.DeepSeq
-Description : Specify how to marshall Idris' IR.
+Description : NFData instances for Idris' types
 Copyright   :
 License     : BSD3
 Maintainer  : The Idris Community.
@@ -26,322 +26,9 @@ import Control.DeepSeq
 import qualified Cheapskate.Types as CT
 import qualified Idris.Docstrings as D
 
-instance NFData a => NFData (D.Docstring a) where
-  rnf (D.DocString opts contents) = rnf opts `seq` rnf contents `seq` ()
-
+-- These types don't have Generic instances
 instance NFData CT.Options where
   rnf (CT.Options x1 x2 x3 x4) = rnf x1 `seq` rnf x2 `seq` rnf x3 `seq` rnf x4 `seq` ()
-
-instance NFData ConsoleWidth where
-  rnf InfinitelyWide = ()
-  rnf (ColsWide x) = rnf x `seq` ()
-  rnf AutomaticWidth = ()
-
-instance NFData PrimFn where
-    rnf (LPlus x) = rnf x `seq` ()
-    rnf (LMinus x) = rnf x `seq` ()
-    rnf (LTimes x) = rnf x `seq` ()
-    rnf (LUDiv x) = rnf x `seq` ()
-    rnf (LSDiv x) = rnf x `seq` ()
-    rnf (LURem x) = rnf x `seq` ()
-    rnf (LSRem x) = rnf x `seq` ()
-    rnf (LAnd x) = rnf x `seq` ()
-    rnf (LOr x) = rnf x `seq` ()
-    rnf (LXOr x) = rnf x `seq` ()
-    rnf (LCompl x) = rnf x `seq` ()
-    rnf (LSHL x) = rnf x `seq` ()
-    rnf (LLSHR x) = rnf x `seq` ()
-    rnf (LASHR x) = rnf x `seq` ()
-    rnf (LEq x) = rnf x `seq` ()
-    rnf (LLt x) = rnf x `seq` ()
-    rnf (LLe x) = rnf x `seq` ()
-    rnf (LGt x) = rnf x `seq` ()
-    rnf (LGe x) = rnf x `seq` ()
-    rnf (LSLt x) = rnf x `seq` ()
-    rnf (LSLe x) = rnf x `seq` ()
-    rnf (LSGt x) = rnf x `seq` ()
-    rnf (LSGe x) = rnf x `seq` ()
-    rnf (LSExt x1 x2) = rnf x1 `seq` rnf x2 `seq` ()
-    rnf (LZExt x1 x2) = rnf x1 `seq` rnf x2 `seq` ()
-    rnf (LTrunc x1 x2) = rnf x1 `seq` rnf x2 `seq` ()
-    rnf (LStrConcat) = ()
-    rnf (LStrLt) = ()
-    rnf (LStrEq) = ()
-    rnf (LStrLen) = ()
-    rnf (LIntFloat x) = rnf x `seq` ()
-    rnf (LFloatInt x) = rnf x `seq` ()
-    rnf (LIntStr x) = rnf x `seq` ()
-    rnf (LStrInt x) = rnf x `seq` ()
-    rnf (LFloatStr) = ()
-    rnf (LStrFloat) = ()
-    rnf (LChInt x) = rnf x `seq` ()
-    rnf (LIntCh x) = rnf x `seq` ()
-    rnf (LBitCast x1 x2) = rnf x1 `seq` rnf x2 `seq` ()
-    rnf (LFExp) = ()
-    rnf (LFLog) = ()
-    rnf (LFSin) = ()
-    rnf (LFCos) = ()
-    rnf (LFTan) = ()
-    rnf (LFASin) = ()
-    rnf (LFACos) = ()
-    rnf (LFATan) = ()
-    rnf (LFSqrt) = ()
-    rnf (LFFloor) = ()
-    rnf (LFCeil) = ()
-    rnf (LFNegate) = ()
-    rnf (LStrHead) = ()
-    rnf (LStrTail) = ()
-    rnf (LStrCons) = ()
-    rnf (LStrIndex) = ()
-    rnf (LStrRev) = ()
-    rnf (LStrSubstr) = ()
-    rnf (LReadStr) = ()
-    rnf (LWriteStr) = ()
-    rnf (LSystemInfo) = ()
-    rnf (LFork) = ()
-    rnf (LPar) = ()
-    rnf (LExternal x) = rnf x `seq` ()
-    rnf (LNoOp) = ()
-
-instance NFData SyntaxRules where
-    rnf (SyntaxRules xs) = rnf xs `seq` ()
-
-instance NFData DynamicLib where
-    rnf (Lib x _) = rnf x `seq` ()
-
-
-instance NFData Opt where
-    rnf (Filename str) = rnf  str `seq` ()
-    rnf (Quiet) = ()
-    rnf (NoBanner) = ()
-    rnf (ColourREPL bool) = rnf  bool `seq` ()
-    rnf (Idemode) = ()
-    rnf (IdemodeSocket) = ()
-    rnf (ShowLoggingCats) = ()
-    rnf (ShowLibs) = ()
-    rnf (ShowLibdir) = ()
-    rnf (ShowIncs) = ()
-    rnf (ShowPkgs) = ()
-    rnf (NoBasePkgs) = ()
-    rnf (NoPrelude) = ()
-    rnf (NoBuiltins) = ()
-    rnf (NoREPL) = ()
-    rnf (OLogging i) = rnf  i `seq` ()
-    rnf (OLogCats cs) = rnf  cs `seq` ()
-    rnf (Output str) = rnf  str `seq` ()
-    rnf (Interface) = ()
-    rnf (TypeCase) = ()
-    rnf (TypeInType) = ()
-    rnf (DefaultTotal) = ()
-    rnf (DefaultPartial) = ()
-    rnf (WarnPartial) = ()
-    rnf (WarnReach) = ()
-    rnf (EvalTypes) = ()
-    rnf (DesugarNats) = ()
-    rnf (NoCoverage) = ()
-    rnf (ErrContext) = ()
-    rnf (ShowImpl) = ()
-    rnf (Verbose) = ()
-    rnf (Port str) = rnf  str `seq` ()
-    rnf (IBCSubDir str) = rnf  str `seq` ()
-    rnf (ImportDir str) = rnf  str `seq` ()
-    rnf (PkgBuild str) = rnf  str `seq` ()
-    rnf (PkgInstall str) = rnf  str `seq` ()
-    rnf (PkgClean str) = rnf  str `seq` ()
-    rnf (PkgCheck str) = rnf  str `seq` ()
-    rnf (PkgREPL str) = rnf  str `seq` ()
-    rnf (PkgMkDoc str) = rnf  str `seq` ()
-    rnf (PkgTest str) = rnf  str `seq` ()
-    rnf (PkgIndex fp) = rnf  fp `seq` ()
-    rnf (WarnOnly) = ()
-    rnf (Pkg str) = rnf  str `seq` ()
-    rnf (BCAsm str) = rnf  str `seq` ()
-    rnf (DumpDefun str) = rnf  str `seq` ()
-    rnf (DumpCases str) = rnf  str `seq` ()
-    rnf (UseCodegen cg) = rnf  cg `seq` ()
-    rnf (CodegenArgs str) = rnf  str `seq` ()
-    rnf (OutputTy ot) = rnf  ot `seq` ()
-    rnf (Extension le) = rnf  le `seq` ()
-    rnf (InterpretScript str) = rnf  str `seq` ()
-    rnf (EvalExpr str) = rnf  str `seq` ()
-    rnf (TargetTriple str) = rnf  str `seq` ()
-    rnf (TargetCPU str) = rnf  str `seq` ()
-    rnf (OptLevel i) = rnf  i `seq` ()
-    rnf (AddOpt o) = rnf  o `seq` ()
-    rnf (RemoveOpt o) = rnf  o `seq` ()
-    rnf (Client str) = rnf  str `seq` ()
-    rnf (ShowOrigErr) = ()
-    rnf (AutoWidth) = ()
-    rnf (AutoSolve) = ()
-    rnf (UseConsoleWidth cw) = rnf  cw `seq` ()
-    rnf DumpHighlights = ()
-    rnf NoElimDeprecationWarnings = ()
-    rnf NoOldTacticDeprecationWarnings = ()
-
-
-instance NFData TIData where
-    rnf TIPartial = ()
-    rnf (TISolution xs) = rnf xs `seq` ()
-
-instance NFData IOption where
-    rnf (IOption
-         opt_logLevel
-         opt_logcats
-         opt_typecase
-         opt_typeintype
-         opt_coverage
-         opt_showimp
-         opt_errContext
-         opt_repl
-         opt_verbose
-         opt_nobanner
-         opt_quiet
-         opt_codegen
-         opt_outputTy
-         opt_ibcsubdir
-         opt_importdirs
-         opt_triple
-         opt_cpu
-         opt_cmdline
-         opt_origerr
-         opt_autoSolve
-         opt_autoImport
-         opt_optimise
-         opt_printdepth
-         opt_evaltypes
-         opt_desugarnats
-         opt_autoimpls) =
-         rnf opt_logLevel
-         `seq` rnf opt_typecase
-         `seq` rnf opt_typeintype
-         `seq` rnf opt_coverage
-         `seq` rnf opt_showimp
-         `seq` rnf opt_errContext
-         `seq` rnf opt_repl
-         `seq` rnf opt_verbose
-         `seq` rnf opt_nobanner
-         `seq` rnf opt_quiet
-         `seq` rnf opt_codegen
-         `seq` rnf opt_outputTy
-         `seq` rnf opt_ibcsubdir
-         `seq` rnf opt_importdirs
-         `seq` rnf opt_triple
-         `seq` rnf opt_cpu
-         `seq` rnf opt_cmdline
-         `seq` rnf opt_origerr
-         `seq` rnf opt_autoSolve
-         `seq` rnf opt_autoImport
-         `seq` rnf opt_optimise
-         `seq` rnf opt_printdepth
-         `seq` rnf opt_evaltypes
-         `seq` rnf opt_desugarnats
-         `seq` rnf opt_autoimpls
-         `seq` ()
-
-instance NFData LanguageExt where
-    rnf TypeProviders = ()
-    rnf ErrorReflection = ()
-
-instance NFData Optimisation where
-    rnf PETransform = ()
-
-instance NFData ColourTheme where
-    rnf (ColourTheme keywordColour
-                     boundVarColour
-                     implicitColour
-                     functionColour
-                     typeColour
-                     dataColour
-                     promptColour
-                     postulateColour) =
-        rnf keywordColour
-        `seq` rnf boundVarColour
-        `seq` rnf implicitColour
-        `seq` rnf functionColour
-        `seq` rnf typeColour
-        `seq` rnf dataColour
-        `seq` rnf promptColour
-        `seq` rnf postulateColour
-        `seq` ()
-
-instance NFData IdrisColour where
-  rnf (IdrisColour _ x2 x3 x4 x5) = rnf x2 `seq` rnf x3 `seq` rnf x4 `seq` rnf x5 `seq` ()
-
-instance NFData OutputType where
-    rnf Raw        = ()
-    rnf Object     = ()
-    rnf Executable = ()
-
-instance NFData IBCWrite where
-    rnf (IBCFix fixDecl) = rnf fixDecl `seq` ()
-    rnf (IBCImp name) = rnf name `seq` ()
-    rnf (IBCStatic name) = rnf name `seq` ()
-    rnf (IBCClass name) = rnf name `seq` ()
-    rnf (IBCInstance b1 b2 n1 n2) = rnf b1 `seq` rnf b2 `seq` rnf n1 `seq` rnf n2 `seq` ()
-    rnf (IBCDSL name) = rnf name `seq` ()
-    rnf (IBCData name) = rnf name `seq` ()
-    rnf (IBCOpt name) = rnf name `seq` ()
-    rnf (IBCMetavar name) = rnf name `seq` ()
-    rnf (IBCSyntax syntax) = rnf syntax `seq` ()
-    rnf (IBCKeyword string) = rnf string `seq` ()
-    rnf (IBCImport imp) = rnf imp `seq` ()
-    rnf (IBCImportDir filePath) = rnf filePath `seq` ()
-    rnf (IBCObj codegen filePath) = rnf codegen `seq` rnf filePath `seq` ()
-    rnf (IBCLib codegen string) = rnf codegen `seq` rnf string `seq` ()
-    rnf (IBCCGFlag codegen string) = rnf codegen `seq` rnf string `seq` ()
-    rnf (IBCDyLib string) = rnf string `seq` ()
-    rnf (IBCHeader codegen string) = rnf codegen `seq` rnf string `seq` ()
-    rnf (IBCAccess name accessibility) = rnf name `seq` rnf accessibility `seq` ()
-    rnf (IBCMetaInformation name metaInformation) = rnf name `seq` rnf metaInformation `seq` ()
-    rnf (IBCTotal name totality) = rnf name `seq` rnf totality `seq` ()
-    rnf (IBCInjective name inj) = rnf name `seq` rnf inj `seq` ()
-    rnf (IBCFlags name fnOpts) = rnf name `seq` rnf fnOpts `seq` ()
-    rnf (IBCFnInfo name fnInfo) = rnf name `seq` rnf fnInfo `seq` ()
-    rnf (IBCTrans name terms) = rnf name `seq` rnf terms `seq` ()
-    rnf (IBCErrRev terms) = rnf terms `seq` ()
-    rnf (IBCCG name) = rnf name `seq` ()
-    rnf (IBCDoc name) = rnf name `seq` ()
-    rnf (IBCCoercion name) = rnf name `seq` ()
-    rnf (IBCDef name) = rnf name `seq` ()
-    rnf (IBCNameHint names) = rnf names `seq` ()
-    rnf (IBCLineApp filePath int pTerm) = rnf filePath `seq` rnf int `seq` rnf pTerm `seq` ()
-    rnf (IBCErrorHandler name) = rnf name `seq` ()
-    rnf (IBCFunctionErrorHandler n1 n2 n3) = rnf n1 `seq` rnf n2 `seq` rnf n3 `seq` ()
-    rnf (IBCPostulate name) = rnf name `seq` ()
-    rnf (IBCExtern extern) = rnf extern `seq` ()
-    rnf (IBCTotCheckErr fc string) = rnf fc `seq` rnf string `seq` ()
-    rnf (IBCParsedRegion fc) = rnf fc `seq` ()
-    rnf (IBCModDocs name) = rnf name `seq` ()
-    rnf (IBCUsage usage) = rnf usage `seq` ()
-    rnf (IBCExport name) = rnf name `seq` ()
-    rnf (IBCAutoHint n1 n2) = rnf n1 `seq` rnf n2 `seq` ()
-    rnf (IBCDeprecate n1 n2) = rnf n1 `seq` rnf n2 `seq` ()
-    rnf (IBCRecord x) = rnf x `seq` ()
-    rnf (IBCFragile n1 n2) = rnf n1 `seq` rnf n2 `seq` ()
-    rnf (IBCConstraint n1 n2) = rnf n1 `seq` rnf n2 `seq` ()
-
-
-instance NFData a => NFData (D.Block a) where
-  rnf (D.Para lines) = rnf lines `seq` ()
-  rnf (D.Header i lines) = rnf i `seq` rnf lines `seq` ()
-  rnf (D.Blockquote bs) = rnf bs `seq` ()
-  rnf (D.List b t xs) = rnf b `seq` rnf t `seq` rnf xs `seq` ()
-  rnf (D.CodeBlock attr txt tm) = rnf attr `seq` rnf txt `seq` ()
-  rnf (D.HtmlBlock txt) = rnf txt `seq` ()
-  rnf D.HRule = ()
-
-instance NFData a => NFData (D.Inline a) where
-  rnf (D.Str txt) = rnf txt `seq` ()
-  rnf D.Space = ()
-  rnf D.SoftBreak = ()
-  rnf D.LineBreak = ()
-  rnf (D.Emph xs) = rnf xs `seq` ()
-  rnf (D.Strong xs) = rnf xs `seq` ()
-  rnf (D.Code xs tm) = rnf xs `seq` rnf tm `seq` ()
-  rnf (D.Link a b xs) = rnf a `seq` rnf b `seq` rnf xs `seq` ()
-  rnf (D.Image a b c) = rnf a `seq` rnf b `seq` rnf c `seq` ()
-  rnf (D.Entity a) = rnf a `seq` ()
-  rnf (D.RawHtml x) = rnf x `seq` ()
 
 instance NFData CT.ListType where
   rnf (CT.Bullet c) = rnf c `seq` ()
@@ -354,373 +41,65 @@ instance NFData CT.NumWrapper where
   rnf CT.PeriodFollowing = ()
   rnf CT.ParenFollowing = ()
 
-instance NFData DocTerm where
-        rnf Unchecked = ()
-        rnf (Checked x1) = rnf x1 `seq` ()
-        rnf (Example x1) = rnf x1 `seq` ()
-        rnf (Failing x1) = rnf x1 `seq` ()
+instance NFData DynamicLib where
+    rnf (Lib x _) = rnf x `seq` ()
 
--- All generated by 'derive'
+instance NFData IdrisColour where
+  rnf (IdrisColour _ x2 x3 x4 x5) = rnf x2 `seq` rnf x3 `seq` rnf x4 `seq` rnf x5 `seq` ()
 
-instance NFData SizeChange where
-        rnf Smaller = ()
-        rnf Same = ()
-        rnf Bigger = ()
-        rnf Unknown = ()
-
-instance NFData FnInfo where
-        rnf (FnInfo x1) = rnf x1 `seq` ()
-
-instance NFData Codegen where
-        rnf (Via x1 x2) = rnf x1 `seq` rnf x2 `seq` ()
-        rnf Bytecode = ()
-
-instance NFData IRFormat where
-        rnf _ = ()
-
-instance NFData LogCat where
-       rnf _ = ()
-
-instance NFData CGInfo where
-        rnf (CGInfo x1 x2 x3)
-          = rnf x1 `seq`
-              rnf x2 `seq` rnf x3 `seq` ()
-
-instance NFData Fixity where
-        rnf (Infixl x1) = rnf x1 `seq` ()
-        rnf (Infixr x1) = rnf x1 `seq` ()
-        rnf (InfixN x1) = rnf x1 `seq` ()
-        rnf (PrefixN x1) = rnf x1 `seq` ()
-
-instance NFData FixDecl where
-        rnf (Fix x1 x2) = rnf x1 `seq` rnf x2 `seq` ()
-
-instance NFData Static where
-        rnf Static = ()
-        rnf Dynamic = ()
-
-instance NFData ArgOpt where
-        rnf _ = ()
-
-instance NFData Plicity where
-        rnf (Imp x1 x2 x3 x4 x5)
-          = rnf x1 `seq` rnf x2 `seq` rnf x3 `seq` rnf x4 `seq` rnf x5 `seq` ()
-        rnf (Exp x1 x2 x3)
-          = rnf x1 `seq` rnf x2 `seq` rnf x3 `seq` ()
-        rnf (Constraint x1 x2)
-          = rnf x1 `seq` rnf x2 `seq` ()
-        rnf (TacImp x1 x2 x3)
-          = rnf x1 `seq` rnf x2 `seq` rnf x3 `seq` ()
-
-instance NFData FnOpt where
-        rnf Inlinable = ()
-        rnf TotalFn = ()
-        rnf PartialFn = ()
-        rnf CoveringFn = ()
-        rnf Coinductive = ()
-        rnf AssertTotal = ()
-        rnf Dictionary = ()
-        rnf Implicit = ()
-        rnf NoImplicit = ()
-        rnf (CExport x1) = rnf x1 `seq` ()
-        rnf ErrorHandler = ()
-        rnf ErrorReverse = ()
-        rnf Reflection = ()
-        rnf (Specialise x1) = rnf x1 `seq` ()
-        rnf Constructor = ()
-        rnf AutoHint = ()
-        rnf PEGenerated = ()
-
-instance NFData DataOpt where
-        rnf Codata = ()
-        rnf DefaultEliminator = ()
-        rnf DefaultCaseFun = ()
-        rnf DataErrRev = ()
-
-instance (NFData t) => NFData (PDecl' t) where
-        rnf (PFix x1 x2 x3) = rnf x1 `seq` rnf x2 `seq` rnf x3 `seq` ()
-        rnf (PTy x1 x2 x3 x4 x5 x6 x7 x8)
-          = rnf x1 `seq`
-              rnf x2 `seq`
-                rnf x3 `seq`
-                  rnf x4 `seq`
-                    rnf x5 `seq` rnf x6 `seq` rnf x7 `seq` rnf x8 `seq` ()
-        rnf (PPostulate x1 x2 x3 x4 x5 x6 x7 x8)
-          = rnf x1 `seq`
-              rnf x2 `seq`
-                rnf x3 `seq`
-                  rnf x4 `seq`
-                    rnf x5 `seq` rnf x6 `seq` rnf x7 `seq` rnf x8 `seq` ()
-        rnf (PClauses x1 x2 x3 x4)
-          = rnf x1 `seq` rnf x2 `seq` rnf x3 `seq` rnf x4 `seq` ()
-        rnf (PCAF x1 x2 x3) = rnf x1 `seq` rnf x2 `seq` rnf x3 `seq` ()
-        rnf (PData x1 x2 x3 x4 x5 x6)
-          = rnf x1 `seq`
-              rnf x2 `seq`
-                rnf x3 `seq` rnf x4 `seq` rnf x5 `seq` rnf x6 `seq` ()
-        rnf (PParams x1 x2 x3) = rnf x1 `seq` rnf x2 `seq` rnf x3 `seq` ()
-        rnf (POpenInterfaces x1 x2 x3) = rnf x1 `seq` rnf x2 `seq` rnf x3 `seq` ()
-        rnf (PNamespace x1 x2 x3) = rnf x1 `seq` rnf x2 `seq` rnf x3 `seq` ()
-        rnf (PRecord x1 x2 x3 x4 x5 x6 x7 x8 x9 x10 x11 x12)
-          = rnf x1 `seq`
-              rnf x2 `seq`
-                rnf x3 `seq`
-                  rnf x4 `seq`
-                    rnf x5 `seq`
-                      rnf x6 `seq`
-                        rnf x7 `seq`
-                          rnf x8 `seq`
-                            rnf x9 `seq`
-                              rnf x10 `seq` rnf x11 `seq` rnf x12 `seq` ()
-        rnf (PClass x1 x2 x3 x4 x5 x6 x8 x7 x9 x10 x11 x12)
-          = rnf x1 `seq`
-              rnf x2 `seq`
-                rnf x3 `seq`
-                  rnf x4 `seq`
-                    rnf x5 `seq`
-                      rnf x6 `seq`
-                        rnf x7 `seq`
-                          rnf x8 `seq`
-                            rnf x9 `seq`
-                              rnf x10 `seq`
-                                rnf x11 `seq` rnf x12 `seq` ()
-        rnf (PInstance x1 x2 x3 x4 x5 x6 x7 x8 x9 x10 x11 x12 x13 x14 x15)
-          = rnf x1 `seq`
-              rnf x2 `seq`
-                rnf x3 `seq`
-                  rnf x4 `seq`
-                    rnf x5 `seq`
-                      rnf x6 `seq`
-                        rnf x7 `seq`
-                          rnf x8 `seq`
-                            rnf x9 `seq` rnf x10 `seq` rnf x11 `seq` rnf x12 `seq` rnf x13 `seq` rnf x14 `seq` rnf x15 `seq` ()
-        rnf (PDSL x1 x2) = rnf x1 `seq` rnf x2 `seq` ()
-        rnf (PSyntax x1 x2) = rnf x1 `seq` rnf x2 `seq` ()
-        rnf (PMutual x1 x2) = rnf x1 `seq` rnf x2 `seq` ()
-        rnf (PDirective x1) = ()
-        rnf (PProvider x1 x2 x3 x4 x5 x6)
-          = rnf x1 `seq`
-              rnf x2 `seq`
-                rnf x3 `seq`
-                  rnf x4 `seq`
-                    rnf x5 `seq` rnf x6 `seq` ()
-        rnf (PTransform x1 x2 x3 x4)
-          = rnf x1 `seq` rnf x2 `seq` rnf x3 `seq` rnf x4 `seq` ()
-        rnf (PRunElabDecl x1 x2 x3)
-          = rnf x1 `seq` rnf x2 `seq` x3 `seq` ()
-
-instance NFData t => NFData (ProvideWhat' t)  where
-        rnf (ProvTerm ty tm)   = rnf ty `seq` rnf tm `seq` ()
-        rnf (ProvPostulate tm) = rnf tm `seq` ()
-
-instance NFData PunInfo where
-        rnf x = x `seq` ()
-
-instance (NFData t) => NFData (PClause' t) where
-        rnf (PClause x1 x2 x3 x4 x5 x6)
-          = rnf x1 `seq`
-              rnf x2 `seq` rnf x3 `seq` rnf x4 `seq` rnf x5 `seq` rnf x6 `seq` ()
-        rnf (PWith x1 x2 x3 x4 x5 x6 x7)
-          = rnf x1 `seq`
-              rnf x2 `seq` rnf x3 `seq` rnf x4 `seq` rnf x5 `seq` rnf x6 `seq` rnf x7 `seq` ()
-        rnf (PClauseR x1 x2 x3 x4)
-          = rnf x1 `seq` rnf x2 `seq` rnf x3 `seq` rnf x4 `seq` ()
-        rnf (PWithR x1 x2 x3 x4 x5)
-          = rnf x1 `seq` rnf x2 `seq` rnf x3 `seq` rnf x4 `seq` rnf x5 `seq` ()
-
-instance (NFData t) => NFData (PData' t) where
-        rnf (PDatadecl x1 x2 x3 x4)
-          = rnf x1 `seq` rnf x2 `seq` rnf x3 `seq` rnf x4 `seq` ()
-        rnf (PLaterdecl x1 x2 x3) = rnf x1 `seq` rnf x2 `seq` rnf x3 `seq` ()
-
-instance NFData PTerm where
-        rnf (PQuote x1) = rnf x1 `seq` ()
-        rnf (PRef x1 x2 x3) = rnf x1 `seq` rnf x2 `seq` x3 `seq` ()
-        rnf (PInferRef x1 x2 x3) = rnf x1 `seq` rnf x2 `seq` x3 `seq` ()
-        rnf (PPatvar x1 x2) = rnf x1 `seq` rnf x2 `seq` ()
-        rnf (PLam _ x1 x2 x3 x4) = rnf x1 `seq` rnf x2 `seq` rnf x3 `seq` rnf x4 `seq` ()
-        rnf (PPi x1 x2 x3 x4 x5)
-          = rnf x1 `seq` rnf x2 `seq` rnf x3 `seq` rnf x4 `seq` rnf x5 `seq` ()
-        rnf (PLet _ x1 x2 x3 x4 x5)
-          = rnf x1 `seq` rnf x2 `seq` rnf x3 `seq` rnf x4 `seq` rnf x5 `seq` ()
-        rnf (PTyped x1 x2) = rnf x1 `seq` rnf x2 `seq` ()
-        rnf (PAppImpl x1 x2) = rnf x1 `seq` rnf x2 `seq` ()
-        rnf (PApp x1 x2 x3) = rnf x1 `seq` rnf x2 `seq` rnf x3 `seq` ()
-        rnf (PWithApp x1 x2 x3) = rnf x1 `seq` rnf x2 `seq` rnf x3 `seq` ()
-        rnf (PAppBind x1 x2 x3) = rnf x1 `seq` rnf x2 `seq` rnf x3 `seq` ()
-        rnf (PMatchApp x1 x2) = rnf x1 `seq` rnf x2 `seq` ()
-        rnf (PCase x1 x2 x3) = rnf x1 `seq` rnf x2 `seq` rnf x3 `seq` ()
-        rnf (PIfThenElse x1 x2 x3 x4) = rnf x1 `seq` rnf x2 `seq` rnf x3 `seq` rnf x4 `seq` ()
-        rnf (PTrue x1 x2) = rnf x1 `seq` rnf x2 `seq` ()
-        rnf (PResolveTC x1) = rnf x1 `seq` ()
-        rnf (PRewrite x1 x2 x3 x4 x5)
-          = rnf x1 `seq` rnf x2 `seq` rnf x3 `seq` rnf x4 `seq` rnf x5 `seq` ()
-        rnf (PPair x1 x2 x3 x4 x5) = rnf x1 `seq` rnf x2 `seq` rnf x3 `seq` rnf x4 `seq` x5 `seq` ()
-        rnf (PDPair x1 x2 x3 x4 x5 x6)
-          = rnf x1 `seq` rnf x2 `seq` rnf x3 `seq` rnf x4 `seq` rnf x5 `seq` x6 `seq` ()
-        rnf (PAs x1 x2 x3) = rnf x1 `seq` rnf x2 `seq` rnf x3 `seq` ()
-        rnf (PAlternative x1 x2 x3) = rnf x1 `seq` rnf x2 `seq` rnf x3 `seq` ()
-        rnf (PHidden x1) = rnf x1 `seq` ()
-        rnf (PType fc) = rnf fc `seq` ()
-        rnf (PUniverse _) = ()
-        rnf (PGoal x1 x2 x3 x4)
-          = rnf x1 `seq` rnf x2 `seq` rnf x3 `seq` rnf x4 `seq` ()
-        rnf (PConstant x1 x2) = x1 `seq` x2 `seq` ()
-        rnf Placeholder = ()
-        rnf (PDoBlock x1) = rnf x1 `seq` ()
-        rnf (PIdiom x1 x2) = rnf x1 `seq` rnf x2 `seq` ()
-        rnf (PReturn x1) = rnf x1 `seq` ()
-        rnf (PMetavar x1 x2) = rnf x1 `seq` rnf x2 `seq` ()
-        rnf (PProof x1) = rnf x1 `seq` ()
-        rnf (PTactics x1) = rnf x1 `seq` ()
-        rnf (PElabError x1) = rnf x1 `seq` ()
-        rnf PImpossible = ()
-        rnf (PCoerced x1) = rnf x1 `seq` ()
-        rnf (PDisamb x1 x2) = rnf x1 `seq` rnf x2 `seq` ()
-        rnf (PUnifyLog x1) = rnf x1 `seq` ()
-        rnf (PNoImplicits x1) = rnf x1 `seq` ()
-        rnf (PQuasiquote x1 x2) = rnf x1 `seq` rnf x2 `seq` ()
-        rnf (PUnquote x1) = rnf x1 `seq` ()
-        rnf (PQuoteName x1 x2 x3) = rnf x1 `seq` rnf x2 `seq` rnf x3 `seq` ()
-        rnf (PRunElab x1 x2 x3) = rnf x1 `seq` rnf x2 `seq` rnf x3 `seq` ()
-        rnf (PConstSugar x1 x2) = rnf x1 `seq` rnf x2 `seq` ()
-
-instance NFData PAltType where
-        rnf (ExactlyOne x1) = rnf x1 `seq` ()
-        rnf FirstSuccess = ()
-        rnf TryImplicit = ()
-
-instance (NFData t) => NFData (PTactic' t) where
-        rnf (Intro x1) = rnf x1 `seq` ()
-        rnf Intros = ()
-        rnf (Focus x1) = rnf x1 `seq` ()
-        rnf (Refine x1 x2) = rnf x1 `seq` rnf x2 `seq` ()
-        rnf (Rewrite x1) = rnf x1 `seq` ()
-        rnf DoUnify = ()
-        rnf (Induction x1) = rnf x1 `seq` ()
-        rnf (CaseTac x1) = rnf x1 `seq` ()
-        rnf (Equiv x1) = rnf x1 `seq` ()
-        rnf (Claim x1 x2) = rnf x1 `seq` rnf x2 `seq` ()
-        rnf (MatchRefine x1) = rnf x1 `seq` ()
-        rnf (LetTac x1 x2) = rnf x1 `seq` rnf x2 `seq` ()
-        rnf (LetTacTy x1 x2 x3) = rnf x1 `seq` rnf x2 `seq` rnf x3 `seq` ()
-        rnf (Exact x1) = rnf x1 `seq` ()
-        rnf Compute = ()
-        rnf Trivial = ()
-        rnf TCInstance = ()
-        rnf (ProofSearch r r1 r2 x1 x2 x3)
-          = rnf x1 `seq` rnf x2 `seq` rnf x3 `seq` ()
-        rnf Solve = ()
-        rnf Attack = ()
-        rnf ProofState = ()
-        rnf ProofTerm = ()
-        rnf Undo = ()
-        rnf (Try x1 x2) = rnf x1 `seq` rnf x2 `seq` ()
-        rnf (TSeq x1 x2) = rnf x1 `seq` rnf x2 `seq` ()
-        rnf (ApplyTactic x1) = rnf x1 `seq` ()
-        rnf (ByReflection x1) = rnf x1 `seq` ()
-        rnf (Reflect x1) = rnf x1 `seq` ()
-        rnf (Fill x1) = rnf x1 `seq` ()
-        rnf (GoalType x1 x2) = rnf x1 `seq` rnf x2 `seq` ()
-        rnf Qed = ()
-        rnf Abandon = ()
-        rnf (TCheck x1) = rnf x1 `seq` ()
-        rnf (TEval x1) = rnf x1 `seq` ()
-        rnf (TDocStr x1) = x1 `seq` ()
-        rnf (TSearch x1) = rnf x1 `seq` ()
-        rnf Skip = ()
-        rnf (TFail x1) = rnf x1 `seq` ()
-        rnf SourceFC = ()
-        rnf Unfocus = ()
-
-instance (NFData t) => NFData (PDo' t) where
-        rnf (DoExp x1 x2) = rnf x1 `seq` rnf x2 `seq` ()
-        rnf (DoBind x1 x2 x3 x4) = rnf x1 `seq` rnf x2 `seq` rnf x3 `seq` rnf x4 `seq` ()
-        rnf (DoBindP x1 x2 x3 x4) = rnf x1 `seq` rnf x2 `seq` rnf x3 `seq` rnf x4 `seq` ()
-        rnf (DoLet x1 x2 x3 x4 x5)
-          = rnf x1 `seq` rnf x2 `seq` rnf x3 `seq` rnf x4 `seq` rnf x5 `seq` ()
-        rnf (DoLetP x1 x2 x3) = rnf x1 `seq` rnf x2 `seq` rnf x3 `seq` ()
-
-instance (NFData t) => NFData (PArg' t) where
-        rnf (PImp x1 x2 x3 x4 x5)
-          = rnf x1 `seq` rnf x2 `seq` rnf x3 `seq` rnf x4 `seq` rnf x5 `seq` ()
-        rnf (PExp x1 x2 x3 x4)
-          = rnf x1 `seq` rnf x2 `seq` rnf x3 `seq` rnf x4 `seq` ()
-        rnf (PConstraint x1 x2 x3 x4)
-          = rnf x1 `seq` rnf x2 `seq` rnf x3 `seq` rnf x4 `seq` ()
-        rnf (PTacImplicit x1 x2 x3 x4 x5)
-          = rnf x1 `seq`
-              rnf x2 `seq` rnf x3 `seq` rnf x4 `seq` rnf x5 `seq` ()
-
-instance NFData ClassInfo where
-        rnf (CI x1 x2 x3 x4 x5 x6 x7)
-          = rnf x1 `seq`
-              rnf x2 `seq` rnf x3 `seq` rnf x4 `seq` rnf x5 `seq` rnf x6 `seq` rnf x7 `seq` ()
-
-instance NFData RecordInfo where
-        rnf (RI x1 x2 x3)
-          = rnf x1 `seq` rnf x2 `seq` rnf x3 `seq` ()
-
-instance NFData OptInfo where
-        rnf (Optimise x1 x2)
-          = rnf x1 `seq` rnf x2 `seq` ()
-
-instance NFData TypeInfo where
-        rnf (TI x1 x2 x3 x4 x5) = rnf x1 `seq` rnf x2 `seq` rnf x3 `seq` rnf x4 `seq` rnf x5 `seq` ()
-
-instance (NFData t) => NFData (DSL' t) where
-        rnf (DSL x1 x2 x3 x4 x5 x6 x7 x8 x9 x10)
-          = rnf x1 `seq`
-              rnf x2 `seq`
-                rnf x3 `seq`
-                  rnf x4 `seq`
-                    rnf x5 `seq`
-                      rnf x6 `seq` rnf x7 `seq` rnf x8 `seq` rnf x9 `seq` rnf x10 `seq` ()
-
-instance NFData SynContext where
-        rnf PatternSyntax = ()
-        rnf TermSyntax = ()
-        rnf AnySyntax = ()
-
-instance NFData Syntax where
-        rnf (Rule x1 x2 x3) = rnf x1 `seq` rnf x2 `seq` rnf x3 `seq` ()
-        rnf (DeclRule x1 x2) = rnf x1 `seq` rnf x2 `seq` ()
-
-instance NFData SSymbol where
-        rnf (Keyword x1) = rnf x1 `seq` ()
-        rnf (Symbol x1) = rnf x1 `seq` ()
-        rnf (Binding x1) = rnf x1 `seq` ()
-        rnf (Expr x1) = rnf x1 `seq` ()
-        rnf (SimpleExpr x1) = rnf x1 `seq` ()
-
-instance NFData Using where
-        rnf (UImplicit x1 x2) = rnf x1 `seq` rnf x2 `seq` ()
-        rnf (UConstraint x1 x2) = rnf x1 `seq` rnf x2 `seq` ()
-
-instance NFData SyntaxInfo where
-        rnf (Syn x1 x2 x3 x4 x5 x6 x7 x8 x9 x10 x11 x12 x13 x14 x15)
-          = rnf x1 `seq`
-              rnf x2 `seq`
-                rnf x3 `seq`
-                  rnf x4 `seq`
-                    rnf x5 `seq`
-                      rnf x6 `seq` rnf x7 `seq` rnf x8 `seq` rnf x9 `seq` rnf x10 `seq` rnf x11 `seq` rnf x12 `seq` rnf x13 `seq` rnf x14 `seq` rnf x15 `seq` ()
-
+-- Handle doesn't have an NFData instance
 instance NFData OutputMode where
-  rnf (RawOutput x) = () -- no instance for Handle, so this is a bit wrong
+  rnf (RawOutput x) = ()
   rnf (IdeMode x y) = rnf x `seq` ()
 
-instance NFData DefaultTotality where
-  rnf DefaultCheckingTotal = ()
-  rnf DefaultCheckingPartial = ()
-  rnf DefaultCheckingCovering = ()
-
-instance NFData IState where
-  rnf (IState x1 x2 x3 x4 x5 x6 x7 x8 x9 x10 x11 x12 x13 x14 x15 x16 x17 x18 x19 x20
-              x21 x22 x23 x24 x25 x26 x27 x28 x29 x30 x31 x32 x33 x34 x35 x36 x37 x38 x39 x40
-              x41 x42 x43 x44 x45 x46 x47 x48 x49 x50 x51 x52 x53 x54 x55 x56 x57 x58 x59 x60
-              x61 x62 x63 x64 x65 x66 x67 x68 x69 x70 x71 x72 x73 x74 x75 x76 x77)
-     = rnf x1 `seq` rnf x2 `seq` rnf x3 `seq` rnf x4 `seq` rnf x5 `seq` rnf x6 `seq` rnf x7 `seq` rnf x8 `seq` rnf x9 `seq` rnf x10 `seq` () `seq` rnf x11 `seq` rnf x12 `seq` rnf x13 `seq` rnf x14 `seq` rnf x15 `seq` rnf x16 `seq` rnf x17 `seq` rnf x18 `seq` rnf x19 `seq` rnf x20 `seq`
-       rnf x21 `seq` rnf x22 `seq` rnf x23 `seq` rnf x24 `seq` rnf x25 `seq` rnf x26 `seq` rnf x27 `seq` rnf x28 `seq` rnf x29 `seq` rnf x30 `seq` rnf x31 `seq` rnf x32 `seq` rnf x33 `seq` rnf x34 `seq` rnf x35 `seq` rnf x36 `seq` rnf x37 `seq` rnf x38 `seq` rnf x39 `seq` rnf x40 `seq`
-       rnf x41 `seq` rnf x42 `seq` rnf x43 `seq` rnf x44 `seq` rnf x45 `seq` rnf x46 `seq` rnf x47 `seq` rnf x48 `seq` rnf x49 `seq` rnf x50 `seq` rnf x51 `seq` rnf x52 `seq` rnf x53 `seq` rnf x54 `seq` rnf x55 `seq` rnf x56 `seq` rnf x57 `seq` rnf x58 `seq` rnf x59 `seq` rnf x60 `seq`
-       rnf x61 `seq` rnf x62 `seq` rnf x63 `seq` rnf x64 `seq` rnf x65 `seq` rnf x66 `seq` rnf x67 `seq` rnf x68 `seq` rnf x69 `seq` rnf x70 `seq` rnf x71 `seq` rnf x72 `seq` rnf x73 `seq` rnf x74 `seq` rnf x75 `seq` rnf x76 `seq` rnf x77 `seq` ()
+instance NFData a => NFData (D.Docstring a)
+instance NFData ConsoleWidth
+instance NFData PrimFn
+instance NFData SyntaxRules
+instance NFData Opt
+instance NFData TIData
+instance NFData IOption
+instance NFData LanguageExt
+instance NFData Optimisation
+instance NFData ColourTheme
+instance NFData OutputType
+instance NFData IBCWrite
+instance NFData a => NFData (D.Block a)
+instance NFData a => NFData (D.Inline a)
+instance NFData DocTerm
+instance NFData SizeChange
+instance NFData FnInfo
+instance NFData Codegen
+instance NFData IRFormat
+instance NFData LogCat
+instance NFData CGInfo
+instance NFData Fixity
+instance NFData FixDecl
+instance NFData Static
+instance NFData ArgOpt
+instance NFData Plicity
+instance NFData FnOpt
+instance NFData DataOpt
+instance NFData Directive
+instance (NFData t) => NFData (PDecl' t)
+instance NFData t => NFData (ProvideWhat' t)
+instance NFData PunInfo
+instance (NFData t) => NFData (PClause' t)
+instance (NFData t) => NFData (PData' t)
+instance NFData PTerm
+instance NFData PAltType
+instance (NFData t) => NFData (PTactic' t)
+instance (NFData t) => NFData (PDo' t)
+instance (NFData t) => NFData (PArg' t)
+instance NFData ClassInfo
+instance NFData RecordInfo
+instance NFData OptInfo
+instance NFData TypeInfo
+instance (NFData t) => NFData (DSL' t)
+instance NFData SynContext
+instance NFData Syntax
+instance NFData SSymbol
+instance NFData Using
+instance NFData SyntaxInfo
+instance NFData DefaultTotality
+instance NFData IState

--- a/src/Idris/Docstrings.hs
+++ b/src/Idris/Docstrings.hs
@@ -6,7 +6,7 @@ License     : BSD3
 Maintainer  : The Idris Community.
 -}
 
-{-# LANGUAGE DeriveFunctor, ScopedTypeVariables #-}
+{-# LANGUAGE DeriveFunctor, DeriveGeneric, ScopedTypeVariables #-}
 {-# OPTIONS_GHC -fwarn-incomplete-patterns #-}
 module Idris.Docstrings (
     Docstring(..), Block(..), Inline(..), parseDocstring, renderDocstring
@@ -30,7 +30,7 @@ import Data.Foldable (Foldable)
 import Data.Traversable (Traversable)
 import qualified Data.Sequence as S
 
-import Control.DeepSeq (NFData(..))
+import GHC.Generics (Generic)
 
 import Text.Blaze.Html (Html)
 
@@ -39,7 +39,7 @@ data DocTerm = Unchecked
              | Checked Term
              | Example Term
              | Failing Err
-  deriving Show
+  deriving (Show, Generic)
 
 -- | Render a term in the documentation
 renderDocTerm :: (Term -> Doc OutputAnnotation) -> (Term -> Term) -> DocTerm -> String -> Doc OutputAnnotation
@@ -53,7 +53,7 @@ renderDocTerm pp norm (Failing err) src = annotate (AnnErr err) $ text src
 -- | Representation of Idris's inline documentation. The type paramter
 -- represents the type of terms that are associated with code blocks.
 data Docstring a = DocString CT.Options (Blocks a)
-  deriving (Show, Functor, Foldable, Traversable)
+  deriving (Show, Functor, Foldable, Traversable, Generic)
 
 type Blocks a = S.Seq (Block a)
 
@@ -65,7 +65,7 @@ data Block a = Para (Inlines a)
              | CodeBlock CT.CodeAttr T.Text a
              | HtmlBlock T.Text
              | HRule
-             deriving (Show, Functor, Foldable, Traversable)
+             deriving (Show, Functor, Foldable, Traversable, Generic)
 
 data Inline a = Str T.Text
               | Space
@@ -78,7 +78,7 @@ data Inline a = Str T.Text
               | Image (Inlines a) T.Text T.Text
               | Entity T.Text
               | RawHtml T.Text
-              deriving (Show, Functor, Foldable, Traversable)
+              deriving (Show, Functor, Foldable, Traversable, Generic)
 
 type Inlines a = S.Seq (Inline a)
 


### PR DESCRIPTION
This gets rid of a lot of code. Much of it was generated with
the "derive" tool, but some of it wasn't. I tested compilation speed
by compiling the benchmarks with bench[1] and there was no
statistically significant difference.

[1]: https://github.com/Gabriel439/bench