### PR TITLE
Bumped cabal version in idris.cabal

### DIFF
--- a/idris.cabal
+++ b/idris.cabal
@@ -40,7 +40,7 @@ Description:    Idris is a general purpose language with full dependent types.
                 .
                 * Hugs style interactive environment
 
-Cabal-Version:  >= 1.8
+Cabal-Version:  >= 1.8.1
 
 Build-type:     Custom
 
@@ -289,7 +289,7 @@ Library
                 , vector < 0.12
                 , vector-binary-instances < 0.3
                 , zip-archive > 0.2.3.5 && < 0.4
-                , safe
+                , safe == 0.3.9
                 , fsnotify >= 0.2 && < 2.2
                 , async < 2.2
 


### PR DESCRIPTION
Bug in compiling safe using cabal 1.20 and ghc 7.6.3.
The bump might force cabal to build safe properly.