### PR TITLE
Run Idris in a UTF-8-compatible codepage on Windows

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -32,6 +32,10 @@
 + The REPL now colourises output on MinTTY consoles (e.g., Cygwin and MSYS)
   on Windows, which previously did not occur due to a bug.
 
++ Idris now runs in a UTF-8-compatible codepage on Windows. This fixes many
+  Unicode-rendering issues on Windows (e.g., error messages stating
+  `commitBuffer: invalid argument (invalid character)`).
+
 ## Library Updates
 
 + Terminating programs has been improved with more appropriate

--- a/idris.cabal
+++ b/idris.cabal
@@ -263,6 +263,7 @@ Library
                 , blaze-markup >= 0.5.2.1 && < 0.9
                 , bytestring < 0.11
                 , cheapskate < 0.2
+                , code-page >= 0.1 && < 0.2
                 , containers >= 0.5 && < 0.6
                 , deepseq < 1.5
                 , directory >= 1.2.2.0 && < 1.2.3.0 || > 1.2.3.0

--- a/src/Idris/ErrReverse.hs
+++ b/src/Idris/ErrReverse.hs
@@ -10,8 +10,8 @@ Maintainer  : The Idris Community.
 module Idris.ErrReverse(errReverse) where
 
 import Idris.AbsSyntax
+import Idris.Core.Evaluate (unfold)
 import Idris.Core.TT
-import Idris.Core.Evaluate(unfold)
 import Util.Pretty
 
 import Data.List
@@ -26,7 +26,7 @@ errReverse ist t = rewrite 5 (do_unfold t) -- (elideLambdas t)
     do_unfold :: Term -> Term
     do_unfold t = let ns = idris_errReduce ist in
                       if null ns then t
-                         else unfold (tt_ctxt ist) [] 
+                         else unfold (tt_ctxt ist) []
                                      (map (\x -> (x, 1000)) (idris_errReduce ist))
                                      t
 

--- a/src/Idris/Main.hs
+++ b/src/Idris/Main.hs
@@ -44,16 +44,20 @@ import System.Directory
 import System.Exit
 import System.FilePath
 import System.IO
+import System.IO.CodePage (withCP65001)
 import Text.Trifecta.Result (ErrInfo(..), Result(..))
 
 -- | How to run Idris programs.
 runMain :: Idris () -> IO ()
-runMain prog = do res <- runExceptT $ execStateT prog idrisInit
-                  case res of
-                       Left err -> do
-                         putStrLn $ "Uncaught error: " ++ show err
-                         exitFailure
-                       Right _ -> return ()
+runMain prog = withCP65001 $ do
+               -- Run in codepage 65001 on Windows so that UTF-8 characters can
+               -- be displayed properly. See #3000.
+  res <- runExceptT $ execStateT prog idrisInit
+  case res of
+       Left err -> do
+         putStrLn $ "Uncaught error: " ++ show err
+         exitFailure
+       Right _ -> return ()
 
 -- | The main function of Idris that when given a set of Options will
 -- launch Idris into the desired interaction mode either: REPL;


### PR DESCRIPTION
Currently, Idris on Windows is rather prone to crashing when displaying fancy UTF-8 characters, as #3000 is evidence of. I feel like the simplest solution to just make Idris run in a codepage which supports UTF-8, which this PR accomplishes.

This uses the lightweight `code-page` library which, on Windows:

1. Changes the codepage to 65001, which is UTF-8 aware
2. Changes the encoding that GHC uses internally to `utf8` using `hSetEncoding`

And on other platforms, does nothing. This is how [`criterion`](https://github.com/bos/criterion/pull/125) and [`doctest`](https://github.com/sol/doctest/pull/149) currently handle Unicode on Windows as well.

Fixes #3000.