### PR TITLE
Prelude: implement Functor for `Pair a`

### DIFF
--- a/libs/prelude/Prelude/Functor.idr
+++ b/libs/prelude/Prelude/Functor.idr
@@ -1,5 +1,6 @@
 module Prelude.Functor
 
+import Builtins
 import Prelude.Basics
 
 %access public export
@@ -22,3 +23,5 @@ infixl 4 <$>
 (<$>) : Functor f => (func : a -> b) -> f a -> f b
 func <$> x = map func x
 
+Functor (Pair a) where
+  map f (x, y) = (x, f y)

--- a/test/docs003/expected
+++ b/test/docs003/expected
@@ -10,6 +10,7 @@ Methods:
         
         The function is Total
 Implementations:
+    Functor (Pair a)
     Functor List
     Functor (IO' ffi)
     Functor Stream


### PR DESCRIPTION
I wanted to use `map` on a pair yesterday and got a type error. It turns out that there's no Functor implementation for Pair in the prelude. Is this intentional? If so, feel free to close this PR.

In any case, this patch adds the implementation in `Functor.idr`, which kind of the only place to define it, since `Pair` is defined in `Builtins.idr` rather than its own module, and `Functor.idr` imports `Builtins.idr`.