### PR TITLE
Removed unused copyright field in Haddock documentation.

### DIFF
--- a/src/IRTS/BCImp.hs
+++ b/src/IRTS/BCImp.hs
@@ -1,7 +1,7 @@
 {-|
 Module      : IRTS.BCImp
 Description : Bytecode for a register/variable based VM (e.g. for generating code in an imperative language where we let the language deal with GC)
-Copyright   :
+
 License     : BSD3
 Maintainer  : The Idris Community.
 -}

--- a/src/IRTS/Bytecode.hs
+++ b/src/IRTS/Bytecode.hs
@@ -2,7 +2,7 @@
 Module      : IRTS.Bytecode
 Description : Bytecode for a stack based VM (e.g. for generating C code with an accurate hand written GC)
 
-Copyright   :
+
 License     : BSD3
 Maintainer  : The Idris Community.
 

--- a/src/IRTS/CodegenC.hs
+++ b/src/IRTS/CodegenC.hs
@@ -1,7 +1,7 @@
 {-|
 Module      : IRTS.CodegenC
 Description : The default code generator for Idris, generating C code.
-Copyright   :
+
 License     : BSD3
 Maintainer  : The Idris Community.
 -}

--- a/src/IRTS/CodegenCommon.hs
+++ b/src/IRTS/CodegenCommon.hs
@@ -2,7 +2,7 @@
 {-|
 Module      : IRTS.CodegenCommon
 Description : Common data structures required for all code generators.
-Copyright   :
+
 License     : BSD3
 Maintainer  : The Idris Community.
 -}

--- a/src/IRTS/CodegenJavaScript.hs
+++ b/src/IRTS/CodegenJavaScript.hs
@@ -1,7 +1,7 @@
 {-|
 Module      : IRTS.CodegenJavaScript
 Description : The JavaScript code generator.
-Copyright   :
+
 License     : BSD3
 Maintainer  : The Idris Community.
 -}

--- a/src/IRTS/Compiler.hs
+++ b/src/IRTS/Compiler.hs
@@ -1,7 +1,7 @@
 {-|
 Module      : IRTS.Compiler
 Description : Coordinates the compilation process.
-Copyright   :
+
 License     : BSD3
 Maintainer  : The Idris Community.
 -}

