### PR TITLE
use Double instead of Float in docs

### DIFF
--- a/docs/faq/faq.rst
+++ b/docs/faq/faq.rst
@@ -198,7 +198,7 @@ cannot be specified explicitly. The REPL command ``:type Type 1`` will
 result in an error, as will attempting to specify the universe level
 of any type.
 
-Why does Idris use ``Float`` and ``Double`` instead of ``Float32`` and ``Float64``?
+Why does Idris use ``Double`` instead of ``Float64``?
 ===================================================================================
 
 Historically the C language and many other languages have used the
@@ -212,8 +212,8 @@ the size is described in the type name.
 
 Due to developer familiarity with the older naming convention, and
 choice by the developers of Idris, Idris uses the C style convention.
-That is, the names ``Float`` and ``Double`` are used to describe
-single and double precision numbers.
+That is, the name ``Double`` is used to describe double precision
+numbers, and Idris does not support 32 bit floats at present.
 
 What is -ffreestanding?
 =======================

--- a/docs/reference/ffi.rst
+++ b/docs/reference/ffi.rst
@@ -341,7 +341,7 @@ follows:
 
       data JS_Types : Type -> Type where
            JS_Str   : JS_Types String
-           JS_Float : JS_Types Float
+           JS_Float : JS_Types Double
            JS_Ptr   : JS_Types Ptr
            JS_Unit  : JS_Types ()
            JS_FnT   : JS_FnTypes a -> JS_Types (JsFn a)

--- a/docs/reference/repl.rst
+++ b/docs/reference/repl.rst
@@ -367,7 +367,7 @@ some string, and prints the results. For example:
 
     prim__eqChar : Char -> Char -> Int
 
-    prim__eqFloat : Float -> Float -> Int
+    prim__eqFloat : Double -> Double -> Int
 
     prim__eqInt : Int -> Int -> Int
 

--- a/docs/tutorial/interfaces.rst
+++ b/docs/tutorial/interfaces.rst
@@ -6,7 +6,7 @@ Interfaces
 
 We often want to define functions which work across several different
 data types. For example, we would like arithmetic operators to work on
-``Int``, ``Integer`` and ``Float`` at the very least. We would like
+``Int``, ``Integer`` and ``Double`` at the very least. We would like
 ``==`` to work on the majority of data types. We would like to be able
 to display different types in a uniform way.
 

--- a/docs/tutorial/miscellany.rst
+++ b/docs/tutorial/miscellany.rst
@@ -151,7 +151,7 @@ function:
 
     interpFTy : FTy -> Type
     interpFTy FInt    = Int
-    interpFTy FFloat  = Float
+    interpFTy FFloat  = Double
     interpFTy FChar   = Char
     interpFTy FString = String
     interpFTy FPtr    = Ptr
@@ -237,7 +237,7 @@ command or the ``%dynamic`` directive. For example:
 
     Idris> :dynamic libm.so
     Idris> :x unsafePerformIO ((mkForeign (FFun "sin" [FFloat] FFloat)) 1.6)
-    0.9995736030415051 : Float
+    0.9995736030415051 : Double
 
 Type Providers
 ==============

--- a/docs/tutorial/syntax.rst
+++ b/docs/tutorial/syntax.rst
@@ -73,7 +73,7 @@ bound is below the upper bound using ``so``:
 .. code-block:: idris
 
     data Interval : Type where
-       MkInterval : (lower : Float) -> (upper : Float) ->
+       MkInterval : (lower : Double) -> (upper : Double) ->
                     so (lower < upper) -> Interval
 
 We can define a syntax which, in patterns, always matches ``oh`` for

--- a/docs/tutorial/typesfuns.rst
+++ b/docs/tutorial/typesfuns.rst
@@ -8,7 +8,7 @@ Primitive Types
 ===============
 
 Idris defines several primitive types: ``Int``, ``Integer`` and
-``Float`` for numeric operations, ``Char`` and ``String`` for text
+``Double`` for numeric operations, ``Char`` and ``String`` for text
 manipulation, and ``Ptr`` which represents foreign pointers. There are
 also several data types declared in the library, including ``Bool``,
 with values ``True`` and ``False``. We can declare some constants with


### PR DESCRIPTION
since `Float` is deprecated in futher versions of Idris, maybe we should fix it use `Double` on the doc instead of catalysing some misunderstanding.

```
Use of deprecated name Float
```