### PR TITLE
Run test suite in parallel by default

### DIFF
--- a/idris.cabal
+++ b/idris.cabal
@@ -374,7 +374,7 @@ Test-suite regression-and-feature-tests
 
 
   ghc-prof-options: -auto-all -caf-all
-  ghc-options:      -threaded -rtsopts -funbox-strict-fields
+  ghc-options:      -threaded -rtsopts -with-rtsopts=-N -funbox-strict-fields
 
 Executable idris-codegen-c
   Main-is:        Main.hs

--- a/test/delab001/run
+++ b/test/delab001/run
@@ -1,3 +1,3 @@
 #!/usr/bin/env bash
-${IDRIS:-idris} $@ --quiet --nocolor delab001.idr < input
+${IDRIS:-idris} $@ --quiet --port none --nocolor delab001.idr < input
 rm -f *.ibc

--- a/test/docs001/run
+++ b/test/docs001/run
@@ -1,3 +1,3 @@
 #!/usr/bin/env bash
-${IDRIS:-idris} $@ --quiet --nocolor docs001.idr < input
+${IDRIS:-idris} $@ --quiet --port none --nocolor docs001.idr < input
 rm *.ibc

--- a/test/docs002/run
+++ b/test/docs002/run
@@ -1,3 +1,3 @@
 #!/usr/bin/env bash
-${IDRIS:-idris} $@ --nobanner --nocolor --quiet docs002.idr < input
+${IDRIS:-idris} $@ --nobanner --nocolor --quiet --port none docs002.idr < input
 rm *.ibc

--- a/test/docs003/run
+++ b/test/docs003/run
@@ -1,3 +1,3 @@
 #!/usr/bin/env bash
-${IDRIS:-idris} $@ --quiet --nocolor docs003.idr < input
+${IDRIS:-idris} $@ --quiet --port none --nocolor docs003.idr < input
 rm *.ibc

--- a/test/docs004/run
+++ b/test/docs004/run
@@ -1,3 +1,3 @@
 #!/usr/bin/env bash
-${IDRIS:-idris} $@ --quiet --nocolor docs004.idr < input
+${IDRIS:-idris} $@ --quiet --port none --nocolor docs004.idr < input
 rm *.ibc

--- a/test/docs005/run
+++ b/test/docs005/run
@@ -1,3 +1,3 @@
 #!/usr/bin/env bash
-${IDRIS:-idris} $@ --quiet --nocolor docs005.idr < input
+${IDRIS:-idris} $@ --quiet --port none --nocolor docs005.idr < input
 rm *.ibc

--- a/test/dsl001/run
+++ b/test/dsl001/run
@@ -1,5 +1,5 @@
 #!/usr/bin/env bash
 ${IDRIS:-idris} $@ test001.idr -o test001
 ./test001
-${IDRIS:-idris} $@ test001.idr --quiet < input
+${IDRIS:-idris} $@ test001.idr --quiet --port none < input
 rm -f test001 test001.ibc

--- a/test/ffi001/run
+++ b/test/ffi001/run
@@ -1,3 +1,3 @@
 #!/usr/bin/env bash
-${IDRIS:-idris} $@ --quiet --nocolour test022.idr --exec main
+${IDRIS:-idris} $@ --quiet --port none --nocolour test022.idr --exec main
 rm -f *.ibc

--- a/test/ffi002/run
+++ b/test/ffi002/run
@@ -1,3 +1,3 @@
 #!/usr/bin/env bash
-${IDRIS:-idris} $@ --quiet test023.idr -o test023
+${IDRIS:-idris} $@ --quiet --port none test023.idr -o test023
 rm -f test023 *.ibc

--- a/test/ffi003/run
+++ b/test/ffi003/run
@@ -1,3 +1,3 @@
 #!/usr/bin/env bash
-${IDRIS:-idris} $@ --quiet --nocolour test024.idr --exec main < input
+${IDRIS:-idris} $@ --quiet --port none --nocolour test024.idr --exec main < input
 rm -f *.ibc

--- a/test/ffi004/run
+++ b/test/ffi004/run
@@ -1,3 +1,3 @@
 #!/usr/bin/env bash
-${IDRIS:-idris} $@ --quiet --nocolour --check test026.idr
+${IDRIS:-idris} $@ --quiet --port none --nocolour --check test026.idr
 rm -f *.ibc

