### PR TITLE
Tidy stderr output from base001

### DIFF
--- a/test/base001/run
+++ b/test/base001/run
@@ -1,10 +1,12 @@
 #!/usr/bin/env bash
 
+set -u
+
 if [[ ${OSTYPE} = 'msys' ]]; then
   cat expected # skip this test on Windows
 else
-  ${IDRIS:-idris} $@ --build base001.ipkg | grep -v 'make.*:'
-  ./base001 2>&1 | grep -v './does-not-exist: No such file or directory'
+  ${IDRIS:-idris} "$@" --build base001.ipkg | grep -v 'make.*:'
+  ./base001 2>&1 | grep -v '^sh:.*\./does-not-exist:'
   make clean | grep -v 'make.*:'
-  rm -f *.ibc base001
+  rm -f -- *.ibc base001
 fi

--- a/test/base001/run
+++ b/test/base001/run
@@ -4,7 +4,7 @@ if [[ ${OSTYPE} = 'msys' ]]; then
   cat expected # skip this test on Windows
 else
   ${IDRIS:-idris} $@ --build base001.ipkg | grep -v 'make.*:'
-  ./base001
+  ./base001 2>&1 | grep -v './does-not-exist: No such file or directory'
   make clean | grep -v 'make.*:'
   rm -f *.ibc base001
 fi


### PR DESCRIPTION
Avoid having expected errors appear on stderr (in the build log).

Before:

```sh-session
steshaw@paris:~/Projects/idris/test/base001 git:(master) 
$ stack test --test-arguments '-p base001'                                              <<<
idris-0.12.2: test (suite: regression-and-feature-tests, args: -p base001)

Regression and feature tests
  Base
    base001: 
Error: test/base001
sh: 1: ./does-not-exist: not found
sh: 1: ./does-not-exist: not found

OK (7.64s)

All 1 tests passed (7.70s)
```

After:

```sh-session
steshaw@paris:~/Projects/idris/test/base001 git:(tidy-stderr-output-from-base001) 
➯ stack test --test-arguments '-p base001'                                              <<<
idris-0.12.2: test (suite: regression-and-feature-tests, args: -p base001)

Regression and feature tests
  Base
    base001: OK (7.87s)

All 1 tests passed (7.95s)
```