### PR TITLE
Fix the build on MSYS2 (Windows) when MSYSTEM=MINGW{32,64}

### DIFF
--- a/config.mk
+++ b/config.mk
@@ -1,4 +1,6 @@
-ifneq (, $(findstring MSYS, $(shell uname -a)))
+UNAME_INFO      := $(shell uname -a)
+
+ifeq ($(filter , $(findstring MSYS, $(UNAME_INFO)) $(findstring MINGW, $(UNAME_INFO))),)
 	ifeq (cc,$(CC))
 		# In MSYS2, when using the mingw version of gcc, there is no cc -> gcc
 		# symlink. We can't use ?= here because CC is set implicitly to cc.


### PR DESCRIPTION
Currently, when you try to build Idris on Windows using MSYS2, it can either succeed or fail depending on which variant on the MSYS2 shell you use. There are three different ways to launch MSYS2:

1. One where the environmental variable `MSYSTEM=MSYS2`
2. One where `MSYSTEM=MINGW32`
3. One where `MSYSTEM=MINGW64`

Why does this matter? `MSYSTEM` affects whether or not Idris's `Makefile`s set the `CC` variable or not. From `config.mk` ([here](https://github.com/idris-lang/Idris-dev/blob/735fbd21eae2c2b79b757ad68b4cbbbfc592fcd0/config.mk#L1-L8)):

```makefile
ifneq (, $(findstring MSYS, $(shell uname -a)))
	ifeq (cc,$(CC))
		# In MSYS2, when using the mingw version of gcc, there is no cc -> gcc
		# symlink. We can't use ?= here because CC is set implicitly to cc.
		# Cross compiling users can set CC to their cross compiler.
		CC		=gcc
	endif
endif
```

Currently, `config.mk` uses `uname -a` to determine if we're using the mingw version of `gcc`. But the output of `uname -a` is determined by the value of `MSYSTEM`! For example, if `MSYSTEM=MSYS`, then we have:

```
$ uname -a
MSYS_NT-10.0 T450s-Win64 2.6.1(0.305/5/3) 2017-01-25 00:01 x86_64 Msys
```

And everything works out OK, since the string `MSYS` appears in it. But if `MSYSTEM` equals, say `MINGW64`, then you're in trouble:

```
$ uname -a
MINGW64_NT-10.0 T450s-Win64 2.6.1(0.305/5/3) 2017-01-25 00:01 x86_64 Msys
```

Now `MSYS` doesn't appear anywhere! And `CC` never gets set, which later causes the build to fail:

```
$ cabal build
Building idris-0.99...
Preprocessing library idris-0.99...
Preprocessing executable 'idris' for idris-0.99...
Preprocessing executable 'idris-codegen-c' for idris-0.99...
Preprocessing executable 'idris-codegen-javascript' for idris-0.99...
Preprocessing executable 'idris-codegen-node' for idris-0.99...
Building libraries...
make: Entering directory '/c/Users/RyanGlScott/Documents/Hacking/Idris/idris-dev/libs'
make -C prelude build
make[1]: Entering directory '/c/Users/RyanGlScott/Documents/Hacking/Idris/idris-dev/libs/prelude'
../../dist/build/idris/idris --build prelude.ipkg
make[1]: Leaving directory '/c/Users/RyanGlScott/Documents/Hacking/Idris/idris-dev/libs/prelude'
make -C base build
make[1]: Entering directory '/c/Users/RyanGlScott/Documents/Hacking/Idris/idris-dev/libs/base'
../../dist/build/idris/idris --build base.ipkg
make[1]: Leaving directory '/c/Users/RyanGlScott/Documents/Hacking/Idris/idris-dev/libs/base'
make -C contrib build
make[1]: Entering directory '/c/Users/RyanGlScott/Documents/Hacking/Idris/idris-dev/libs/contrib'
../../dist/build/idris/idris --build contrib.ipkg
make[1]: Leaving directory '/c/Users/RyanGlScott/Documents/Hacking/Idris/idris-dev/libs/contrib'
make -C effects build
make[1]: Entering directory '/c/Users/RyanGlScott/Documents/Hacking/Idris/idris-dev/libs/effects'
../../dist/build/idris/idris --build effects.ipkg
make[1]: Leaving directory '/c/Users/RyanGlScott/Documents/Hacking/Idris/idris-dev/libs/effects'
make -C pruviloj build
make[1]: Entering directory '/c/Users/RyanGlScott/Documents/Hacking/Idris/idris-dev/libs/pruviloj'
../../dist/build/idris/idris --build pruviloj.ipkg
make[1]: Leaving directory '/c/Users/RyanGlScott/Documents/Hacking/Idris/idris-dev/libs/pruviloj'
make: Leaving directory '/c/Users/RyanGlScott/Documents/Hacking/Idris/idris-dev/libs'
make: Entering directory '/c/Users/RyanGlScott/Documents/Hacking/Idris/idris-dev/rts'
make: cc: Command not found
cc -O2 -Wall -DHAS_PTHREAD -DIDRIS_ENABLE_STATS  -I/usr/local/include  -DIDRIS_TARGET_OS="\"unix\"" -DIDRIS_TARGET_TRIPLE="\"\"" -fPIC   -c -o idris_rts.o idris_rts.c
/bin/sh: cc: command not found
make: *** [<builtin>: idris_rts.o] Error 127
make: Leaving directory '/c/Users/RyanGlScott/Documents/Hacking/Idris/idris-dev/rts'
```

Sad beans.

I fixed this problem in this PR by making a small change to `config.mk`:

```diff
diff --git a/config.mk b/config.mk
index 57f507d4..5c6b8b15 100644
--- a/config.mk
+++ b/config.mk
@@ -1,4 +1,6 @@
-ifneq (, $(findstring MSYS, $(shell uname -a)))
+UNAME_INFO      := $(shell uname -a)
+
+ifeq ($(filter , $(findstring MSYS, $(UNAME_INFO)) $(findstring MINGW, $(UNAME_INFO))),)
        ifeq (cc,$(CC))
                # In MSYS2, when using the mingw version of gcc, there is no cc -> gcc
                # symlink. We can't use ?= here because CC is set implicitly to cc.
```

This looks more complicated than it actually is. I'm working around the fact that there is no logical OR operator for `ifneq` in `Makefile` jargon, so I'm adapting the approach [here](http://stackoverflow.com/a/8297537) to say "if the output of `uname -a` neither contains `MSYS` nor `MINGW`". This is admittedly quite ugly, and there might be a more principled way to do this. But it does fix the problem.