### PR TITLE
Work around GHCJS's patched export of isWindows from System.FilePath

### DIFF
--- a/src/Idris/REPL.hs
+++ b/src/Idris/REPL.hs
@@ -75,6 +75,14 @@ import Text.Trifecta.Result(Result(..), ErrInfo(..))
 
 import System.Console.Haskeline as H
 import System.FilePath
+  ( (</>)
+  , (<.>)
+  , splitExtension
+  , addExtension
+  , dropExtension
+  , takeExtension
+  , takeDirectory
+  )
 import System.Exit
 import System.Environment
 import System.Process


### PR DESCRIPTION
Right now Idris fails to compile under GHCJS because [GHCJS's `System.FilePath` module](https://github.com/ghcjs/ghcjs-boot/blob/master/patches/filepath.patch) exports an `isWindows` name. This clashes with Idris's internal `Util.System.isWindows` function.

I've worked around this here by importing only the required names from `System.FilePath`.

There's an [open issue](https://github.com/ghcjs/ghcjs-boot/issues/38) in the GHCJS repository to fix this once and for all, but since the issue has a simple workaround I thought I'd submit this patch to Idris too.

Thanks! 🙂