### PR TITLE
Import dependencies in Atom

### DIFF
--- a/docs/tutorial/modules.rst
+++ b/docs/tutorial/modules.rst
@@ -299,3 +299,25 @@ which can be inferred by the type checker:
 
     *params> show (append _ _ (MkVects _ [1,2,3] [4,5,6]))
     "[1, 2, 3, 4, 5, 6]" : String
+
+
+**********************
+Modules Dependencies Using Atom 
+**********************
+
+If you are using the Atom editor and have a dependency on another package, 
+corresponding to for instance ``import Lightyear`` or ``import Pruviloj``, 
+you need to let Atom know that it should be loaded. The easiest way to 
+accomplish that is with a .ipkg file. The general contents of an ipkg file 
+will be described in the next section of the tutorial, but for now here is 
+a simple recipe for this trivial case. 
+
+- Create a folder myProject. 
+
+- Add a file myProject.ipkg containing just a couple of lines: 
+
+``package myProject`` 
+
+``pkgs = pruviloj, lightyear`` 
+
+- In Atom, use the File menu to Open Folder myProject. 


### PR DESCRIPTION
This communicates the solution Rui Barreiro and David Christiansen explained to me for Atom. 
https://groups.google.com/forum/#!topic/idris-lang/5i0FZoYj8A0

The formatting is not perfect, somebody needs to check it for consistency with the rest of the tutorial. 

I'm also not sure about where exactly this information belongs, since it relates to both imports and to packages, tutorial and Atom. I've put it where I would most likely look for it. 