### PR TITLE
Fix interpreter paths for NixOS by using /usr/bin/env

### DIFF
--- a/mkpkg.sh
+++ b/mkpkg.sh
@@ -1,4 +1,4 @@
-#!/bin/sh
+#!/usr/bin/env sh
 
 set -euo pipefail
 

--- a/stylize.sh
+++ b/stylize.sh
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 
 set -e
 


### PR DESCRIPTION
A small patch to allow the build scripts to work on NixOS. 
NixOS does not have the FHS `/bin/bash`-esque paths, so the shebangs don't work.