### PR TITLE
Revert "Pass on the output on stderr from tests. (#3310)"

### DIFF
--- a/test/TestRun.hs
+++ b/test/TestRun.hs
@@ -122,11 +122,9 @@ mkGoldenTests testFamilies flags =
 runTest :: String -> Flags -> IO ()
 runTest path flags = do
   let run = (proc "bash" ("run" : flags)) {cwd = Just path,
-                                           std_out = CreatePipe,
-                                           std_err = CreatePipe}
-  (_, output, error_out) <- readCreateProcessWithExitCode run ""
+                                           std_out = CreatePipe}
+  (_, output, _) <- readCreateProcessWithExitCode run ""
   writeFile (path </> "output") output
-  hPutStrLn stderr error_out
 
 main :: IO ()
 main = do


### PR DESCRIPTION
Apparently tasty gets upset at the write to stderr

This reverts commit c1810b88b37925a85f54b4046b36ba1cff4530ff.