### PR TITLE
Travis twiddling

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -9,7 +9,7 @@ addons:
     packages:
       - ghc-7.6.3
       - ghc-7.8.4
-      - ghc-7.10.2
+      - ghc-7.10.3
       - ghc-8.0.1
       - cabal-install-1.20
       - cabal-install-1.22
@@ -25,18 +25,14 @@ matrix:
       # separate caches for different compiler versions
       # until https://github.com/travis-ci/travis-ci/issues/4393 is resolved
       compiler: ": #GHC 7.6.3"
-    - env: CABALVER="1.20" GHCVER="7.8.4" TESTS="lib_doc doc"
-      compiler: ": #GHC 7.8.4"
-    - env: CABALVER="1.20" GHCVER="7.8.4" TESTS="test_js"
-      compiler: ": #GHC 7.8.4"
     - env: CABALVER="1.20" GHCVER="7.8.4" TESTS="test_c"
       compiler: ": #GHC 7.8.4"
-    - env: CABALVER="1.22" GHCVER="7.10.2" TESTS="lib_doc doc"
-      compiler: ": #GHC 7.10.2"
-    - env: CABALVER="1.22" GHCVER="7.10.2" TESTS="test_js"
-      compiler: ": #GHC 7.10.2"
-    - env: CABALVER="1.22" GHCVER="7.10.2" TESTS="test_c"
-      compiler: ": #GHC 7.10.2"
+    - env: CABALVER="1.22" GHCVER="7.10.3" TESTS="lib_doc doc"
+      compiler: ": #GHC 7.10.3"
+    - env: CABALVER="1.22" GHCVER="7.10.3" TESTS="test_js"
+      compiler: ": #GHC 7.10.3"
+    - env: CABALVER="1.22" GHCVER="7.10.3" TESTS="test_c"
+      compiler: ": #GHC 7.10.3"
     - env: CABALVER="1.24" GHCVER="8.0.1" TESTS="lib_doc doc"
       compiler: ": #GHC 8.0.1"
     - env: CABALVER="1.24" GHCVER="8.0.1" TESTS="test_js"


### PR DESCRIPTION
Reduce the number of Travis targets, by just building one for 7.8.

Use the latest point release of 7.10, 7.10.3.

Spare GHC 7.6, it still works and it's what's in Debian.