### PR TITLE
check for non-negative return values in idris_writeStr

### DIFF
--- a/rts/idris_stdfgn.c
+++ b/rts/idris_stdfgn.c
@@ -61,7 +61,7 @@ int fileSize(void* h) {
 
 int idris_writeStr(void* h, char* str) {
     FILE* f = (FILE*)h;
-    if (fputs(str, f)) {
+    if (fputs(str, f) >= 0) {
         return 0;
     } else {
         return -1;


### PR DESCRIPTION
Trying to compile and run a simple program like
```
main : IO ()
main = do 
   res <- writeFile "test.txt" "foo" 
   putStrLn $ show res
   pure ()
```
on Windows gives us `Left File Write Error`, while on Linux it's `Right ()`. In both cases the file does get created (though not properly closed in Win case).
Apparently the issue is that a successful call to `fputs` returns 1 on Linux vs 0 on Windows.
According to references like [MSDN](https://msdn.microsoft.com/en-us/library/t33ya8ky.aspx) and [cppreference.com](http://en.cppreference.com/w/cpp/io/c/fputs), "a non-negative value" indicates success, so 0 is also acceptable.