### PR TITLE
Add implementations of `VerifiedSemigroup Nat` etc to contrib

### DIFF
--- a/libs/contrib/Control/Algebra/NumericImplementations.idr
+++ b/libs/contrib/Control/Algebra/NumericImplementations.idr
@@ -9,6 +9,8 @@ import Data.ZZ
 
 %access public export
 
+-- Integer
+
 Semigroup Integer where
   (<+>) = (+)
 
@@ -18,7 +20,7 @@ Monoid Integer where
 Group Integer where
   inverse = (* -1)
 
-AbelianGroup Integer where 
+AbelianGroup Integer where
 
 Ring Integer where
   (<.>) = (*)
@@ -26,6 +28,7 @@ Ring Integer where
 RingWithUnity Integer where
   unity = 1
 
+-- Int
 
 Semigroup Int where
   (<+>) = (+)
@@ -44,6 +47,7 @@ Ring Int where
 RingWithUnity Int where
   unity = 1
 
+-- Double
 
 Semigroup Double where
   (<+>) = (+)
@@ -65,23 +69,38 @@ RingWithUnity Double where
 Field Double where
   inverseM f _ = 1 / f
 
+-- Nat
 
-Semigroup Nat where
+[PlusNatSemi] Semigroup Nat where
   (<+>) = (+)
 
-Monoid Nat where
+[PlusNatMonoid] Monoid Nat using PlusNatSemi where
   neutral = 0
 
-Semigroup ZZ where
+[MultNatSemi] Semigroup Nat where
+  (<+>) = (*)
+
+[MultNatMonoid] Monoid Nat using MultNatSemi where
+  neutral = 1
+
+-- ZZ
+
+[PlusZZSemi] Semigroup ZZ where
   (<+>) = (+)
 
-Monoid ZZ where
+[PlusZZMonoid] Monoid ZZ using PlusZZSemi where
   neutral = 0
 
-Group ZZ where
+Group ZZ using PlusZZMonoid where
   inverse = (* -1)
 
 AbelianGroup ZZ where
+
+[MultZZSemi] Semigroup ZZ where
+  (<+>) = (*)
+
+[MultZZMonoid] Monoid ZZ using MultZZSemi where
+  neutral = 1
 
 Ring ZZ where
   (<.>) = (*)
@@ -89,6 +108,7 @@ Ring ZZ where
 RingWithUnity ZZ where
   unity = 1
 
+-- Complex
 
 Semigroup a => Semigroup (Complex a) where
   (<+>) (a :+ b) (c :+ d) = (a <+> c) :+ (b <+> d)

--- a/libs/contrib/Interfaces/Verified.idr
+++ b/libs/contrib/Interfaces/Verified.idr
@@ -69,7 +69,6 @@ interface (Monad m, VerifiedApplicative m) => VerifiedMonad (m : Type -> Type) w
   monadAssociativity : (mx : m a) -> (f : a -> m b) -> (g : b -> m c) ->
                        (mx >>= f) >>= g = mx >>= (\x => f x >>= g)
 
--- The believe_me is there because idris won't seem to unify (pure x = Just x) with Refl
 VerifiedMonad Maybe where
     monadApplicative Nothing Nothing = Refl
     monadApplicative Nothing (Just x) = Refl
@@ -77,7 +76,7 @@ VerifiedMonad Maybe where
     monadApplicative (Just x) (Just y) = Refl
     monadLeftIdentity x f = Refl
     monadRightIdentity Nothing = Refl
-    monadRightIdentity (Just x) = (believe_me (Refl {A = Maybe a} {x = Just x}))
+    monadRightIdentity (Just x) = Refl
     monadAssociativity Nothing f g = Refl
     monadAssociativity (Just x) f g = Refl
 

