### PR TITLE
Updated CONTRIBUTORS to reflect actual contributors.

### DIFF
--- a/CONTRIBUTORS
+++ b/CONTRIBUTORS
@@ -1,56 +1,215 @@
 Thanks to the following for their help and contributions:
 
-Ozgur Akgun
-Ahmad Salim Al-Sibahi
-Edward Chadwick Amsden
-Michael R. Bernstein
-Jan Bessai
-Nicola Botta
-Edwin Brady
-Vitaly Bragilevsky
-Jakob Brünker
-Alyssa Carter
-Carter Charbonneau
-David Raymond Christiansen
+a3gis
 Aaron Craelius
-Jason Dagit
 Adam Sandberg Eriksson
-Guglielmo Fachini
-Simon Fowler
-Google
-Zack Grannan
-Sean Hunt
+Adam Schønemann
+Adolfo Ochagavía
+Ahmad Salim Al-Sibahi
+Aistis Raulinaitis
+Alex Feldman-Crough
+Alexander Berntsen
+Alexander Shabalin
+Alyssa Carter
+Andreas Bogk
+Andreas Reuleaux
+Andrei Dziahel
+Andrew Cann
+Andrew Stewart Gibson
+Andy Morris
+Anthony Cantor
+Anthony---faineance
+Apostolis Xekoukoulotakis
+Athan Clark
+Bartosz Przygoda
+Ben Gamari
+Ben Sherman
+ben-schulz
+Benjamin Hodgson
+Benjamin Saunders
+Björn Aili
+bmastenbrook
+Brent Yorgey
+Brian Koropoff
+Brian McKenna
+Bryn Keller
+Calvin Beck
+Carsten König
+Carter Charbonneau
+Casper M. H. Holmgreen
+cchantep
 Cezar Ionescu
-Heath Johns
-Irene Knapp
-Paul Koerbitz
-Niklas Larsson
-Shea Levy
-Mathnerd314
+Chao-Hong Chen
+Chetan Taralekar
+Chris Allen
+Christopher Schwaab
+Cliff Harvey
+Cliff L. Biffle
+Colin Adams
+comco
+Craig McLaughlin
+cswords
+Daniel Waterworth
+Daniël Heres
+Darin Morrison
+David Feuer
+David Kraeutmann
+David Raymond Christiansen
+defanor
+Dennis Griffith
+Dirk Ullrich
+Dmitry Bushev
+Dmitry Tsygankov
+Dominic Mulligan
+Dominik Peteler
+Echo Nolan
+Eduard Nicodei
+Edward Amsden
+Edward O'Callaghan
+Edwin Brady
+Eric Casteleijn
+Eric Mertens
+Eric Walkingshaw
+Eric Weinstein
+Erkin Batu Altunbaş
+Ertugrul Söylemez
+EvanR
+Fabian Thorand
+fiendfan1
+Franklin Chen
+Frederic Koehler
+Friedrich von Never
+Gabe McArthur
+Gabor Greif
+Gabriel Garcia
+George Leontiev
+Gleb Alexeyev
+Google
+Greg Anderson
+Greg Pfeil
+Guglielmo Fachini
 Hannes Mehnert
+Heath Johns
+Heather
+Hector A. Escobedo IV
+identical snowflake
+Ignas Vyšniauskas
+Ilan Godik
+Imuli
+Irene Knapp
+Jack Henahan
+Jacob Mitchell
+Jakob Brünker
+Jan Bessai
+Jan de Muijnck-Hughes
+Jan Doms
+Jan Stolarek
+Jason Dagit
+Jason Gross
+Jean-Remi Desjardins
+Jeff Hemphill
+Jefferson Carpenter
+Jens Petersen
+Jeremy W. Sherman
+jhegedus42
+joe9
+Johannes Griebler
+John Connor
+John Dobronszki
+John Wiegley
+Jon Atack
+Jonas Westerlund
+Jonathan Sterling
+Joseph Huang
+Josh Vera
+JP Smith
+Juliusz Chroboczek
+Jurriën Stutterheim
+Jürgen Peters
+Karlos Kaeeikaas
+Kester Tong
+lambdadomain
+Langston Barrett
+Leif Warner
+Leon Schoorl
+Luke Palmer
+Mark Farrell
+Markus Klink
+Markus Pfeiffer
+Mathnerd314
+Mattias Lundell
+Matvey B. Aksenov
+Matúš Tejiščák
+Maxim Ivanov
 Mekeor Melire
 Melissa Mozifian
-Jan de Muijnck-Hughes
-Dominic Mulligan
-Echo Nolan
-Tom Prince
-raichoo
+Melvar Chen
+Michael A. Smith
+Michael Bernstein
+Michael Gilliland
+Michael Hensler
+Michael Maloney
+Michael McGirr
+Michael Thompson
+Michael Weiss
+Miikka Koskinen
+Mitchell Rosen
+Miëtek Bak
+Mort Yao
+Nathan Dinsmore
+Nicola Botta
+Niklas Larsson
+Norbert Melzer
+Oskar Wickström
+Ozgur Akgun
+Patrik Jansson
+Paul Koerbitz
+Per Fredelius
+Peter Minten
 Philip Rasmussen
-Aistis Raulinaitis
+PoroCYon
+raichoo
 Reynir Reynisson
+Ricky Elrod
+Robert Clipsham
+Robert Edström
+Ross Meikleham
+Ryan Scott
+Sam Elliott
+Sam T
+Saurabh Rawat
+Sean Hunt
+Sebastian de Bellefon
+Sebastian Dröge
 Seo Sanghyeon
-Benjamin Saunders
-Alexander Shabalin
-Jeremy W. Sherman
-Timo Petteri Sinnemäki
-JP Smith
+Sergei Trofimovich
+Shane Pearman
+Shea Levy
+Simon Fowler
 startling
-Chetan T
-Matúš Tejiščák
-Dirk Ullrich
-Leif Warner
-Daniel Waterworth
-Eric Weinstein
-Jonas Westerlund
-Björn Aili
+Stefan Bleibinhaus
+stepcut
+Stephen Drodge
+Steven Shaw
+Stuart Gale
+suhorng
+Sune Alkærsig
+Sven Koschnicke
+tdidriksen
+Tenor Biel
+Thomas Cooper
+Tim Dysinger
+Tim McGilchrist
+Timo Petteri Sinnemäki
+Tom Prince
+TorosFanny
+Trevor Elliott
+uwap
+Vitaly Bragilevsky
+xged
+XIE Yuheng
+Yacine Hmito
+Zack Grannan
 Zheng Jihui
+zjhmale
+Сухарик


### PR DESCRIPTION
Sadly we haven't be good at keeping the list of contributors up-to-date.

This fix takes the unique list fo contributors from the git logs, and
updated the list in CONTRIBUTORS. There may be a duplication of contributors
whose usernames couldn't be resolved to proper names. Duplicate names were
remove in the first place.