### PR TITLE
ommit internal error from REPL when using search command

### DIFF
--- a/src/Idris/REPL/Parser.hs
+++ b/src/Idris/REPL/Parser.hs
@@ -520,7 +520,7 @@ packageBasedCmd valParser cmd name =
 
 cmd_search :: String -> P.IdrisParser (Either String Command)
 cmd_search = packageBasedCmd
-  (P.typeExpr (defaultSyntax { implicitAllowed = True })) Search
+  (P.fullExpr (defaultSyntax { implicitAllowed = True })) Search
 
 cmd_proofsearch :: String -> P.IdrisParser (Either String Command)
 cmd_proofsearch name = do


### PR DESCRIPTION
Fixes #3221 

and fix a typo by the way. it takes a while to finally figure out where this internal error msg comes from. [#1](https://github.com/idris-lang/Idris-dev/blob/master/src/Idris/REPL.hs#L331-L332) [#2](https://github.com/idris-lang/Idris-dev/blob/master/src/Idris/Elab/Term.hs#L1325) [#3](https://github.com/idris-lang/Idris-dev/blob/master/src/Idris/AbsSyntaxTree.hs#L2132) [#4](https://github.com/idris-lang/Idris-dev/blob/master/src/Idris/Delaborate.hs#L299)

actually, i don't think the `!a` type reported in the issue makes any sense, there is no meaning to apply `!` to a type right? even in a dependently typed programming language cause

```idris
(!) : m a -> a
```