### PR TITLE
Make fetching of data files more robust. Fixes #3544

### DIFF
--- a/src/IRTS/System.hs
+++ b/src/IRTS/System.hs
@@ -6,7 +6,7 @@ License     : BSD3
 Maintainer  : The Idris Community.
 -}
 {-# LANGUAGE CPP #-}
-module IRTS.System( getDataFileName
+module IRTS.System( getIdrisDataFileByName
                   , getCC
                   , getLibFlags
                   , getIdrisDataDir
@@ -41,6 +41,11 @@ getIdrisDataDir = do
       ddir <- getDataDir
       return ddir
     Just ddir -> return ddir
+
+getIdrisDataFileByName :: String -> IO FilePath
+getIdrisDataFileByName fn = do
+  dir <- getIdrisDataDir
+  return $ dir </> fn
 
 overrideIdrisSubDirWith :: String  -- ^ Sub directory in `getDataDir` location.
                         -> String  -- ^ Environment variable to get new location from.

--- a/src/Idris/IdrisDoc.hs
+++ b/src/Idris/IdrisDoc.hs
@@ -19,7 +19,7 @@ import Idris.Docs
 import Idris.Docstrings (nullDocstring)
 import qualified Idris.Docstrings as Docstrings
 import Idris.Parser.Helpers (opChars)
-import IRTS.System (getDataFileName)
+import IRTS.System (getIdrisDataFileByName)
 
 import Control.Applicative ((<|>))
 import Control.Monad (forM_)
@@ -708,5 +708,5 @@ copyDependencies :: FilePath -- ^ The base directory to which
                              --   dependencies should be written
                  -> IO ()
 copyDependencies dir =
-  do styles <- getDataFileName $ "idrisdoc" </> "styles.css"
+  do styles <- getIdrisDataFileByName $ "idrisdoc" </> "styles.css"
      copyFile styles (dir </> "styles.css")

--- a/src/Idris/Info.hs
+++ b/src/Idris/Info.hs
@@ -22,6 +22,7 @@ module Idris.Info
   , getIdrisHistoryFile
   , getIdrisInstalledPackages
   , getIdrisLoggingCategories
+  , getIdrisDataFileByName
   ) where
 
 import Idris.AbsSyntax (loggingCatsStr)
@@ -34,6 +35,7 @@ import Version_idris (gitHash)
 import Data.Version
 import System.Directory
 import System.FilePath
+
 getIdrisDataDir :: IO String
 getIdrisDataDir = S.getIdrisDataDir
 
@@ -88,3 +90,6 @@ getIdrisInstalledPackages = installedPackages
 
 getIdrisLoggingCategories :: IO [String]
 getIdrisLoggingCategories = return $ words loggingCatsStr
+
+getIdrisDataFileByName :: String -> IO FilePath
+getIdrisDataFileByName = S.getIdrisDataFileByName


### PR DESCRIPTION
`getDataFileName` didn't take into account possible changes in Idris' datadir that were not cabal made. This fix adds a more robust variant of `getDataFileName`.