### PR TITLE
Import Pruviloj.Core as public for eliminators

### DIFF
--- a/libs/pruviloj/Pruviloj/Derive/Eliminators.idr
+++ b/libs/pruviloj/Pruviloj/Derive/Eliminators.idr
@@ -3,7 +3,7 @@ module Pruviloj.Derive.Eliminators
 import Language.Reflection.Utils
 import Data.Vect
 
-import Pruviloj.Core
+import public Pruviloj.Core
 import Pruviloj.Internals.TyConInfo
 import Pruviloj.Internals
 import Pruviloj.Renamers


### PR DESCRIPTION
This fixes #3476, where the Infer datatype was not seen if clients
didn't import Pruviloj or Pruviloj.Core together with
Pruviloj.Derive.Eliminators.