### PR TITLE
Improve progress reporting.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,14 @@
   + `FirstClassReflection`, which must be enabled to define a `%reflection`
     function
 
+## Tool Updates
+
++ Output from verbose Idris has been updated to more accurately reflect 
+  its progress through the compiler. Idris, when verbose, will report
+  explicitly: Type Checking; Totality Checking; IBC Generation; 
+  Compiling; and Code Generation.
+  
+
 ## Library Updates
 
 + Terminating programs has been improved with more appropriate

--- a/src/IRTS/Compiler.hs
+++ b/src/IRTS/Compiler.hs
@@ -53,7 +53,9 @@ import System.Process
 -- |  Compile to simplified forms and return CodegenInfo
 compile :: Codegen -> FilePath -> Maybe Term -> Idris CodegenInfo
 compile codegen f mtm
-   = do checkMVs  -- check for undefined metavariables
+   = do v <- verbose
+        when v $ iputStrLn "Compiling Output."
+        checkMVs  -- check for undefined metavariables
         checkTotality -- refuse to compile if there are totality problems
         exports <- findExports
         let rootNames = case mtm of
@@ -108,7 +110,7 @@ compile codegen f mtm
             Just f -> runIO $ writeFile f (dumpDefuns defuns)
         triple <- Idris.AbsSyntax.targetTriple
         cpu <- Idris.AbsSyntax.targetCPU
-        logCodeGen 1 "Building output"
+        when v $ iputStrLn "Generating Code."
         case checked of
             OK c -> do return $ CodegenInfo f outty triple cpu
                                             hdrs impdirs objs libs flags

--- a/src/Idris/AbsSyntaxTree.hs
+++ b/src/Idris/AbsSyntaxTree.hs
@@ -120,7 +120,7 @@ defaultOpts = IOption { opt_logLevel   = 0
                       , opt_showimp    = False
                       , opt_errContext = False
                       , opt_repl       = True
-                      , opt_verbose    = True
+                      , opt_verbose    = False
                       , opt_nobanner   = False
                       , opt_quiet      = False
                       , opt_codegen    = Via IBCFormat "c"

--- a/src/Idris/IBC.hs
+++ b/src/Idris/IBC.hs
@@ -220,7 +220,8 @@ writeArchive fp i = do let a = L.foldl (\x y -> addEntryToArchive y x) emptyArch
 
 writeIBC :: FilePath -> FilePath -> Idris ()
 writeIBC src f
-    = do logIBC 1 $ "Writing ibc " ++ show f
+    = do v <- verbose
+         when v $ iputStrLn $ "Writing IBC for: " ++ show f
          i <- getIState
 --          case (Data.List.map fst (idris_metavars i)) \\ primDefs of
 --                 (_:_) -> ifail "Can't write ibc when there are unsolved metavariables"
@@ -313,7 +314,7 @@ ibc i (IBCCG n) f = case lookupCtxtExact n (idris_callgraph i) of
                         _ -> ifail "IBC write failed"
 ibc i (IBCCoercion n) f = return f { ibc_coercions = n : ibc_coercions f }
 ibc i (IBCAccess n a) f = return f { ibc_access = (n,a) : ibc_access f }
-ibc i (IBCFlags n) f 
+ibc i (IBCFlags n) f
     = case lookupCtxtExact n (idris_flags i) of
            Just a -> return f { ibc_flags = (n,a): ibc_flags f }
            _ -> ifail "IBC write failed"

--- a/src/Idris/Parser.hs
+++ b/src/Idris/Parser.hs
@@ -1803,7 +1803,7 @@ loadSource lidr f toline
                                   setContext ctxt')
                            (map snd (idris_totcheck i))
                   -- build size change graph from simplified definitions
-                  logLvl 1 "Totality checking"
+                  when v $ iputStrLn $ "Totality checking " ++ f
                   i <- getIState
                   mapM_ buildSCG (idris_totcheck i)
                   mapM_ checkDeclTotality (idris_totcheck i)
@@ -1826,7 +1826,7 @@ loadSource lidr f toline
 
                   logLvl 1 ("Finished " ++ f)
                   ibcsd <- valIBCSubDir i
-                  logLvl 1 "Universe checking"
+                  logLvl 1 $ "Universe checking " ++ f
                   iucheck
                   let ibc = ibcPathNoFallback ibcsd f
                   i <- getIState

--- a/test/base001/expected
+++ b/test/base001/expected
@@ -1,4 +1,8 @@
 Type checking ./base001.idr
+Totality checking ./base001.idr
+Writing IBC for: "./base001.ibc"
+Compiling Output.
+Generating Code.
 exit1: Executing cmd 'exit 1'
 exit1: raw exitStatus = 256
 exit1: WEXITSTATUS(exitStatus) = 1

--- a/test/pkg008/expected
+++ b/test/pkg008/expected
@@ -1,10 +1,16 @@
 Entering directory `./src'
 Type checking ./NumOps.idr
+Totality checking ./NumOps.idr
+Writing IBC for: "./NumOps.ibc"
 Type checking ./Test.idr
+Totality checking ./Test.idr
+Writing IBC for: "./Test.ibc"
 Leaving directory `./src'
-Test Passed
-Test Passed
 Entering directory `./src'
+Compiling Output.
+Generating Code.
+Test Passed
+Test Passed
 Leaving directory `./src'
 Entering directory `./src'
 Removed: NumOps.ibc


### PR DESCRIPTION
This commit improves the default progress reporting to clearly indicate at which stage Idris is during compilation.

For a simple hello world program with no dependencies, the output using `-V` will be:

```
$ idris Hello.idr -o a.out -V
Type checking ./Hello.idr
Totality checking ./Hello.idr
Writing IBC for: "./Hello.ibc"
Compiling Output.
Generating Code.
```