### PR TITLE
Remove incorrect CPP and require newer Cabal instead, attempt 2.

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -71,10 +71,6 @@ before_install:
         export ZCAT=gzcat;
         export PKG_CONFIG_PATH=/usr/local/opt/libffi/lib/pkgconfig:$PKG_CONFIG_PATH;
     fi
-  # work around https://github.com/haskell/cabal/issues/1666 : cabal-install
-  # will not install the required version of the Cabal library if a project
-  # requires it only for Setup.hs (i.e. it’s not a normal dependency).
-  - cabal install Cabal --constraint Cabal==${CABALVER}.*
   - if [ -n "$STYLISH" ]; then ./stylize.sh; exit $?; fi
 
 install:
@@ -88,6 +84,10 @@ install:
               $HOME/.cabal/packages/hackage.haskell.org/00-index.tar;
     fi
   - travis_retry cabal update -v
+  # work around https://github.com/haskell/cabal/issues/1666 : cabal-install
+  # will not install the required version of the Cabal library if a project
+  # requires it only for Setup.hs (i.e. it’s not a normal dependency).
+  - cabal install Cabal --constraint Cabal==${CABALVER}.*
   # Run build with 2 parallel jobs
   # The container environment reports 16 cores,
   # causing cabal's default configuration (jobs: $ncpus)

--- a/.travis.yml
+++ b/.travis.yml
@@ -74,7 +74,7 @@ before_install:
   # work around https://github.com/haskell/cabal/issues/1666 : cabal-install
   # will not install the required version of the Cabal library if a project
   # requires it only for Setup.hs (i.e. it’s not a normal dependency).
-  - cabal install "Cabal-${CABALVER}.*"
+  - cabal install Cabal --constraint Cabal==${CABALVER}.*
   - if [ -n "$STYLISH" ]; then ./stylize.sh; exit $?; fi
 
 install:

--- a/.travis.yml
+++ b/.travis.yml
@@ -71,6 +71,10 @@ before_install:
         export ZCAT=gzcat;
         export PKG_CONFIG_PATH=/usr/local/opt/libffi/lib/pkgconfig:$PKG_CONFIG_PATH;
     fi
+  # work around https://github.com/haskell/cabal/issues/1666 : cabal-install
+  # will not install the required version of the Cabal library if a project
+  # requires it only for Setup.hs (i.e. it’s not a normal dependency).
+  - cabal install "Cabal-${CABALVER}.*"
   - if [ -n "$STYLISH" ]; then ./stylize.sh; exit $?; fi
 
 install:

--- a/.travis.yml
+++ b/.travis.yml
@@ -13,12 +13,12 @@ matrix:
     - os: osx
       env: CABALVER="1.24" GHCVER="8.0.1" TESTS="test_c"
       compiler: ": #GHC 8.0.1"
-    - env: CABALVER="1.20" GHCVER="7.6.3" TESTS="test_c"
+    - env: CABALVER="1.22" GHCVER="7.6.3" TESTS="test_c"
       compiler: ": #GHC 7.6.3"
-      addons: {apt: {packages: [cabal-install-1.20,ghc-7.6.3,cppcheck,hscolour], sources: [hvr-ghc]}}
-    - env: CABALVER="1.20" GHCVER="7.8.4" TESTS="test_c"
+      addons: {apt: {packages: [cabal-install-1.22,ghc-7.6.3,cppcheck,hscolour], sources: [hvr-ghc]}}
+    - env: CABALVER="1.22" GHCVER="7.8.4" TESTS="test_c"
       compiler: ": #GHC 7.8.4"
-      addons: {apt: {packages: [cabal-install-1.20,ghc-7.8.4,cppcheck,hscolour], sources: [hvr-ghc]}}
+      addons: {apt: {packages: [cabal-install-1.22,ghc-7.8.4,cppcheck,hscolour], sources: [hvr-ghc]}}
     - env: CABALVER="1.22" GHCVER="7.10.3" TESTS="lib_doc doc"
       compiler: ": #GHC 7.10.3"
       addons: {apt: {packages: [cabal-install-1.22,ghc-7.10.3,cppcheck,hscolour], sources: [hvr-ghc]}}

