### PR TITLE
Made Mac OS X package generatation more robust.

### DIFF
--- a/mkpkg.sh
+++ b/mkpkg.sh
@@ -1,26 +1,64 @@
 #!/bin/sh
 
-VERSION=$1
+set -euo pipefail
 
-echo "Building version-$VERSION\n\n"
-echo "Have you: set the release flag, checked the demos and the tutorial?"
-read $foo
+if [ "$#" -lt 1 ]; then
+    echo "Usage $0 [version number] ?[idris bin location]"
+    echo ""
+    echo "The first argument is the version number"
+    echo ""
+    echo "The second argument is optional, and used to point to a"
+    echo "custom location in which idris was recently built i.e."
+    echo "withing .stack-work or .cabal-sandbox. The location must"
+    echo "be given relative to the project root of a package in the "
+    echo "libs/ directory."
+    exit 1
+fi
+
+VERSION=${1:-}
+
+echo "==> Building version-$VERSION"
+echo ""
+echo "Q: Have you: (a) set the release flag & (b) checked the demos and the tutorial?"
+read ${FOO:-}
 
 git tag v$VERSION -a
 
+echo "==> Building Source Distribution"
 cabal sdist
 
 # Generate Idris library docs and put them in lib_docs.tar.gz in the root
-make lib_doc
+echo "==> Generating API Documentation."
+echo "==> Determining version of Idris to use."
+if [ -z ${2+x} ];
+then
+    echo "==> Using default location.";
+    make lib_doc
+else
+    echo "==> Using custom location.";
+    make -C libs IDRIS=$2 doc
+fi
+
 DOCDIR=`mktemp -d /tmp/docsXXXXX`
+
 cp -r libs/base/base_doc "$DOCDIR"
 cp -r libs/prelude/prelude_doc "$DOCDIR"
 cp -r libs/effects/effects_doc "$DOCDIR"
 cp -r libs/contrib/contrib_doc "$DOCDIR"
+
 tar -czvf lib_docs.tar.gz -C "$DOCDIR" prelude_doc base_doc effects_doc contrib_doc
 
+echo "==> Building Binaries"
 cabal configure --prefix=/usr/local
-cabal build
-cabal copy --destdir=/tmp/idris-pkg/
-pkgbuild --id org.idris-lang --root /tmp/idris-pkg/ idris-$VERSION.pkg 
 
+cabal build
+
+echo "==> Creating Package"
+mkdir -p /tmp/idris-pkg/
+
+cabal copy --destdir=/tmp/idris-pkg/
+
+pkgbuild --identifier org.idris-lang \
+         --version "v$VERSION"       \
+         --root /tmp/idris-pkg/      \
+         idris-$VERSION.pkg


### PR DESCRIPTION
+ Improved error handling.
+ Improved script progress reporting.
+ Allowed for custom pointing to Idris that is not built by cabal i.e. stack.
+ Fix pkgbuild error by creating the `tmp` directory. You must have permission to write to `tmp`.
+ Added metadata and fixed flag to `pkgbuild`.