--- a/libs/contrib/Interfaces/Verified.idr
+++ b/libs/contrib/Interfaces/Verified.idr
@@ -21,8 +21,6 @@ interface Functor f => VerifiedFunctor (f : Type -> Type) where
                        (g1 : a -> b) -> (g2 : b -> c) ->
                        map (g2 . g1) x = (map g2 . map g1) x
 
--- TODO VerifiedFunctor instances for: List, Stream, Either e
-
 VerifiedFunctor Maybe where
   functorIdentity Nothing = Refl
   functorIdentity (Just x) = Refl
@@ -57,8 +55,6 @@ VerifiedApplicative Maybe where
   applicativeInterchange x Nothing = Refl
   applicativeInterchange x (Just y) = Refl
 
--- TODO VerifiedApplicative instances for: List, Stream, Either e
-
 interface (Monad m, VerifiedApplicative m) => VerifiedMonad (m : Type -> Type) where
   monadApplicative : (mf : m (a -> b)) -> (mx : m a) ->
                      mf <*> mx = mf >>= \f =>
@@ -80,8 +76,6 @@ VerifiedMonad Maybe where
     monadAssociativity Nothing f g = Refl
     monadAssociativity (Just x) f g = Refl
 
--- TODO VerifiedMonad instances for: List, Stream, Either e
-
 interface Semigroup a => VerifiedSemigroup a where
   total semigroupOpIsAssociative : (l, c, r : a) -> l <+> (c <+> r) = (l <+> c) <+> r
 
@@ -99,16 +93,6 @@ implementation VerifiedSemigroup (List a) where
 
 [MultZZSemiV] VerifiedSemigroup ZZ using MultZZSemi where
   semigroupOpIsAssociative = multAssociativeZ
-
--- TODO Verified versions of...
---  (Semigroup m, Semigroup n) => Semigroup (m, n) where
---    (a, b) <+> (c, d) = (a <+> c, b <+> d)
---
--- Semigroup (Maybe a)
---
--- [collectJust] Semigroup a => Semigroup (Maybe a)
---
--- libs/base/Data/Morphisms.idr: implementation Monoid (Endomorphism a)
 
 interface (VerifiedSemigroup a, Monoid a) => VerifiedMonoid a where
   total monoidNeutralIsNeutralL : (l : a) -> l <+> Algebra.neutral = l
@@ -133,12 +117,6 @@ interface (VerifiedSemigroup a, Monoid a) => VerifiedMonoid a where
 implementation VerifiedMonoid (List a) where
   monoidNeutralIsNeutralL = appendNilRightNeutral
   monoidNeutralIsNeutralR xs = Refl
-
--- TODO Verified versions of...
---  (Monoid m, Monoid n) => Monoid (m, n) where
---    neutral = (neutral, neutral)
---
--- Monoid (Maybe a)
 
 interface (VerifiedMonoid a, Group a) => VerifiedGroup a where
   total groupInverseIsInverseL : (l : a) -> l <+> inverse l = Algebra.neutral

--- a/libs/contrib/Interfaces/Verified.idr
+++ b/libs/contrib/Interfaces/Verified.idr
@@ -156,10 +156,6 @@ VerifiedRingWithUnity ZZ where
   ringWithUnityIsUnityL = multOneRightNeutralZ
   ringWithUnityIsUnityR = multOneLeftNeutralZ
 
---interface (VerifiedRingWithUnity a, Field a) => VerifiedField a where
---  total fieldInverseIsInverseL : (l : a) -> (notId : Not (l = Algebra.neutral)) -> l <.> (inverseM l notId) = Algebra.unity
---  total fieldInverseIsInverseR : (r : a) -> (notId : Not (r = Algebra.neutral)) -> (inverseM r notId) <.> r = Algebra.unity
-
 interface JoinSemilattice a => VerifiedJoinSemilattice a where
   total joinSemilatticeJoinIsAssociative : (l, c, r : a) -> join l (join c r) = join (join l c) r
   total joinSemilatticeJoinIsCommutative : (l, r : a)    -> join l r = join r l
