### PR TITLE
Fix stderr testing issue

### DIFF
--- a/src/Idris/Output.hs
+++ b/src/Idris/Output.hs
@@ -21,6 +21,7 @@ import Idris.IdeMode
 
 import Util.Pretty
 import Util.ScreenSize (getScreenWidth)
+import Util.System (isATTY)
 
 import Control.Monad.Trans.Except (ExceptT (ExceptT), runExceptT)
 
@@ -67,13 +68,14 @@ iRender d = do w <- getWidth
                let ideMode = case idris_outputmode ist of
                                 IdeMode _ _ -> True
                                 _            -> False
+               tty <- runIO isATTY
                case w of
                  InfinitelyWide -> return $ renderPretty 1.0 1000000000 d
                  ColsWide n -> return $
                                if n < 1
                                  then renderPretty 1.0 1000000000 d
                                  else renderPretty 0.8 n d
-                 AutomaticWidth | ideMode  -> return $ renderPretty 1.0 80 d
+                 AutomaticWidth | ideMode || not tty -> return $ renderPretty 1.0 80 d
                                 | otherwise -> do width <- runIO getScreenWidth
                                                   return $ renderPretty 0.8 width d
 

--- a/test/TestRun.hs
+++ b/test/TestRun.hs
@@ -9,6 +9,7 @@ import qualified Data.IntMap as IMap
 
 import System.Directory
 import System.Environment
+import System.Exit
 import System.Process
 import System.Info
 import System.IO
@@ -90,10 +91,10 @@ mkGoldenTests testFamilies flags =
 -- this thing.
 runTest :: String -> Flags -> IO ()
 runTest path flags = do
-  let run = (proc "bash" ("run" : flags)) {cwd = Just path,
-                                           std_out = CreatePipe}
-  (_, output, _) <- readCreateProcessWithExitCode run ""
+  let run = (proc "bash" ("run" : flags)) {cwd = Just path}
+  (_, output, error_out) <- readCreateProcessWithExitCode run ""
   writeFile (path </> "output") (normalise output)
+  when (error_out /= "") $ hPutStrLn stderr ("\nError: " ++ path ++ "\n" ++ error_out)
     where
       -- Normalise paths e.g. '.\foo.idr' to './foo.idr'.
       -- Also embedded paths e.g. ".\\Prelude\\List.idr" to "./Prelude/List.idr".

--- a/test/basic006/expected
+++ b/test/basic006/expected
@@ -1,5 +1,4 @@
-test020a.idr:16:18:
-When checking right hand side of foo with expected type
+test020a.idr:16:18:When checking right hand side of foo with expected type
         List a
 
 When checking an application of function Prelude.List.reverse:

--- a/test/basic009/expected
+++ b/test/basic009/expected
@@ -1,8 +1,7 @@
 MAIN-PASS
 Faulty.idr:6:9-12:WARNING: num is bound as an implicit
 	Did you mean to refer to A.num?
-Faulty.idr:7:7:
-When checking right hand side of fault with expected type
+Faulty.idr:7:7:When checking right hand side of fault with expected type
         num = 0
 
 Type mismatch between

--- a/test/basic018/expected
+++ b/test/basic018/expected
@@ -2,8 +2,7 @@ basic018.idr:7:12-17:WARNING: thing is bound as an implicit
 	Did you mean to refer to Main.thing?
 basic018.idr:12:8-13:WARNING: thing is bound as an implicit
 	Did you mean to refer to Main.thing?
-basic018.idr:13:6:
-When checking right hand side of test with expected type
+basic018.idr:13:6:When checking right hand side of test with expected type
         thing = S 41
 
 Type mismatch between

--- a/test/directives001/expected
+++ b/test/directives001/expected
@@ -6,9 +6,7 @@ directives001.idr:15:7:Use of deprecated name directives001.Foo
 To be replaced with `Bar`.
 directives001.idr:15:7:Use of deprecated name directives001.Foo
 To be replaced with `Bar`.
-directives001.idr:26:8:
-Use of a fragile construct directives001.mkBar
+directives001.idr:26:8:Use of a fragile construct directives001.mkBar
 How `Bar`s are to be created is still being discussed, `mkBar` is subject to change.
