### PR TITLE
Fix .lidr compiler message source position.

### DIFF
--- a/src/Idris/Unlit.hs
+++ b/src/Idris/Unlit.hs
@@ -19,8 +19,9 @@ unlit f s = do let s' = map ulLine (lines s)
 data LineType = Prog | Blank | Comm
 
 ulLine :: String -> (LineType, String)
-ulLine ('>':' ':xs)        = (Prog, xs)
-ulLine ('>':xs)            = (Prog, xs)
+ulLine ('>':' ':xs)        = (Prog, ' ':' ':xs) -- Replace with spaces, otherwise text position numbers will be bogus.
+ulLine ('>':xs)            = (Prog, ' '    :xs) -- The parser can deal with this, because /every/ (code) line is prefixed
+                                                -- with a '>'.
 ulLine xs | all isSpace xs = (Blank, "")
 -- make sure it's not a doc comment
           | otherwise      = (Comm, '-':'-':' ':'>':xs)
@@ -29,7 +30,7 @@ check :: FilePath -> Int -> [(LineType, String)] -> TC ()
 check f l (a:b:cs) = do chkAdj f l (fst a) (fst b)
                         check f (l+1) (b:cs)
 check f l [x] = return ()
-check f l [] = return ()
+check f l [ ] = return ()
 
 -- Issue #1593 on the issue checker.
 --

--- a/test/basic010/run
+++ b/test/basic010/run
@@ -4,7 +4,7 @@ set -eu
 
 TIMEOUT=../scripts/timeout
 
-$TIMEOUT 10 "${IDRIS:-idris}" "$@" Main.idr --nocolour --check --warnreach -o basic010
-$TIMEOUT 5  ./basic010
+$TIMEOUT 20 "${IDRIS:-idris}" "$@" Main.idr --nocolour --check --warnreach -o basic010
+$TIMEOUT 20  ./basic010
 
 rm -f -- *.ibc basic010

--- a/test/regression002/expected
+++ b/test/regression002/expected
@@ -6,8 +6,8 @@ reg003a.idr:9:6:When checking type of Main.test:
 No such variable EvenList
 reg006.idr:17:1:
 RBTree.lookup is possibly not total due to recursive path RBTree.lookup --> RBTree.lookup
-reg007.lidr:8:1:A.n is already defined
-reg007.lidr:12:11-17:When checking right hand side of hurrah with expected type
+reg007.lidr:8:3:A.n is already defined
+reg007.lidr:12:13-19:When checking right hand side of hurrah with expected type
         0 = 1
 
 Type mismatch between

--- a/test/totality011/expected
+++ b/test/totality011/expected
@@ -1,2 +1,2 @@
-totality011.lidr:22:1:
+totality011.lidr:22:3:
 Main.weCanOnlyGetOlder is not total as there are missing cases


### PR DESCRIPTION
The compiler reports bogus file positions in compiler warnings in a literate Idris program, for example:

```idris
> module Main
>
> main : IO ()
> main = "This is obviously a compiler error."
```

Without this fix, the compiler would report an error at the 'n' in "main" on the last line, while it's supposed to be at the '='.
This PR fixes the issue.