### PR TITLE
Check for node when running test suite.

### DIFF
--- a/test/TestRun.hs
+++ b/test/TestRun.hs
@@ -107,11 +107,17 @@ runTest path flags = do
       normalise [] = []
 
 main :: IO ()
-main =
-  defaultMainWithIngredients ingredients $
-    askOption $ \(NodeOpt node) ->
-      let (codegen, flags) = if node then (JS, ["--codegen", "node"])
-                                     else (C , [])
-       in
-        mkGoldenTests (testFamiliesForCodegen codegen)
-                    (flags ++ idrisFlags)
+main = do
+  node <- findExecutable "node"
+  case node of
+    Nothing -> do
+      putStrLn "For running the test suite against Node, node must be installed."
+      exitFailure
+    Just _  -> do
+      defaultMainWithIngredients ingredients $
+        askOption $ \(NodeOpt node) ->
+          let (codegen, flags) = if node then (JS, ["--codegen", "node"])
+                                         else (C , [])
+           in
+            mkGoldenTests (testFamiliesForCodegen codegen)
+                        (flags ++ idrisFlags)


### PR DESCRIPTION
If node isn't installed then don't run the test suite. This check
could possibly be performed when the test option for running node
is set, but it is not clear how.

Regardless, if you are contributing a pull request then you would
need to run the tests for both `C` and `Node` codegens.