### PR TITLE
Some internal structural Changes.

### DIFF
--- a/idris.cabal
+++ b/idris.cabal
@@ -206,6 +206,7 @@ Library
                 , Idris.Reflection
                 , Idris.REPL
                 , Idris.REPL.Parser
+                , Idris.REPL.Commands
                 , Idris.Transforms
                 , Idris.TypeSearch
                 , Idris.Unlit

--- a/main/Main.hs
+++ b/main/Main.hs
@@ -6,7 +6,6 @@ import Control.Monad ( when )
 
 import Idris.AbsSyntax
 import Idris.REPL
--- import Idris.Imports
 import Idris.Error
 import Idris.CmdOptions
 import Idris.Info

--- a/src/Idris/AbsSyntax.hs
+++ b/src/Idris/AbsSyntax.hs
@@ -47,6 +47,8 @@ import Debug.Trace
 
 import System.IO.Error(isUserError, ioeGetErrorString, tryIOError)
 
+import Network (PortID(PortNumber))
+
 import Util.Pretty
 import Util.ScreenSize
 import Util.System
@@ -2496,3 +2498,126 @@ mkUniqueNames env shadows tm
   mkUniq ql nmap (PUnquote tm) = fmap PUnquote (mkUniq (ql - 1) nmap tm)
 
   mkUniq ql nmap tm = descendM (mkUniq ql nmap) tm
+
+
+getFile :: Opt -> Maybe String
+getFile (Filename str) = Just str
+getFile _ = Nothing
+
+getBC :: Opt -> Maybe String
+getBC (BCAsm str) = Just str
+getBC _ = Nothing
+
+getOutput :: Opt -> Maybe String
+getOutput (Output str) = Just str
+getOutput _ = Nothing
+
+getIBCSubDir :: Opt -> Maybe String
+getIBCSubDir (IBCSubDir str) = Just str
+getIBCSubDir _ = Nothing
+
+getImportDir :: Opt -> Maybe String
+getImportDir (ImportDir str) = Just str
+getImportDir _ = Nothing
+
+getPkgDir :: Opt -> Maybe String
+getPkgDir (Pkg str) = Just str
+getPkgDir _ = Nothing
+
+getPkg :: Opt -> Maybe (Bool, String)
+getPkg (PkgBuild str) = Just (False, str)
+getPkg (PkgInstall str) = Just (True, str)
+getPkg _ = Nothing
+
+getPkgClean :: Opt -> Maybe String
+getPkgClean (PkgClean str) = Just str
+getPkgClean _ = Nothing
+
+getPkgREPL :: Opt -> Maybe String
+getPkgREPL (PkgREPL str) = Just str
+getPkgREPL _ = Nothing
+
+getPkgCheck :: Opt -> Maybe String
+getPkgCheck (PkgCheck str) = Just str
+getPkgCheck _              = Nothing
+
+-- | Returns None if given an Opt which is not PkgMkDoc
+--   Otherwise returns Just x, where x is the contents of PkgMkDoc
+getPkgMkDoc :: Opt          -- ^ Opt to extract
+            -> Maybe String -- ^ Result
+getPkgMkDoc (PkgMkDoc str) = Just str
+getPkgMkDoc _              = Nothing
+
+getPkgTest :: Opt          -- ^ the option to extract
+           -> Maybe String -- ^ the package file to test
+getPkgTest (PkgTest f) = Just f
+getPkgTest _ = Nothing
+
+getCodegen :: Opt -> Maybe Codegen
+getCodegen (UseCodegen x) = Just x
+getCodegen _ = Nothing
+
+getCodegenArgs :: Opt -> Maybe String
+getCodegenArgs (CodegenArgs args) = Just args
+getCodegenArgs _ = Nothing
+
+getConsoleWidth :: Opt -> Maybe ConsoleWidth
+getConsoleWidth (UseConsoleWidth x) = Just x
+getConsoleWidth _ = Nothing
+
+
+getExecScript :: Opt -> Maybe String
+getExecScript (InterpretScript expr) = Just expr
+getExecScript _ = Nothing
+
+getPkgIndex :: Opt -> Maybe FilePath
+getPkgIndex (PkgIndex file) = Just file
+getPkgIndex _ = Nothing
+
+getEvalExpr :: Opt -> Maybe String
+getEvalExpr (EvalExpr expr) = Just expr
+getEvalExpr _ = Nothing
+
+getOutputTy :: Opt -> Maybe OutputType
+getOutputTy (OutputTy t) = Just t
+getOutputTy _ = Nothing
+
+getLanguageExt :: Opt -> Maybe LanguageExt
+getLanguageExt (Extension e) = Just e
+getLanguageExt _ = Nothing
+
+getTriple :: Opt -> Maybe String
+getTriple (TargetTriple x) = Just x
+getTriple _ = Nothing
+
+getCPU :: Opt -> Maybe String
+getCPU (TargetCPU x) = Just x
+getCPU _ = Nothing
+
+getOptLevel :: Opt -> Maybe Int
+getOptLevel (OptLevel x) = Just x
+getOptLevel _ = Nothing
+
+getOptimisation :: Opt -> Maybe (Bool,Optimisation)
+getOptimisation (AddOpt p)    = Just (True,  p)
+getOptimisation (RemoveOpt p) = Just (False, p)
+getOptimisation _             = Nothing
+
+getColour :: Opt -> Maybe Bool
+getColour (ColourREPL b) = Just b
+getColour _ = Nothing
+
+getClient :: Opt -> Maybe String
+getClient (Client x) = Just x
+getClient _ = Nothing
+
+-- Get the first valid port
+getPort :: [Opt] -> Maybe PortID
+getPort [] = Nothing
+getPort (Port p:xs)
+    | all (`elem` ['0'..'9']) p = Just (PortNumber $ fromIntegral (read p))
+    | otherwise                 = getPort xs
+getPort (_:xs) = getPort xs
+
+opt :: (Opt -> Maybe a) -> [Opt] -> [a]
+opt = mapMaybe

