### PR TITLE
Prelude.Bits: clarify serialization of BitsX for X={8,16,32,64}

### DIFF
--- a/libs/prelude/Prelude/Bits.idr
+++ b/libs/prelude/Prelude/Bits.idr
@@ -2,12 +2,14 @@ module Prelude.Bits
 
 import Builtins
 
+import Prelude.Algebra
 import Prelude.Basics
 import Prelude.Bool
 import Prelude.Cast
 import Prelude.Chars
 import Prelude.Interfaces
 import Prelude.Foldable
+import Prelude.Functor
 import Prelude.Nat
 import Prelude.List
 import Prelude.Strings
@@ -15,8 +17,54 @@ import Prelude.Strings
 %access public export
 %default total
 
-b8ToString : Bits8 -> String
-b8ToString c = pack (with List [c1, c2])
+--------------------------------------------------------------------------------
+-- Convert to `List Bits8`
+--------------------------------------------------------------------------------
+
+||| Convert to list of `Bits8` with the most signficant byte at the
+||| head.
+b8ToBytes : Bits8 -> List Bits8
+b8ToBytes b = [b]
+
+||| Convert to list of `Bits8` with the most signficant byte at the
+||| head.
+b16ToBytes : Bits16 -> List Bits8
+b16ToBytes b =
+  [ prim__truncB16_B8 (prim__lshrB16 b 8)
+  , prim__truncB16_B8 b
+  ]
+
+||| Convert to list of `Bits8` with the most signficant byte at the
+||| head.
+b32ToBytes : Bits32 -> List Bits8
+b32ToBytes b =
+  [ prim__truncB32_B8 (prim__lshrB32 b 24)
+  , prim__truncB32_B8 (prim__lshrB32 b 16)
+  , prim__truncB32_B8 (prim__lshrB32 b 8)
+  , prim__truncB32_B8 b
+  ]
+
+||| Convert to list of `Bits8` with the most signficant byte at the
+||| head.
+b64ToBytes : Bits64 -> List Bits8
+b64ToBytes b =
+  [ prim__truncB64_B8 (prim__lshrB64 b 56)
+  , prim__truncB64_B8 (prim__lshrB64 b 48)
+  , prim__truncB64_B8 (prim__lshrB64 b 40)
+  , prim__truncB64_B8 (prim__lshrB64 b 32)
+  , prim__truncB64_B8 (prim__lshrB64 b 24)
+  , prim__truncB64_B8 (prim__lshrB64 b 16)
+  , prim__truncB64_B8 (prim__lshrB64 b 8)
+  , prim__truncB64_B8 b
+  ]
+
+--------------------------------------------------------------------------------
+-- Hex Strings
+--------------------------------------------------------------------------------
+
+||| Encode `Bits8` as a 2-character hex string.
+b8ToHexString : Bits8 -> String
+b8ToHexString c = pack [c1, c2]
   where getDigit : Bits8 -> Char
         getDigit b = let n = prim__zextB8_Int b in
                      if n >= 0 && n <= 9
@@ -27,30 +75,64 @@ b8ToString c = pack (with List [c1, c2])
         c1 = getDigit (prim__andB8 (prim__lshrB8 c 4) 15)
         c2 = getDigit (prim__andB8 c 15)
 
+||| Encode `Bits16` as a 4-character hex string.
+b16ToHexString : Bits16 -> String
+b16ToHexString c = concatMap b8ToHexString (b16ToBytes c)
 
+||| Encode `Bits32` as an 8-character hex string.
+b32ToHexString : Bits32 -> String
+b32ToHexString c = concatMap b8ToHexString (b32ToBytes c)
+
+||| Encode `Bits64` as a 16-character hex string.
+b64ToHexString : Bits64 -> String
+b64ToHexString c = concatMap b8ToHexString (b64ToBytes c)
+
+
+--------------------------------------------------------------------------------
+-- Binary Strings
+--------------------------------------------------------------------------------
+
+||| Encode `Bits8` as an 8-character binary string.
+b8ToBinString : Bits8 -> String
+b8ToBinString b = pack $ map (bitChar b) [7,6,5,4,3,2,1,0]
+  where bitChar : Bits8 -> Bits8 -> Char
+        bitChar b i = case b `prim__andB8` (1 `prim__shlB8` i) of
+                           0 => '0'
+                           _ => '1'
+
+||| Encode `Bits16` as a 16-character binary string.
+b16ToBinString : Bits16 -> String
+b16ToBinString c = concatMap b8ToBinString (b16ToBytes c)
+
+||| Encode `Bits32` as a 32-character binary string.
+b32ToBinString : Bits32 -> String
+b32ToBinString c = concatMap b8ToBinString (b32ToBytes c)
+
+||| Encode `Bits64` as a 64-character binary string.
+b64ToBinString : Bits64 -> String
+b64ToBinString c = concatMap b8ToBinString (b64ToBytes c)
+
+
+--------------------------------------------------------------------------------
+-- Deprecated String Functions
+--------------------------------------------------------------------------------
+
+||| Encode `Bits8` as a 2-character hex string.
+b8ToString : Bits8 -> String
+b8ToString = b8ToHexString
+%deprecate b8ToString "Please use `b8ToHexString` instead."
+
+||| Encode `Bits16` as a 4-character hex string.
 b16ToString : Bits16 -> String
