### PR TITLE
Widen bounds on optparse-applicative and aeson

### DIFF
--- a/idris.cabal
+++ b/idris.cabal
@@ -251,7 +251,7 @@ Library
                 , Tools_idris
 
   Build-depends:  base >=4 && <5
-                , aeson >= 0.6 && < 0.12
+                , aeson >= 0.6 && < 1.1
                 , annotated-wl-pprint >= 0.7 && < 0.8
                 , ansi-terminal < 0.7
                 , ansi-wl-pprint < 0.7
@@ -271,7 +271,7 @@ Library
                 , ieee754 >= 0.7 && < 0.8
                 , mtl >= 2.1 && < 2.3
                 , network < 2.7
-                , optparse-applicative >= 0.11 && < 0.13
+                , optparse-applicative >= 0.11 && < 0.14
                 , parsers >= 0.9 && < 0.13
                 , pretty < 1.2
                 , regex-tdfa >= 1.2


### PR DESCRIPTION
This makes Idris buildable against Stackage Nightly, so the badge can be green again.