--- a/Setup.hs
+++ b/Setup.hs
@@ -274,22 +274,13 @@ idrisInstall verbosity copy pkg local = unless (execOnly (configFlags local)) $ 
 -- -----------------------------------------------------------------------------
 -- Test
 
--- FIXME: We use the __GLASGOW_HASKELL__ macro because MIN_VERSION_cabal seems
--- to be broken !
-
 -- There are two "dataDir" in cabal, and they don't relate to each other.
 -- When fetching modules, idris uses the second path (in the pkg record),
 -- which by default is the root folder of the project.
 -- We want it to be the install directory where we put the idris libraries.
 fixPkg pkg target = pkg { dataDir = target }
 
--- The "Args" argument of the testHooks has been added in cabal 1.22.0,
--- and should therefore be ignored for prior versions.
-#if __GLASGOW_HASKELL__ < 710
-originalTestHook _ = testHook simpleUserHooks
-#else
 originalTestHook = testHook simpleUserHooks
-#endif
 
 idrisTestHook args pkg local hooks flags = do
   let target = datadir $ L.absoluteInstallDirs pkg local NoCopyDest
@@ -314,9 +305,5 @@ main = defaultMainWithHooks $ simpleUserHooks
    , preSDist = idrisPreSDist
    , sDistHook = idrisSDist (sDistHook simpleUserHooks)
    , postSDist = idrisPostSDist
-#if __GLASGOW_HASKELL__ < 710
-   , testHook = idrisTestHook ()
-#else
    , testHook = idrisTestHook
-#endif
    }

--- a/idris.cabal
+++ b/idris.cabal
@@ -313,13 +313,36 @@ Library
   if impl(ghc < 7.8.4)
      build-depends: tagsoup < 0.14.1
 
-  Extensions:     MultiParamTypeClasses
-                , DeriveFoldable
-                , DeriveTraversable
-                , FunctionalDependencies
-                , FlexibleContexts
-                , FlexibleInstances
-                , TemplateHaskell
+  Default-language: Haskell98
+
+  Default-extensions: MultiParamTypeClasses
+                    , FlexibleInstances
+                    , FlexibleContexts
+                    , DeriveFoldable
+                    , DeriveTraversable
+
+  Other-extensions: Arrows
+                  , BangPatterns
+                  , ConstraintKinds
+                  , CPP
+                  , DeriveDataTypeable
+                  , DeriveFunctor
+                  , DeriveGeneric
+                  , ExistentialQuantification
+                  , ForeignFunctionInterface
+                  , FunctionalDependencies
+                  , GeneralizedNewtypeDeriving
+                  , LambdaCase
+                  , MultiWayIf
+                  , OverlappingInstances
+                  , OverloadedStrings
+                  , PatternGuards
+                  , RankNTypes
+                  , ScopedTypeVariables
+                  , StandaloneDeriving
+                  , TupleSections
+                  , TypeSynonymInstances
+                  , ViewPatterns
 
   ghc-prof-options: -auto-all -caf-all
 
@@ -358,6 +381,8 @@ Executable idris
                 , haskeline >= 0.7
                 , transformers
 
+  Default-language: Haskell98
+
   ghc-prof-options: -auto-all -caf-all
   ghc-options:      -threaded -rtsopts -funbox-strict-fields
 
@@ -382,9 +407,10 @@ Test-suite regression-and-feature-tests
                , tasty-rerun >= 1.0.0
                , bytestring
                , transformers
-  if impl(ghc < 7.10)
-    Extensions: DeriveDataTypeable
 
+  Default-language: Haskell98
+
+  Default-extensions: DeriveDataTypeable
 
   ghc-prof-options: -auto-all -caf-all
   ghc-options:      -threaded -rtsopts -with-rtsopts=-N -funbox-strict-fields
@@ -399,6 +425,8 @@ Executable idris-codegen-c
                 , haskeline >= 0.7
                 , transformers
 
+  Default-language: Haskell98
+
   ghc-prof-options: -auto-all -caf-all
   ghc-options:      -threaded -rtsopts -funbox-strict-fields
 
@@ -412,6 +440,8 @@ Executable idris-codegen-javascript
                 , haskeline >= 0.7
                 , transformers
 
