### PR TITLE
Remove `expect` package from travis configuration

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -19,7 +19,6 @@ addons:
       - cabal-install-1.22
       - cabal-install-1.24
       # test dependencies
-      - expect
       - cppcheck
       - hscolour
 


### PR DESCRIPTION
The `expect` command is only used on Mac OS as a fallback for (lack of) `timeout`. On Mac `expect` is a standard utility.