### PR TITLE
Fix building with optparse-applicative-0.13.0

### DIFF
--- a/idris.cabal
+++ b/idris.cabal
@@ -362,7 +362,7 @@ Test-suite regression-and-feature-tests
                , filepath
                , directory
                , haskeline >= 0.7
-               , optparse-applicative >= 0.11 && < 0.13
+               , optparse-applicative >= 0.11 && < 0.14
                , tagged
                , tasty >= 0.8
                , tasty-golden >= 2.0

--- a/src/Idris/CmdOptions.hs
+++ b/src/Idris/CmdOptions.hs
@@ -1,3 +1,4 @@
+{-# LANGUAGE CPP #-}
 {-|
 Module      : Idris.CmdOptions
 Description : A parser for the CmdOptions for the Idris executable.
@@ -26,6 +27,9 @@ import Control.Monad.Trans.Except (throwE)
 import Control.Monad.Trans.Reader (ask)
 import Data.Char
 import Data.Maybe
+#if MIN_VERSION_optparse_applicative(0,13,0)
+import Data.Monoid ((<>))
+#endif
 import Options.Applicative
 import Options.Applicative.Arrows
 import Options.Applicative.Types (ReadM(..))

--- a/test/TestRun.hs
+++ b/test/TestRun.hs
@@ -1,3 +1,4 @@
+{-# LANGUAGE CPP #-}
 module Main where
 
 import TestData
@@ -6,6 +7,9 @@ import Control.Monad
 import Data.Char (isLetter)
 import qualified Data.IntMap as IMap
 import Data.List
+#if MIN_VERSION_optparse_applicative(0,13,0)
+import Data.Monoid ((<>))
+#endif
 import Data.Proxy
 import Data.Typeable
 import Options.Applicative


### PR DESCRIPTION
In #3445 I widened the bound on optparse-applicative to include version 0.13.
Since I only widened it on the library and not the test suite, so long as the
test suite was turned on cabal-install always selected 0.12 which allowed build
failures to pass undetected. This commit fixes them with some CPP.