### PR TITLE
Updated Stack Resolver to LTS 7.10.

### DIFF
--- a/stack-shell.nix
+++ b/stack-shell.nix
@@ -2,7 +2,7 @@ with (import <nixpkgs> {});
 
 let
   # MUST match resolver in stack.yaml
-  resolver = haskell.packages.lts-7_0.ghc;
+  resolver = haskell.packages.lts-7_10.ghc;
 
   native_libs = [
     libffi

--- a/stack.yaml
+++ b/stack.yaml
@@ -1,4 +1,4 @@
-resolver: lts-7.0
+resolver: lts-7.10
 
 packages:
   - location: .
@@ -10,7 +10,7 @@ flags:
 
 extra-deps:
   - libffi-0.1
-
+  - safe-0.3.9
 nix:
   enable: false
   shell-file: stack-shell.nix


### PR DESCRIPTION
Unfortunatly, due to upstream problems with safe we have had to pin safe to version 0.3.9. As a result we have had to declare this in the stack file as an extra dependancy, LTS 7.10 gives safe 0.3.10.