### PR TITLE
When asked Idris will 'audit' Idris projects.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -36,6 +36,11 @@
   Unicode-rendering issues on Windows (e.g., error messages stating
   `commitBuffer: invalid argument (invalid character)`).
 
++ Idris now has a `--warnipkg` flag to enable auditing of Idris
+  packages during build time. Currently auditing check's the list of
+  modules specified in the `iPKG` file with those presented in the
+  package directory.
+
 ## Library Updates
 
 + Terminating programs has been improved with more appropriate

--- a/docs/reference/packages.rst
+++ b/docs/reference/packages.rst
@@ -138,6 +138,8 @@ Given an Idris package file ``text.ipkg`` it can be used with the Idris compiler
 
 + ``idris --testpkg test.ipkg`` will compile and run any embedded tests you have specified in the ``tests`` parameter.
 
+When building or install packages the commandline flag ``--warnipkg`` will audit the project and warn of any potentiable problems.
+
 Once the test package has been installed, the command line option
 ``--package test`` makes it accessible (abbreviated to ``-p test``).
 For example::

--- a/idris.cabal
+++ b/idris.cabal
@@ -266,7 +266,7 @@ Library
                 , code-page >= 0.1 && < 0.2
                 , containers >= 0.5 && < 0.6
                 , deepseq < 1.5
-                , directory >= 1.2.2.0 && < 1.2.3.0 || > 1.2.3.0
+                , directory >= 1.2.5.0
                 , filepath < 1.5
                 , fingertree >= 0.1 && < 0.2
                 , haskeline >= 0.7 && < 0.8

--- a/idris.cabal
+++ b/idris.cabal
@@ -266,7 +266,7 @@ Library
                 , code-page >= 0.1 && < 0.2
                 , containers >= 0.5 && < 0.6
                 , deepseq < 1.5
-                , directory >= 1.2.5.0
+                , directory >= 1.2.2.0 && < 1.2.3.0 || > 1.2.3.0
                 , filepath < 1.5
                 , fingertree >= 0.1 && < 0.2
                 , haskeline >= 0.7 && < 0.8

--- a/src/Idris/AbsSyntaxTree.hs
+++ b/src/Idris/AbsSyntaxTree.hs
@@ -523,6 +523,7 @@ data Opt = Filename String
          | DefaultPartial
          | WarnPartial
          | WarnReach
+         | AuditIPkg
          | EvalTypes
          | NoCoverage
          | ErrContext

--- a/src/Idris/CmdOptions.hs
+++ b/src/Idris/CmdOptions.hs
@@ -126,6 +126,7 @@ parseFlags = many $
   <|> flag' DefaultPartial (long "partial")
   <|> flag' WarnPartial    (long "warnpartial" <> help "Warn about undeclared partial functions")
   <|> flag' WarnReach      (long "warnreach"   <> help "Warn about reachable but inaccessible arguments")
+  <|> flag' AuditIPkg      (long "warnipkg"    <> help "Warn about possible incorrect package specifications")
   <|> flag' NoCoverage     (long "nocoverage")
   <|> flag' ErrContext     (long "errorcontext")
 