-b16ToString c = c1 ++ c2 where
-  c1 = b8ToString upper where
-    upper : Bits8
-    upper = prim__truncB16_B8 (prim__lshrB16 c 8)
-  c2 = b8ToString lower where
-    lower : Bits8
-    lower = prim__truncB16_B8 c
+b16ToString = b16ToHexString
+%deprecate b16ToString "Please use `b16ToHexString` instead."
 
+||| Encode `Bits32` as a 8-character hex string.
 b32ToString : Bits32 -> String
-b32ToString c = c1 ++ c2 where
-  c1 = b16ToString upper where
-    upper : Bits16
-    upper = prim__truncB32_B16 (prim__andB32 (prim__lshrB32 c 16) 0x0000ffff)
-  c2 = b16ToString lower where
-    lower : Bits16
-    lower = prim__truncB32_B16 c
+b32ToString = b32ToHexString
+%deprecate b32ToString "Please use `b32ToHexString` instead."
 
+||| Encode `Bits64` as a 16-character hex string.
 b64ToString : Bits64 -> String
-b64ToString c = c1 ++ c2 where
-  c1 = b32ToString upper where
-    upper : Bits32
-    upper = prim__truncB64_B32 (prim__andB64 (prim__lshrB64 c 32) 0x00000000ffffffff)
-  c2 = b32ToString lower where
-    lower : Bits32
-    lower = prim__truncB64_B32 c
+b64ToString = b64ToHexString
+%deprecate b64ToString "Please use `b64ToHexString` instead."

--- a/libs/prelude/Prelude/Show.idr
+++ b/libs/prelude/Prelude/Show.idr
@@ -164,16 +164,16 @@ Show () where
   show () = "()"
 
 Show Bits8 where
-  show b = b8ToString b
+  show b = b8ToHexString b
 
 Show Bits16 where
-  show b = b16ToString b
+  show b = b16ToHexString b
 
 Show Bits32 where
-  show b = b32ToString b
+  show b = b32ToHexString b
 
 Show Bits64 where
-  show b = b64ToString b
+  show b = b64ToHexString b
 
 (Show a, Show b) => Show (a, b) where
     show (x, y) = "(" ++ show x ++ ", " ++ show y ++ ")"

--- a/src/IRTS/CodegenJavaScript.hs
+++ b/src/IRTS/CodegenJavaScript.hs
@@ -757,19 +757,19 @@ jsOP _ reg op args = JSAssign (translateReg reg) jsOP'
             )
           ]
 
-      | (LTrunc (ITFixed IT16) (ITFixed IT8)) <- op
+      | (LTrunc (ITFixed _from) (ITFixed IT8)) <- op
       , (arg:_)                               <- args =
           jsPackUBits8 (
             JSBinOp "&" (jsUnPackBits $ translateReg arg) (JSNum (JSInt 0xFF))
           )
 
-      | (LTrunc (ITFixed IT32) (ITFixed IT16)) <- op
+      | (LTrunc (ITFixed _from) (ITFixed IT16)) <- op
       , (arg:_)                                <- args =
           jsPackUBits16 (
             JSBinOp "&" (jsUnPackBits $ translateReg arg) (JSNum (JSInt 0xFFFF))
           )
 
-      | (LTrunc (ITFixed IT64) (ITFixed IT32)) <- op
+      | (LTrunc (ITFixed _from) (ITFixed IT32)) <- op
       , (arg:_)                                <- args =
           jsPackUBits32 (
             jsMeth (jsMeth (translateReg arg) "and" [


### PR DESCRIPTION
* Add bXToHexString and bXToBinString
* Deprecate bXToString
* Add documentation
* Add bXToBytes : BitsX -> List Bits8 functions