### PR TITLE
A simple extension system for embedded code generators

### DIFF
--- a/src/IRTS/Compiler.hs
+++ b/src/IRTS/Compiler.hs
@@ -29,6 +29,7 @@ import IRTS.Lang
 import IRTS.LangOpts
 import IRTS.Portable
 import IRTS.Simplified
+import IRTS.System (getExtCodeGenerator)
 
 import Prelude hiding (id, (.))
 
@@ -136,21 +137,23 @@ generate codegen mainmod ir
   = case codegen of
        -- Built-in code generators (FIXME: lift these out!)
        Via _ "c" -> codegenC ir
-       -- Any external code generator
-       Via fm cg -> do input <- case fm of
-                                    IBCFormat -> return mainmod
-                                    JSONFormat -> do
-                                        tempdir <- getTemporaryDirectory
-                                        (fn, h) <- openTempFile tempdir "idris-cg.json"
-                                        writePortable h ir
-                                        hClose h
-                                        return fn
-                       let cmd = "idris-codegen-" ++ cg
-                           args = [input, "-o", outputFile ir] ++ compilerFlags ir
-                       exit <- rawSystem cmd args
-                       when (exit /= ExitSuccess) $
-                            putStrLn ("FAILURE: " ++ show cmd ++ " " ++ show args)
+       -- Any extension or external code generator
+       Via fm cg -> getExtCodeGenerator cg >>= maybe (external fm cg) ($ ir)
        Bytecode -> dumpBC (simpleDecls ir) (outputFile ir)
+  where external fm cg = do
+          input <- case fm of
+                     IBCFormat -> return mainmod
+                     JSONFormat -> do
+                                     tempdir <- getTemporaryDirectory
+                                     (fn, h) <- openTempFile tempdir "idris-cg.json"
+                                     writePortable h ir
+                                     hClose h
+                                     return fn
+          let cmd = "idris-codegen-" ++ cg
+              args = [input, "-o", outputFile ir] ++ compilerFlags ir
+          exit <- rawSystem cmd args
+          when (exit /= ExitSuccess) $
+            putStrLn ("FAILURE: " ++ show cmd ++ " " ++ show args)
 
 irMain :: TT Name -> Idris LDecl
 irMain tm = do

--- a/src/Idris/Info/Show.hs
+++ b/src/Idris/Info/Show.hs
@@ -1,7 +1,9 @@
 module Idris.Info.Show where
 
 import Idris.Info
+import IRTS.System (getExtInfoStrings)
 
+import Control.Monad (unless)
 import System.Exit
 
 showIdrisCRTSDir :: IO ()
@@ -136,6 +138,9 @@ showIdrisInfo = do
   putStrLn $ unwords (["-", "History File:",    hfile])
   putStrLn $ unwords (["-", "REPL Init Script", iscript])
 
+  strs <- getExtInfoStrings
+  unless (null strs) $ putStrLn "Bundled Extensions:"
+  mapM_ (\(name, val) -> putStrLn $ unwords ["-", name ++ ":", val]) strs
 
 showExitIdrisInfo :: IO ()
 showExitIdrisInfo = do


### PR DESCRIPTION
Addresses #3542 and a followup of #3577. It is "step 1" from the last comment there.

This makes possible for people to create and publish embedded code generators.

Such a package would depend on `idris` and produce an executable to be used in place of the normal `idris`. In the `main` function, the appropriate `register*` functions would be called.

It is also possible to create a batteries included package, that imports many such codegens from multiple 3rd parties and creates an `idris` executable. Maintaining it would be reasonably simple, as only the `Main.hs` of `idris` is cloned, and would have to be updated only rarely.

A template project that shows how to do just that can be found [here](https://github.com/mmn80/idris-codegen-ext). In the README file there is more detailed info. It took maybe 20 mins to set up. I cloned the C codegen and RTS from `idris`, and the repo can be used as a starting point for development of a custom C RTS (which is what I intend to do for my Erlang style code loading project).

This PR does not change anything about `idris` unless used as described (in a separate package).