### PR TITLE
Add restriction to gcd

### DIFF
--- a/libs/prelude/Prelude/Nat.idr
+++ b/libs/prelude/Prelude/Nat.idr
@@ -93,7 +93,6 @@ hyper (S pn)   a (S pb) = hyper pn a (hyper (S pn) a pb)
 
 ||| Proofs that `n` or `m` is not equal to Z
 data NotBothZero : (n, m : Nat) -> Type where
-  NeitherIsZero  : NotBothZero (S n) (S m)
   LeftIsNotZero  : NotBothZero (S n) m
   RightIsNotZero : NotBothZero n     (S m)
 
@@ -393,9 +392,9 @@ log2 (S n) = log2NZ (S n) SIsNotZ
 --------------------------------------------------------------------------------
 -- GCD and LCM
 --------------------------------------------------------------------------------
-gcd : (a: Nat) -> (b: Nat) -> {auto ok: NotBothZero a b} -> Nat
-gcd a Z = a
-gcd Z b = b
+gcd : (a: Nat) -> (b: Nat) -> .{auto ok: NotBothZero a b} -> Nat
+gcd a Z     = a
+gcd Z b     = b
 gcd a (S b) = assert_total $ gcd (S b) (modNatNZ a (S b) SIsNotZ)
 
 lcm : Nat -> Nat -> Nat

--- a/libs/prelude/Prelude/Nat.idr
+++ b/libs/prelude/Prelude/Nat.idr
@@ -396,12 +396,12 @@ log2 (S n) = log2NZ (S n) SIsNotZ
 gcd : (a: Nat) -> (b: Nat) -> {auto ok: NotBothZero a b} -> Nat
 gcd a Z = a
 gcd Z b = b
-gcd a (S b) = assert_total (gcd (S b) (a `modNat` (S b)))
+gcd a (S b) = assert_total $ gcd (S b) (modNatNZ a (S b) SIsNotZ)
 
 lcm : Nat -> Nat -> Nat
 lcm _ Z     = Z
 lcm Z _     = Z
-lcm a (S b) = assert_total (divNat (a * (S b)) (gcd a (S b)))
+lcm a (S b) = assert_total $ divNat (a * (S b)) (gcd a (S b))
 
 
 --------------------------------------------------------------------------------

--- a/libs/prelude/Prelude/Nat.idr
+++ b/libs/prelude/Prelude/Nat.idr
@@ -91,6 +91,13 @@ hyper (S pn)   a (S pb) = hyper pn a (hyper (S pn) a pb)
 -- Comparisons
 --------------------------------------------------------------------------------
 
+||| Proofs that `n` or `m` is not equal to Z
+data NotBothZero : (n, m : Nat) -> Type where
+  NeitherIsZero  : NotBothZero (S n) (S m)
+  LeftIsNotZero  : NotBothZero (S n) m
+  RightIsNotZero : NotBothZero n     (S m)
+
+
 ||| Proofs that `n` is less than or equal to `m`
 ||| @ n the smaller number
 ||| @ m the larger number
@@ -386,16 +393,15 @@ log2 (S n) = log2NZ (S n) SIsNotZ
 --------------------------------------------------------------------------------
 -- GCD and LCM
 --------------------------------------------------------------------------------
-partial
-gcd : Nat -> Nat -> Nat
+gcd : (a: Nat) -> (b: Nat) -> {auto ok: NotBothZero a b} -> Nat
 gcd a Z = a
-gcd a b = assert_total (gcd b (a `modNat` b))
+gcd Z b = b
+gcd a (S b) = assert_total (gcd (S b) (a `modNat` (S b)))
 
-partial
 lcm : Nat -> Nat -> Nat
-lcm _ Z = Z
-lcm Z _ = Z
-lcm x y = divNat (x * y) (gcd x y)
+lcm _ Z     = Z
+lcm Z _     = Z
+lcm a (S b) = assert_total (divNat (a * (S b)) (gcd a (S b)))
 
 
 --------------------------------------------------------------------------------


### PR DESCRIPTION
This PR restricts the domain of `gcd` since it incorrectly returned `0` for `gcd 0 0`. It closes issue #3517 and it should now be possible to prove that `gcd a b` is not zero.