--- a/test/idrisdoc009/run
+++ b/test/idrisdoc009/run
@@ -1,3 +1,3 @@
 #!/usr/bin/env bash
-${IDRIS:-idris} $@ --nocolour --quiet Test.idr < input
+${IDRIS:-idris} $@ --nocolour --quiet --port none Test.idr < input
 rm -f *.ibc

--- a/test/interactive001/run
+++ b/test/interactive001/run
@@ -1,3 +1,3 @@
 #!/usr/bin/env bash
-${IDRIS:-idris} $@ --quiet test032.idr < input
+${IDRIS:-idris} $@ --quiet --port none test032.idr < input
 rm -f *.ibc

--- a/test/interactive002/run
+++ b/test/interactive002/run
@@ -1,3 +1,3 @@
 #!/usr/bin/env bash
-${IDRIS:-idris} $@ --quiet interactive002.idr < input
+${IDRIS:-idris} $@ --quiet --port none interactive002.idr < input
 rm -f *.ibc

--- a/test/interactive003/run
+++ b/test/interactive003/run
@@ -1,3 +1,3 @@
 #!/usr/bin/env bash
-${IDRIS:-idris} $@ --quiet interactive003.idr < input
+${IDRIS:-idris} $@ --quiet --port none interactive003.idr < input
 rm -f *.ibc

--- a/test/interactive004/run
+++ b/test/interactive004/run
@@ -1,3 +1,3 @@
 #!/usr/bin/env bash
-${IDRIS:-idris} $@ --quiet interactive004.idr < input
+${IDRIS:-idris} $@ --quiet --port none interactive004.idr < input
 rm -f *.ibc

--- a/test/interactive005/run
+++ b/test/interactive005/run
@@ -1,5 +1,5 @@
 #!/usr/bin/env bash
-${IDRIS:-idris} $@ --nocolour --quiet interactive005.idr --consolewidth 70 < input
+${IDRIS:-idris} $@ --nocolour --quiet --port none interactive005.idr --consolewidth 70 < input
 rm -f *.ibc
 rm -f hello.bytecode
 rm -f hello

--- a/test/interactive006/run
+++ b/test/interactive006/run
@@ -1,3 +1,3 @@
 #!/usr/bin/env bash
-${IDRIS:-idris} $@ --quiet --port 5000 interactive006.idr < input
+${IDRIS:-idris} $@ --quiet --port none --port 5000 interactive006.idr < input
 rm -f *.ibc

--- a/test/interactive007/run
+++ b/test/interactive007/run
@@ -1,2 +1,2 @@
 #!/usr/bin/env bash
-${IDRIS:-idris} $@ -p contrib --nobanner --nocolor < input | perl -pe 's-Data\\Z-Data/Z-g'
+${IDRIS:-idris} $@ -p contrib --nobanner --nocolor --port none < input | perl -pe 's-Data\\Z-Data/Z-g'

--- a/test/interactive008/run
+++ b/test/interactive008/run
@@ -1,2 +1,2 @@
 #!/usr/bin/env bash
-${IDRIS:-idris} $@ --nobanner --nocolor < input
+${IDRIS:-idris} $@ --nobanner --nocolor --port none < input

--- a/test/interactive009/run
+++ b/test/interactive009/run
@@ -1,3 +1,3 @@
 #!/usr/bin/env bash
-${IDRIS:-idris} $@ --quiet interactive009.idr < input
+${IDRIS:-idris} $@ --quiet --port none interactive009.idr < input
 rm -f *.ibc

--- a/test/interactive010/run
+++ b/test/interactive010/run
@@ -1,2 +1,2 @@
 #!/usr/bin/env bash
-${IDRIS:-idris} $@ --quiet --nobanner --nocolor  < input
+${IDRIS:-idris} $@ --quiet --port none --nobanner --nocolor  < input

--- a/test/interactive011/run
+++ b/test/interactive011/run
@@ -1,3 +1,3 @@
 #!/usr/bin/env bash
-${IDRIS:-idris} $@ --quiet interactive011.idr < input
+${IDRIS:-idris} $@ --quiet --port none interactive011.idr < input
 rm -f *.ibc

--- a/test/interactive012/run
+++ b/test/interactive012/run
@@ -1,3 +1,3 @@
 #!/usr/bin/env bash
