### PR TITLE
Fix allocation of buffer

### DIFF
--- a/rts/idris_buffer.c
+++ b/rts/idris_buffer.c
@@ -3,7 +3,7 @@
 
 typedef struct {
     int size;
-    uint8_t* data;
+    uint8_t data[0];
 } Buffer;
 
 void* idris_newBuffer(int bytes) {
@@ -13,7 +13,6 @@ void* idris_newBuffer(int bytes) {
     }
 
     buf->size = bytes;
-    buf->data = (uint8_t*)(buf+1);
     memset(buf->data, 0, bytes);
 
     return buf;
@@ -25,7 +24,7 @@ void idris_copyBuffer(void* from, int start, int len,
     Buffer* bto = to;
 
     if (loc >= 0 && loc+len <= bto->size) {
-        memcpy((bto->data)+loc, (bfrom->data)+start, len);
+        memcpy(bto->data + loc, bfrom->data + start, len);
     }
 }
 

--- a/test/buffer001/buffer001.idr
+++ b/test/buffer001/buffer001.idr
@@ -26,3 +26,8 @@ main = do Just buf <- newBuffer 40
           closeFile h
 
           printLn !(bufferData buf3)
+
+          -- Small buffer, tests issue #3828
+          Just small <- newBuffer 3
+          setByte small 0 0
+          setByte small 2 1


### PR DESCRIPTION
Use a zero-length array to represent the memory allocated after the size. Remove spurious assignment.

Fixes #3828