### PR TITLE
Make C codegen fail more.

### DIFF
--- a/src/IRTS/CodegenC.hs
+++ b/src/IRTS/CodegenC.hs
@@ -340,6 +340,7 @@ bcc i (FOREIGNCALL l rty (FStr fn) args)
       = indent i ++
         c_irts (toFType rty) (creg l ++ " = ")
                    (fn ++ "(" ++ showSep "," (map fcall args) ++ ")") ++ ";\n"
+bcc i (FOREIGNCALL l rty _ args) = error "Foreign Function calls cannot be partially applied, without being inlined."
 bcc i (NULL r) = indent i ++ creg r ++ " = NULL;\n" -- clear, so it'll be GCed
 bcc i (ERROR str) = indent i ++ "fprintf(stderr, " ++ show str ++ "); fprintf(stderr, \"\\n\"); exit(-1);\n"
 -- bcc i c = error (show c) -- indent i ++ "// not done yet\n"

--- a/test/TestData.hs
+++ b/test/TestData.hs
@@ -114,14 +114,16 @@ testFamiliesData = [
       (  8, ANY  ),
       (  9, ANY  )]),
   ("ffi",             "FFI",
-    [ (  1, ANY  ),
-      (  2, ANY  ),
-      (  3, ANY  ),
-      (  4, ANY  ),
-      (  5, ANY  ),
-      (  6, C_CG ),
-      (  7, C_CG ),
-      (  8, C_CG )]),
+    [ (  1, ANY  )
+    , (  2, ANY  )
+    , (  3, ANY  )
+    , (  4, ANY  )
+    , (  5, ANY  )
+    , (  6, C_CG )
+    , (  7, C_CG )
+    , (  8, C_CG )
+    , (  9, C_CG )
+    ]),
   ("folding",         "Folding",
     [ (  1, ANY  )]),
   ("idrisdoc",        "Idris documentation",

--- a/test/ffi009/Bad.idr
+++ b/test/ffi009/Bad.idr
@@ -1,0 +1,36 @@
+module Bad
+
+%include c "ffi009.h"
+
+private
+get_allocation_size : Ptr -> IO Int
+get_allocation_size = foreign FFI_C "get_allocation_size" (Ptr -> IO Int)
+
+-- [ NOTE ]
+--
+-- As `commen_call` is a partial function and not inline, Idris should complain.
+
+private
+common_call : String -> Int -> IO ManagedPtr
+common_call f l = do
+  ptr <- foreign FFI_C
+                 f
+                 (Int -> IO Ptr)
+                 l
+  len <- get_allocation_size ptr
+  pure (prim__registerPtr ptr len)
+
+func_foo : IO ManagedPtr
+func_foo = common_call "foo" 4
+
+func_bar : IO ManagedPtr
+func_bar = common_call "bar" 8
+
+
+namespace Main
+  main : IO ()
+  main = do
+    foo <- func_foo
+    bar <- func_bar
+
+    printLn "I should not be seen."

--- a/test/ffi009/Good.idr
+++ b/test/ffi009/Good.idr
@@ -1,0 +1,37 @@
+module Good
+
+%include c "ffi009.h"
+
+private
+get_allocation_size : Ptr -> IO Int
+get_allocation_size = foreign FFI_C "get_allocation_size" (Ptr -> IO Int)
+
+-- [ NOTE ]
+--
+-- As `commen_call` is a partial function and not inline, Idris should complain.
+
+private
+%inline
+common_call : String -> Int -> IO ManagedPtr
+common_call f l = do
+  ptr <- foreign FFI_C
+                 f
+                 (Int -> IO Ptr)
+                 l
+  len <- get_allocation_size ptr
+  pure (prim__registerPtr ptr len)
+
+func_foo : IO ManagedPtr
+func_foo = common_call "foo" 4
+
+func_bar : IO ManagedPtr
+func_bar = common_call "bar" 8
+
+
+namespace Main
+  main : IO ()
+  main = do
+    foo <- func_foo
+    bar <- func_bar
+
+    printLn "I should be seen."

--- a/test/ffi009/expected
+++ b/test/ffi009/expected
@@ -1,0 +1,1 @@
+"I should be seen."

--- a/test/ffi009/ffi009.c
+++ b/test/ffi009/ffi009.c
@@ -1,0 +1,44 @@
+#include "ffi009.h"
+
+
+Vect* foo(int length)
+{
+  return new_empty_vect(length);
+}
+
+Vect* bar(int length)
+{
+  return new_empty_vect(length * 2);
+}
+
+
+Vect* new_empty_vect(int l)
+{
+  unsigned char* vect;
+
+  vect = malloc(sizeof(unsigned char) * l);
+
+  if (vect == NULL){
+    free(vect);
+    return NULL;
+  }
+
+  Vect* v = malloc(sizeof(Vect));
+
+  if (v==NULL){
+    free(vect);
+    free(v);
+    return NULL;
+  }
+
+  v->value  = vect;
+  v->length = l;
+
+  return v;
+}
+
+
+int get_allocation_size(Vect* v)
+{
+  return sizeof(Vect) + v->length;
+}

--- a/test/ffi009/ffi009.h
+++ b/test/ffi009/ffi009.h
@@ -1,0 +1,20 @@
+#ifndef FFI009_H
+#define FFI009_H
+
+#include <idris_rts.h>
+
+
+typedef struct
+{
+  unsigned char* value;
+  int length;
+} Vect;
+
+int get_allocation_size(Vect* v);
+
+Vect* new_empty_vect(int length);
+
+Vect* foo(int length);
+Vect* bar(int length);
+
+#endif /* FFI009_H */

--- a/test/ffi009/run
+++ b/test/ffi009/run
@@ -1,0 +1,5 @@
+#!/usr/bin/env bash
+${IDRIS:-idris} $@ Bad.idr -o bad --cg-opt "ffi009.c" --cg-opt "-fno-strict-overflow"
+${IDRIS:-idris} $@ Good.idr -o good --cg-opt "ffi009.c"
+./good
+rm -f *.ibc good


### PR DESCRIPTION
There was an uncaught case in the C Codegen that allowed partially applied foreign function calls to let through. This should be fixed higher up the toolchain, we add a error statement here as a last resort.

Partially addresses #3403