### PR TITLE
Improve `System.Exit` Fixes #3488.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,11 @@
+# New in 0.999
+
+## Library Updates
+
++ Terminating programs has been improved with more appropriate
+  functions (`exitWith`, `exitFailure`, and `exitSuccess`) and a data
+  structure (`ExitCode`) to capture a program's return code.
+
 # New in 0.99:
 
 ## Language updates

--- a/libs/base/Debug/Error.idr
+++ b/libs/base/Debug/Error.idr
@@ -12,9 +12,8 @@ error : {default (%runElab sourceLocation) loc : SourceLocation} ->
         (message : String) ->
         a
 error {loc = FileLoc filename (line, col) _} message =
-  believe_me . unsafePerformIO $ 
+  unsafePerformIO $
     do let place = filename ++ " line " ++ show line ++ " column " ++ show col
        let message' = place ++ ": " ++ message
        putStrLn message'
        exit 1
-

--- a/libs/effects/Effect/Exception.idr
+++ b/libs/effects/Effect/Exception.idr
@@ -17,7 +17,7 @@ implementation Handler (Exception a) List where
 
 implementation Show a => Handler (Exception a) IO where
      handle _ (Raise e) k = do printLn e
-                               believe_me (exit 1)
+                               (exit 1)
 
 implementation Handler (Exception a) (IOExcept a) where
      handle _ (Raise e) k = ioe_fail e
@@ -30,4 +30,3 @@ EXCEPTION t = MkEff () (Exception t)
 
 raise : a -> Eff b [EXCEPTION a]
 raise err = call $ Raise err
-


### PR DESCRIPTION
Brings core functions for temrinating programs in line with Haskell requivalents.