### PR TITLE
Use correct fixity info for :printdef

### DIFF
--- a/src/Idris/REPL.hs
+++ b/src/Idris/REPL.hs
@@ -1512,7 +1512,7 @@ pprintDef asCore n =
                   let ppTm t = annotate (AnnTerm (zip vars (repeat False)) t) .
                                pprintPTerm (ppOptionIst ist)
                                      (zip vars (repeat False))
-                                     [] [] .
+                                     [] (idris_infixes ist) .
                                delab ist $
                                t
                   in group $ ppTm lhs <+> text "=" <$> (group . align . hang 2 $ ppTm rhs)

--- a/test/delab001/expected
+++ b/test/delab001/expected
@@ -5,8 +5,8 @@ foo n = case n of
 bar : Nat -> String -> String
 bar x y = case x of
             0 => y
-            S _ => (y ++ y)
+            S _ => y ++ y
 append : List a -> List a -> List a
 append xs ys = case xs of
                  [] => ys
-                 (x :: xs) => (x :: (append xs ys))
+                 x :: xs => x :: append xs ys


### PR DESCRIPTION
This prevents over-parenthesization.