### PR TITLE
Use older process for GHC 7.6 and 7.8

### DIFF
--- a/idris.cabal
+++ b/idris.cabal
@@ -1050,7 +1050,6 @@ Library
                 , optparse-applicative >= 0.11 && < 0.13
                 , parsers >= 0.9 && < 0.13
                 , pretty < 1.2
-                , process < 1.5
                 , split < 0.3
                 , terminal-size < 0.4
                 , text >=1.2.1.0 && < 1.3
@@ -1068,9 +1067,14 @@ Library
                 , fsnotify >= 0.2 && < 2.2
                 , async < 2.2
 
+
   -- zlib >= 0.6.1 is broken with GHC < 7.10.3
+  -- Travis is broken for 7.6 and 7.8 with a newer process
   if impl(ghc < 7.10.3)
      build-depends: zlib < 0.6.1
+                  , process < 1.3
+  else
+     build-depends: process < 1.5
 
   Extensions:     MultiParamTypeClasses
                 , DeriveFoldable


### PR DESCRIPTION
cabal config crashes on travis otherwise