### PR TITLE
Keep filename args in the order specified on the cmd line

### DIFF
--- a/test/dsl003/expected
+++ b/test/dsl003/expected
@@ -1,2 +1,2 @@
-ForAll INT (ForAll INT (ItHolds (Var (FS FZ) === Var FZ))) : Spec []
 Refl : ARR BOOL (ARR INT UNIT) = ARR BOOL (ARR INT UNIT)
+ForAll INT (ForAll INT (ItHolds (Var (FS FZ) === Var FZ))) : Spec []


### PR DESCRIPTION
Currently filenames are processed in the reverse order to that specified on the command line.

This change also contains some tweaks that were suggested by ghc-mod.