### PR TITLE
Make idris distro friendly

### DIFF
--- a/Setup.hs
+++ b/Setup.hs
@@ -254,7 +254,8 @@ idrisInstall verbosity copy pkg local = unless (execOnly (configFlags local)) $ 
       target = datadir $ L.absoluteInstallDirs pkg local copy
 
       installStdLib = do
-        let target' = target -- </> "libs"
+        envTarget <- lookupEnv "TARGET"
+        let target' = maybe target id envTarget -- </> "libs"
         putStrLn $ "Installing libraries in " ++ target'
         makeInstall "libs" target'
 

--- a/src/Idris/Imports.hs
+++ b/src/Idris/Imports.hs
@@ -94,7 +94,7 @@ findPkgIndex p = do let idx = pkgIndex p
 installedPackages :: IO [String]
 installedPackages = do
   idir <- getIdrisLibDir
-  filterM (goodDir idir) =<< dirContents idir
+  filterM (goodDir idir) =<< concat <$> (mapM dirContents (splitSearchPath idir))
   where
   allFilesInDir base fp = do
     let fullpath = base </> fp
@@ -102,7 +102,9 @@ installedPackages = do
     if isDir
       then fmap concat (mapM (allFilesInDir fullpath) =<< dirContents fullpath)
       else return [fp]
-  dirContents = fmap (filter (not . (`elem` [".", ".."]))) . getDirectoryContents
+  prependDirname dir = fmap (fmap (dir </>))
+  filterPaths = fmap (filter (not . (`elem` [".", ".."])))
+  dirContents dir = prependDirname dir (filterPaths (getDirectoryContents dir))
   goodDir idir d = any (".ibc" `isSuffixOf`) <$> allFilesInDir idir d
 
 


### PR DESCRIPTION
IDRIS_LIBRARY_PATH accepts a colon separated search path.

The idris install procedure respects the TARGET environment variable.

Closes #3573 