### PR TITLE
Also look for nodejs in addition to node in the testsuite

### DIFF
--- a/test/TestRun.hs
+++ b/test/TestRun.hs
@@ -108,7 +108,9 @@ runTest path flags = do
 
 main :: IO ()
 main = do
-  node <- findExecutable "node"
+  nodePath   <- findExecutable "node"
+  nodejsPath <- findExecutable "nodejs"
+  let node = nodePath <|> nodejsPath
   case node of
     Nothing -> do
       putStrLn "For running the test suite against Node, node must be installed."


### PR DESCRIPTION
Many Linux distributions (e.g., Ubuntu) install `nodejs` instead of `node`, so it makes sense to search for it as well.