### PR TITLE
Enable tasty test listing with --list-tests

### DIFF
--- a/test/TestRun.hs
+++ b/test/TestRun.hs
@@ -54,7 +54,8 @@ instance IsOption NodeOpt where
   optionCLParser = fmap NodeOpt $ switch (long nodeArg <> help nodeHelp)
 
 ingredients :: [Ingredient]
-ingredients = [rerunningTests [consoleTestReporter],
+ingredients = defaultIngredients ++
+              [rerunningTests [consoleTestReporter],
                includingOptions [Option (Proxy :: Proxy NodeOpt)] ]
 
 ----------------------------------------------------------------------- [ Core ]


### PR DESCRIPTION
By including [`defaultIngredients`](https://hackage.haskell.org/package/tasty-0.11.0.3/docs/src/Test-Tasty.html#defaultIngredients) in the ingredients for tasty tests, enable use of the `--list-tests` option.

## regression-and-sanity-tests --help

```sh-session
$ stack test --flag idris:execonly --test-arguments '--help'
idris-0.12.1: test (suite: regression-and-sanity-tests, args: --help)

Mmm... tasty test suite

Usage: regression-and-sanity-tests [-p|--pattern ARG] [-t|--timeout ARG]
                                   [-l|--list-tests] [-j|--num-threads ARG]
                                   [-q|--quiet] [--hide-successes] [--color ARG]
                                   [--rerun-log-file ARG] [--rerun-update]
                                   [--rerun-filter ARG] [-q|--quiet]
                                   [--hide-successes] [--color ARG] [--node]
                                   [--accept]

Available options:
  -h,--help                Show this help text
  -p,--pattern ARG         Select only tests that match pattern
  -t,--timeout ARG         Timeout for individual tests (suffixes: ms,s,m,h;
                           default: s)
  -l,--list-tests          Do not run the tests; just print their names
  -j,--num-threads ARG     Number of threads to use for tests execution
  -q,--quiet               Do not produce any output; indicate success only by
                           the exit code
  --hide-successes         Do not print tests that passed successfully
  --color ARG              When to use colored output. Options are 'never',
                           'always' and 'auto' (default: 'auto')
  --rerun-log-file ARG     The path to which rerun's state file should be saved
  --rerun-update           If present the log file will be updated, otherwise it
                           will be left unchanged
  --rerun-filter ARG       A comma separated list to specify which tests to run
                           when comparing against previous test runs. Valid
                           options are: everything, failures, exceptions, new
  -q,--quiet               Do not produce any output; indicate success only by
                           the exit code
  --hide-successes         Do not print tests that passed successfully
  --color ARG              When to use colored output. Options are 'never',
                           'always' and 'auto' (default: 'auto')
  --node                   Performs the tests with the node code generator
  --accept                 Accept current results of golden tests
```

## regression-and-sanity-tests --list-tests

```sh-session
$ stack test --flag idris:execonly --test-arguments '--list-tests'
idris-0.12.1: test (suite: regression-and-sanity-tests, args: --list-tests)

Regression and sanity tests/Basic/basic001
Regression and sanity tests/Basic/basic002
Regression and sanity tests/Basic/basic003
Regression and sanity tests/Basic/basic004
Regression and sanity tests/Basic/basic005
Regression and sanity tests/Basic/basic006
Regression and sanity tests/Basic/basic007
Regression and sanity tests/Basic/basic008
Regression and sanity tests/Basic/basic009
Regression and sanity tests/Basic/basic010
Regression and sanity tests/Basic/basic011
Regression and sanity tests/Basic/basic012
Regression and sanity tests/Basic/basic013
Regression and sanity tests/Basic/basic014
Regression and sanity tests/Basic/basic015
Regression and sanity tests/Basic/basic016
Regression and sanity tests/Basic/basic017
Regression and sanity tests/Basic/basic018
Regression and sanity tests/Bignum/bignum001
Regression and sanity tests/Bignum/bignum002
Regression and sanity tests/Bounded/bounded001
Regression and sanity tests/Corecords/corecords001
Regression and sanity tests/Corecords/corecords002
Regression and sanity tests/De-elaboration/delab001
Regression and sanity tests/Directives/directives001
Regression and sanity tests/Directives/directives002
Regression and sanity tests/Disambiguation/disambig002
...
```