-directives001.idr:26:8:
-Use of a fragile construct directives001.mkBar
+directives001.idr:26:8:Use of a fragile construct directives001.mkBar
 How `Bar`s are to be created is still being discussed, `mkBar` is subject to change.

--- a/test/docs003/expected
+++ b/test/docs003/expected
@@ -6,8 +6,7 @@ Parameters:
 
 Methods:
     map : Functor f => (func : a -> b) -> f a -> f b
-        Apply a function across everything of type 'a' in a
-        parameterised type
+        Apply a function across everything of type 'a' in a parameterised type
         
         The function is Total
 Implementations:

--- a/test/error003/expected
+++ b/test/error003/expected
@@ -1,5 +1,4 @@
-ErrorReflection.idr:68:5:
-When checking right hand side of bad with expected type
+ErrorReflection.idr:68:5:When checking right hand side of bad with expected type
         Tm [] TUnit
 
 DSL type error: (t(504) => t'(503)) doesn't match ()

--- a/test/error005/expected
+++ b/test/error005/expected
@@ -1,34 +1,29 @@
-error005.idr:13:1:
-When checking right hand side of two with expected type
+error005.idr:13:1:When checking right hand side of two with expected type
         Fin 2
 
 When checking argument prf to function Data.Fin.fromInteger:
         When using 2 as a literal for a Fin 2 
                 2 is not strictly less than 2
-error005.idr:16:1:
-When checking right hand side of hahaha with expected type
+error005.idr:16:1:When checking right hand side of hahaha with expected type
         Fin n
 
 When checking argument prf to function Data.Fin.fromInteger:
         When using 0 as a literal for a Fin n 
                 0 is not strictly less than n
-error005.idr:22:1:
-When checking right hand side of notOk with expected type
+error005.idr:22:1:When checking right hand side of notOk with expected type
         Fin (plus 2 n)
 
 When checking argument prf to function Data.Fin.fromInteger:
         When using 2 as a literal for a Fin (S (S n)) 
                 2 is not strictly less than S (S n)
-error005.idr:23:24:
-When checking right hand side of b0rken with expected type
+error005.idr:23:24:When checking right hand side of b0rken with expected type
         Fin 3
 
 When checking argument prf to function Data.Fin.fromInteger:
         When using n as a literal for a Fin 3 
                 Could not show that n is less than 3 because n is a bound
                 variable instead of a constant Integer
-error005.idr:28:1:
-When checking right hand side of x with expected type
+error005.idr:28:1:When checking right hand side of x with expected type
         Fin 4
 
 When checking argument prf to function Data.Fin.fromInteger:

--- a/test/layout001/expected
+++ b/test/layout001/expected
@@ -72,8 +72,7 @@ y
 ^ 
 Checking layout001n.idr
 Checking mplus1.idr
-mplus1.idr:13:31:
-When checking right hand side of term with expected type
+mplus1.idr:13:31:When checking right hand side of term with expected type
         Maybe Int
 
 When checking an application of function Prelude.Applicative.pure:

--- a/test/proof011/expected
+++ b/test/proof011/expected
@@ -1,14 +1,18 @@
-proof011.idr:19:9:
-When checking right hand side of vassoc' with expected type
+proof011.idr:19:9:When checking right hand side of vassoc' with expected type
         (x :: xs) ++ ys ++ zs = ((x :: xs) ++ ys) ++ zs
 
-rewriting xs ++ ys ++ xs to (xs ++ ys) ++
-                            xs did not change type x :: xs ++ ys ++ zs =
-                                                   x :: (xs ++ ys) ++ zs
-proof011a.idr:13:9:
-When checking right hand side of vassoc' with expected type
+rewriting xs ++ ys ++ xs to (xs ++ ys) ++ xs did not change type x ::
+                                                                 xs ++
+                                                                 ys ++ zs =
+                                                                 x ::
+                                                                 (xs ++ ys) ++
+                                                                 zs
+proof011a.idr:13:9:When checking right hand side of vassoc' with expected type
         (x :: xs) ++ ys ++ zs = ((x :: xs) ++ ys) ++ zs
 
-rewriting xs ++ ys ++ xs to (xs ++ ys) ++
-                            xs did not change type x :: xs ++ ys ++ zs =
-                                                   x :: (xs ++ ys) ++ zs
+rewriting xs ++ ys ++ xs to (xs ++ ys) ++ xs did not change type x ::
+                                                                 xs ++
+                                                                 ys ++ zs =
+                                                                 x ::
+                                                                 (xs ++ ys) ++
+                                                                 zs

--- a/test/quasiquote003/expected
+++ b/test/quasiquote003/expected
@@ -1,5 +1,4 @@
-NoInfer.idr:11:5:
-When checking right hand side of zzz with expected type
+NoInfer.idr:11:5:When checking right hand side of zzz with expected type
         TT
 
 No such variable k

--- a/test/reg007/expected
+++ b/test/reg007/expected
@@ -1,6 +1,5 @@
 reg007.lidr:8:1:A.n is already defined
-reg007.lidr:12:11-17:
-When checking right hand side of hurrah with expected type
+reg007.lidr:12:11-17:When checking right hand side of hurrah with expected type
         0 = 1
 
 Type mismatch between

--- a/test/reg018/expected
+++ b/test/reg018/expected
@@ -8,5 +8,4 @@ reg018b.idr:11:1:
 A.B implementation of Prelude.Show.Show is possibly not total due to: A.showB
 reg018c.idr:21:1:
 CodataTest.inf is possibly not total due to: with block in CodataTest.inf
-reg018d.idr:8:1:
-Main.pull is not total as there are missing cases
+reg018d.idr:8:1:Main.pull is not total as there are missing cases

--- a/test/reg023/expected
+++ b/test/reg023/expected
@@ -1,5 +1,4 @@
-reg023.idr:7:5:
-When checking right hand side of bad with expected type
+reg023.idr:7:5:When checking right hand side of bad with expected type
         f Nat
 
 Type mismatch between

--- a/test/reg027/expected
+++ b/test/reg027/expected
@@ -1,4 +1,3 @@
 <<int fn>>
 6
-reg027a.idr:9:16:
-Overlapping implementation: Show (Int -> a) already defined
+reg027a.idr:9:16:Overlapping implementation: Show (Int -> a) already defined

--- a/test/reg028/expected
+++ b/test/reg028/expected
@@ -1,5 +1,4 @@
-reg028.idr:5:1:
-tbad.bad is possibly not total due to: with block in tbad.bad
+reg028.idr:5:1:tbad.bad is possibly not total due to: with block in tbad.bad
 reg028a.idr:17:14-19:
 This style of tactic proof is deprecated. See %runElab for the replacement.
 reg028a.idr:11:1:

--- a/test/reg044/expected
+++ b/test/reg044/expected
@@ -1,7 +1,6 @@
 reg044.idr:4:6-11:
 This style of tactic proof is deprecated. See %runElab for the replacement.
-reg044.idr:4:4:
-When checking right hand side of Main.pf with expected type
+reg044.idr:4:4:When checking right hand side of Main.pf with expected type
         (b : Nat) -> (a : Nat) -> (S a = S b) -> a = b
 
 Type mismatch between

--- a/test/reg049/expected
+++ b/test/reg049/expected
@@ -1,7 +1,6 @@
 reg049.idr:2:9:When checking constructor Main.Bogus:
 Void is not Main.Foo
-reg049.idr:5:6:
-When checking right hand side of uhOh with expected type
+reg049.idr:5:6:When checking right hand side of uhOh with expected type
         Void
 
 No such variable Bogus

--- a/test/reg068/expected
+++ b/test/reg068/expected
@@ -1,5 +1,4 @@
-reg068.idr:1:6:
-Main.nat has a name which may be implicitly bound.
+reg068.idr:1:6:Main.nat has a name which may be implicitly bound.
 This is likely to lead to problems!
 reg068.idr:2:6:Main.ze has a name which may be implicitly bound.
 This is likely to lead to problems!

--- a/test/reg069/expected
+++ b/test/reg069/expected
@@ -1,2 +1,1 @@
-Mod.idr:11:1:
-public export Mod.natexp can't refer to export Mod.natfn
+Mod.idr:11:1:public export Mod.natexp can't refer to export Mod.natfn

--- a/test/reg072/expected
+++ b/test/reg072/expected
@@ -1,5 +1,4 @@
-DoubleEquality.idr:4:87:
-When checking right hand side of oops with expected type
+DoubleEquality.idr:4:87:When checking right hand side of oops with expected type
         Void
 
 When checking argument value to function Prelude.Basics.the:

--- a/test/syntax001/expected
+++ b/test/syntax001/expected
@@ -1,5 +1,4 @@
-Syntax.idr:6:7-9:1:
-When checking right hand side of foo with expected type
+Syntax.idr:6:7-9:1:When checking right hand side of foo with expected type
         Nat
 
 When checking an application of function Prelude.Interfaces.+:
@@ -7,8 +6,7 @@ When checking an application of function Prelude.Interfaces.+:
                 String (Type of "argh")
         and
                 Nat (Expected type)
-SyntaxTest.idr:5:7-6:1:
-When checking right hand side of foo with expected type
+SyntaxTest.idr:5:7-6:1:When checking right hand side of foo with expected type
         Nat
 
 When checking an application of function Prelude.Interfaces.+:

--- a/test/totality001/expected
+++ b/test/totality001/expected
@@ -1,6 +1,3 @@
-test010.idr:15:1:
-Main.foo is possibly not total due to: Main.MkBad
-test010a.idr:9:1:
-main.bar is possibly not total due to: main.MkBad
-test010b.idr:9:1:
-main.bar is possibly not total due to: main.MkBad
+test010.idr:15:1:Main.foo is possibly not total due to: Main.MkBad
+test010a.idr:9:1:main.bar is possibly not total due to: main.MkBad
+test010b.idr:9:1:main.bar is possibly not total due to: main.MkBad

--- a/test/totality002/expected
+++ b/test/totality002/expected
@@ -2,5 +2,4 @@ test017.idr:94:26-31:
 This style of tactic proof is deprecated. See %runElab for the replacement.
 test017a.idr:7:1:
 scg.vtrans is possibly not total due to recursive path scg.vtrans --> scg.vtrans
-test017b.idr:4:1:
-foo.foo is possibly not total due to recursive path foo.foo
+test017b.idr:4:1:foo.foo is possibly not total due to recursive path foo.foo

--- a/test/totality004/expected
+++ b/test/totality004/expected
@@ -1,5 +1,4 @@
 [1, 2, 2, 4, 3, 6, 4, 8, 5, 10]
 totality004a.idr:13:1:
 Main.process is possibly not total due to recursive path Main.process --> Main.process --> Main.process
-totality004a.idr:24:1:
-Main.main is possibly not total due to: Main.process
+totality004a.idr:24:1:Main.main is possibly not total due to: Main.process

--- a/test/totality006/expected
+++ b/test/totality006/expected
@@ -1,5 +1,4 @@
-totality006.idr:8:1:
-Main.prf is not total as there are missing cases
+totality006.idr:8:1:Main.prf is not total as there are missing cases
 totality006a.idr:11:6:prf' (S _) (S _) Oh is a valid case
 totality006b.idr:10:1:
 totality006b.blargh is not total as there are missing cases

--- a/test/totality008/expected
+++ b/test/totality008/expected
@@ -1,2 +1,1 @@
-totality008.idr:7:1:
-Main.ElimT is possibly not total due to: Main.C2
+totality008.idr:7:1:Main.ElimT is possibly not total due to: Main.C2

--- a/test/totality010/expected
+++ b/test/totality010/expected
@@ -1,4 +1,2 @@
-totality010.idr:27:1:
-Main.evenNotS is not total as there are missing cases
-totality010.idr:30:1:
-Main.bad is possibly not total due to: Main.evenNotS
+totality010.idr:27:1:Main.evenNotS is not total as there are missing cases
+totality010.idr:30:1:Main.bad is possibly not total due to: Main.evenNotS

--- a/test/totality015/expected
+++ b/test/totality015/expected
@@ -1,6 +1,4 @@
 totality015a.idr:52:3:
 Main.quiz is possibly not total due to recursive path Main.quiz --> Main.quiz
-totality015a.idr:42:3:
-Main.correct is possibly not total due to: Main.quiz
-totality015a.idr:47:3:
-Main.wrong is possibly not total due to: Main.quiz
+totality015a.idr:42:3:Main.correct is possibly not total due to: Main.quiz
+totality015a.idr:47:3:Main.wrong is possibly not total due to: Main.quiz


### PR DESCRIPTION
Don't query width when not a tty

This causes trouble when running non-interactively.

Also reinstate the stderr output now that that problem is solved.

Run diff on the test output if test fails. 

Fixes #3323 