### PR TITLE
testPkg exits with the wrapped tests exit code

### DIFF
--- a/main/Main.hs
+++ b/main/Main.hs
@@ -1,5 +1,11 @@
 module Main where
 
+import System.Exit ( ExitCode(..), exitWith, exitSuccess )
+
+import Control.Monad ( unless, when, (>=>) )
+import Data.Maybe    ( fromMaybe )
+import Data.Foldable ( foldrM )
+
 import Idris.AbsSyntax
 import Idris.CmdOptions
 import Idris.Error
@@ -9,8 +15,8 @@ import Idris.Package
 
 import Util.System (setupBundledCC)
 
-import Control.Monad (when)
-import System.Exit (exitSuccess)
+import Util.System ( setupBundledCC )
+import System.Exit ( ExitCode(..), exitWith)
 
 processShowOptions :: [Opt] -> Idris ()
 processShowOptions opts = runIO $ do
@@ -49,7 +55,13 @@ processPackageOptions opts = do
   check opts getPkgMkDoc $ \fs -> runIO $ do
     mapM_ (documentPkg opts) fs
   check opts getPkgTest $ \fs -> runIO $ do
-    mapM_ (testPkg opts) fs
+
+    codes <- mapM (testPkg opts) fs
+    -- check if any of the tests exited with an exit code other
+    -- than zero; if they did, exit with exit code 1
+    unless (null $ filter (/= ExitSuccess) codes) $
+       exitWith (ExitFailure 1)
+
   check opts getPkg $ \fs -> runIO $ do
     mapM_ (buildPkg opts (WarnOnly `elem` opts)) fs
   check opts getPkgREPL $ \fs -> case fs of


### PR DESCRIPTION
It's fairly common to use exit codes to report test status, but the
`testPkg` function exits with a success code regardless of how the test
functions wrapped in the temporary module exit if they type check.

This code retains the exit code returned from the call to `rawSystem`,
and exits the test function with the same exit code, allowing tests to
call `exit 1` to report their error code to their parent processes.
