### PR TITLE
Make Idris work with GHC 7.6.3 and Tagsoup 0.14.1

### DIFF
--- a/idris.cabal
+++ b/idris.cabal
@@ -310,6 +310,11 @@ Library
   else
      build-depends: safe >= 0.3.9
 
+  if impl(ghc < 7.8.4)
+     build-depends: tagsoup < 0.14.1
+  else
+     build-depends: tagsoup >= 0.14.1
+
   Extensions:     MultiParamTypeClasses
                 , DeriveFoldable
                 , DeriveTraversable


### PR DESCRIPTION
Tagsoup 0.14.1 does not compile cleanly with ghc 7.6.3. So let's amend
the cabal file to ensure an appropriate version of tagsoup is selected.

*Note* tagsoup is a dependency of a dependency of a dependency.