### PR TITLE
Add :! for running shell commands from the REPL

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -27,6 +27,8 @@
   `--V0`, `--V1`, and `--V2`. The old aliases of `-V` and `--verbose`
   persist.
 
++ New REPL command `:!` that runs an external shell command.
+
 ## Library Updates
 
 + Terminating programs has been improved with more appropriate

--- a/src/Idris/Completion.hs
+++ b/src/Idris/Completion.hs
@@ -159,6 +159,7 @@ completeColour (prev, next) = case words (reverse prev) of
 completeCmd :: String -> CompletionFunc Idris
 completeCmd cmd (prev, next) = fromMaybe completeCmdName $ fmap completeArg $ lookupInHelp cmd
     where completeArg FileArg = completeFilename (prev, next)
+          completeArg ShellCommandArg = completeFilename (prev, next)
           completeArg NameArg = completeName UpTo [] (prev, next)
           completeArg OptionArg = completeOption (prev, next)
           completeArg ModuleArg = noCompletion (prev, next)

--- a/src/Idris/Help.hs
+++ b/src/Idris/Help.hs
@@ -11,6 +11,7 @@ module Idris.Help (CmdArg(..), extraHelp) where
 data CmdArg = ExprArg               -- ^ The command takes an expression
             | NameArg               -- ^ The command takes a name
             | FileArg               -- ^ The command takes a file
+            | ShellCommandArg       -- ^ The command takes a shell command name
             | ModuleArg             -- ^ The command takes a module name
             | PkgArgs               -- ^ The command takes a list of package names
             | NumberArg             -- ^ The command takes a number
@@ -30,6 +31,7 @@ instance Show CmdArg where
     show ExprArg          = "<expr>"
     show NameArg          = "<name>"
     show FileArg          = "<filename>"
+    show ShellCommandArg  = "<command>"
     show ModuleArg        = "<module>"
     show PkgArgs          = "<package list>"
     show NumberArg        = "<number>"

--- a/src/Idris/REPL.hs
+++ b/src/Idris/REPL.hs
@@ -590,7 +590,8 @@ splitName s = case reverse $ splitOn "." s of
 idemodeProcess :: FilePath -> Command -> Idris ()
 idemodeProcess fn Warranty = process fn Warranty
 idemodeProcess fn Help = process fn Help
-idemodeProcess fn (RunShellCommand cmd) = process fn (RunShellCommand cmd)
+idemodeProcess fn (RunShellCommand cmd) =
+  iPrintError ":! is not currently supported in IDE mode."
 idemodeProcess fn (ChangeDirectory f) =
   do process fn (ChangeDirectory f)
      dir <- runIO $ getCurrentDirectory

--- a/src/Idris/REPL.hs
+++ b/src/Idris/REPL.hs
@@ -590,6 +590,7 @@ splitName s = case reverse $ splitOn "." s of
 idemodeProcess :: FilePath -> Command -> Idris ()
 idemodeProcess fn Warranty = process fn Warranty
 idemodeProcess fn Help = process fn Help
+idemodeProcess fn (RunShellCommand cmd) = process fn (RunShellCommand cmd)
 idemodeProcess fn (ChangeDirectory f) =
   do process fn (ChangeDirectory f)
      dir <- runIO $ getCurrentDirectory
@@ -817,6 +818,7 @@ insertScript prf (x : xs) = x : insertScript prf xs
 process :: FilePath -> Command -> Idris ()
 process fn Help = iPrintResult displayHelp
 process fn Warranty = iPrintResult warranty
+process fn (RunShellCommand cmd) = runIO $ system cmd >> return ()
 process fn (ChangeDirectory f)
                  = do runIO $ setCurrentDirectory f
                       return ()

--- a/src/Idris/REPL/Commands.hs
+++ b/src/Idris/REPL/Commands.hs
@@ -17,6 +17,7 @@ data Command = Quit
              | Reload
              | Watch
              | Load FilePath (Maybe Int) -- up to maximum line number
+             | RunShellCommand FilePath
              | ChangeDirectory FilePath
              | ModImport String
              | Edit

--- a/src/Idris/REPL/Parser.hs
+++ b/src/Idris/REPL/Parser.hs
@@ -78,6 +78,7 @@ parserCommandsForHelp =
   , noArgCmd ["w", "watch"] Watch "Watch the current file for changes"
   , (["l", "load"], FileArg, "Load a new file"
     , strArg (\f -> Load f Nothing))
+  , (["!"], ShellCommandArg, "Run a shell command", strArg RunShellCommand)
   , (["cd"], FileArg, "Change working directory"
     , strArg ChangeDirectory)
   , (["module"], ModuleArg, "Import an extra module", moduleArg ModImport) -- NOTE: dragons


### PR DESCRIPTION
This adds to the Idris REPL a counterpart to GHCi's `:!` command, an incredibly useful feature which lets you shell out to some other command. I use this quite frequently to run `ls`, `vim`, and other utilities as I am working in an interactive REPL session.

The code for running and tab-completing `:!` is adapted from GHCi's implementation [here](http://git.haskell.org/ghc.git/blob/9fd87ef8a16fbbce35205ae63d75d239bb575ccc:/ghc/GHCi/UI.hs#l1204) and [here](http://git.haskell.org/ghc.git/blob/9fd87ef8a16fbbce35205ae63d75d239bb575ccc:/ghc/GHCi/UI.hs#l2996), respectively.