### PR TITLE
Add Control.Pipeline to contrib ipkg

### DIFF
--- a/libs/contrib/contrib.ipkg
+++ b/libs/contrib/contrib.ipkg
@@ -8,6 +8,7 @@ modules = CFFI, CFFI.Types, CFFI.Memory,
           Control.Algebra.NumericImplementations,
           Control.Isomorphism.Primitives,
           Control.Partial,
+          Control.Pipeline,
           Control.ST, Control.ST.ImplicitCall, Control.ST.Exception,
 
           Interfaces.Verified,


### PR DESCRIPTION
I was trying to import `Control.Pipeline` for a toy thing from a homebrew built source distribution and the compiler was telling me it wasn't finding it. After checking the build output, there was no `Pipeline.ibc` file and `Control.Pipeline` wasn't in `contrib.ipkg`. So... 1 + 1.