### PR TITLE
Do not append "libs" to "objs" when parsing "objs".

### DIFF
--- a/src/Pkg/PParser.hs
+++ b/src/Pkg/PParser.hs
@@ -184,7 +184,7 @@ pClause = do reserved "executable"; lchar '=';
       <|> do reserved "objs"; lchar '=';
              ls <- sepBy1 (fst <$> identifier) (lchar ',')
              st <- get
-             put (st { objs = libdeps st ++ ls })
+             put (st { objs = objs st ++ ls })
 
       <|> do reserved "makefile"; lchar '=';
              mk <- fst <$> iName []


### PR DESCRIPTION
This is a little fix for the ipkg parser. Currently you run into trouble when your "libs" are specified before your "objs" (because the parser appends "libs" instead of "objs"). Looks like a copy/paste slip up.