--- a/src/IRTS/Defunctionalise.hs
+++ b/src/IRTS/Defunctionalise.hs
@@ -1,7 +1,7 @@
 {-|
 Module      : IRTS.Defunctionalise
 Description : Defunctionalise Idris' IR.
-Copyright   :
+
 License     : BSD3
 Maintainer  : The Idris Community.
 

--- a/src/IRTS/DumpBC.hs
+++ b/src/IRTS/DumpBC.hs
@@ -1,7 +1,7 @@
 {-|
 Module      : IRTS.DumpBC
 Description : Serialise Idris to its IBC format.
-Copyright   :
+
 License     : BSD3
 Maintainer  : The Idris Community.
 -}

--- a/src/IRTS/Exports.hs
+++ b/src/IRTS/Exports.hs
@@ -1,7 +1,7 @@
 {-|
 Module      : IRTS.Exports
 Description : Deal with external things.
-Copyright   :
+
 License     : BSD3
 Maintainer  : The Idris Community.
 -}

--- a/src/IRTS/Inliner.hs
+++ b/src/IRTS/Inliner.hs
@@ -1,7 +1,7 @@
 {-|
 Module      : IRTS.Inliner
 Description : Inline expressions.
-Copyright   :
+
 License     : BSD3
 Maintainer  : The Idris Community.
 -}

--- a/src/IRTS/JavaScript/AST.hs
+++ b/src/IRTS/JavaScript/AST.hs
@@ -1,7 +1,7 @@
 {-|
 Module      : IRTS.JavaScript.AST
 Description : Data structures and functions used with the JavaScript codegen.
-Copyright   :
+
 License     : BSD3
 Maintainer  : The Idris Community.
 -}

--- a/src/IRTS/Lang.hs
+++ b/src/IRTS/Lang.hs
@@ -1,7 +1,7 @@
 {-|
 Module      : IRTS.Lang
 Description : Internal representation of Idris' constructs.
-Copyright   :
+
 License     : BSD3
 Maintainer  : The Idris Community.
 -}

--- a/src/IRTS/LangOpts.hs
+++ b/src/IRTS/LangOpts.hs
@@ -1,7 +1,7 @@
 {-|
 Module      : IRTS.LangOpts
 Description : Transformations to apply to Idris' IR.
-Copyright   :
+
 License     : BSD3
 Maintainer  : The Idris Community.
 -}

--- a/src/IRTS/Portable.hs
+++ b/src/IRTS/Portable.hs
@@ -1,7 +1,7 @@
 {-|
 Module      : IRTS.Portable
 Description : Serialise Idris' IR to JSON.
-Copyright   :
+
 License     : BSD3
 Maintainer  : The Idris Community.
 -}

--- a/src/IRTS/Simplified.hs
+++ b/src/IRTS/Simplified.hs
@@ -1,7 +1,7 @@
 {-|
 Module      : IRTS.Simplified
 Description : Simplified expressions, where functions/constructors can only be applied to variables.
-Copyright   :
+
 License     : BSD3
 Maintainer  : The Idris Community.
 -}

--- a/src/IRTS/System.hs
+++ b/src/IRTS/System.hs
@@ -1,7 +1,7 @@
 {-|
 Module      : IRTS.System
 Description : Utilities for interacting with the System.
-Copyright   :
+
 License     : BSD3
 Maintainer  : The Idris Community.
 -}

--- a/src/Idris/ASTUtils.hs
+++ b/src/Idris/ASTUtils.hs
@@ -1,7 +1,7 @@
 {-|
 Module      : Idris.ASTUtils
 Description : This implements just a few basic lens-like concepts to ease state updates. Similar to fclabels in approach, just without the extra dependency.
-Copyright   :
+
 License     : BSD3
 Maintainer  : The Idris Community.
 

--- a/src/Idris/AbsSyntax.hs
+++ b/src/Idris/AbsSyntax.hs
@@ -1,7 +1,7 @@
 {-|
 Module      : Idris.AbsSyntax
 Description : Provides Idris' core data definitions and utility code.
-Copyright   :
+
 License     : BSD3
 Maintainer  : The Idris Community.
 -}

--- a/src/Idris/AbsSyntaxTree.hs
+++ b/src/Idris/AbsSyntaxTree.hs
@@ -1,7 +1,7 @@
 {-|
 Module      : Idris.AbsSyntaxTree
 Description : Core data definitions used in Idris.
-Copyright   :
+
 License     : BSD3
 Maintainer  : The Idris Community.
 -}

--- a/src/Idris/Apropos.hs
+++ b/src/Idris/Apropos.hs
@@ -1,7 +1,7 @@
 {-|
 Module      : Idris.Apropos
 Description : Search loaded Idris code and named modules for things.
-Copyright   :
+
 License     : BSD3
 Maintainer  : The Idris Community.
 -}

--- a/src/Idris/CaseSplit.hs
+++ b/src/Idris/CaseSplit.hs
@@ -1,7 +1,7 @@
 {-|
 Module      : Idris.CaseSplit
 Description : Module to provide case split functionality.
-Copyright   :
+
 License     : BSD3
 Maintainer  : The Idris Community.
 

--- a/src/Idris/Chaser.hs
+++ b/src/Idris/Chaser.hs
@@ -1,7 +1,7 @@
 {-|
 Module      : Idris.Chaser
 Description : Module chaser to determine cycles and import modules.
-Copyright   :
+
 License     : BSD3
 Maintainer  : The Idris Community.
 -}

--- a/src/Idris/Colours.hs
+++ b/src/Idris/Colours.hs
@@ -2,7 +2,7 @@
 {-|
 Module      : Idris.Colours
 Description : Support for colours within Idris.
-Copyright   :
+
 License     : BSD3
 Maintainer  : The Idris Community.
 -}

--- a/src/Idris/Completion.hs
+++ b/src/Idris/Completion.hs
@@ -1,7 +1,7 @@
 {-|
 Module      : Idris.Completion
 Description : Support for command-line completion at the REPL and in the prover.
-Copyright   :
+
 License     : BSD3
 Maintainer  : The Idris Community.
 -}

--- a/src/Idris/Core/Binary.hs
+++ b/src/Idris/Core/Binary.hs
@@ -1,7 +1,7 @@
 {-|
 Module      : Idris.Core.Binary
 Description : Binary instances for the core datatypes
-Copyright   :
+
 License     : BSD3
 Maintainer  : The Idris Community.
 -}

--- a/src/Idris/Core/CaseTree.hs
+++ b/src/Idris/Core/CaseTree.hs
@@ -1,7 +1,7 @@
 {-|
 Module      : Idris.Core.CaseTree
 Description : Module to define and interact with case trees.
-Copyright   :
+
 License     : BSD3
 Maintainer  : The Idris Community.
 

--- a/src/Idris/Core/Constraints.hs
+++ b/src/Idris/Core/Constraints.hs
@@ -1,7 +1,7 @@
 {-|
 Module      : Idris.Core.Constraints
 Description : Check universe constraints.
-Copyright   :
+
 License     : BSD3
 Maintainer  : The Idris Community.
 -}

--- a/src/Idris/Core/DeepSeq.hs
+++ b/src/Idris/Core/DeepSeq.hs
@@ -1,7 +1,7 @@
 {-|
 Module      : Idris.Core.DeepSeq
 Description : NFData instances for TT.
-Copyright   :
+
 License     : BSD3
 Maintainer  : The Idris Community.
 -}

--- a/src/Idris/Core/Elaborate.hs
+++ b/src/Idris/Core/Elaborate.hs
@@ -1,7 +1,7 @@
 {-|
 Module      : Idris.Core.Elaborate
 Description : A high level language of tactic composition, for building elaborators from a high level language into the core theory.
-Copyright   :
+
 License     : BSD3
 Maintainer  : The Idris Community.
 

--- a/src/Idris/Core/Evaluate.hs
+++ b/src/Idris/Core/Evaluate.hs
@@ -1,7 +1,7 @@
 {-|
 Module      : Idris.Core.Evaluate
 Description : Evaluate Idris expressions.
-Copyright   :
+
 License     : BSD3
 Maintainer  : The Idris Community.
 -}

--- a/src/Idris/Core/Execute.hs
+++ b/src/Idris/Core/Execute.hs
@@ -1,7 +1,7 @@
 {-|
 Module      : Idris.Core.Execute
 Description : Execute Idris code and deal with FFI.
-Copyright   :
+
 License     : BSD3
 Maintainer  : The Idris Community.
 -}

--- a/src/Idris/Core/ProofState.hs
+++ b/src/Idris/Core/ProofState.hs
@@ -1,7 +1,7 @@
 {-|
 Module      : Idris.Core.ProofState
 Description : Proof state implementation.
-Copyright   :
+
 License     : BSD3
 Maintainer  : The Idris Community.
 

--- a/src/Idris/Core/ProofTerm.hs
+++ b/src/Idris/Core/ProofTerm.hs
@@ -1,7 +1,7 @@
 {-|
 Module      : Idris.Core.ProofTerm
 Description : Proof term. implementation and utilities.
-Copyright   :
+
 License     : BSD3
 Maintainer  : The Idris Community.
 -}

--- a/src/Idris/Core/TT.hs
+++ b/src/Idris/Core/TT.hs
@@ -1,7 +1,7 @@
 {-|
 Module      : Idris.Core.TT
 Description : The core language of Idris, TT.
-Copyright   :
+
 License     : BSD3
 Maintainer  : The Idris Community.
 

--- a/src/Idris/Core/Typecheck.hs
+++ b/src/Idris/Core/Typecheck.hs
@@ -1,7 +1,7 @@
 {-|
 Module      : Idris.Core.Typecheck
 Description : Idris' type checker.
-Copyright   :
+
 License     : BSD3
 Maintainer  : The Idris Community.
 -}

--- a/src/Idris/Core/Unify.hs
+++ b/src/Idris/Core/Unify.hs
@@ -1,7 +1,7 @@
 {-|
 Module      : Idris.Core.Unify
 Description : Idris' unification code.
-Copyright   :
+
 License     : BSD3
 Maintainer  : The Idris Community.
 

--- a/src/Idris/Core/WHNF.hs
+++ b/src/Idris/Core/WHNF.hs
@@ -1,7 +1,7 @@
 {-|
 Module      : Idris.Core.WHNF
 Description : Reduction to Weak Head Normal Form
-Copyright   :
+
 License     : BSD3
 Maintainer  : The Idris Community.
 -}

--- a/src/Idris/Coverage.hs
+++ b/src/Idris/Coverage.hs
@@ -1,7 +1,7 @@
 {-|
 Module      : Idris.Coverage
 Description : Clause generation for coverage checking
-Copyright   :
+
 License     : BSD3
 Maintainer  : The Idris Community.
 -}

--- a/src/Idris/DSL.hs
+++ b/src/Idris/DSL.hs
@@ -1,7 +1,7 @@
 {-|
 Module      : Idris.DSL
 Description : Code to deal with DSL blocks.
-Copyright   :
+
 License     : BSD3
 Maintainer  : The Idris Community.
 -}

--- a/src/Idris/DataOpts.hs
+++ b/src/Idris/DataOpts.hs
@@ -1,7 +1,7 @@
 {-|
 Module      : Idris.DataOpts
 Description : Optimisations for Idris code i.e. Forcing, detagging and collapsing.
-Copyright   :
+
 License     : BSD3
 Maintainer  : The Idris Community.
 -}

--- a/src/Idris/DeepSeq.hs
+++ b/src/Idris/DeepSeq.hs
@@ -1,7 +1,7 @@
 {-|
 Module      : Idris.DeepSeq
 Description : NFData instances for Idris' types
-Copyright   :
+
 License     : BSD3
 Maintainer  : The Idris Community.
 -}

--- a/src/Idris/Delaborate.hs
+++ b/src/Idris/Delaborate.hs
@@ -1,7 +1,7 @@
 {-|
 Module      : Idris.Delaborate
 Description : Convert core TT back into high level syntax, primarily for display purposes.
-Copyright   :
+
 License     : BSD3
 Maintainer  : The Idris Community.
 -}

--- a/src/Idris/Directives.hs
+++ b/src/Idris/Directives.hs
@@ -1,7 +1,7 @@
 {-|
 Module      : Idris.Directives
 Description : Act upon Idris directives.
-Copyright   :
+
 License     : BSD3
 Maintainer  : The Idris Community.
 -}

--- a/src/Idris/Docs.hs
+++ b/src/Idris/Docs.hs
@@ -1,7 +1,7 @@
 {-|
 Module      : Idris.Docs
 Description : Data structures and utilities to work with Idris Documentation.
-Copyright   :
+
 License     : BSD3
 Maintainer  : The Idris Community.
 -}

--- a/src/Idris/Docstrings.hs
+++ b/src/Idris/Docstrings.hs
@@ -1,7 +1,7 @@
 {-|
 Module      :  Idris.Docstrings
 Description : Wrapper around Markdown library.
-Copyright   :
+
 License     : BSD3
 Maintainer  : The Idris Community.
 -}

--- a/src/Idris/Elab/AsPat.hs
+++ b/src/Idris/Elab/AsPat.hs
@@ -1,7 +1,7 @@
 {-|
 Module      : Idris.Elab.AsPat
 Description : Code to elaborate pattern variables.
-Copyright   :
+
 License     : BSD3
 Maintainer  : The Idris Community.
 -}

--- a/src/Idris/Elab/Clause.hs
+++ b/src/Idris/Elab/Clause.hs
@@ -1,7 +1,7 @@
 {-|
 Module      : Idris.Elab.Clause
 Description : Code to elaborate clauses.
-Copyright   :
+
 License     : BSD3
 Maintainer  : The Idris Community.
 -}

--- a/src/Idris/Elab/Data.hs
+++ b/src/Idris/Elab/Data.hs
@@ -1,7 +1,7 @@
 {-|
 Module      : Idris.Elab.Data
 Description : Code to elaborate data structures.
-Copyright   :
+
 License     : BSD3
 Maintainer  : The Idris Community.
 -}

--- a/src/Idris/Elab/Implementation.hs
+++ b/src/Idris/Elab/Implementation.hs
@@ -1,7 +1,7 @@
 {-|
 Module      : Idris.Elab.Implementation
 Description : Code to elaborate instances.
-Copyright   :
+
 License     : BSD3
 Maintainer  : The Idris Community.
 -}

--- a/src/Idris/Elab/Interface.hs
+++ b/src/Idris/Elab/Interface.hs
@@ -1,7 +1,7 @@
 {-|
 Module      : Idris.Elab.Interface
 Description : Code to elaborate interfaces.
-Copyright   :
+
 License     : BSD3
 Maintainer  : The Idris Community.
 -}

--- a/src/Idris/Elab/Provider.hs
+++ b/src/Idris/Elab/Provider.hs
@@ -1,7 +1,7 @@
 {-|
 Module      : Idris.Elab.Provider
 Description : Code to elaborate type providers.
-Copyright   :
+
 License     : BSD3
 Maintainer  : The Idris Community.
 -}

--- a/src/Idris/Elab/Quasiquote.hs
+++ b/src/Idris/Elab/Quasiquote.hs
@@ -1,7 +1,7 @@
 {-|
 Module      : Idris.Elab.Quasiquote
 Description : Code to elaborate quasiquotations.
-Copyright   :
+
 License     : BSD3
 Maintainer  : The Idris Community.
 -}

--- a/src/Idris/Elab/Record.hs
+++ b/src/Idris/Elab/Record.hs
@@ -1,7 +1,7 @@
 {-|
 Module      : Idris.Elab.Record
 Description : Code to elaborate records.
-Copyright   :
+
 License     : BSD3
 Maintainer  : The Idris Community.
 -}

--- a/src/Idris/Elab/Rewrite.hs
+++ b/src/Idris/Elab/Rewrite.hs
@@ -1,7 +1,7 @@
 {-|
 Module      : Idris.Elab.Rewrite
 Description : Code to elaborate rewrite rules.
-Copyright   :
+
 License     : BSD3
 Maintainer  : The Idris Community.
 -}

--- a/src/Idris/Elab/RunElab.hs
+++ b/src/Idris/Elab/RunElab.hs
@@ -1,7 +1,7 @@
 {-|
 Module      : Idris.Elab.RunElab
 Description : Code to run the elaborator process.
-Copyright   :
+
 License     : BSD3
 Maintainer  : The Idris Community.
 -}

--- a/src/Idris/Elab/Term.hs
+++ b/src/Idris/Elab/Term.hs
@@ -1,7 +1,7 @@
 {-|
 Module      : Idris.Elab.Term
 Description : Code to elaborate terms.
-Copyright   :
+
 License     : BSD3
 Maintainer  : The Idris Community.
 -}

--- a/src/Idris/Elab/Transform.hs
+++ b/src/Idris/Elab/Transform.hs
@@ -1,7 +1,7 @@
 {-|
 Module      : Idris.Elab.Transform
 Description : Transformations for elaborate terms.
-Copyright   :
+
 License     : BSD3
 Maintainer  : The Idris Community.
 -}

--- a/src/Idris/Elab/Type.hs
+++ b/src/Idris/Elab/Type.hs
@@ -1,7 +1,7 @@
 {-|
 Module      : Idris.Elab.Type
 Description : Code to elaborate types.
-Copyright   :
+
 License     : BSD3
 Maintainer  : The Idris Community.
 -}

--- a/src/Idris/Elab/Utils.hs
+++ b/src/Idris/Elab/Utils.hs
@@ -1,7 +1,7 @@
 {-|
 Module      : Idris.Elab.Utils
 Description : Elaborator utilities.
-Copyright   :
+
 License     : BSD3
 Maintainer  : The Idris Community.
 -}

--- a/src/Idris/Elab/Value.hs
+++ b/src/Idris/Elab/Value.hs
@@ -1,7 +1,7 @@
 {-|
 Module      : Idris.Elab.Value
 Description : Code to elaborate values.
-Copyright   :
+
 License     : BSD3
 Maintainer  : The Idris Community.
 -}

--- a/src/Idris/ElabDecls.hs
+++ b/src/Idris/ElabDecls.hs
@@ -1,7 +1,7 @@
 {-|
 Module      : Idris.ElabDecls
 Description : Code to elaborate declarations.
-Copyright   :
+
 License     : BSD3
 Maintainer  : The Idris Community.
 -}

--- a/src/Idris/Erasure.hs
+++ b/src/Idris/Erasure.hs
@@ -1,7 +1,7 @@
 {-|
 Module      : Idris.Erasure
 Description : Utilities to erase irrelevant stuff.
-Copyright   :
+
 License     : BSD3
 Maintainer  : The Idris Community.
 -}

--- a/src/Idris/ErrReverse.hs
+++ b/src/Idris/ErrReverse.hs
@@ -1,7 +1,7 @@
 {-|
 Module      : Idris.ErrReverse
 Description : Utility to make errors readable using transformations.
-Copyright   :
+
 License     : BSD3
 Maintainer  : The Idris Community.
 -}

--- a/src/Idris/Error.hs
+++ b/src/Idris/Error.hs
@@ -1,7 +1,7 @@
 {-|
 Module      : Idris.Error
 Description : Utilities to deal with error reporting.
-Copyright   :
+
 License     : BSD3
 Maintainer  : The Idris Community.
 -}

--- a/src/Idris/Help.hs
+++ b/src/Idris/Help.hs
@@ -1,7 +1,7 @@
 {-|
 Module      : Idris.Help
 Description : Utilities to aid with the REPL's HELP system.
-Copyright   :
+
 License     : BSD3
 Maintainer  : The Idris Community.
 -}

--- a/src/Idris/IBC.hs
+++ b/src/Idris/IBC.hs
@@ -1,7 +1,7 @@
 {-|
 Module      : Idris.IBC
 Description : Core representations and code to generate IBC files.
-Copyright   :
+
 License     : BSD3
 Maintainer  : The Idris Community.
 -}

--- a/src/Idris/IdeMode.hs
+++ b/src/Idris/IdeMode.hs
@@ -1,7 +1,7 @@
 {-|
 Module      : Idris.IdeMode
 Description : Idris' IDE Mode
-Copyright   :
+
 License     : BSD3
 Maintainer  : The Idris Community.
 -}

--- a/src/Idris/IdrisDoc.hs
+++ b/src/Idris/IdrisDoc.hs
@@ -1,7 +1,7 @@
 {-|
 Module      : Idris.IdrisDoc
 Description : Generation of HTML documentation for Idris code
-Copyright   :
+
 License     : BSD3
 Maintainer  : The Idris Community.
 -}

--- a/src/Idris/Imports.hs
+++ b/src/Idris/Imports.hs
@@ -1,7 +1,7 @@
 {-|
 Module      : Idris.Imports
 Description : Code to handle import declarations.
-Copyright   :
+
 License     : BSD3
 Maintainer  : The Idris Community.
 -}

--- a/src/Idris/Info.hs
+++ b/src/Idris/Info.hs
@@ -1,7 +1,7 @@
 {-|
 Module      : Idris.Info
 Description : Get information about Idris.
-Copyright   : 2016 The Idris Community
+ 2016 The Idris Community
 License     : BSD3
 Maintainer  : The Idris Community.
 -}

--- a/src/Idris/Inliner.hs
+++ b/src/Idris/Inliner.hs
@@ -1,7 +1,7 @@
 {-|
 Module      : Idris.Inliner
 Description : Idris' Inliner.
-Copyright   :
+
 License     : BSD3
 Maintainer  : The Idris Community.
 -}

--- a/src/Idris/Interactive.hs
+++ b/src/Idris/Interactive.hs
@@ -1,7 +1,7 @@
 {-|
 Module      : Idris.Interactive
 Description : Bits and pieces for editing source files interactively, called from the REPL
-Copyright   :
+
 License     : BSD3
 Maintainer  : The Idris Community.
 -}

--- a/src/Idris/Output.hs
+++ b/src/Idris/Output.hs
@@ -1,7 +1,7 @@
 {-|
 Module      : Idris.Output
 Description : Utilities to display Idris' internals and other informtation to the user.
-Copyright   :
+
 License     : BSD3
 Maintainer  : The Idris Community.
 -}

--- a/src/Idris/Package.hs
+++ b/src/Idris/Package.hs
@@ -1,7 +1,7 @@
 {-|
 Module      : Idris.Package
 Description : Functionality for working with Idris packages.
-Copyright   :
+
 License     : BSD3
 Maintainer  : The Idris Community.
 -}

--- a/src/Idris/Package/Parser.hs
+++ b/src/Idris/Package/Parser.hs
@@ -1,7 +1,7 @@
 {-|
 Module      : Idris.Package.Parser
 Description : `iPKG` file parser and package description information.
-Copyright   :
+
 License     : BSD3
 Maintainer  : The Idris Community.
 -}

--- a/src/Idris/Parser.hs
+++ b/src/Idris/Parser.hs
@@ -1,7 +1,7 @@
 {-|
 Module      : Idris.Parser
 Description : Idris' parser.
-Copyright   :
+
 License     : BSD3
 Maintainer  : The Idris Community.
 -}

--- a/src/Idris/Parser/Data.hs
+++ b/src/Idris/Parser/Data.hs
@@ -1,7 +1,7 @@
 {-|
 Module      : Idris.Parser.Data
 Description : Parse Data declarations.
-Copyright   :
+
 License     : BSD3
 Maintainer  : The Idris Community.
 -}

--- a/src/Idris/Parser/Expr.hs
+++ b/src/Idris/Parser/Expr.hs
@@ -1,7 +1,7 @@
 {-|
 Module      : Idris.Parser.Expr
 Description : Parse Expressions.
-Copyright   :
+
 License     : BSD3
 Maintainer  : The Idris Community.
 -}

--- a/src/Idris/Parser/Helpers.hs
+++ b/src/Idris/Parser/Helpers.hs
@@ -1,7 +1,7 @@
 {-|
 Module      : Idris.Parser.Helpers
 Description : Utilities for Idris' parser.
-Copyright   :
+
 License     : BSD3
 Maintainer  : The Idris Community.
 -}

--- a/src/Idris/Parser/Ops.hs
+++ b/src/Idris/Parser/Ops.hs
@@ -1,7 +1,7 @@
 {-|
 Module      : Idris.Parser.Ops
 Description : Parser for operators and fixity declarations.
-Copyright   :
+
 License     : BSD3
 Maintainer  : The Idris Community.
 -}

--- a/src/Idris/PartialEval.hs
+++ b/src/Idris/PartialEval.hs
@@ -1,7 +1,7 @@
 {-|
 Module      : Idris.PartialEval
 Description : Implementation of a partial evaluator.
-Copyright   :
+
 License     : BSD3
 Maintainer  : The Idris Community.
 -}

--- a/src/Idris/Primitives.hs
+++ b/src/Idris/Primitives.hs
@@ -1,7 +1,7 @@
 {-|
 Module      : Idris.Primitives
 Description : Provision of primitive data types.
-Copyright   :
+
 License     : BSD3
 Maintainer  : The Idris Community.
 -}

--- a/src/Idris/ProofSearch.hs
+++ b/src/Idris/ProofSearch.hs
@@ -1,7 +1,7 @@
 {-|
 Module      : Idris.ProofSearch
 Description : Searches current context for proofs'
-Copyright   :
+
 License     : BSD3
 Maintainer  : The Idris Community.
 -}

--- a/src/Idris/Prover.hs
+++ b/src/Idris/Prover.hs
@@ -1,7 +1,7 @@
 {-|
 Module      : Idris.Prover
 Description : Idris' theorem prover.
-Copyright   :
+
 License     : BSD3
 Maintainer  : The Idris Community.
 -}

--- a/src/Idris/Providers.hs
+++ b/src/Idris/Providers.hs
@@ -1,7 +1,7 @@
 {-|
 Module      : Idris.Providers
 Description : Idris' 'Type Provider' implementation.
-Copyright   :
+
 License     : BSD3
 Maintainer  : The Idris Community.
 -}

--- a/src/Idris/REPL/Browse.hs
+++ b/src/Idris/REPL/Browse.hs
@@ -1,7 +1,7 @@
 {-|
 Module      : Idris.REPL.Browse
 Description : Browse the current namespace.
-Copyright   :
+
 License     : BSD3
 Maintainer  : The Idris Community.
 -}

--- a/src/Idris/Reflection.hs
+++ b/src/Idris/Reflection.hs
@@ -1,7 +1,7 @@
 {-|
 Module      : Idris.Reflection
 Description : Code related to Idris's reflection system. This module contains quoters and unquoters along with some supporting datatypes.
-Copyright   :
+
 License     : BSD3
 Maintainer  : The Idris Community.
 -}

--- a/src/Idris/Termination.hs
+++ b/src/Idris/Termination.hs
@@ -1,7 +1,7 @@
 {-|
 Module      : Idris.Coverage
 Description : The coverage and totality checkers for Idris are in this module.
-Copyright   :
+
 License     : BSD3
 Maintainer  : The Idris Community.
 -}

--- a/src/Idris/Transforms.hs
+++ b/src/Idris/Transforms.hs
@@ -1,7 +1,7 @@
 {-|
 Module      : Idris.Transforms
 Description : A collection of transformations.
-Copyright   :
+
 License     : BSD3
 Maintainer  : The Idris Community.
 -}

--- a/src/Idris/TypeSearch.hs
+++ b/src/Idris/TypeSearch.hs
@@ -1,7 +1,7 @@
 {-|
 Module      : Idris.TypeSearch
 Description : A Hoogle for Idris.
-Copyright   :
+
 License     : BSD3
 Maintainer  : The Idris Community.
 -}

--- a/src/Idris/Unlit.hs
+++ b/src/Idris/Unlit.hs
@@ -1,7 +1,7 @@
 {-|
 Module      : Idris.Unlit
 Description : Turn literate programs into normal programs.
-Copyright   :
+
 License     : BSD3
 Maintainer  : The Idris Community.
 -}

--- a/src/Idris/WhoCalls.hs
+++ b/src/Idris/WhoCalls.hs
@@ -1,7 +1,7 @@
 {-|
 Module      : Idris.WhoCalls
 Description : Find function callers and callees.
-Copyright   :
+
 License     : BSD3
 Maintainer  : The Idris Community.
 -}

--- a/src/Util/DynamicLinker.hs
+++ b/src/Util/DynamicLinker.hs
@@ -1,7 +1,7 @@
 {-|
 Module      : Util.DynamicLinker
 Description : Platform-specific dynamic linking support. Add new platforms to this file through conditional compilation.
-Copyright   :
+
 License     : BSD3
 Maintainer  : The Idris Community.
 -}

--- a/src/Util/Net.hs
+++ b/src/Util/Net.hs
@@ -1,7 +1,7 @@
 {-|
 Module      : Util.Net
 Description : Utilities for Network IO.
-Copyright   :
+
 License     : BSD3
 Maintainer  : The Idris Community.
 -}

--- a/src/Util/Pretty.hs
+++ b/src/Util/Pretty.hs
@@ -1,7 +1,7 @@
 {-|
 Module      : Util.Pretty
 Description : Utilities for Pretty Printing.
-Copyright   :
+
 License     : BSD3
 Maintainer  : The Idris Community.
 -}

--- a/src/Util/ScreenSize.hs
+++ b/src/Util/ScreenSize.hs
@@ -1,7 +1,7 @@
 {-|
 Module      : Util.ScreenSize
 Description : Utilities for getting screen width.
-Copyright   :
+
 License     : BSD3
 Maintainer  : The Idris Community.
 -}

--- a/src/Util/System.hs
+++ b/src/Util/System.hs
@@ -1,7 +1,7 @@
 {-|
 Module      : Util.System
 Description : Utilities for interacting with the system.
-Copyright   :
+
 License     : BSD3
 Maintainer  : The Idris Community.
 -}


### PR DESCRIPTION
We *should* make the effort to document this properly. However, I don't know what the proper attribution should be. So rather than having it blank, lets remove it completely.