+  Default-language: Haskell98
+
   ghc-prof-options: -auto-all -caf-all
   ghc-options:      -threaded -rtsopts -funbox-strict-fields
 
@@ -424,6 +454,8 @@ Executable idris-codegen-node
                 , filepath
                 , haskeline >= 0.7
                 , transformers
+
+  Default-language: Haskell98
 
   ghc-prof-options: -auto-all -caf-all
   ghc-options:      -threaded -rtsopts -funbox-strict-fields

--- a/idris.cabal
+++ b/idris.cabal
@@ -40,7 +40,7 @@ Description:    Idris is a general purpose language with full dependent types.
                 .
                 * Hugs style interactive environment
 
-Cabal-Version:  >= 1.8.1
+Cabal-Version:  >= 1.22
 
 Build-type:     Custom
 

--- a/src/Idris/AbsSyntax.hs
+++ b/src/Idris/AbsSyntax.hs
@@ -5,8 +5,7 @@ Copyright   :
 License     : BSD3
 Maintainer  : The Idris Community.
 -}
-
-{-# LANGUAGE DeriveFunctor, PatternGuards #-}
+{-# LANGUAGE DeriveFunctor, PatternGuards, TypeSynonymInstances #-}
 
 module Idris.AbsSyntax(
     module Idris.AbsSyntax

--- a/src/Idris/AbsSyntaxTree.hs
+++ b/src/Idris/AbsSyntaxTree.hs
@@ -5,8 +5,8 @@ Copyright   :
 License     : BSD3
 Maintainer  : The Idris Community.
 -}
-
-{-# LANGUAGE DeriveDataTypeable, DeriveFunctor, DeriveGeneric, PatternGuards #-}
+{-# LANGUAGE DeriveDataTypeable, DeriveFunctor, DeriveGeneric,
+             PatternGuards, TypeSynonymInstances #-}
 
 module Idris.AbsSyntaxTree where
 

--- a/src/Idris/Core/Elaborate.hs
+++ b/src/Idris/Core/Elaborate.hs
@@ -10,7 +10,7 @@ because this gives us a language to build derived tactics out of the
 primitives.
 -}
 
-{-# LANGUAGE FlexibleInstances, MultiParamTypeClasses, PatternGuards #-}
+{-# LANGUAGE PatternGuards #-}
 module Idris.Core.Elaborate (
     module Idris.Core.Elaborate
   , module Idris.Core.ProofState

--- a/src/Idris/Core/Evaluate.hs
+++ b/src/Idris/Core/Evaluate.hs
@@ -5,8 +5,7 @@ Copyright   :
 License     : BSD3
 Maintainer  : The Idris Community.
 -}
-{-# LANGUAGE BangPatterns, DeriveGeneric, FlexibleInstances,
-             MultiParamTypeClasses, PatternGuards #-}
+{-# LANGUAGE BangPatterns, DeriveGeneric, PatternGuards #-}
 {-# OPTIONS_GHC -fwarn-incomplete-patterns #-}
 
 module Idris.Core.Evaluate(normalise, normaliseTrace, normaliseC,

--- a/src/Idris/Core/ProofState.hs
+++ b/src/Idris/Core/ProofState.hs
@@ -10,7 +10,7 @@ proofs, and some high level commands for introducing new theorems,
 evaluation/checking inside the proof system, etc.
 -}
 
-{-# LANGUAGE FlexibleInstances, MultiParamTypeClasses, PatternGuards #-}
+{-# LANGUAGE PatternGuards #-}
 module Idris.Core.ProofState(
     ProofState(..), newProof, envAtFocus, goalAtFocus
   , Tactic(..), Goal(..), processTactic, nowElaboratingPS

--- a/src/Idris/Core/ProofTerm.hs
+++ b/src/Idris/Core/ProofTerm.hs
@@ -6,7 +6,7 @@ License     : BSD3
 Maintainer  : The Idris Community.
 -}
 
-{-# LANGUAGE FlexibleInstances, MultiParamTypeClasses, PatternGuards #-}
+{-# LANGUAGE PatternGuards #-}
 module Idris.Core.ProofTerm(
     ProofTerm, Goal(..), mkProofTerm, getProofTerm
   , resetProofTerm

--- a/src/Idris/Core/TT.hs
+++ b/src/Idris/Core/TT.hs
@@ -22,8 +22,8 @@ TT is the core language of Idris. The language has:
    * We have a simple collection of tactics which we use to elaborate source
      programs with implicit syntax into fully explicit terms.
 -}
-{-# LANGUAGE DeriveDataTypeable, DeriveFunctor, DeriveGeneric, FlexibleContexts,
-             FunctionalDependencies, MultiParamTypeClasses, PatternGuards #-}
+{-# LANGUAGE DeriveDataTypeable, DeriveFunctor, DeriveGeneric,
+             FunctionalDependencies, PatternGuards #-}
 {-# OPTIONS_GHC -fwarn-incomplete-patterns #-}
 module Idris.Core.TT(
     AppStatus(..), ArithTy(..), Binder(..), Const(..), Ctxt(..)

--- a/src/Idris/Core/Typecheck.hs
+++ b/src/Idris/Core/Typecheck.hs
@@ -6,8 +6,7 @@ License     : BSD3
 Maintainer  : The Idris Community.
 -}
 
-{-# LANGUAGE DeriveFunctor, FlexibleInstances, MultiParamTypeClasses,
-             PatternGuards #-}
+{-# LANGUAGE DeriveFunctor, PatternGuards #-}
 
 module Idris.Core.Typecheck where
 

--- a/src/Idris/ElabDecls.hs
+++ b/src/Idris/ElabDecls.hs
@@ -6,8 +6,7 @@ License     : BSD3
 Maintainer  : The Idris Community.
 -}
 
-{-# LANGUAGE DeriveFunctor, FlexibleInstances, MultiParamTypeClasses,
-             PatternGuards #-}
+{-# LANGUAGE DeriveFunctor, PatternGuards #-}
 
 module Idris.ElabDecls where
 

--- a/src/Idris/IdeMode.hs
+++ b/src/Idris/IdeMode.hs
@@ -7,7 +7,7 @@ Maintainer  : The Idris Community.
 -}
 {-# OPTIONS_GHC -fwarn-incomplete-patterns #-}
 
-{-# LANGUAGE FlexibleInstances, IncoherentInstances, PatternGuards #-}
+{-# LANGUAGE IncoherentInstances, PatternGuards #-}
 
 module Idris.IdeMode(parseMessage, convSExp, WhatDocs(..), IdeModeCommand(..), sexpToCommand, toSExp, SExp(..), SExpable, Opt(..), ideModeEpoch, getLen, getNChar, sExpToString) where
 

--- a/src/Idris/REPL.hs
+++ b/src/Idris/REPL.hs
@@ -4,9 +4,7 @@ Description : Entry Point for the Idris REPL and CLI.
 License     : BSD3
 Maintainer  : The Idris Community.
 -}
-
-{-# LANGUAGE PatternGuards #-}
-
+{-# LANGUAGE CPP, DeriveFunctor, PatternGuards #-}
 module Idris.REPL
   ( idemodeStart
   , startServer


### PR DESCRIPTION
An updated attempt at #3519.

The `MIN_VERSION_*` macros are only generated during setup, i.e. after Setup.hs
is compiled. The GHC version is not a proxy for the Cabal version, as it is
trivial to install a newer version of Cabal and cabal-install with
cabal-install, and in that case the Setup.hs would not typecheck (this is what happened for me). Since it
doesn’t appear to be possible to switch on the Cabal version, this change
simply declares a requirement for a newer version.

The second commit (fixing warnings from cabal after raising the version) is possibly opinionated. Feel extra free to leave it off or change it.

Specifically, if the `cabal-version` constraint is above 1.10, each component
should have a `default-language` field. It appears the default was/is
`Haskell98`, so I entered that for each component.

Similarly, the `extensions` field is then deprecated in favor of
`default-extensions` and `other-extensions`. For these I have investigated which
extensions are actually required globally (i.e. some files assume them but do
not declare them) and have entered these as `default-extensions` and removed
them from any files that did declare them. I then collected all additional
extensions declared in any files into `other-extensions`.

It may be a good idea to think about these settings and change them, and also to
prune declared but unused extensions from the source files, but in this commit I
have only tried to replicate the previous settings (minus removing default extensions declared in the files; perhaps I should have left that to a later extension-pruning step as well).
