### PR TITLE
Support presentations of abstract names in output

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,7 @@
++ Names are now annotated with their representations over the IDE
+  protocol, which allows IDEs to provide commands that work on special
+  names that don't have syntax, such as case block names.
+
 # New in 1.0
 
 + It's about time

--- a/src/Idris/IdeMode.hs
+++ b/src/Idris/IdeMode.hs
@@ -128,7 +128,8 @@ namespaceOf _         = Nothing
 
 instance SExpable OutputAnnotation where
   toSExp (AnnName n ty d t) = toSExp $ [(SymbolAtom "name", StringAtom (show n)),
-                                        (SymbolAtom "implicit", BoolAtom False)] ++
+                                        (SymbolAtom "implicit", BoolAtom False),
+                                        (SymbolAtom "key", StringAtom (encodeName n))] ++
                                        maybeProps [("decor", ty)] ++
                                        maybeProps [("doc-overview", d), ("type", t)] ++
                                        maybeProps [("namespace", namespaceOf n)]
@@ -171,6 +172,12 @@ instance SExpable OutputAnnotation where
              maybeProps [("source-file", file)]
   toSExp AnnQuasiquote = toSExp [(SymbolAtom "quasiquotation", True)]
   toSExp AnnAntiquote = toSExp [(SymbolAtom "antiquotation", True)]
+
+encodeName :: Name -> String
+encodeName n = UTF8.toString . Base64.encode . Lazy.toStrict . Binary.encode $ n
+
+decodeName :: String -> Name
+decodeName = Binary.decode . Lazy.fromStrict . Base64.decodeLenient . UTF8.fromString
 
 encodeTerm :: [(Name, Bool)] -> Term -> String
 encodeTerm bnd tm = UTF8.toString . Base64.encode . Lazy.toStrict . Binary.encode $


### PR DESCRIPTION
When Idris sends strings over the IDE protocol, it includes
out-of-band semantic information that allows regions of the string to
_represent_ their underlying data. In particular, terms are serialized
and sent with their representations, allowing things like interactive
error messages in IDE clients.

This patch adds a similar capability for names. Now, serialized
datatypes are sent with names, allowing names that don't have syntax
to be the subjects of commands. This is very convenient when working
with metaprogramming or debugging the compiler.

The change is backwards-compatible, because it has to be enabled in
each IDE client, and if they aren't sent serialized names, then they
don't act differently from today.