### PR TITLE
Allowed `--highlight` in pkg commands.

### DIFF
--- a/src/Idris/Package.hs
+++ b/src/Idris/Package.hs
@@ -499,6 +499,7 @@ mergeOptions copts popts =
     chkOpt o@(UseCodegen _)   = Right o
     chkOpt o@(Verbose _)      = Right o
     chkOpt o@(AuditIPkg)      = Right o
+    chkOpt o@(DumpHighlights) = Right o
     chkOpt o                  = Left (unwords ["\t", show o, "\n"])
 
     genErrMsg :: [String] -> String
@@ -508,6 +509,7 @@ mergeOptions copts popts =
         , "\t--log <lvl>, --total, --warnpartial, --warnreach, --warnipkg"
         , "\t--ibcsubdir <path>, -i --idrispath <path>"
         , "\t--logging-categories <cats>"
+        , "\t--highlight"
         , "\nThe options need removing are:"
         , unlines es
         ]

--- a/test/pkg001/expected
+++ b/test/pkg001/expected
@@ -4,6 +4,7 @@ The only changeable options are:
 	--log <lvl>, --total, --warnpartial, --warnreach, --warnipkg
 	--ibcsubdir <path>, -i --idrispath <path>
 	--logging-categories <cats>
+	--highlight
 
 The options need removing are:
 	 Quiet 


### PR DESCRIPTION
Rather than have to edit a package's `ipkg` you can now invoke the dump highlight options directly from the command line.

```sh
idris --build mypackage.ipkg --highlight
```