-${IDRIS:-idris} $@ --nocolour --consolewidth 70 --quiet interactive012.idr < input
+${IDRIS:-idris} $@ --nocolour --consolewidth 70 --quiet --port none interactive012.idr < input
 rm -f *.ibc

--- a/test/interactive013/run
+++ b/test/interactive013/run
@@ -1,3 +1,3 @@
 #!/usr/bin/env bash
-${IDRIS:-idris} $@ --quiet interactive013.idr < input
+${IDRIS:-idris} $@ --quiet --port none interactive013.idr < input
 rm -f *.ibc

--- a/test/interfaces001/run
+++ b/test/interfaces001/run
@@ -1,3 +1,3 @@
 #!/usr/bin/env bash
-${IDRIS:-idris} $@ --quiet --nocolour --consolewidth 70 InterfaceName.idr < input
+${IDRIS:-idris} $@ --quiet --port none --nocolour --consolewidth 70 InterfaceName.idr < input
 rm -f *.ibc

--- a/test/layout001/run
+++ b/test/layout001/run
@@ -1,6 +1,6 @@
 #!/usr/bin/env bash
 
-${IDRIS:-idris} --nobanner --nocolour --quiet <<!
+${IDRIS:-idris} --nobanner --nocolour --quiet --port none <<!
 :load layout001a.idr
 :load layout001b.idr
 :load layout001c.idr

--- a/test/primitives002/run
+++ b/test/primitives002/run
@@ -48,7 +48,7 @@ for T in "${TESTS[@]}"
 do
     echo ${T%% *} ${T##*#}
     generate_testfile "tmptest.idr" "${T%%#*}"
-    ${IDRIS:-idris} $@ --quiet tmptest.idr -o tmptest || echo "missing primitive in ${CG}"
+    ${IDRIS:-idris} $@ --quiet --port none tmptest.idr -o tmptest || echo "missing primitive in ${CG}"
     ./tmptest <<<"${T##*#}"
     rm tmptest.idr tmptest.ibc tmptest
 done

--- a/test/proof009/run
+++ b/test/proof009/run
@@ -1,3 +1,3 @@
 #!/usr/bin/env bash
-${IDRIS:-idris} $@ --consolewidth 70 --quiet proof009.idr < input
+${IDRIS:-idris} $@ --consolewidth 70 --quiet --port none proof009.idr < input
 rm -f *.ibc

--- a/test/quasiquote006/run
+++ b/test/quasiquote006/run
@@ -1,3 +1,3 @@
 #!/usr/bin/env bash
-${IDRIS:-idris} $@ --check --nocolour --quiet --consolewidth 70 quasiquote006.idr
+${IDRIS:-idris} $@ --check --nocolour --quiet --port none --consolewidth 70 quasiquote006.idr
 rm -f *.ibc

--- a/test/reg041/run
+++ b/test/reg041/run
@@ -1,5 +1,5 @@
 #!/usr/bin/env bash
-${IDRIS:-idris} $@ --quiet ott.idr -e example
+${IDRIS:-idris} $@ --quiet --port none ott.idr -e example
 ${IDRIS:-idris} $@ showu.idr -o reg040
 ./reg040
 rm -f reg040 *.ibc

--- a/test/reg075/run
+++ b/test/reg075/run
@@ -1,3 +1,3 @@
 #!/usr/bin/env bash
-${IDRIS:-idris} $@ --quiet reg075.idr < input
+${IDRIS:-idris} $@ --quiet --port none reg075.idr < input
 rm -f *.ibc

--- a/test/regression002/run
+++ b/test/regression002/run
@@ -1,6 +1,6 @@
 #!/usr/bin/env bash
 
-${IDRIS:-idris} $@ --nobanner --nocolour --quiet <<!
+${IDRIS:-idris} $@ --nobanner --nocolour --quiet --port none <<!
 :load reg003.idr
 :load reg003a.idr
 :load reg006.idr

--- a/test/unique004/run
+++ b/test/unique004/run
@@ -1,6 +1,6 @@
 #!/usr/bin/env bash
 
-${IDRIS:-idris} --nobanner --nocolour --quiet <<!
+${IDRIS:-idris} --nobanner --nocolour --quiet --port none <<!
 :load unique001a.idr
 :load unique001b.idr
 :load unique001c.idr


### PR DESCRIPTION
This is a lot faster on my machine. It outputs a bunch of "idris: bind: resource busy (Address already in use)" lines but they're irrelevant since AFAIK the tests don't actually connect to the socket.