### PR TITLE
Simplify generating the simplified language

### DIFF
--- a/src/IRTS/Simplified.hs
+++ b/src/IRTS/Simplified.hs
@@ -42,15 +42,15 @@ data SAlt = SConCase Int Int Name [Name] SExp
 data SDecl = SFun Name [Name] Int SExp
   deriving Show
 
-hvar :: State (DDefs, Int) Int
-hvar = do (l, h) <- get
-          put (l, h + 1)
-          return h
 
 ldefs :: State (DDefs, Int) DDefs
 ldefs = do (l, h) <- get
            return l
 
+-- | Simplify an expression by let-binding argument expressions that
+-- are not variables
+-- The boolean parameter indicates whether the expression is at tail
+-- call position.
 simplify :: Bool -> DExp -> State (DDefs, Int) SExp
 simplify tl (DV (Loc i)) = return (SV (Loc i))
 simplify tl (DV (Glob x))
@@ -58,67 +58,62 @@ simplify tl (DV (Glob x))
          case lookupCtxtExact x ctxt of
               Just (DConstructor _ t 0) -> return $ SCon Nothing t x []
               _ -> return $ SV (Glob x)
-simplify tl (DApp tc n args) = do args' <- mapM sVar args
-                                  mkapp (SApp (tl || tc) n) args'
+simplify tl (DApp tc n args) = bindExprs args (SApp (tl || tc) n)
 simplify tl (DForeign ty fn args)
-                            = do args' <- mapM sVar (map snd args)
-                                 let fargs = zip (map fst args) args'
-                                 mkfapp (SForeign ty fn) fargs
+    = let (fdescs, exprs) = unzip args
+      in bindExprs exprs (\vars -> SForeign ty fn (zip fdescs vars))
 simplify tl (DLet n v e) = do v' <- simplify False v
                               e' <- simplify tl e
                               return (SLet (Glob n) v' e')
 simplify tl (DUpdate n e) = do e' <- simplify False e
                                return (SUpdate (Glob n) e')
-simplify tl (DC loc i n args) = do args' <- mapM sVar args
-                                   mkapp (SCon loc i n) args'
-simplify tl (DProj t i) = do v <- sVar t
-                             case v of
-                                (x, Nothing) -> return (SProj x i)
-                                (Glob x, Just e) ->
-                                    return (SLet (Glob x) e (SProj (Glob x) i))
-simplify tl (DCase up e alts) = do v <- sVar e
-                                   alts' <- mapM (sAlt tl) alts
-                                   case v of
-                                      (x, Nothing) -> return (SCase up x alts')
-                                      (Glob x, Just e) ->
-                                          return (SLet (Glob x) e (SCase up (Glob x) alts'))
+simplify tl (DC loc i n args) = bindExprs args (SCon loc i n)
+simplify tl (DProj t i) = bindExpr t (\var -> SProj var i)
+simplify tl (DCase up e alts)
+    = do alts' <- mapM (sAlt tl) alts
+         bindExpr e (\var -> SCase up var alts')
 simplify tl (DChkCase e alts)
-                           = do v <- sVar e
-                                alts' <- mapM (sAlt tl) alts
-                                case v of
-                                    (x, Nothing) -> return (SChkCase x alts')
-                                    (Glob x, Just e) ->
-                                        return (SLet (Glob x) e (SChkCase (Glob x) alts'))
+    = do alts' <- mapM (sAlt tl) alts
+         bindExpr e (\var -> SChkCase var alts')
 simplify tl (DConst c) = return (SConst c)
-simplify tl (DOp p args) = do args' <- mapM sVar args
-                              mkapp (SOp p) args'
+simplify tl (DOp p args) = bindExprs args (SOp p)
 simplify tl DNothing = return SNothing
 simplify tl (DError str) = return $ SError str
 
-sVar (DV (Glob x))
+
+-- | Let-bind a list of expressions to variables and construct the
+-- inner expression with the bound variables.
+-- If an expression in the list is already a variable we don’t bind it
+-- again.
+bindExprs :: [DExp] -> ([LVar] -> SExp) -> State (DDefs, Int) SExp
+bindExprs es f = bindExprs' es f [] where
+    bindExprs' [] f vars = return $ f (reverse vars)
+    bindExprs' (e:es) f vars =
+        bindExprM e (\var -> bindExprs' es f (var:vars))
+
+-- | Special case of 'bindExprs' for just one expression
+bindExpr :: DExp -> (LVar -> SExp) -> State (DDefs, Int) SExp
+bindExpr e f = bindExprM e (return . f)
+
+bindExprM :: DExp -> (LVar -> State (DDefs, Int) SExp) -> State (DDefs, Int) SExp
+bindExprM (DV (Glob x)) f
     = do ctxt <- ldefs
          case lookupCtxtExact x ctxt of
-              Just (DConstructor _ t 0) -> sVar (DC Nothing t x [])
-              _ -> return (Glob x, Nothing)
-sVar (DV x) = return (x, Nothing)
-sVar e = do e' <- simplify False e
-            i <- hvar
-            return (Glob (sMN i "R"), Just e')
+              Just (DConstructor _ t 0) -> bindExprM (DC Nothing t x []) f
+              _ -> f (Glob x)
+bindExprM (DV var) f = f var
+bindExprM e f =
+    do e' <- simplify False e
+       var <- freshVar
+       f' <- f var
+       return $ SLet var e' f'
+    where
+        freshVar = do (defs, i) <- get
+                      put (defs, i + 1)
+                      return (Glob (sMN i "R"))
 
-mkapp f args = mkapp' f args [] where
-   mkapp' f [] args = return $ f (reverse args)
-   mkapp' f ((x, Nothing) : xs) args = mkapp' f xs (x : args)
-   mkapp' f ((x, Just e) : xs) args
-       = do sc <- mkapp' f xs (x : args)
-            return (SLet x e sc)
 
-mkfapp f args = mkapp' f args [] where
-   mkapp' f [] args = return $ f (reverse args)
-   mkapp' f ((ty, (x, Nothing)) : xs) args = mkapp' f xs ((ty, x) : args)
-   mkapp' f ((ty, (x, Just e)) : xs) args
-       = do sc <- mkapp' f xs ((ty, x) : args)
-            return (SLet x e sc)
-
+sAlt :: Bool -> DAlt -> State (DDefs, Int) SAlt
 sAlt tl (DConCase i n args e) = do e' <- simplify tl e
                                    return (SConCase (-1) i n args e')
 sAlt tl (DConstCase c e) = do e' <- simplify tl e


### PR DESCRIPTION
This commit merges the `sVar`, `mkapp`, and `mkfapp` helper functions that are used in `simplify` and reduces code duplication

We introduce a new `bindExprs` function that let-binds expressions that are not variables and constructs an inner expression in the scope of the bindings with the variables.