### PR TITLE
Generalized the Num instance for Complex

### DIFF
--- a/libs/base/Data/Complex.idr
+++ b/libs/base/Data/Complex.idr
@@ -70,7 +70,7 @@ implementation Neg a => Num (Complex a) where
     (*) (a:+b) (c:+d) = ((a*c-b*d):+(b*c+a*d))
     fromInteger x = (fromInteger x:+0)
 
--- We can't do "implementation Neg a => Num (Complex a)" because
+-- We can't do "implementation Neg a => Neg (Complex a)" because
 -- we need "abs" which needs "magnitude" which needs "sqrt" which needs Double
 implementation Neg (Complex Double) where
     negate = map negate

--- a/libs/base/Data/Complex.idr
+++ b/libs/base/Data/Complex.idr
@@ -63,15 +63,16 @@ conjugate (r:+i) = (r :+ (0-i))
 implementation Functor Complex where
     map f (r :+ i) = f r :+ f i
 
--- We can't do "implementation Num a => Num (Complex a)" because
--- we need "abs" which needs "magnitude" which needs "sqrt" which needs Double
-implementation Num (Complex Double) where
+-- We can do "implementation Neg a => Num (Complex a)" because
+-- we don't need "abs", only (-)
+implementation Neg a => Num (Complex a) where
     (+) (a:+b) (c:+d) = ((a+c):+(b+d))
     (*) (a:+b) (c:+d) = ((a*c-b*d):+(b*c+a*d))
     fromInteger x = (fromInteger x:+0)
 
+-- We can't do "implementation Neg a => Num (Complex a)" because
+-- we need "abs" which needs "magnitude" which needs "sqrt" which needs Double
 implementation Neg (Complex Double) where
     negate = map negate
     (-) (a:+b) (c:+d) = ((a-c):+(b-d))
     abs (a:+b) = (magnitude (a:+b):+0)
-

--- a/libs/base/Data/Complex.idr
+++ b/libs/base/Data/Complex.idr
@@ -76,3 +76,10 @@ implementation Neg (Complex Double) where
     negate = map negate
     (-) (a:+b) (c:+d) = ((a-c):+(b-d))
     abs (a:+b) = (magnitude (a:+b):+0)
+
+-- As soon as abs moves out of Neg (issue #3500), the following would become a
+-- valid instance:
+
+-- implementation Neg a => Neg (Complex a) where
+--     negate = map negate
+--     (-) (a:+b) (c:+d) = ((a-c):+(b-d))


### PR DESCRIPTION
Due to a historical artifact, the `Num` implementation for `Complex` only covered `Double`, because
`abs` used to be in `Num` (like in Haskell). Since these implementations are now split, we can
implent Num with only `Neg a` instead of Double.

As soon as `abs` moves out of `Neg` (issue #3500), we can also loosen the requirment for the `Neg`
implementation to only need `Neg a`:

```idris
implementation Neg a => Neg (Complex a) where
    negate = map negate
    (-) (a:+b) (c:+d) = ((a-c):+(b-d))
```