### PR TITLE
Improvements to iPKG code.

### DIFF
--- a/idris.cabal
+++ b/idris.cabal
@@ -1042,7 +1042,9 @@ Library
                 , IRTS.Simplified
                 , IRTS.System
 
-                , Pkg.Package
+                , Idris.Package
+                , Idris.Package.Common
+
                 , Util.DynamicLinker
                 , Util.ScreenSize
                 , Util.System
@@ -1051,7 +1053,7 @@ Library
                   Util.Pretty
                 , Util.Net
 
-                , Pkg.PParser
+                , Idris.Package.Parser
 
                 -- Auto Generated
                 , Paths_idris

--- a/main/Main.hs
+++ b/main/Main.hs
@@ -10,11 +10,13 @@ import Idris.Imports
 import Idris.Error
 import Idris.CmdOptions
 
+import Idris.Package
+
 import IRTS.System ( getLibFlags, getIdrisLibDir, getIncFlags )
 
 import Util.System ( setupBundledCC )
 
-import Pkg.Package
+
 
 -- Main program reads command line options, parses the main program, and gets
 -- on with the REPL.

--- a/src/Idris/Package.hs
+++ b/src/Idris/Package.hs
@@ -1,12 +1,12 @@
 {-|
-Module      : Pkg.Package
+Module      : Idris.Package
 Description : Functionality for working with Idris packages.
 Copyright   :
 License     : BSD3
 Maintainer  : The Idris Community.
 -}
 {-# LANGUAGE CPP #-}
-module Pkg.Package where
+module Idris.Package where
 
 import System.Process
 import System.Directory
@@ -38,7 +38,8 @@ import Idris.Output
 import Idris.Imports
 import Idris.Error (ifail)
 
-import Pkg.PParser
+import Idris.Package.Common
+import Idris.Package.Parser
 
 import IRTS.System
 
@@ -48,6 +49,9 @@ import IRTS.System
 -- * invoke the makefile if there is one
 -- * invoke idris on each module, with idris_opts
 -- * install everything into datadir/pname, if install flag is set
+
+getPkgDesc :: FilePath -> IO PkgDesc
+getPkgDesc = parseDesc
 
 --  --------------------------------------------------------- [ Build Packages ]
 

--- a/src/Idris/Package/Common.hs
+++ b/src/Idris/Package/Common.hs
@@ -1,0 +1,42 @@
+{-|
+Module      : Idris.Package.Common
+Description : Data structures common to all `iPKG` file formats.
+Copyright   :
+License     : BSD3
+Maintainer  : The Idris Community.
+-}
+module Idris.Package.Common where
+
+import Idris.Core.TT
+import Idris.REPL
+import Idris.AbsSyntaxTree
+
+-- | Description of an Idris package.
+data PkgDesc = PkgDesc {
+    pkgname       :: String       -- ^ Name associated with a package.
+  , pkgdeps       :: [String]     -- ^ List of packages this package depends on.
+  , pkgbrief      :: Maybe String -- ^ Brief description of the package.
+  , pkgversion    :: Maybe String -- ^ Version string to associate with the package.
+  , pkgreadme     :: Maybe String -- ^ Location of the README file.
+  , pkglicense    :: Maybe String -- ^ Description of the licensing information.
+  , pkgauthor     :: Maybe String -- ^ Author information.
+  , pkgmaintainer :: Maybe String -- ^ Maintainer information.
+  , pkghomepage   :: Maybe String -- ^ Website associated with the package.
+  , pkgsourceloc  :: Maybe String -- ^ Location of the source files.
+  , pkgbugtracker :: Maybe String -- ^ Location of the project's bug tracker.
+  , libdeps       :: [String]     -- ^ External dependencies.
+  , objs          :: [String]     -- ^ Object files required by the package.
+  , makefile      :: Maybe String -- ^ Makefile used to build external code. Used as part of the FFI process.
+  , idris_opts    :: [Opt]        -- ^ List of options to give the compiler.
+  , sourcedir     :: String       -- ^ Source directory for Idris files.
+  , modules       :: [Name]       -- ^ Modules provided by the package.
+  , idris_main    :: Name         -- ^ If an executable in which module can the Main namespace and function be found.
+  , execout       :: Maybe String -- ^ What to call the executable.
+  , idris_tests   :: [Name]       -- ^ Lists of tests to execute against the package.
+  } deriving (Show)
+
+-- | Default settings for package descriptions.
+defaultPkg :: PkgDesc
+defaultPkg = PkgDesc "" [] Nothing Nothing Nothing Nothing
+                        Nothing Nothing Nothing Nothing
+                        Nothing [] [] Nothing [] "" [] (sUN "") Nothing []

--- a/src/Idris/Package/Parser.hs
+++ b/src/Idris/Package/Parser.hs
@@ -1,5 +1,5 @@
 {-|
-Module      : Pkg.PParser
+Module      : Idris.Package.Parser
 Description : `iPKG` file parser and package description information.
 Copyright   :
 License     : BSD3
@@ -9,7 +9,7 @@ Maintainer  : The Idris Community.
 #if !(MIN_VERSION_base(4,8,0))
 {-# LANGUAGE OverlappingInstances #-}
 #endif
-module Pkg.PParser where
+module Idris.Package.Parser where
 
 import Text.Trifecta hiding (span, charLiteral, natural, symbol, char, string, whiteSpace)
 import qualified Text.PrettyPrint.ANSI.Leijen as PP
@@ -18,6 +18,8 @@ import Idris.REPL
 import Idris.AbsSyntaxTree
 import Idris.Parser.Helpers hiding (stringLiteral)
 import Idris.CmdOptions
+
+import Idris.Package.Common
 
 import Control.Monad.State.Strict
 import Control.Applicative
@@ -28,35 +30,6 @@ import Data.List (union)
 import Util.System
 
 type PParser = StateT PkgDesc IdrisInnerParser
-
-data PkgDesc = PkgDesc {
-    pkgname       :: String       -- ^ Name associated with a package.
-  , pkgdeps       :: [String]     -- ^ List of packages this package depends on.
-  , pkgbrief      :: Maybe String -- ^ Brief description of the package.
-  , pkgversion    :: Maybe String -- ^ Version string to associate with the package.
-  , pkgreadme     :: Maybe String -- ^ Location of the README file.
-  , pkglicense    :: Maybe String -- ^ Description of the licensing information.
-  , pkgauthor     :: Maybe String -- ^ Author information.
-  , pkgmaintainer :: Maybe String -- ^ Maintainer information.
-  , pkghomepage   :: Maybe String -- ^ Website associated with the package.
-  , pkgsourceloc  :: Maybe String -- ^ Location of the source files.
-  , pkgbugtracker :: Maybe String -- ^ Location of the project's bug tracker.
-  , libdeps       :: [String]     -- ^ External dependencies.
-  , objs          :: [String]     -- ^ Object files required by the package.
-  , makefile      :: Maybe String -- ^ Makefile used to build external code. Used as part of the FFI process.
-  , idris_opts    :: [Opt]        -- ^ List of options to give the compiler.
-  , sourcedir     :: String       -- ^ Source directory for Idris files.
-  , modules       :: [Name]       -- ^ Modules provided by the package.
-  , idris_main    :: Name         -- ^ If an executable in which module can the Main namespace and function be found.
-  , execout       :: Maybe String -- ^ What to call the executable.
-  , idris_tests   :: [Name]       -- ^ Lists of tests to execute against the package.
-  } deriving (Show)
-
--- | Default settings for package descriptions.
-defaultPkg :: PkgDesc
-defaultPkg = PkgDesc "" [] Nothing Nothing Nothing Nothing
-                        Nothing Nothing Nothing Nothing
-                        Nothing [] [] Nothing [] "" [] (sUN "") Nothing []
 
 instance HasLastTokenSpan PParser where
   getLastTokenSpan = return Nothing


### PR DESCRIPTION
This commit rehomes the code for package building and installation
under the Idris namespace, allowing for projects that use the code to
use a more meaningful import statement.

This commit also factors out the ipkg data type from the parser.