@@ -169,31 +165,3 @@ interface MeetSemilattice a => VerifiedMeetSemilattice a where
   total meetSemilatticeMeetIsAssociative : (l, c, r : a) -> meet l (meet c r) = meet (meet l c) r
   total meetSemilatticeMeetIsCommutative : (l, r : a)    -> meet l r = meet r l
   total meetSemilatticeMeetIsIdempotent  : (e : a)       -> meet e e = e
-
-{- FIXME: Some maintenance required here.
-   Algebra.top and Algebra.bottom don't exist!
--}
-{-
-
-interface (VerifiedJoinSemilattice a, BoundedJoinSemilattice a) => VerifiedBoundedJoinSemilattice a where
-  total boundedJoinSemilatticeBottomIsBottom : (e : a) -> join e Algebra.bottom = e
-
-interface (VerifiedMeetSemilattice a, BoundedMeetSemilattice a) => VerifiedBoundedMeetSemilattice a where
-  total boundedMeetSemilatticeTopIsTop : (e : a) -> meet e Algebra.top = e
-
-interface (VerifiedJoinSemilattice a, VerifiedMeetSemilattice a) => VerifiedLattice a where
-  total latticeMeetAbsorbsJoin : (l, r : a) -> meet l (join l r) = l
-  total latticeJoinAbsorbsMeet : (l, r : a) -> join l (meet l r) = l
-
-interface (VerifiedBoundedJoinSemilattice a, VerifiedBoundedMeetSemilattice a, VerifiedLattice a) => VerifiedBoundedLattice a where { }
-
-
---interface (VerifiedRingWithUnity a, VerifiedAbelianGroup b, Module a b) => VerifiedModule a b where
---  total moduleScalarMultiplyComposition : (x,y : a) -> (v : b) -> x <#> (y <#> v) = (x <.> y) <#> v
---  total moduleScalarUnityIsUnity : (v : b) -> Algebra.unity {a} <#> v = v
---  total moduleScalarMultDistributiveWRTVectorAddition : (s : a) -> (v, w : b) -> s <#> (v <+> w) = (s <#> v) <+> (s <#> w)
---  total moduleScalarMultDistributiveWRTModuleAddition : (s, t : a) -> (v : b) -> (s <+> t) <#> v = (s <#> v) <+> (t <#> v)
-
---interface (VerifiedField a, VerifiedModule a b) => VerifiedVectorSpace a b where {}
-
--}


### PR DESCRIPTION
New interfaces and implementations in contrib, building up the coverage of `Verified` implementations which provide proof terms to witness that the base instance obeys the appropriate laws.  Includes a back-compatibility breakage - demotion of the instance of `Semigroup Nat` into a named instance.

Example: `VerifiedSemigroup Nat` contains a witness for associativity of the operation defined in `Semigroup Nat`.

- New implementations of algebraic interfaces for numeric types, for example SemiGroup for multiplication on Nat (as well as addition).  ZZ now has the whole numeric tower covered up to `RingWithUnity` - ditto Nat where appropriate.

- All these instances now have `Verified` counterparts as well (libs/contrib/Interfaces/Verified.idr), for example the instance `[PlusNatSemiV] VerifiedSemigroup Nat` extends `[PlusNatSemi] Semigroup Nat` with a member that is a proof term `semigroupOpIsAssociative`.

- Some non-numeric `Verified` interfaces and instances are added too - for example `VerifiedFunctor Maybe`.  There are TODO placeholders for extending coverage further (`VerifiedFunctor List` for example).

- Back-compatibility break in contrib: in libs/contrib/Control/Algebra/NumericImplementations.idr, the `Semigroup Nat` instance is demoted into a named instance called `PlusNatSemi`.  This puts it on a par with the new `MultNatSemi`.  Similarly `Monoid Nat`, `SemiGroup ZZ` and `Monoid ZZ`.