### PR TITLE
Pruviloj: Use binderTy from Language.Reflection.Utils.

### DIFF
--- a/libs/pruviloj/Pruviloj/Derive/Eliminators.idr
+++ b/libs/pruviloj/Pruviloj/Derive/Eliminators.idr
@@ -63,7 +63,7 @@ mkIh info motiveName recArg argty fam =
                 focus ihT
                 attack
                 for_ {b=()} argArgs $ \(n, b) =>
-                  forall n (getBinderTy b)
+                  forall n (binderTy b)
                 let argTm : Raw = mkApp (Var recArg) (map (Var . fst) argArgs)
                 argTmTy <- forget (snd !(check !getEnv argTm))
                 argHoles <- apply (Var motiveName)
@@ -239,7 +239,7 @@ getElimClause info elimn methCount (cn, args, resTy) whichCon =
 
   where bindLam : List (TTName, Binder Raw) -> Raw -> Raw
         bindLam [] x = x
-        bindLam ((n, b)::rest) x = RBind n (Lam (getBinderTy b)) $ bindLam rest x
+        bindLam ((n, b)::rest) x = RBind n (Lam (binderTy b)) $ bindLam rest x
 
 getElimClauses : TyConInfo -> (elimn : TTName) ->
                  List (TTName, List CtorArg, Raw) -> Elab (List (FunClause Raw))

--- a/libs/pruviloj/Pruviloj/Internals.idr
+++ b/libs/pruviloj/Pruviloj/Internals.idr
@@ -1,7 +1,7 @@
 ||| Internal details of the library, not for public consumption.
 module Pruviloj.Internals
 
-
+import Language.Reflection.Utils
 import Pruviloj.Core
 import Pruviloj.Renamers
 
@@ -50,16 +50,6 @@ extractBinders (RBind n b tm) = let (bs, res) = extractBinders tm
 extractBinders tm = ([], tm)
 
 
-||| Get the type annotation from a binder
-getBinderTy : Binder t -> t
-getBinderTy (Lam t) = t
-getBinderTy (Pi t _) = t
-getBinderTy (Let t _) = t
-getBinderTy (Hole t) = t
-getBinderTy (GHole t) = t
-getBinderTy (Guess t _) = t
-getBinderTy (PVar t) = t
-getBinderTy (PVTy t) = t
 
 ||| Map a list `[x1, x2, ..., xn]` to `[(0, x1), (1, x2), ..., (n-1, xn)]`
 enumerate : List a -> List (Nat, a)
@@ -70,11 +60,11 @@ enumerate xs = enumerate' xs 0
 
 bindPats : List (TTName, Binder Raw) -> Raw -> Raw
 bindPats [] res = res
-bindPats ((n, b)::bs) res = RBind n (PVar (getBinderTy b)) $ bindPats bs res
+bindPats ((n, b)::bs) res = RBind n (PVar (binderTy b)) $ bindPats bs res
 
 bindPatTys : List (TTName, Binder Raw) -> Raw -> Raw
 bindPatTys [] res = res
-bindPatTys ((n, b)::bs) res = RBind n (PVTy (getBinderTy b)) $ bindPatTys bs res
+bindPatTys ((n, b)::bs) res = RBind n (PVTy (binderTy b)) $ bindPatTys bs res
 
 
 ||| Helper for elaborating pattern clauses. This helper takes care of


### PR DESCRIPTION
A small redundancy that needs to be eliminated.