### PR TITLE
A test for lines/unlines.

### DIFF
--- a/idris.cabal
+++ b/idris.cabal
@@ -615,6 +615,10 @@ Extra-source-files:
                        test/meta004/*.idr
                        test/meta004/expected
 
+                       test/prelude001/expected
+                       test/prelude001/prelude001.idr
+                       test/prelude001/run
+
                        test/primitives001/run
                        test/primitives001/*.idr
                        test/primitives001/expected

--- a/test/TestData.hs
+++ b/test/TestData.hs
@@ -168,6 +168,8 @@ testFamiliesData = [
       (  2, ANY  ),
       (  3, ANY  ),
       (  4, ANY  )]),
+  ("prelude",         "Prelude",
+    [ (  1, ANY  )]),
   ("primitives",      "Primitive types",
     [ (  1, ANY  ),
       (  2, ANY  ),

--- a/test/prelude001/expected
+++ b/test/prelude001/expected
@@ -1,0 +1,10 @@
+True
+True
+True
+True
+True
+True
+True
+True
+True
+True

--- a/test/prelude001/prelude001.idr
+++ b/test/prelude001/prelude001.idr
@@ -1,0 +1,17 @@
+module Main
+
+main : IO ()
+main = do
+  printLn $ lines "" == []
+  -- `lines` seems to ignore too many trailing newlines.
+  printLn $ lines "\n" == [] -- FIXME: Should be [""].
+  printLn $ lines "\n\n" == [] -- FIXME: Should be ["", ""].
+  printLn $ lines "\n\n\n" == [] -- FIXME: Should be ["", "", ""].
+  printLn $ lines "1\n2\n3" == ["1", "2", "3"]
+  printLn $ lines "1\n2\n3\n" == ["1", "2", "3"]
+  printLn $ unlines [] == ""
+  -- `unlines` works as advertised doesn't follow Haskell here.
+  -- When files are written using unlines, vim complains of "noeoln".
+  printLn $ unlines ["1"] == "1" -- FIXME: Should be "1\n"
+  printLn $ unlines ["1", "2"] == "1\n2" -- FIXME: Should be "1\n2\n"
+  printLn $ unlines ["1", "2", "3"] == "1\n2\n3" -- FIXME: Should be "1\n2\n3\n"

--- a/test/prelude001/run
+++ b/test/prelude001/run
@@ -1,0 +1,4 @@
+#!/usr/bin/env bash
+${IDRIS:-idris} $@ prelude001.idr -o prelude001
+./prelude001
+rm -f prelude001 *.ibc


### PR DESCRIPTION
A test for the current behaviour of `lines` and `unlines` which I believe to be incorrect (or at least misleading). I've raised an issue about this: #3278.

Note that this can be merged as-is as it tests the current behaviour of `lines` and `unlines`. However, I'm happy to work it into a fix for the issue.