### PR TITLE
Allow Travis to work when repo isn't named Idris-dev

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -2,6 +2,10 @@ sudo: false
 
 language: c
 
+env:
+  global:
+    - PKGNAME=idris
+
 addons:
   apt:
     sources:
@@ -113,8 +117,8 @@ install:
 before_script:
   - cabal sdist
   - cd ..
-  - tar -xf Idris-dev/dist/idris*.tar.gz
-  - cd idris*
+  - tar -xf */dist/${PKGNAME}*.tar.gz
+  - cd ${PKGNAME}*
 script:
 ###
   - echo 'Configure...' && echo -en 'travis_fold:start:script.configure\\r'


### PR DESCRIPTION
I'd like to be able to run Travis CI against [my personal Idris repository](https://github.com/steshaw/idris). This is not possible at the moment because the `.travis.yml` file relies on the name of the repository. This PR removes that dependency so that it doesn't matter what your repository is called.

If you like, you can [view the successful build](https://travis-ci.org/steshaw/idris/builds/150003902) of this push to my personal repository.