--- a/src/Idris/Package.hs
+++ b/src/Idris/Package.hs
@@ -8,6 +8,26 @@ Maintainer  : The Idris Community.
 {-# LANGUAGE CPP #-}
 module Idris.Package where
 
+import System.Directory
+import System.Directory (copyFile, createDirectoryIfMissing)
+import System.Exit
+import System.FilePath (addExtension, addTrailingPathSeparator, dropExtension,
+                        hasExtension, normalise, takeDirectory, takeExtension,
+                        takeFileName, (</>))
+import System.IO
+import System.Process
+
+import Util.System
+
+import Control.Monad
+import Control.Monad.Trans.Except (runExceptT)
+import Control.Monad.Trans.State.Strict (execStateT)
+import Data.Either (partitionEithers)
+import Data.Either (partitionEithers)
+import Data.List
+import Data.List.Split (splitOn)
+import Data.Maybe (fromMaybe)
+
 import Idris.AbsSyntax
 import Idris.Core.TT
 import Idris.Error (ifail)
@@ -17,28 +37,13 @@ import Idris.Imports
 import Idris.Main (idris, idrisMain)
 import Idris.Output (pshow)
 import Idris.Output
-import Idris.Package.Common
-import Idris.Package.Parser
 import Idris.Parser (loadModule)
 import Idris.REPL
+
+import Idris.Package.Common
+import Idris.Package.Parser
+
 import IRTS.System
-
-import Util.System
-
-import Control.Monad
-import Control.Monad.Trans.Except (runExceptT)
-import Control.Monad.Trans.State.Strict (execStateT)
-import Data.Either (partitionEithers)
-import Data.List
-import Data.List.Split (splitOn)
-import Data.Maybe (fromMaybe)
-import System.Directory
-import System.Directory (copyFile, createDirectoryIfMissing)
-import System.Exit
-import System.FilePath (addExtension, addTrailingPathSeparator, hasExtension,
-                        normalise, takeDirectory, takeFileName, (</>))
-import System.IO
-import System.Process
 
 -- To build a package:
 -- * read the package description
@@ -75,14 +80,18 @@ buildPkg copts warnonly (install, fp) = do
             Left emsg -> do
               putStrLn emsg
               exitWith (ExitFailure 1)
-            Right opts -> buildMods opts (modules pkgdesc)
+            Right opts -> do
+              auditPackage (AuditIPkg `elem` opts) pkgdesc
+              buildMods opts (modules pkgdesc)
         Just o -> do
           let exec = dir </> o
           case mergeOptions copts (idx : NoREPL : Verbose 1 : Output exec : idris_opts pkgdesc) of
             Left emsg -> do
               putStrLn emsg
               exitWith (ExitFailure 1)
-            Right opts -> buildMain opts (idris_main pkgdesc)
+            Right opts -> do
+              auditPackage (AuditIPkg `elem` opts) pkgdesc
+              buildMain opts (idris_main pkgdesc)
     case m_ist of
       Nothing  -> exitWith (ExitFailure 1)
       Just ist -> do
@@ -120,6 +129,7 @@ checkPkg copts warnonly quit fpath = do
           putStrLn emsg
           exitWith (ExitFailure 1)
         Right opts -> do
+          auditPackage (AuditIPkg `elem` opts) pkgdesc
           buildMods opts (modules pkgdesc)
     when quit $ case res of
                   Nothing -> exitWith (ExitFailure 1)
@@ -301,10 +311,50 @@ installPkg altdests pkgdesc = inPkgDir pkgdesc $ do
 -- Methods for building, testing, installing, and removal of idris
 -- packages.
 
+auditPackage :: Bool -> PkgDesc -> IO ()
+auditPackage False _    = return ()
+auditPackage True  ipkg = do
+    cwd <- getCurrentDirectory
+
+    let ms = map (sourcedir ipkg </>) $ map (toPath . showCG) (modules ipkg)
+    ms' <- mapM makeAbsolute ms
+
+    ifiles <- getIdrisFiles cwd
+
+    let ifiles' = map dropExtension ifiles
+
+    not_listed <- mapM makeRelativeToCurrentDirectory (ifiles' \\ ms')
+
+    putStrLn $ unlines $
+         ["Warning: The following modules are not listed in your iPkg file:\n"]
+      ++ map (\m -> unwords ["-", m]) not_listed
+      ++ ["\nModules that are not listed, are not installed."]
+
+  where
+    toPath n = foldl1' (</>) $ splitOn "." n
+
+    getIdrisFiles :: FilePath -> IO [FilePath]
+    getIdrisFiles dir = do
+      contents <- listDirectory dir
+      files <- forM contents (findRest dir)
+      return $ filter (isIdrisFile) (concat files)
+
+    isIdrisFile :: FilePath -> Bool
+    isIdrisFile fp = takeExtension fp == ".idr" || takeExtension fp == ".lidr"
+
+    findRest :: FilePath -> FilePath -> IO [FilePath]
+    findRest dir fn = do
+      path <- makeAbsolute (dir </> fn)
+      isDir <- doesDirectoryExist path
+      if isDir
+        then getIdrisFiles path
+        else return [path]
+
 buildMods :: [Opt] -> [Name] -> IO (Maybe IState)
 buildMods opts ns = do let f = map (toPath . showCG) ns
                        idris (map Filename f ++ opts)
-    where toPath n = foldl1' (</>) $ splitOn "." n
+    where
+      toPath n = foldl1' (</>) $ splitOn "." n
 
 testLib :: Bool -> String -> String -> IO Bool
 testLib warn p f
@@ -443,13 +493,14 @@ mergeOptions copts popts =
     chkOpt o@(ImportDir _ )   = Right o
     chkOpt o@(UseCodegen _)   = Right o
     chkOpt o@(Verbose _)      = Right o
+    chkOpt o@(AuditIPkg)      = Right o
     chkOpt o                  = Left (unwords ["\t", show o, "\n"])
 
     genErrMsg :: [String] -> String
     genErrMsg es = unlines
         [ "Not all command line options can be used to override package options."
         , "\nThe only changeable options are:"
-        , "\t--log <lvl>, --total, --warnpartial, --warnreach"
+        , "\t--log <lvl>, --total, --warnpartial, --warnreach, --warnipkg"
         , "\t--ibcsubdir <path>, -i --idrispath <path>"
         , "\t--logging-categories <cats>"
         , "\nThe options need removing are:"

--- a/src/Idris/Package.hs
+++ b/src/Idris/Package.hs
@@ -335,7 +335,12 @@ auditPackage True  ipkg = do
 
     getIdrisFiles :: FilePath -> IO [FilePath]
     getIdrisFiles dir = do
-      contents <- listDirectory dir
+      contents <- getDirectoryContents dir
+      let contents' = filter (\fname -> fname /= "." && fname /= "..") contents
+
+      -- [ NOTE ] Directory >= 1.2.5.0 introduced `listDirectory` but later versions of directory appear to be causing problems with ghc 7.10.3 and cabal 1.22 in travis. Let's reintroduce the old ranges for directory to be sure.
+
+
       files <- forM contents (findRest dir)
       return $ filter (isIdrisFile) (concat files)
 

--- a/test/pkg001/expected
+++ b/test/pkg001/expected
@@ -1,7 +1,7 @@
 Not all command line options can be used to override package options.
 
 The only changeable options are:
-	--log <lvl>, --total, --warnpartial, --warnreach
+	--log <lvl>, --total, --warnpartial, --warnreach, --warnipkg
 	--ibcsubdir <path>, -i --idrispath <path>
 	--logging-categories <cats>
 


### PR DESCRIPTION
It would be nice to be able to audit Idris packages for 'common' mistakes, and warn developers of _potential_ problems.
This commit introduces a means to 'audit' idris files and warn when asked.

These checks are called with the flag `--warnipkg`.

Currently there is only one check: Idris files specified in the package's directory but not in the ipkg file itself.
