### PR TITLE
Do not run idle GCs

### DIFF
--- a/idris.cabal
+++ b/idris.cabal
@@ -359,7 +359,7 @@ Executable idris
                 , transformers
 
   ghc-prof-options: -auto-all -caf-all
-  ghc-options:      -threaded -rtsopts -funbox-strict-fields
+  ghc-options:      -threaded -rtsopts -funbox-strict-fields -with-rtsopts=-I0
 
 Test-suite regression-and-feature-tests
   Type:           exitcode-stdio-1.0


### PR DESCRIPTION
They cause an idle repl to do a major collection three times every
second to no use, with corresponding CPU use.