### PR TITLE
added a `disableBuffering` action into Prelude.Interactive

### DIFF
--- a/libs/prelude/IO.idr
+++ b/libs/prelude/IO.idr
@@ -124,6 +124,9 @@ unsafePerformIO : IO' ffi a -> a
 unsafePerformIO (MkIO f) = unsafePerformPrimIO
         (prim_io_bind (f (TheWorld prim__TheWorld)) (\ b => prim_io_pure b))
 
+prim_noIOBuffering : IO' l Int
+prim_noIOBuffering = MkIO (\w => prim_io_pure (prim__noBuffering (world w)))
+
 prim_read : IO' l String
 prim_read = MkIO (\w => prim_io_pure (prim__readString (world w)))
 

--- a/libs/prelude/Prelude/Interactive.idr
+++ b/libs/prelude/Prelude/Interactive.idr
@@ -25,6 +25,17 @@ import IO
 
 ---- some basic io
 
+||| Disables buffering in both stdin and stdout
+||| so that output is written immediately, and never stored in the buffer
+||| and the next input item is read and returned
+|||
+||| this is useful to circumvent problem with IO on some windows system
+||| where stdout output sometimes is only shown after prompted input from
+||| stdin
+disableBuffering : IO ()
+disableBuffering = do prim_noIOBuffering
+                      pure ()
+
 ||| Output a string to stdout without a trailing newline, for any FFI
 ||| descriptor
 putStr' : String -> IO' ffi ()

--- a/rts/idris_stdfgn.c
+++ b/rts/idris_stdfgn.c
@@ -53,6 +53,11 @@ int fileSize(void* h) {
     }
 }
 
+int idris_noBuffering() {
+   setvbuf(stdin, NULL, _IONBF, 0); //turn off buffering
+   setvbuf(stdout, NULL, _IONBF, 0); //turn off buffering
+}
+
 int idris_writeStr(void* h, char* str) {
     FILE* f = (FILE*)h;
     if (fputs(str, f)) {

--- a/rts/idris_stdfgn.h
+++ b/rts/idris_stdfgn.h
@@ -16,6 +16,8 @@ int fileError(void* h);
 int fileSize(void* h);
 
 // return 0 on success
+int idris_noBuffering();
+// return 0 on success
 int idris_writeStr(void*h, char* str);
 // construct a file error structure (see Prelude.File) from errno
 VAL idris_mkFileError(VM* vm);

--- a/src/IRTS/CodegenC.hs
+++ b/src/IRTS/CodegenC.hs
@@ -593,7 +593,7 @@ doOp v LStrConcat [l,r] = v ++ "idris_concat(vm, " ++ creg l ++ ", " ++ creg r +
 doOp v LStrLt [l,r] = v ++ "idris_strlt(vm, " ++ creg l ++ ", " ++ creg r ++ ")"
 doOp v LStrEq [l,r] = v ++ "idris_streq(vm, " ++ creg l ++ ", " ++ creg r ++ ")"
 
-doOp v LNoBuffering [_] = v ++ "idris_noBuffering()"
+doOp v LNoBuffering _ = v ++ "idris_noBuffering()"
 doOp v LReadStr [_] = v ++ "idris_readStr(vm, stdin)"
 doOp v LWriteStr [_,s]
              = v ++ "MKINT((i_int)(idris_writeStr(stdout"

--- a/src/IRTS/CodegenC.hs
+++ b/src/IRTS/CodegenC.hs
@@ -593,6 +593,7 @@ doOp v LStrConcat [l,r] = v ++ "idris_concat(vm, " ++ creg l ++ ", " ++ creg r +
 doOp v LStrLt [l,r] = v ++ "idris_strlt(vm, " ++ creg l ++ ", " ++ creg r ++ ")"
 doOp v LStrEq [l,r] = v ++ "idris_streq(vm, " ++ creg l ++ ", " ++ creg r ++ ")"
 
+doOp v LNoBuffering [_] = v ++ "idris_noBuffering()"
 doOp v LReadStr [_] = v ++ "idris_readStr(vm, stdin)"
 doOp v LWriteStr [_,s]
              = v ++ "MKINT((i_int)(idris_writeStr(stdout"

--- a/src/IRTS/Lang.hs
+++ b/src/IRTS/Lang.hs
@@ -83,7 +83,7 @@ data PrimFn = LPlus ArithTy | LMinus ArithTy | LTimes ArithTy
             | LFSqrt | LFFloor | LFCeil | LFNegate
 
             | LStrHead | LStrTail | LStrCons | LStrIndex | LStrRev | LStrSubstr
-            | LReadStr | LWriteStr
+            | LNoBuffering | LReadStr | LWriteStr
 
             -- system info
             | LSystemInfo

--- a/src/IRTS/Portable.hs
+++ b/src/IRTS/Portable.hs
@@ -192,6 +192,7 @@ instance ToJSON PrimFn where
     toJSON LStrIndex = object ["LStrIndex" .= Null]
     toJSON LStrRev = object ["LStrRev" .= Null]
     toJSON LStrSubstr = object ["LStrSubstr" .= Null]
+    toJSON LNoBuffering = object ["LNoBuffering" .= Null]
     toJSON LReadStr = object ["LReadStr" .= Null]
     toJSON LWriteStr = object ["LWriteStr" .= Null]
     toJSON LSystemInfo = object ["LSystemInfo" .= Null]

--- a/src/Idris/Core/Execute.hs
+++ b/src/Idris/Core/Execute.hs
@@ -434,6 +434,7 @@ prf = sUN "prim__readFile"
 pwf = sUN "prim__writeFile"
 prs = sUN "prim__readString"
 pws = sUN "prim__writeString"
+pnb = sUN "prim__noBuffering"
 pbm = sUN "prim__believe_me"
 pstdin = sUN "prim__stdin"
 pstdout = sUN "prim__stdout"
@@ -448,6 +449,11 @@ force = sUN "Force"
 -- them into ExecVal functions
 getOp :: Name -> [ExecVal] -> Maybe (Exec ExecVal, [ExecVal])
 getOp fn (_ : _ : x : xs) | fn == pbm = Just (return x, xs)
+getOp fn (_:xs)
+    | fn == pnb =
+              Just (do execIO $ hSetBuffering stdin NoBuffering
+                       execIO $ hSetBuffering stdout NoBuffering
+                       return (EConstant (I 0)), xs)
 getOp fn (_ : EConstant (Str n) : xs)
     | fn == pws =
               Just (do execIO $ putStr n

--- a/src/Idris/Primitives.hs
+++ b/src/Idris/Primitives.hs
@@ -175,6 +175,8 @@ primitives =
    Prim (sUN "prim__strSubstr") (ty [AType (ATInt ITNative), AType (ATInt ITNative), StrType] StrType) 3 (p_strSubstr)
     (3, LStrSubstr) total,
 
+   Prim (sUN "prim__noBuffering") (ty [WorldType] (AType (ATInt ITNative))) 2 (p_cantreduce)
+     (2, LNoBuffering) total, -- total is okay, because we have 'WorldType'
    Prim (sUN "prim__readString") (ty [WorldType] StrType) 1 (p_cantreduce)
      (1, LReadStr) total, -- total is okay, because we have 'WorldType'
    Prim (sUN "prim__writeString") (ty [WorldType,StrType] (AType (ATInt ITNative))) 2 (p_cantreduce)


### PR DESCRIPTION
this command will be translated into a call `hSetBuffering` or `setvbuf`
to disable buffering in stdin/stdout

the reason for this is that on windows you sometimes need disable buffering
to see the prompt when doing something like this:

    do putStr "What's your name? "
       name <- getLine
       ...