### PR TITLE
Allow Idris to install IdrisDoc into a central location & fix some issues with how paths are overridden.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -40,10 +40,14 @@
 
 * Idris' documentation system now displays the documentation for auto
   implicits in the output of `:doc`. This is tested for in `docs005`.
-
 * New command line flag `--info` that displays information about the installation.
-
 * New command line flag `--sourcepath <dir>` that allows adding directories to the source search path.
+* Allow 'installation' of a package's IdrisDoc documentation into a central location. The default location is the subdirectory `docs` of Idris' data directory.
+  * New flag `--installdoc <ipkg>` provided to install documentation
+  * New flag `--docdir` provided to show default documentation installation location.
+  * New environment variable `IDRIS_DOC_PATH` to allow specification of an alternative installation path for documentation.
+* Semantic meaning behind several environment variables has been clarified in documentation and code. See compilation section of the reference manual for more details.
+
 ## Miscellaneous updates
 
 * The test suite now uses [tasty-golden](https://hackage.haskell.org/package/tasty-golden). New tests must be registered in `test/TestData.hs`, as explained in the relevant `README.md`.
@@ -51,7 +55,7 @@
 
 ## UI Changes
 
-* The :e command can now handle an $EDITOR with arguments in it, like "emacs -nw" 
+* The :e command can now handle an $EDITOR with arguments in it, like "emacs -nw"
 
 
 # New in 0.12:

--- a/Setup.hs
+++ b/Setup.hs
@@ -268,7 +268,6 @@ idrisInstall verbosity copy pkg local = unless (execOnly (configFlags local)) $ 
          notice verbosity $ unwords ["Copying man page to", mandest]
          installOrdinaryFiles verbosity mandest [("man", "idris.1")]
 
-
       makeInstall src target =
          make verbosity [ "-C", src, "install" , "TARGET=" ++ target, "IDRIS=" ++ idrisCmd local]
 

--- a/Setup.hs
+++ b/Setup.hs
@@ -254,7 +254,7 @@ idrisInstall verbosity copy pkg local = unless (execOnly (configFlags local)) $ 
       target = datadir $ L.absoluteInstallDirs pkg local copy
 
       installStdLib = do
-        let target' = target </> "libs"
+        let target' = target -- </> "libs"
         putStrLn $ "Installing libraries in " ++ target'
         makeInstall "libs" target'
 

--- a/docs/reference/compilation.rst
+++ b/docs/reference/compilation.rst
@@ -86,22 +86,30 @@ overridden through environment variables.  The provided variables are:
 
 * `IDRIS_CC` Change the `C` compiler used by the `C` backend.
 * `IDRIS_CFLAGS` Change the `C` flags passed to the `C` compiler.
-* `TARGET`   Change the target directory to generate files.
-* `IDRIS_LIBRARY_PATH` Change the location of where installed packages are found.
+* `TARGET`   Change the target directory i.e. `data dir` where Idris installs files when installing using Cabal/Stack.
+* `IDRIS_LIBRARY_PATH` Change the location of where installed packages are found/installed.
+* `IDRIS_DOC_PATH`  Change the location of where generated idrisdoc for packages are installed.
 
-Alternativly, and perhaps a cleaner approach is to configure these
-options using the CLI options.  Idris also supports options to augment
-the paths used, and pass options to the code generator backend.
+.. note::
 
-The option `--cg-opt <ARG>` can be used to pass options to the code
-generator. The format of `<ARG>` is dependent on the selected backend.
+   In versions of Idris prior to 0.12.3 the environment variables
+   `IDRIS_LIBRARY_PATH` and `TARGET` were both used to affect the
+   installation of single packages and direct where Idris installed
+   its data. The meaning of these variables has changed, and command
+   line options are preferred when changing where individual packages
+   are installed.
 
-Further, Idris does support multiple include paths.  The CLI option
-`-i <dir>` allows you to add a directory to the library search path; this
-option can be used multiple times. This is a cleaner option when you
-wish to add single directories to the `IDRIS_LIBRARY_PATH` than
-ammending `IDRIS_LIBRARY_PATH` directly.
-To add directories to the source search path, use the `--sourcepath <dir>` option.
+The CLI option `--ibcsubdir` can be used to direct where generated IBC
+files are placed.  However, this means Idris will install files in a
+non-standard location separate from the rest of the installed
+packages. The CLI option `--idrispath <dir>` allows you to add a
+directory to the library search path; this option can be used multiple
+times and can be shortened to `-i <dir>`. Similary, the `--sourcepath
+<dir>` option can be used to add directories to the source search
+path. There is no shortened version for this option as `-s` is a
+reserved flag.
 
-Moreover, rather than using `TARGET` the CLI option `--ibcsubdir` can
-be used to direct where built IBC files are placed.
+Further, Idris also supports options to augment the paths used, and
+pass options to the code generator backend.  The option `--cg-opt
+<ARG>` can be used to pass options to the code generator. The format
+of `<ARG>` is dependent on the selected backend.

--- a/libs/Makefile
+++ b/libs/Makefile
@@ -34,5 +34,4 @@ doc_clean:
 	$(MAKE)	-C effects doc_clean
 	$(MAKE)	-C pruviloj doc_clean
 
-
 .PHONY: build install clean doc doc_clean

--- a/libs/base/Makefile
+++ b/libs/base/Makefile
@@ -4,8 +4,9 @@ PKG := base
 build:
 	$(IDRIS) --build ${PKG}.ipkg
 
-install: 
+install:
 	$(IDRIS) --install ${PKG}.ipkg
+	${IDRIS} --installdoc ${PKG}.ipkg
 
 clean:
 	$(IDRIS) --clean ${PKG}.ipkg
@@ -21,4 +22,4 @@ doc_clean:
 linecount:
 	find . -name '*.idr' | xargs wc -l
 
-.PHONY: build install clean rebuild linecount
+.PHONY: build install clean rebuild linecount doc doc_clean

--- a/libs/contrib/Makefile
+++ b/libs/contrib/Makefile
@@ -4,8 +4,9 @@ PKG := contrib
 build:
 	$(IDRIS) --build ${PKG}.ipkg
 
-install: 
+install:
 	$(IDRIS) --install ${PKG}.ipkg
+	${IDRIS} --installdoc ${PKG}.ipkg
 
 clean:
 	$(IDRIS) --clean ${PKG}.ipkg
@@ -21,4 +22,4 @@ doc_clean:
 linecount:
 	find . -name '*.idr' | xargs wc -l
 
-.PHONY: build install clean rebuild linecount
+.PHONY: build install clean rebuild linecount doc doc_clean

--- a/libs/effects/Makefile
+++ b/libs/effects/Makefile
@@ -9,6 +9,7 @@ clean:
 
 install:
 	$(IDRIS) --install ${PKG}.ipkg
+	${IDRIS} --installdoc ${PKG}.ipkg
 
 rebuild: clean build
 

--- a/libs/prelude/Makefile
+++ b/libs/prelude/Makefile
@@ -4,8 +4,9 @@ PKG   := prelude
 build:
 	$(IDRIS) --build ${PKG}.ipkg
 
-install: 
+install:
 	$(IDRIS) --install ${PKG}.ipkg
+	${IDRIS} --installdoc ${PKG}.ipkg
 
 clean:
 	$(IDRIS) --clean ${PKG}.ipkg

--- a/libs/pruviloj/Makefile
+++ b/libs/pruviloj/Makefile
@@ -9,6 +9,7 @@ clean:
 
 install:
 	$(IDRIS) --install ${PKG}.ipkg
+	${IDRIS} --installdoc ${PKG}.ipkg
 
 rebuild: clean build
 

--- a/main/Main.hs
+++ b/main/Main.hs
@@ -18,7 +18,8 @@ processShowOptions opts = runIO $ do
   when (ShowLoggingCats `elem` opts)  $ showExitIdrisLoggingCategories
   when (ShowIncs `elem` opts)         $ showExitIdrisFlagsInc
   when (ShowLibs `elem` opts)         $ showExitIdrisFlagsLibs
-  when (ShowLibdir `elem` opts)       $ showExitIdrisLibDir
+  when (ShowLibDir `elem` opts)       $ showExitIdrisLibDir
+  when (ShowDocDir `elem` opts)       $ showExitIdrisDocDir
   when (ShowPkgs `elem` opts)         $ showExitIdrisInstalledPackages
 
 check :: [Opt] -> (Opt -> Maybe a) -> ([a] -> Idris ()) -> Idris ()

--- a/src/IRTS/CodegenC.hs
+++ b/src/IRTS/CodegenC.hs
@@ -66,8 +66,8 @@ codegenC' defs out exec incs objs libs flags exports iface dbg
          let h = concatMap toDecl (map fst bc)
          let cc = concatMap (uncurry toC) bc
          let hi = concatMap ifaceC (concatMap getExp exports)
-         d <- getDataDir
-         mprog <- readFile (d </> "rts" </> "idris_main" <.> "c")
+         d <- getIdrisCRTSDir
+         mprog <- readFile (d </> "idris_main" <.> "c")
          let cout = headers incs ++ debug dbg ++ h ++ wrappers ++ cc ++
                      (if (exec == Executable) then mprog else hi)
          case exec of

--- a/src/IRTS/CodegenJavaScript.hs
+++ b/src/IRTS/CodegenJavaScript.hs
@@ -121,27 +121,27 @@ codegenJS_all
   -> OutputType
   -> IO ()
 codegenJS_all target definitions includes libs filename exports outputType = do
-  let bytecode = map toBC definitions
-  let info = initCompileInfo bytecode
-  let js = concatMap (translateDecl info) bytecode
-  let full = concatMap processFunction js
+  let bytecode      = map toBC definitions
+  let info          = initCompileInfo bytecode
+  let js            = concatMap (translateDecl info) bytecode
+  let full          = concatMap processFunction js
   let exportedNames = map translateName ((getExpNames exports) ++ [sUN "call__IO"])
-  let code = deadCodeElim exportedNames full
-  let ext = takeExtension filename
-  let isHtml = target == JavaScript && ext == ".html"
-  let htmlPrologue = T.pack "<!doctype html><html><head><script>\n"
-  let htmlEpilogue = T.pack "\n</script></head><body></body></html>"
-  let (cons, opt) = optimizeConstructors code
-  let (header, rt) = case target of
-                          Node -> ("#!/usr/bin/env node\n", "-node")
+  let code          = deadCodeElim exportedNames full
+  let ext           = takeExtension filename
+  let isHtml        = target == JavaScript && ext == ".html"
+  let htmlPrologue  = T.pack "<!doctype html><html><head><script>\n"
+  let htmlEpilogue  = T.pack "\n</script></head><body></body></html>"
+  let (cons, opt)   = optimizeConstructors code
+  let (header, rt)   = case target of
+                          Node       -> ("#!/usr/bin/env node\n", "-node")
                           JavaScript -> ("", "-browser")
 
   included   <- concat <$> getIncludes includes
-  path       <- (++) <$> getDataDir <*> (pure "/jsrts/")
-  idrRuntime <- readFile $ path ++ "Runtime-common.js"
-  tgtRuntime <- readFile $ concat [path, "Runtime", rt, ".js"]
+  path       <- getIdrisJSRTSDir
+  idrRuntime <- readFile $ path </> "Runtime-common.js"
+  tgtRuntime <- readFile $ path </> concat ["Runtime", rt, ".js"]
   jsbn       <- if compileInfoNeedsBigInt info
-                   then readFile $ path ++ "jsbn/jsbn.js"
+                   then readFile $ path </> "jsbn/jsbn.js"
                    else return ""
   let runtime = (  header
                 ++ includeLibs libs

--- a/src/IRTS/System.hs
+++ b/src/IRTS/System.hs
@@ -12,6 +12,7 @@ module IRTS.System( getDataFileName
                   , getCC
                   , getLibFlags
                   , getIdrisLibDir
+                  , getIdrisDocDir
                   , getIncFlags
                   , getEnvFlags
                   , version
@@ -31,14 +32,22 @@ import Paths_idris (version)
 import Paths_idris
 #endif
 
-overrideDataDirWith :: String -> IO FilePath
-overrideDataDirWith envVar = do
+overrideIdrisDirWith :: String  -- ^ Sub directory in `getDataDir` location.
+                     -> String  -- ^ Environment variable to get new location from.
+                     -> IO FilePath
+overrideIdrisDirWith fp envVar = do
   envValue <- lookupEnv envVar
   case envValue of
     Nothing -> do
       ddir <- getDataDir
-      return (ddir </> "libs")
+      return (ddir </> fp)
     Just ddir -> return ddir
+
+overrideIdrisLibDirWith :: String -> IO FilePath
+overrideIdrisLibDirWith = overrideIdrisDirWith "libs"
+
+overrideIdrisDocDirWith :: String -> IO FilePath
+overrideIdrisDocDirWith = overrideIdrisDirWith "docs"
 
 getCC :: IO String
 getCC = fromMaybe "gcc" <$> lookupEnv "IDRIS_CC"
@@ -47,7 +56,7 @@ getEnvFlags :: IO [String]
 getEnvFlags = maybe [] (splitOn " ") <$> lookupEnv "IDRIS_CFLAGS"
 
 getTargetDir :: IO String
-getTargetDir = overrideDataDirWith "TARGET"
+getTargetDir = overrideIdrisLibDirWith "TARGET"
 
 #if defined(freebsd_HOST_OS) || defined(dragonfly_HOST_OS)\
     || defined(openbsd_HOST_OS) || defined(netbsd_HOST_OS)
@@ -68,7 +77,10 @@ getLibFlags = do dir <- getDataDir
                  return $ ["-L" ++ (dir </> "rts"),
                            "-lidris_rts"] ++ extraLib ++ gmpLib ++ ["-lpthread"]
 
-getIdrisLibDir = addTrailingPathSeparator <$> overrideDataDirWith "IDRIS_LIBRARY_PATH"
+getIdrisLibDir = addTrailingPathSeparator <$> overrideIdrisLibDirWith "IDRIS_LIBRARY_PATH"
+
+getIdrisDocDir = addTrailingPathSeparator <$> overrideIdrisDocDirWith "IDRIS_DOC_PATH"
+
 
 getIncFlags = do dir <- getDataDir
                  return $ ("-I" ++ dir </> "rts") : extraInclude

--- a/src/Idris/AbsSyntax.hs
+++ b/src/Idris/AbsSyntax.hs
@@ -2545,7 +2545,7 @@ getPkgDir (Pkg str) = Just str
 getPkgDir _ = Nothing
 
 getPkg :: Opt -> Maybe (Bool, String)
-getPkg (PkgBuild str) = Just (False, str)
+getPkg (PkgBuild   str) = Just (False, str)
 getPkg (PkgInstall str) = Just (True, str)
 getPkg _ = Nothing
 
@@ -2563,9 +2563,10 @@ getPkgCheck _              = Nothing
 
 -- | Returns None if given an Opt which is not PkgMkDoc
 --   Otherwise returns Just x, where x is the contents of PkgMkDoc
-getPkgMkDoc :: Opt          -- ^ Opt to extract
-            -> Maybe String -- ^ Result
-getPkgMkDoc (PkgMkDoc str) = Just str
+getPkgMkDoc :: Opt                  -- ^ Opt to extract
+            -> Maybe (Bool, String) -- ^ Result
+getPkgMkDoc (PkgDocBuild  str)  = Just (False,str)
+getPkgMkDoc (PkgDocInstall str) = Just (True,str)
 getPkgMkDoc _              = Nothing
 
 getPkgTest :: Opt          -- ^ the option to extract

--- a/src/Idris/AbsSyntaxTree.hs
+++ b/src/Idris/AbsSyntaxTree.hs
@@ -492,7 +492,8 @@ data Opt = Filename String
          | IdemodeSocket
          | ShowAll
          | ShowLibs
-         | ShowLibdir
+         | ShowLibDir
+         | ShowDocDir
          | ShowIncs
          | ShowPkgs
          | ShowLoggingCats
@@ -524,7 +525,8 @@ data Opt = Filename String
          | PkgClean String
          | PkgCheck String
          | PkgREPL String
-         | PkgMkDoc String -- IdrisDoc
+         | PkgDocBuild String -- IdrisDoc
+         | PkgDocInstall String
          | PkgTest String
          | PkgIndex FilePath
          | WarnOnly

--- a/src/Idris/CmdOptions.hs
+++ b/src/Idris/CmdOptions.hs
@@ -129,7 +129,8 @@ parseFlags = many $
   <|> flag' ShowLoggingCats (long "listlogcats" <> help "Display logging categories")
   <|> flag' ShowLibs        (long "link"        <> help "Display link flags")
   <|> flag' ShowPkgs        (long "listlibs"    <> help "Display installed libraries")
-  <|> flag' ShowLibdir      (long "libdir"      <> help "Display library directory")
+  <|> flag' ShowLibDir      (long "libdir"      <> help "Display library directory")
+  <|> flag' ShowDocDir      (long "docdir"      <> help "Display idrisdoc install directory")
   <|> flag' ShowIncs        (long "include"     <> help "Display the includes flags")
 
   <|> flag' Verbose (short 'V' <> long "verbose" <> help "Loud verbosity")
@@ -144,13 +145,14 @@ parseFlags = many $
   <|> (Port <$> option portReader (long "port" <> metavar "PORT" <> help "REPL TCP port - pass \"none\" to not bind any port"))
 
   -- Package commands
-  <|> (PkgBuild   <$> strOption (long "build"    <> metavar "IPKG" <> help "Build package"))
-  <|> (PkgInstall <$> strOption (long "install"  <> metavar "IPKG" <> help "Install package"))
-  <|> (PkgREPL    <$> strOption (long "repl"     <> metavar "IPKG" <> help "Launch REPL, only for executables"))
-  <|> (PkgClean   <$> strOption (long "clean"    <> metavar "IPKG" <> help "Clean package"))
-  <|> (PkgMkDoc   <$> strOption (long "mkdoc"    <> metavar "IPKG" <> help "Generate IdrisDoc for package"))
-  <|> (PkgCheck   <$> strOption (long "checkpkg" <> metavar "IPKG" <> help "Check package only"))
-  <|> (PkgTest    <$> strOption (long "testpkg"  <> metavar "IPKG" <> help "Run tests for package"))
+  <|> (PkgBuild      <$> strOption (long "build"      <> metavar "IPKG" <> help "Build package"))
+  <|> (PkgInstall    <$> strOption (long "install"    <> metavar "IPKG" <> help "Install package"))
+  <|> (PkgREPL       <$> strOption (long "repl"       <> metavar "IPKG" <> help "Launch REPL, only for executables"))
+  <|> (PkgClean      <$> strOption (long "clean"      <> metavar "IPKG" <> help "Clean package"))
+  <|> (PkgDocBuild   <$> strOption (long "mkdoc"      <> metavar "IPKG" <> help "Generate IdrisDoc for package"))
+  <|> (PkgDocInstall <$> strOption (long "installdoc" <> metavar "IPKG" <> help "Install IdrisDoc for package"))
+  <|> (PkgCheck      <$> strOption (long "checkpkg"   <> metavar "IPKG" <> help "Check package only"))
+  <|> (PkgTest       <$> strOption (long "testpkg"    <> metavar "IPKG" <> help "Run tests for package"))
 
   -- Misc options
   <|> (BCAsm <$> strOption (long "bytecode"))

--- a/src/Idris/Info.hs
+++ b/src/Idris/Info.hs
@@ -7,6 +7,7 @@ Maintainer  : The Idris Community.
 -}
 module Idris.Info
   ( getIdrisLibDir
+  , getIdrisDocDir
   , getIdrisFlagsLib
   , getIdrisFlagsInc
   , getIdrisFlagsEnv
@@ -32,6 +33,9 @@ import qualified IRTS.System as S
 import Version_idris (gitHash)
 
 import Paths_idris
+
+getIdrisDocDir :: IO String
+getIdrisDocDir = S.getIdrisDocDir
 
 getIdrisLibDir :: IO String
 getIdrisLibDir = S.getIdrisLibDir

--- a/src/Idris/Info.hs
+++ b/src/Idris/Info.hs
@@ -6,7 +6,10 @@ License     : BSD3
 Maintainer  : The Idris Community.
 -}
 module Idris.Info
-  ( getIdrisLibDir
+  ( getIdrisDataDir
+  , getIdrisCRTSDir
+  , getIdrisJSRTSDir
+  , getIdrisLibDir
   , getIdrisDocDir
   , getIdrisFlagsLib
   , getIdrisFlagsInc
@@ -33,6 +36,15 @@ import qualified IRTS.System as S
 import Version_idris (gitHash)
 
 import Paths_idris
+
+getIdrisDataDir :: IO String
+getIdrisDataDir = S.getIdrisDataDir
+
+getIdrisCRTSDir :: IO String
+getIdrisCRTSDir = S.getIdrisCRTSDir
+
+getIdrisJSRTSDir :: IO String
+getIdrisJSRTSDir = S.getIdrisJSRTSDir
 
 getIdrisDocDir :: IO String
 getIdrisDocDir = S.getIdrisDocDir

--- a/src/Idris/Info/Show.hs
+++ b/src/Idris/Info/Show.hs
@@ -24,6 +24,16 @@ showExitIdrisLibDir = do
   showIdrisLibDir
   exitSuccess
 
+showIdrisDocDir :: IO ()
+showIdrisDocDir = do
+  ldir <- getIdrisDocDir
+  putStrLn ldir
+
+showExitIdrisDocDir :: IO ()
+showExitIdrisDocDir = do
+  showIdrisDocDir
+  exitSuccess
+
 showIdrisFlagsInc :: IO ()
 showIdrisFlagsInc = do
   incFlags <- getIdrisFlagsInc
@@ -68,8 +78,10 @@ showIdrisInfo = do
   putStrLn "Paths:"
   ldir <- getIdrisLibDir
   udir <- getIdrisUserDataDir
+  ddir <- getIdrisDocDir
   putStrLn $ unwords ["-", "Library Dir:", ldir]
   putStrLn $ unwords ["-", "User Dir:",    udir]
+  putStrLn $ unwords ["-", "Documentation Dir:", ddir]
 
   putStrLn "Flags:"
   lflag <- getIdrisFlagsLib

--- a/src/Idris/Info/Show.hs
+++ b/src/Idris/Info/Show.hs
@@ -4,6 +4,26 @@ import System.Exit
 
 import Idris.Info
 
+showIdrisCRTSDir :: IO ()
+showIdrisCRTSDir = do
+  ldir <- getIdrisCRTSDir
+  putStrLn ldir
+
+showExitIdrisCRTSDir :: IO ()
+showExitIdrisCRTSDir = do
+  showIdrisCRTSDir
+  exitSuccess
+
+showIdrisJSRTSDir :: IO ()
+showIdrisJSRTSDir = do
+  ldir <- getIdrisJSRTSDir
+  putStrLn ldir
+
+showExitIdrisJSRTSDir :: IO ()
+showExitIdrisJSRTSDir = do
+  showIdrisJSRTSDir
+  exitSuccess
+
 showIdrisFlagsLibs :: IO ()
 showIdrisFlagsLibs = do
   libFlags <- getIdrisFlagsLib
@@ -12,6 +32,16 @@ showIdrisFlagsLibs = do
 showExitIdrisFlagsLibs :: IO ()
 showExitIdrisFlagsLibs = do
   showIdrisFlagsLibs
+  exitSuccess
+
+showIdrisDataDir :: IO ()
+showIdrisDataDir = do
+  ldir <- getIdrisDataDir
+  putStrLn ldir
+
+showExitIdrisDataDir :: IO ()
+showExitIdrisDataDir = do
+  showIdrisDataDir
   exitSuccess
 
 showIdrisLibDir :: IO ()
@@ -79,7 +109,13 @@ showIdrisInfo = do
   ldir <- getIdrisLibDir
   udir <- getIdrisUserDataDir
   ddir <- getIdrisDocDir
+  idir <- getIdrisDataDir
+  crdir <- getIdrisCRTSDir
+  jrdir <- getIdrisJSRTSDir
+  putStrLn $ unwords ["-", "Data Dir:", idir]
   putStrLn $ unwords ["-", "Library Dir:", ldir]
+  putStrLn $ unwords ["-", "C RTS Dir:", crdir]
+  putStrLn $ unwords ["-", "JS RTS Dir:", jrdir]
   putStrLn $ unwords ["-", "User Dir:",    udir]
   putStrLn $ unwords ["-", "Documentation Dir:", ddir]
 

--- a/src/Idris/Package.hs
+++ b/src/Idris/Package.hs
@@ -285,7 +285,7 @@ installPkg :: [String]  -- ^ Alternate install location
            -> PkgDesc   -- ^ iPKG file.
            -> IO ()
 installPkg altdests pkgdesc = inPkgDir pkgdesc $ do
-  d <- getTargetDir
+  d <- getIdrisLibDir
   let destdir = case altdests of
                   []     -> d
                   (d':_) -> d'
@@ -308,11 +308,11 @@ buildMods opts ns = do let f = map (toPath . showCG) ns
 
 testLib :: Bool -> String -> String -> IO Bool
 testLib warn p f
-    = do d <- getDataDir
+    = do d <- getIdrisCRTSDir
          gcc <- getCC
          (tmpf, tmph) <- tempfile ""
          hClose tmph
-         let libtest = d </> "rts" </> "libtest.c"
+         let libtest = d </> "libtest.c"
          e <- rawSystem gcc [libtest, "-l" ++ f, "-o", tmpf]
          case e of
             ExitSuccess -> return True


### PR DESCRIPTION
**Edit** *Previously this commit was about adding new functionality, this also contains a fix with how paths are obtain and overridden.*

* Allow Idris to Install Idrisdoc to a central location.

+ Default location is `<getDataDir>/docs`.
+ Flag `--info` has been updated to show doc location.
+ New flag `--installdoc <ipkg>` provided to install documentation
+ New flag `--docdir` provided to show documentation installation location.
+ New environment variable `IDRIS_DOC_PATH` to allow alternate means of customisation.
+ Installation for Idris' std libraries has been augmented to install library documentation as well.

* Important Path Values 

Some paths obtained and used by Idris were not consistently overridden. Changes in the second commit address these inconsistencies.