### PR TITLE
Add %access export statement

### DIFF
--- a/docs/tutorial/testing.rst
+++ b/docs/tutorial/testing.rst
@@ -42,6 +42,8 @@ A simple test module, with a qualified name of ``Test.NumOps`` can be declared a
     module Test.NumOps
 
     import Maths.NumOps
+    
+    %access export  -- to make the test functions visible
 
     assertEq : Eq a => (given : a) -> (expected : a) -> IO ()
     assertEq g e = if g == e

--- a/docs/tutorial/testing.rst
+++ b/docs/tutorial/testing.rst
@@ -27,6 +27,8 @@ For example, lets take the following list of functions that are defined in a mod
 .. code-block:: idris
 
     module Maths.NumOps
+    
+    %access export -- to make functions under test visible
 
     double : Num a => a -> a
     double a = a + a


### PR DESCRIPTION
Without the export access declared test functions are not visible to the main function which is generated to execute the tests.