### PR TITLE
Remove a bunch of "deriving instance NFData" hot comments

### DIFF
--- a/src/Idris/AbsSyntaxTree.hs
+++ b/src/Idris/AbsSyntaxTree.hs
@@ -320,7 +320,6 @@ data SizeChange = Smaller | Same | Bigger | Unknown
     deriving (Show, Eq, Generic)
 {-!
 deriving instance Binary SizeChange
-deriving instance NFData SizeChange
 !-}
 
 type SCGEntry = (Name, [Maybe (Int, SizeChange)])
@@ -333,7 +332,6 @@ data CGInfo = CGInfo {
   } deriving (Show, Generic)
 {-!
 deriving instance Binary CGInfo
-deriving instance NFData CGInfo
 !-}
 
 primDefs = [ sUN "unsafePerformPrimIO"
@@ -428,9 +426,6 @@ throwError = Trans.lift . throwE
 data Codegen = Via IRFormat String
              | Bytecode
     deriving (Show, Eq, Generic)
-{-!
-deriving instance NFData Codegen
-!-}
 
 data IRFormat = IBCFormat | JSONFormat deriving (Show, Eq, Generic)
 
@@ -567,7 +562,6 @@ data Fixity = Infixl  { prec :: Int }
     deriving (Eq, Generic)
 {-!
 deriving instance Binary Fixity
-deriving instance NFData Fixity
 !-}
 
 instance Show Fixity where
@@ -584,7 +578,6 @@ instance Show FixDecl where
 
 {-!
 deriving instance Binary FixDecl
-deriving instance NFData FixDecl
 !-}
 
 instance Ord FixDecl where
@@ -595,7 +588,6 @@ data Static = Static | Dynamic
   deriving (Show, Eq, Data, Generic, Typeable)
 {-!
 deriving instance Binary Static
-deriving instance NFData Static
 !-}
 
 -- ^ Mark bindings with their explicitness, and laziness
@@ -620,7 +612,6 @@ data Plicity = Imp { pargopts  :: [ArgOpt]
 
 {-!
 deriving instance Binary Plicity
-deriving instance NFData Plicity
 !-}
 
 is_scoped :: Plicity -> Maybe ImplicitInfo
@@ -664,7 +655,6 @@ data FnOpt = Inlinable -- ^ always evaluate when simplifying
     deriving (Show, Eq, Generic)
 {-!
 deriving instance Binary FnOpt
-deriving instance NFData FnOpt
 !-}
 
 type FnOpts = [FnOpt]
@@ -767,7 +757,6 @@ data PDecl' t
  deriving (Functor, Generic)
 {-!
 deriving instance Binary PDecl'
-deriving instance NFData PDecl'
 !-}
 
 -- | The set of source directives
@@ -839,7 +828,6 @@ data PClause' t = PClause  FC Name t [t] t                    [PDecl' t] -- ^ A 
     deriving (Functor, Generic)
 {-!
 deriving instance Binary PClause'
-deriving instance NFData PClause'
 !-}
 
 -- | Data declaration
@@ -869,7 +857,6 @@ mapPDataFC f g (PLaterdecl n nfc tycon) =
   PLaterdecl n (g nfc) (mapPTermFC f g tycon)
 {-!
 deriving instance Binary PData'
-deriving instance NFData PData'
 !-}
 
 -- Handy to get a free function for applying PTerm -> PTerm functions
@@ -1174,7 +1161,6 @@ mapPTermFC f g (PQuoteName n x fc)            = PQuoteName n x (g fc)
 
 {-!
 dg instance Binary PTerm
-deriving instance NFData PTerm
 !-}
 
 mapPT :: (PTerm -> PTerm) -> PTerm -> PTerm
@@ -1238,7 +1224,6 @@ data PTactic' t = Intro [Name] | Intros | Focus Name
     deriving (Show, Eq, Functor, Foldable, Traversable, Data, Generic, Typeable)
 {-!
 deriving instance Binary PTactic'
-deriving instance NFData PTactic'
 !-}
 instance Sized a => Sized (PTactic' a) where
   size (Intro nms)      = 1 + size nms
@@ -1285,7 +1270,6 @@ data PDo' t = DoExp  FC t
     deriving (Eq, Functor, Data, Generic, Typeable)
 {-!
 deriving instance Binary PDo'
-deriving instance NFData PDo'
 !-}
 
 instance Sized a => Sized (PDo' a) where
@@ -1339,7 +1323,6 @@ instance Sized a => Sized (PArg' a) where
 
 {-!
 deriving instance Binary PArg'
-deriving instance NFData PArg'
 !-}
 
 pimp n t mach = PImp 1 mach [] n t
@@ -1421,7 +1404,6 @@ data InterfaceInfo = CI {
   } deriving (Show, Generic)
 {-!
 deriving instance Binary InterfaceInfo
-deriving instance NFData InterfaceInfo
 !-}
 
 -- Record data
@@ -1442,7 +1424,6 @@ data FnInfo = FnInfo { fn_params :: [Int] }
     deriving (Show, Generic)
 {-!
 deriving instance Binary FnInfo
-deriving instance NFData FnInfo
 !-}
 
 data OptInfo = Optimise {
@@ -1451,7 +1432,6 @@ data OptInfo = Optimise {
   } deriving (Show, Generic)
 {-!
 deriving instance Binary OptInfo
-deriving instance NFData OptInfo
 !-}
 
 -- | Syntactic sugar info
@@ -1468,7 +1448,6 @@ data DSL' t = DSL {
   } deriving (Show, Functor, Generic)
 {-!
 deriving instance Binary DSL'
-deriving instance NFData DSL'
 !-}
 
 type DSL = DSL' PTerm
@@ -1479,7 +1458,6 @@ data SynContext = PatternSyntax
     deriving (Show, Generic)
 {-!
 deriving instance Binary SynContext
-deriving instance NFData SynContext
 !-}
 
 data Syntax = Rule [SSymbol] PTerm SynContext
@@ -1499,7 +1477,6 @@ syntaxSymbols (Rule ss _ _) = ss
 syntaxSymbols (DeclRule ss _) = ss
 {-!
 deriving instance Binary Syntax
-deriving instance NFData Syntax
 !-}
 
 data SSymbol = Keyword Name
@@ -1512,7 +1489,6 @@ data SSymbol = Keyword Name
 
 {-!
 deriving instance Binary SSymbol
-deriving instance NFData SSymbol
 !-}
 
 newtype SyntaxRules = SyntaxRules { syntaxRulesList :: [Syntax] }
@@ -1572,7 +1548,6 @@ data Using = UImplicit Name PTerm
     deriving (Show, Eq, Data, Generic, Typeable)
 {-!
 deriving instance Binary Using
-deriving instance NFData Using
 !-}
 
 data SyntaxInfo = Syn {
@@ -1595,7 +1570,6 @@ data SyntaxInfo = Syn {
   , withAppAllowed    :: Bool
   } deriving (Show, Generic)
 {-!
-deriving instance NFData SyntaxInfo
 deriving instance Binary SyntaxInfo
 !-}
 

--- a/src/Idris/Core/CaseTree.hs
+++ b/src/Idris/Core/CaseTree.hs
@@ -50,7 +50,6 @@ data SC' t = Case CaseType Name [CaseAlt' t]  -- ^ invariant: lowest tags first
     deriving (Eq, Ord, Functor, Generic)
 {-!
 deriving instance Binary SC'
-deriving instance NFData SC'
 !-}
 
 data CaseType = Updatable | Shared
@@ -66,7 +65,6 @@ data CaseAlt' t = ConCase Name Int [Name] !(SC' t)
     deriving (Show, Eq, Ord, Functor, Generic)
 {-!
 deriving instance Binary CaseAlt'
-deriving instance NFData CaseAlt'
 !-}
 
 type CaseAlt = CaseAlt' Term

--- a/src/Idris/Core/Evaluate.hs
+++ b/src/Idris/Core/Evaluate.hs
@@ -757,15 +757,6 @@ deriving instance Binary CaseInfo
 {-!
 deriving instance Binary CaseDefs
 !-}
-{-!
-deriving instance NFData Def
-!-}
-{-!
-deriving instance NFData CaseInfo
-!-}
-{-!
-deriving instance NFData CaseDefs
-!-}
 
 instance Show Def where
     show (Function ty tm) = "Function: " ++ show (ty, tm)
@@ -794,9 +785,6 @@ instance Show Def where
 
 data Accessibility = Hidden | Public | Frozen | Private
     deriving (Eq, Ord, Generic)
-{-!
-deriving instance NFData Accessibility
-!-}
 
 instance Show Accessibility where
   show Public = "public export"
@@ -813,17 +801,11 @@ data Totality = Total [Int] -- ^ well-founded arguments
               | Unchecked
               | Generated
     deriving (Eq, Generic)
-{-!
-deriving instance NFData Totality
-!-}
 
 -- | Reasons why a function may not be total
 data PReason = Other [Name] | Itself | NotCovering | NotPositive | UseUndef Name
              | ExternalIO | BelieveMe | Mutual [Name] | NotProductive
     deriving (Show, Eq, Generic)
-{-!
-deriving instance NFData PReason
-!-}
 
 instance Show Totality where
     show (Total args)= "Total" -- ++ show args ++ " decreasing arguments"

--- a/src/Idris/Core/TT.hs
+++ b/src/Idris/Core/TT.hs
@@ -182,7 +182,6 @@ fileFC s = FileFC s
 
 {-!
 deriving instance Binary FC
-deriving instance NFData FC
 !-}
 
 instance Sized FC where
@@ -246,7 +245,6 @@ data Provenance = ExpectedType
                 | SourceTerm Term
   deriving (Show, Eq, Data, Generic, Typeable)
 {-!
-deriving instance NFData Err
 deriving instance Binary Err
 !-}
 
@@ -343,10 +341,6 @@ instance Applicative TC where
 instance Alternative TC where
     empty = mzero
     (<|>) = mplus
-
-{-!
-deriving instance NFData Err
-!-}
 
 instance Sized ErrorReportPart where
   size (TextPart msg) = 1 + length msg
@@ -499,7 +493,6 @@ caseName _ = False
 
 {-!
 deriving instance Binary Name
-deriving instance NFData Name
 !-}
 
 data SpecialName = WhereN !Int !Name !Name
@@ -514,7 +507,6 @@ data SpecialName = WhereN !Int !Name !Name
   deriving (Eq, Ord, Data, Generic, Typeable)
 {-!
 deriving instance Binary SpecialName
-deriving instance NFData SpecialName
 !-}
 
 sInstanceN :: Name -> [String] -> SpecialName
@@ -695,11 +687,6 @@ intTyName (ITChar) = "Char"
 
 data ArithTy = ATInt IntTy | ATFloat -- TODO: Float vectors https://github.com/idris-lang/Idris-dev/issues/1723
     deriving (Show, Eq, Ord, Data, Generic, Typeable)
-{-!
-deriving instance NFData IntTy
-deriving instance NFData NativeTy
-deriving instance NFData ArithTy
-!-}
 
 instance Pretty ArithTy OutputAnnotation where
     pretty (ATInt ITNative) = text "Int"
@@ -752,7 +739,6 @@ instance Eq Const where
 
 {-!
 deriving instance Binary Const
-deriving instance NFData Const
 !-}
 
 isTypeConst :: Const -> Bool
@@ -850,7 +836,6 @@ instance Pretty Raw OutputAnnotation where
 
 {-!
 deriving instance Binary Raw
-deriving instance NFData Raw
 !-}
 
 data ImplicitInfo = Impl { tcinstance :: Bool, toplevel_imp :: Bool,
@@ -859,7 +844,6 @@ data ImplicitInfo = Impl { tcinstance :: Bool, toplevel_imp :: Bool,
 
 {-!
 deriving instance Binary ImplicitInfo
-deriving instance NFData ImplicitInfo
 !-}
 
 -- The type parameter `b` will normally be something like `TT Name` or just
@@ -910,7 +894,6 @@ data Binder b = Lam   { binderTy  :: !b {-^ type annotation for bound variable-}
   deriving (Show, Eq, Ord, Functor, Foldable, Traversable, Data, Generic, Typeable)
 {-!
 deriving instance Binary Binder
-deriving instance NFData Binder
 !-}
 
 instance Sized a => Sized (Binder a) where
@@ -953,9 +936,6 @@ internalNS = "(internal)"
 data UExp = UVar String Int -- ^ universe variable, with source file to disambiguate
           | UVal Int -- ^ explicit universe level
   deriving (Eq, Ord, Data, Generic, Typeable)
-{-!
-deriving instance NFData UExp
-!-}
 
 instance Sized UExp where
   size _ = 1
@@ -995,7 +975,6 @@ data NameType = Bound
   deriving (Show, Ord, Data, Generic, Typeable)
 {-!
 deriving instance Binary NameType
-deriving instance NFData NameType
 !-}
 
 instance Sized NameType where
@@ -1035,7 +1014,6 @@ data TT n = P NameType n (TT n) -- ^ named references with type
   deriving (Ord, Functor, Data, Generic, Typeable)
 {-!
 deriving instance Binary TT
-deriving instance NFData TT
 !-}
 
 class TermSize a where
@@ -1109,7 +1087,6 @@ data TypeInfo = TI { con_names :: [Name],
     deriving (Show, Generic)
 {-!
 deriving instance Binary TypeInfo
-deriving instance NFData TypeInfo
 !-}
 
 instance Eq n => Eq (TT n) where


### PR DESCRIPTION
These are for the derive tool - the code it generates was replaced with a system based on GHC generics in #3248.