### PR TITLE
Refactor `main/Main.hs`

### DIFF
--- a/main/Main.hs
+++ b/main/Main.hs
@@ -1,8 +1,7 @@
 module Main where
 
-import System.Exit ( exitSuccess )
-
 import Control.Monad ( when )
+import System.Exit ( exitSuccess )
 
 import Idris.AbsSyntax
 import Idris.Error
@@ -14,63 +13,60 @@ import Idris.Main
 
 import Util.System ( setupBundledCC )
 
+processShowOptions :: [Opt] -> Idris ()
+processShowOptions opts = runIO $ do
+  when (ShowAll `elem` opts)          $ showExitIdrisInfo
+  when (ShowLoggingCats `elem` opts)  $ showExitIdrisLoggingCategories
+  when (ShowIncs `elem` opts)         $ showExitIdrisFlagsInc
+  when (ShowLibs `elem` opts)         $ showExitIdrisFlagsLibs
+  when (ShowLibdir `elem` opts)       $ showExitIdrisLibDir
+  when (ShowPkgs `elem` opts)         $ showExitIdrisInstalledPackages
 
+check :: [Opt] -> (Opt -> Maybe a) -> ([a] -> Idris ()) -> Idris ()
+check opts extractOpts action = do
+  case opt extractOpts opts of
+    [] -> return ()
+    fs -> do action fs
+             runIO exitSuccess
 
--- Main program reads command line options, parses the main program, and gets
--- on with the REPL.
+processClientOptions :: [Opt] -> Idris ()
+processClientOptions opts = check opts getClient $ \fs -> case fs of
+  (c:_) -> do
+    setVerbose False
+    setQuiet True
+    case getPort opts of
+      Just  DontListen       -> ifail "\"--client\" and \"--port none\" are incompatible"
+      Just (ListenPort port) -> runIO $ runClient (Just port) c
+      Nothing                -> runIO $ runClient Nothing c
 
-main :: IO ()
-main = do opts <- runArgParser
-          runMain (runIdris opts)
+processPackageOptions :: [Opt] -> Idris ()
+processPackageOptions opts = do
+  check opts getPkgCheck $ \fs -> runIO $ do
+    mapM_ (checkPkg opts (WarnOnly `elem` opts) True) fs
+  check opts getPkgClean $ \fs -> runIO $ do
+    mapM_ (cleanPkg opts) fs
+  check opts getPkgMkDoc $ \fs -> runIO $ do
+    mapM_ (documentPkg opts) fs
+  check opts getPkgTest $ \fs -> runIO $ do
+    mapM_ (testPkg opts) fs
+  check opts getPkg $ \fs -> runIO $ do
+    mapM_ (buildPkg opts (WarnOnly `elem` opts)) fs
+  check opts getPkgREPL $ \fs -> case fs of
+    [f] -> replPkg opts f
+    _   -> ifail "Too many packages"
 
 -- | The main function for the Idris executable.
 runIdris :: [Opt] -> Idris ()
 runIdris opts = do
-    runIO setupBundledCC
-    -- Show information then quit.
-    when (ShowAll `elem` opts)          $ runIO showExitIdrisInfo
-    when (ShowLoggingCats `elem` opts)  $ runIO showExitIdrisLoggingCategories
-    when (ShowIncs `elem` opts)         $ runIO showExitIdrisFlagsInc
-    when (ShowLibs `elem` opts)         $ runIO showExitIdrisFlagsLibs
-    when (ShowLibdir `elem` opts)       $ runIO showExitIdrisLibDir
-    when (ShowPkgs `elem` opts)         $ runIO showExitIdrisInstalledPackages
+  runIO setupBundledCC
+  processShowOptions opts    -- Show information then quit.
+  processClientOptions opts  -- Be a client to an IDE Mode server.
+  processPackageOptions opts -- Work with Idris packages.
+  idrisMain opts             -- Launch REPL or compile mode.
 
-    -- Be a client to an IDE Mode server.
-    case opt getClient opts of
-       []    -> return ()
-       (c:_) -> do setVerbose False
-                   setQuiet True
-                   case getPort opts of
-                     Just  DontListen       ->
-                       ifail "\"--client\" and \"--port none\" are incompatible"
-                     Just (ListenPort port) -> runIO $ runClient (Just port) c
-                     Nothing                -> runIO $ runClient Nothing c
-                   runIO exitSuccess
-
-    -- Work with Idris packages.                   
-    case opt getPkgCheck opts of
-       [] -> return ()
-       fs -> do runIO $ mapM_ (checkPkg opts (WarnOnly `elem` opts) True) fs
-                runIO exitSuccess
-    case opt getPkgClean opts of
-       [] -> return ()
-       fs -> do runIO $ mapM_ (cleanPkg opts) fs
-                runIO exitSuccess
-    case opt getPkgMkDoc opts of                -- IdrisDoc
-       [] -> return ()
-       fs -> do runIO $ mapM_ (documentPkg opts) fs
-                runIO exitSuccess
-    case opt getPkgTest opts of
-       [] -> return ()
-       fs -> do runIO $ mapM_ (testPkg opts) fs
-                runIO exitSuccess
-
-    -- Either launch one of the interaction modes, or install a
-    -- package.
-    case opt getPkg opts of
-       [] -> case opt getPkgREPL opts of
-                  [] -> idrisMain opts
-                  [f] -> replPkg opts f
-                  _ -> ifail "Too many packages"
-       fs -> runIO $ mapM_ (buildPkg opts (WarnOnly `elem` opts)) fs
-
+-- Main program reads command line options, parses the main program, and gets
+-- on with the REPL.
+main :: IO ()
+main = do
+  opts <- runArgParser
+  runMain (runIdris opts)


### PR DESCRIPTION
Worked on some tweaks for `main/Main.hs` while getting my head around what's required for #1126.

- Improved clarity – particularly to where `idrisMain` gets invoked. This was previously buried in the processing of the package commands.
- Remove duplication.

I've got some ideas of how to do option processing better in the future but this is an improvement for now.