### PR TITLE
Add proofs of ring laws to Data.ZZ in contrib

### DIFF
--- a/CONTRIBUTORS
+++ b/CONTRIBUTORS
@@ -42,6 +42,7 @@ Cezar Ionescu
 Chao-Hong Chen
 Chetan Taralekar
 Chris Allen
+Chris Gibbs
 Christopher Schwaab
 Cliff Harvey
 Cliff L. Biffle


### PR DESCRIPTION
Adds proofs to Data.ZZ in contrib - associativity and commutativity for multiplication, and
distributivity of multiplication over addition.

This completes the proofs of the ring axioms for Data.ZZ - finishes the job started in https://github.com/idris-lang/Idris-dev/pull/3612 (already merged).

If this goes in, and if https://github.com/idris-lang/Idris-dev/issues/3616 is fixed at some point, I'll try following up with some instances of 'VerifiedSemigroup' and the like, along the lines of https://github.com/atacratic/Idris-dev/commit/30dbbf7f63ca0eac29ca14fd4eda10d408b839b7