### PR TITLE
More lenient casting from string to number

### DIFF
--- a/src/Idris/Primitives.hs
+++ b/src/Idris/Primitives.hs
@@ -455,8 +455,8 @@ getInt _ = []
 
 strToInt :: IntTy -> [Const] -> Maybe Const
 strToInt ity [Str x] = case reads x of
-                         [(n,"")] -> Just $ toInt ity (n :: Integer)
-                         _        -> Just $ I 0
+                         [(n,s)] -> Just $ if all isSpace s then toInt ity (n :: Integer) else I 0
+                         _       -> Just $ I 0
 strToInt _ _ = Nothing
 
 intToFloat :: [Const] -> Maybe Const
@@ -481,8 +481,8 @@ c_floatToStr :: [Const] -> Maybe Const
 c_floatToStr [Fl x] = Just $ Str (show x)
 c_floatToStr _ = Nothing
 c_strToFloat [Str x] = case reads x of
-                         [(n,"")] -> Just $ Fl n
-                         _ -> Just $ Fl 0
+                         [(n,s)] -> Just $ Fl (if all isSpace s then n else 0)
+                         _       -> Just $ Fl 0
 c_strToFloat _ = Nothing
 
 p_fPrim :: (Double -> Double) -> [Const] -> Maybe Const


### PR DESCRIPTION
Now whitespace is also allowed after the number being cast, like so:

~~~
the Int $ cast "  123  "
the Integer $ cast "  123  "
the Double $ cast "  123  "
~~~

Fixes #3601