--- a/src/Idris/AbsSyntaxTree.hs
+++ b/src/Idris/AbsSyntaxTree.hs
@@ -433,77 +433,6 @@ data IRFormat = IBCFormat | JSONFormat deriving (Show, Eq, Generic)
 
 data HowMuchDocs = FullDocs | OverviewDocs
 
--- | REPL commands
-data Command = Quit
-             | Help
-             | Eval PTerm
-             | NewDefn [PDecl] -- ^ Each 'PDecl' should be either a type declaration (at most one) or a clause defining the same name.
-             | Undefine [Name]
-             | Check PTerm
-             | Core PTerm
-             | DocStr (Either Name Const) HowMuchDocs
-             | TotCheck Name
-             | Reload
-             | Watch
-             | Load FilePath (Maybe Int) -- up to maximum line number
-             | ChangeDirectory FilePath
-             | ModImport String
-             | Edit
-             | Compile Codegen String
-             | Execute PTerm
-             | ExecVal PTerm
-             | Metavars
-             | Prove Bool Name -- ^ If false, use prover, if true, use elab shell
-             | AddProof (Maybe Name)
-             | RmProof Name
-             | ShowProof Name
-             | Proofs
-             | Universes
-             | LogLvl Int
-             | LogCategory [LogCat]
-             | Spec PTerm
-             | WHNF PTerm
-             | TestInline PTerm
-             | Defn Name
-             | Missing Name
-             | DynamicLink FilePath
-             | ListDynamic
-             | Pattelab PTerm
-             | Search [String] PTerm
-             | CaseSplitAt Bool Int Name
-             | AddClauseFrom Bool Int Name
-             | AddProofClauseFrom Bool Int Name
-             | AddMissing Bool Int Name
-             | MakeWith Bool Int Name
-             | MakeCase Bool Int Name
-             | MakeLemma Bool Int Name
-             | DoProofSearch Bool   -- update file
-                             Bool   -- recursive search
-                             Int    -- depth
-                             Name   -- top level name
-                             [Name] -- hints
-             | SetOpt Opt
-             | UnsetOpt Opt
-             | NOP
-             | SetColour ColourType IdrisColour
-             | ColourOn
-             | ColourOff
-             | ListErrorHandlers
-             | SetConsoleWidth ConsoleWidth
-             | SetPrinterDepth (Maybe Int)
-             | Apropos [String] String
-             | WhoCalls Name
-             | CallsWho Name
-             | Browse [String]
-             | MakeDoc String -- IdrisDoc
-             | Warranty
-             | PrintDef Name
-             | PPrint OutputFmt Int PTerm
-             | TransformInfo Name
-             -- Debugging commands
-             | DebugInfo Name
-             | DebugUnify PTerm PTerm
-
 data OutputFmt = HTMLOutput | LaTeXOutput
 
 -- | Recognised logging categories for the Idris compiler.
