### PR TITLE
Implement second part of FORCE_ALIGNMENT fix for arduino targets.

### DIFF
--- a/rts/idris_gc.c
+++ b/rts/idris_gc.c
@@ -73,7 +73,16 @@ VAL copy(VM* vm, VAL x) {
 void cheney(VM *vm) {
     int i;
     int ar;
-    char* scan = vm->heap.heap;
+    char* scan = NULL;
+	
+#ifdef FORCE_ALIGNMENT
+    if (((i_int)(vm->heap.heap)&1) == 1) {
+       scan = vm->heap.heap + 1;
+    } else
+#endif
+    {
+        scan = vm->heap.heap;
+    }	
 
     while(scan < vm->heap.next) {
        size_t inc = *((size_t*)scan);

--- a/rts/idris_gc.c
+++ b/rts/idris_gc.c
@@ -1,3 +1,4 @@
+#include "idris_heap.h"
 #include "idris_rts.h"
 #include "idris_gc.h"
 #include "idris_bitstring.h"
@@ -73,16 +74,7 @@ VAL copy(VM* vm, VAL x) {
 void cheney(VM *vm) {
     int i;
     int ar;
-    char* scan = NULL;
-	
-#ifdef FORCE_ALIGNMENT
-    if (((i_int)(vm->heap.heap)&1) == 1) {
-       scan = vm->heap.heap + 1;
-    } else
-#endif
-    {
-        scan = vm->heap.heap;
-    }	
+    char* scan = aligned_heap_pointer(vm->heap.heap);
 
     while(scan < vm->heap.next) {
        size_t inc = *((size_t*)scan);

--- a/rts/idris_heap.c
+++ b/rts/idris_heap.c
@@ -118,14 +118,7 @@ void alloc_heap(Heap * h, size_t heap_size, size_t growth, char * old)
     }
 
     h->heap = mem;
-#ifdef FORCE_ALIGNMENT
-    if (((i_int)(h->heap)&1) == 1) {
-        h->next = h->heap + 1;
-    } else
-#endif
-    {
-        h->next = h->heap;
-    }
+    h->next = aligned_heap_pointer(h->heap);
     h->end  = h->heap + heap_size;
 
     h->size   = heap_size;
@@ -167,6 +160,17 @@ int is_valid_ref(VAL v) {
 
 int ref_in_heap(Heap * heap, VAL v) {
     return ((VAL)heap->heap <= v) && (v < (VAL)heap->next);
+}
+
+char* aligned_heap_pointer(char * heap) {
+#ifdef FORCE_ALIGNMENT
+    if (((i_int)heap&1) == 1) {
+	    return (heap + 1);
+    } else
+#endif
+    {
+	    return heap;
+    }
 }
 
 // Checks three important properties:

--- a/rts/idris_heap.h
+++ b/rts/idris_heap.h
@@ -98,7 +98,7 @@ typedef struct {
 
 void alloc_heap(Heap * heap, size_t heap_size, size_t growth, char * old);
 void free_heap(Heap * heap);
-
+char* aligned_heap_pointer(char * heap);
 
 #ifdef IDRIS_DEBUG
 void heap_check_all(Heap * heap);


### PR DESCRIPTION
When FORCE_ALIGNMENT was introduced for pointer aligment on 8-bit arduino targets (See idris-lang@47cd264) it was not applied to the initialization of the cheney algorithm during garbage collection. The fix modifies the start of the heap location in the same way the FORCE_ALIGNMENT-define does for the initialization of the FP-heap in alloc_heap(...) in file idris_heap.c.