### PR TITLE
Disable mintty colors for 32-bit

### DIFF
--- a/idris.cabal
+++ b/idris.cabal
@@ -332,8 +332,9 @@ Library
   if os(darwin)
      build-depends: unix < 2.8
   if os(windows)
-     build-depends: mintty >= 0.1 && < 0.2
-                  , Win32 < 2.4
+     build-depends: Win32 < 2.4  
+     if arch(x86_64) 
+        build-depends: mintty >= 0.1 && < 0.2
   if flag(FFI)
      build-depends: libffi < 0.2
      cpp-options:   -DIDRIS_FFI

--- a/src/Util/System.hs
+++ b/src/Util/System.hs
@@ -38,11 +38,10 @@ import System.FilePath (dropFileName, isAbsolute, searchPathSeparator)
 import Tools_idris
 #endif
 
-#ifdef mingw32_HOST_OS
+#if defined(mingw32_HOST_OS) && defined(x86_64_HOST_ARCH)
 import Graphics.Win32.Misc (getStdHandle, sTD_OUTPUT_HANDLE)
 import System.Console.MinTTY (isMinTTYHandle)
 #endif
-
 catchIO :: IO a -> (IOError -> IO a) -> IO a
 catchIO = CE.catch
 
@@ -82,7 +81,7 @@ isATTY = do
 -- Unfortunately, we must check this separately since 'isATTY' always returns
 -- 'False' on MinTTY consoles.
 isMinTTY :: IO Bool
-#ifdef mingw32_HOST_OS
+#if defined(mingw32_HOST_OS) && defined(x86_64_HOST_ARCH)
 isMinTTY = do
   h <- getStdHandle sTD_OUTPUT_HANDLE
   isMinTTYHandle h


### PR DESCRIPTION
When I built the 32-bit release I got absurd linking errors. After a long while I figured out that the mintty colors were the culprit, no doubt via a completely ridiculous mechanism, but I couldn't figure that out. Just disable it for 32-bit Windows. 