@@ -543,6 +472,18 @@ loggingCatsStr = unlines
     , (strLogCat ICoverage)
     , (strLogCat IIBC)
     ]
+
+
+data ElabShellCmd = EQED
+                  | EAbandon
+                  | EUndo
+                  | EProofState
+                  | EProofTerm
+                  | EEval PTerm
+                  | ECheck PTerm
+                  | ESearch PTerm
+                  | EDocStr (Either Name Const)
+  deriving (Show, Eq)
 
 data Opt = Filename String
          | Quiet
@@ -612,17 +553,6 @@ data Opt = Filename String
          | NoElimDeprecationWarnings      -- ^ Don't show deprecation warnings for %elim
          | NoOldTacticDeprecationWarnings -- ^ Don't show deprecation warnings for old-style tactics
     deriving (Show, Eq, Generic)
-
-data ElabShellCmd = EQED
-                  | EAbandon
-                  | EUndo
-                  | EProofState
-                  | EProofTerm
-                  | EEval PTerm
-                  | ECheck PTerm
-                  | ESearch PTerm
-                  | EDocStr (Either Name Const)
-  deriving (Show, Eq)
 
 -- Parsed declarations
 

--- a/src/Idris/CmdOptions.hs
+++ b/src/Idris/CmdOptions.hs
@@ -1,15 +1,22 @@
 {-|
 Module      : Idris.CmdOptions
-Description : CLI for the Idris executable.
-Copyright   :
+Description : A parser for the CmdOptions for the Idris executable.
 License     : BSD3
 Maintainer  : The Idris Community.
 -}
 {-# LANGUAGE Arrows #-}
-module Idris.CmdOptions where
+module Idris.CmdOptions
+  (
+    module Idris.CmdOptions
+  , opt
+  , getClient, getPkg, getPkgCheck, getPkgClean, getPkgMkDoc
+  , getPkgREPL, getPkgTest, getPort, getIBCSubDir
+  ) where
 
 import Idris.AbsSyntaxTree
-import Idris.REPL
+import Idris.AbsSyntax (opt, getClient, getPkg, getPkgCheck, getPkgClean, getPkgMkDoc
+  , getPkgREPL, getPkgTest, getPort, getIBCSubDir)
+-- import Idris.REPL
 import Idris.Info (getIdrisVersion)
 
 import IRTS.CodegenCommon

--- a/src/Idris/Coverage.hs
+++ b/src/Idris/Coverage.hs
@@ -489,7 +489,7 @@ verifyTotality (fc, n)
 
                  case getPartial ist [] ns of
                       Nothing -> return ()
-                      Just bad -> do let t' = Partial (Other bad) 
+                      Just bad -> do let t' = Partial (Other bad)
                                      logCoverage 2 $ "Set to " ++ show t'
                                      setTotality n t'
                                      addIBC (IBCTotal n t')
@@ -503,7 +503,7 @@ verifyTotality (fc, n)
 
     getPartial ist [] [] = Nothing
     getPartial ist bad [] = Just bad
-    getPartial ist bad (n : ns) 
+    getPartial ist bad (n : ns)
         = case lookupTotalExact n (tt_ctxt ist) of
                Just (Partial _) -> getPartial ist (n : bad) ns
                _ -> getPartial ist bad ns

--- a/src/Idris/Package/Common.hs
+++ b/src/Idris/Package/Common.hs
@@ -1,15 +1,14 @@
 {-|
 Module      : Idris.Package.Common
 Description : Data structures common to all `iPKG` file formats.
-Copyright   :
 License     : BSD3
 Maintainer  : The Idris Community.
 -}
 module Idris.Package.Common where
 
-import Idris.Core.TT
-import Idris.REPL
-import Idris.AbsSyntaxTree
+import Idris.Core.TT (Name)
+
+import Idris.AbsSyntaxTree (Opt(..))
 
 -- | Description of an Idris package.
 data PkgDesc = PkgDesc {

--- a/src/Idris/REPL/Commands.hs
+++ b/src/Idris/REPL/Commands.hs
@@ -1,0 +1,76 @@
+module Idris.REPL.Commands where
+
+import Idris.Core.TT
+import Idris.Colours
+import Idris.AbsSyntaxTree
+
+-- | REPL commands
+data Command = Quit
+             | Help
+             | Eval PTerm
+             | NewDefn [PDecl] -- ^ Each 'PDecl' should be either a type declaration (at most one) or a clause defining the same name.
+             | Undefine [Name]
+             | Check PTerm
+             | Core PTerm
+             | DocStr (Either Name Const) HowMuchDocs
+             | TotCheck Name
+             | Reload
+             | Watch
+             | Load FilePath (Maybe Int) -- up to maximum line number
+             | ChangeDirectory FilePath
+             | ModImport String
+             | Edit
+             | Compile Codegen String
+             | Execute PTerm
+             | ExecVal PTerm
+             | Metavars
+             | Prove Bool Name -- ^ If false, use prover, if true, use elab shell
+             | AddProof (Maybe Name)
+             | RmProof Name
+             | ShowProof Name
+             | Proofs
+             | Universes
+             | LogLvl Int
+             | LogCategory [LogCat]
+             | Spec PTerm
+             | WHNF PTerm
+             | TestInline PTerm
+             | Defn Name
+             | Missing Name
+             | DynamicLink FilePath
+             | ListDynamic
+             | Pattelab PTerm
+             | Search [String] PTerm
+             | CaseSplitAt Bool Int Name
+             | AddClauseFrom Bool Int Name
+             | AddProofClauseFrom Bool Int Name
+             | AddMissing Bool Int Name
+             | MakeWith Bool Int Name
+             | MakeCase Bool Int Name
+             | MakeLemma Bool Int Name
+             | DoProofSearch Bool   -- update file
+                             Bool   -- recursive search
+                             Int    -- depth
+                             Name   -- top level name
+                             [Name] -- hints
+             | SetOpt Opt
+             | UnsetOpt Opt
+             | NOP
+             | SetColour ColourType IdrisColour
+             | ColourOn
+             | ColourOff
+             | ListErrorHandlers
+             | SetConsoleWidth ConsoleWidth
+             | SetPrinterDepth (Maybe Int)
+             | Apropos [String] String
+             | WhoCalls Name
+             | CallsWho Name
+             | Browse [String]
+             | MakeDoc String -- IdrisDoc
+             | Warranty
+             | PrintDef Name
+             | PPrint OutputFmt Int PTerm
+             | TransformInfo Name
+             -- Debugging commands
+             | DebugInfo Name
+             | DebugUnify PTerm PTerm

--- a/src/Idris/REPL/Parser.hs
+++ b/src/Idris/REPL/Parser.hs
@@ -1,7 +1,6 @@
 {-|
 Module      : Idris.REPL.Parser
 Description : Parser for the REPL commands.
-Copyright   :
 License     : BSD3
 Maintainer  : The Idris Community.
 -}
@@ -20,6 +19,8 @@ import Idris.AbsSyntax
 import Idris.Core.TT
 import Idris.Help
 import qualified Idris.Parser as P
+
+import Idris.REPL.Commands
 
 import Control.Applicative
 import Control.Monad.State.Strict


### PR DESCRIPTION
In anticipation of moving `idrisMain` out of `Idris.REPL` some
internal changes to Idris are made:

+ Move accessor methods for `Opt` to `AbsSyntax`.
+ Isolate and bring `Commond` under `Idris.REPL` module.
+ Fix some imports arising from changes.
+ Fix import and exports of `CmdOptions`.