### PR TITLE
this command will be translated into a call `hSetBuffering` or `setvbuf`

### DIFF
--- a/libs/prelude/Prelude/Interactive.idr
+++ b/libs/prelude/Prelude/Interactive.idr
@@ -89,6 +89,16 @@ putCharLn c = putStrLn (singleton c)
 getChar : IO Char
 getChar = map cast $ foreign FFI_C "getchar" (IO Int)
 
+||| Disables buffering in both stdin and stdout
+||| so that output is written immediately, and never stored in the buffer
+||| and the next input item is read and returned
+|||
+||| this is useful to circumvent problem with IO on some windows system
+||| where stdout output sometimes is only shown after prompted input from
+||| stdin
+disableBuffering : IO ()
+disableBuffering = foreign FFI_C "idris_disableBuffering" (IO ())
+
 ||| Get the command-line arguments that the program was called with.
 partial
 getArgs : IO (List String)

--- a/rts/idris_rts.c
+++ b/rts/idris_rts.c
@@ -1077,6 +1077,11 @@ const char* idris_getArg(int i) {
     return __idris_argv[i];
 }
 
+void idris_disableBuffering() {
+  setvbuf(stdin, NULL, _IONBF, 0);
+  setvbuf(stdout, NULL, _IONBF, 0);
+}
+
 void stackOverflow() {
   fprintf(stderr, "Stack overflow");
   exit(-1);

--- a/rts/idris_rts.h
+++ b/rts/idris_rts.h
@@ -394,6 +394,9 @@ extern char **__idris_argv;
 int idris_numArgs();
 const char *idris_getArg(int i);
 
+// disable stdin/stdout buffering
+void idris_disableBuffering();
+
 // Handle stack overflow.
 // Just reports an error and exits.
 

--- a/src/Idris/Core/Execute.hs
+++ b/src/Idris/Core/Execute.hs
@@ -398,6 +398,12 @@ execForeign env ctxt arity ty fn xs onfail
                       show ptr ++
                       ". Are all cases covered?"
 
+    | Just (FFun "idris_disableBuffering" _ _) <- foreignFromTT arity ty fn xs
+       = do execIO $ hSetBuffering stdin NoBuffering
+            execIO $ hSetBuffering stdout NoBuffering
+            execApp env ctxt ioUnit (drop arity xs)
+
+
 -- Right now, there's no way to send command-line arguments to the executor,
 -- so just return 0.
 execForeign env ctxt arity ty fn xs onfail


### PR DESCRIPTION
to disable buffering in stdin/stdout

the reason for this is that on windows you sometimes need disable buffering
to see the prompt when doing something like this:

    do putStr "What's your name? "
       name <- getLine
       ...

---

this should take care of [this issue](https://github.com/idris-lang/Idris-dev/issues/3483)