### PR TITLE
Fix the icon object path so it goes in the dir.

### DIFF
--- a/Setup.hs
+++ b/Setup.hs
@@ -206,8 +206,8 @@ getVersion args flags = do
 idrisPreBuild args flags = do
 #ifdef mingw32_HOST_OS
         createDirectoryIfMissingVerbose verbosity True dir
-        windres verbosity ["icons/idris_icon.rc","-o", dir++"idris_icon.o"]
-        return (Nothing, [("idris", emptyBuildInfo { ldOptions = [dir ++ "idris_icon.o"] })])
+        windres verbosity ["icons/idris_icon.rc","-o", dir++"/idris_icon.o"]
+        return (Nothing, [("idris", emptyBuildInfo { ldOptions = [dir ++ "/idris_icon.o"] })])
      where
         verbosity = S.fromFlag $ S.buildVerbosity flags
         dir = S.fromFlagOrDefault "dist" $ S.buildDistPref flags


### PR DESCRIPTION
No functionality change, previously it got a weird filename in the build dir.