### PR TITLE
Allow CDATA to be copied to other VMs

### DIFF
--- a/rts/idris_rts.c
+++ b/rts/idris_rts.c
@@ -792,6 +792,9 @@ VAL doCopyTo(VM* vm, VAL x) {
     case CT_MANAGEDPTR:
         cl = MKMPTRc(vm, x->info.mptr->data, x->info.mptr->size);
         break;
+    case CT_CDATA:
+        cl = MKCDATAc(vm, x->info.c_heap_item);
+        break;
     case CT_BITS8:
         cl = idris_b8CopyForGC(vm, x);
         break;


### PR DESCRIPTION
When using `fork` with access to a CData reference, the RTS will panic
on the assertion that it was unable to match the type of the closure in
doCopyTo. This is because of a missing case for CData.

This change copies the paradigm for other type tags of Closures for
CData.