### PR TITLE
Fixes #3264 Show auto implicit documentaton in Idris Doc.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -26,6 +26,11 @@
 * The File Effect has been updated to take into account changes in
   `Prelude.File` and to provide a 'better' API.
 
+## Tool updates
+
+* Idris' documentation system now displays the documentation for auto
+  implicits in the output of `:doc`. This is tested for in `docs005`.
+
 # New in 0.12:
 
 ## Language updates

--- a/idris.cabal
+++ b/idris.cabal
@@ -858,6 +858,15 @@ Extra-source-files:
                        test/docs003/input
                        test/docs003/*.idr
                        test/docs003/expected
+                       test/docs004/run
+                       test/docs004/input
+                       test/docs004/*.idr
+                       test/docs004/expected
+                       test/docs005/run
+                       test/docs005/input
+                       test/docs005/*.idr
+                       test/docs005/expected
+
 
                        benchmarks/ALL
                        benchmarks/*.pl

--- a/test/docs005/docs005.idr
+++ b/test/docs005/docs005.idr
@@ -1,0 +1,19 @@
+module docs005
+
+import Data.List
+
+%default total
+
+||| A foobar with an auto implicit
+data Foobar : Type where
+  ||| New Foo
+  |||
+  ||| @xs Some `xs`
+  ||| @ys Some `ys`
+  ||| @prf The prf
+  ||| @prf1 A prf
+  NewFoo : (xs : List String)
+        -> (ys : List Nat)
+        -> {prf1 : NonEmpty xs}
+        -> {auto prf : NonEmpty ys}
+        -> Foobar

--- a/test/docs005/expected
+++ b/test/docs005/expected
@@ -1,0 +1,29 @@
+Data type docs005.Foobar : Type
+    A foobar with an auto implicit
+    
+Constructors:
+    NewFoo : (xs : List String) ->
+        (ys : List Nat) -> {auto prf : NonEmpty ys} -> Foobar
+        New Foo
+        Arguments:
+            xs : List String  -- Some xs
+            
+            ys : List Nat  -- Some ys
+            
+            (implicit) prf1 : NonEmpty xs  -- A prf
+            
+            (auto implicit) prf : NonEmpty ys  -- The prf
+            
+docs005.NewFoo : (xs : List String) ->
+    (ys : List Nat) -> {auto prf : NonEmpty ys} -> Foobar
+    New Foo
+    Arguments:
+        xs : List String  -- Some xs
+        
+        ys : List Nat  -- Some ys
+        
+        (implicit) prf1 : NonEmpty xs  -- A prf
+        
+        (auto implicit) prf : NonEmpty ys  -- The prf
+        
+    The function is Total

--- a/test/docs005/input
+++ b/test/docs005/input
@@ -1,0 +1,2 @@
+:doc Foobar
+:doc NewFoo

--- a/test/docs005/run
+++ b/test/docs005/run
@@ -1,0 +1,3 @@
+#!/usr/bin/env bash
+${IDRIS:-idris} --quiet --nocolor docs005.idr < input
+rm *.ibc


### PR DESCRIPTION
This commit also adds `docs004` to the cabal list. It was missing for some reason.