### PR TITLE
JS Codegen — Optimization, phase II

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,13 +1,16 @@
 
 ## Tool Updates
 
-+ New javascript code generator that uses an higher level intermediate
++ New JavaScript code generator that uses an higher level intermediate
   representation.
-  
+
++ Various optimizations of the novel JavaScript code generator to make
+  its results fast.
+
 + Names are now annotated with their representations over the IDE
   protocol, which allows IDEs to provide commands that work on special
-  names that don't have syntax, such as case block names
-  
+  names that don't have syntax, such as case block names.
+
 
 # New in 1.0
 

--- a/src/IRTS/JavaScript/PrimOp.hs
+++ b/src/IRTS/JavaScript/PrimOp.hs
@@ -37,7 +37,7 @@ primDB =
   Map.fromList [
     item (LPlus ATFloat) False PTAny $ binop "+"
   , item (LPlus (ATInt ITChar)) False PTAny $ JsForeign "String.fromCharCode(%0.charCodeAt(0) + %1.charCodeAt(0))"
-  , item (LPlus (ATInt ITNative)) False PTAny $ JsForeign "%0+%1|0"
+  , item (LPlus (ATInt ITNative)) False PTAny $ binop "+"
   , item (LPlus (ATInt (ITFixed IT8))) False PTAny $ JsForeign "%0 + %1 & 0xFF"
   , item (LPlus (ATInt (ITFixed IT16))) False PTAny $ JsForeign "%0 + %1 & 0xFFFF"
   , item (LPlus (ATInt (ITFixed IT32))) False PTAny $ JsForeign "%0+%1|0"
@@ -46,7 +46,7 @@ primDB =
     \[l, r] -> JsForeign "%0.add(%1).and(new $JSRTS.jsbn.BigInteger(%2))" [l,r, JsStr $ show 0xFFFFFFFFFFFFFFFF]
   , item (LMinus ATFloat) False PTAny $ binop "-"
   , item (LMinus (ATInt ITChar)) False PTAny $ JsForeign "String.fromCharCode(%0.charCodeAt(0) - %1.charCodeAt(0))"
-  , item (LMinus (ATInt ITNative)) False PTAny $ JsForeign "%0-%1|0"
+  , item (LMinus (ATInt ITNative)) False PTAny $ binop "-"
   , item (LMinus (ATInt (ITFixed IT8))) False PTAny $ JsForeign "%0 - %1 & 0xFF"
   , item (LMinus (ATInt (ITFixed IT16))) False PTAny $ JsForeign "%0 - %1 & 0xFFFF"
   , item (LMinus (ATInt (ITFixed IT32))) False PTAny $ JsForeign "%0-%1|0"
@@ -55,7 +55,7 @@ primDB =
     \[l, r] -> JsForeign "%0.subtract(%1).and(new $JSRTS.jsbn.BigInteger(%2))" [l,r, JsStr $ show 0xFFFFFFFFFFFFFFFF]
   , item (LTimes ATFloat) False PTAny $ binop "*"
   , item (LTimes (ATInt ITChar)) False PTAny $ JsForeign "String.fromCharCode(%0.charCodeAt(0) * %1.charCodeAt(0))"
-  , item (LTimes (ATInt ITNative)) False PTAny $ JsForeign "%0*%1|0"
+  , item (LTimes (ATInt ITNative)) False PTAny $ binop "*"
   , item (LTimes (ATInt (ITFixed IT8))) False PTAny $ JsForeign "%0 * %1 & 0xFF"
   , item (LTimes (ATInt (ITFixed IT16))) False PTAny $ JsForeign "%0 * %1 & 0xFFFF"
   , item (LTimes (ATInt (ITFixed IT32))) False PTAny $ JsForeign "%0*%1|0"
@@ -71,14 +71,14 @@ primDB =
   , item (LSDiv (ATInt (ITFixed IT16))) False PTAny $ JsForeign "%0 / %1"
   , item (LSDiv (ATInt (ITFixed IT32))) False PTAny $ JsForeign "%0  / %1 |0"
   , item (LSDiv (ATInt (ITFixed IT64))) True PTAny $ JsForeign "%0.divide(%1)"
-  , item (LSDiv (ATInt ITNative)) False PTAny $ JsForeign "%0/%1|0"
+  , item (LSDiv (ATInt ITNative)) False PTAny $ JsForeign "%0/%1|0" -- we need "|0" in this
   , item (LSDiv (ATInt ITBig)) True PTAny $ method "divide"
   , item (LURem (ITFixed IT8)) False PTAny $ JsForeign "%0 % %1"
   , item (LURem (ITFixed IT16)) False PTAny $ JsForeign "%0 % %1"
   , item (LURem (ITFixed IT32)) False PTAny $ JsForeign "(%0>>>0) % (%1>>>0) |0"
   , item (LURem (ITFixed IT64)) True PTAny $ method "remainder"
   , item (LSRem ATFloat) False PTAny $ binop "%"
-  , item (LSRem (ATInt ITNative)) False PTAny $ JsForeign "%0 % %1 |0"
+  , item (LSRem (ATInt ITNative)) False PTAny $ binop "%"
   , item (LSRem (ATInt (ITFixed IT8))) False PTAny $ JsForeign "%0 % %1"
   , item (LSRem (ATInt (ITFixed IT16))) False PTAny $ JsForeign "%0 % %1"
   , item (LSRem (ATInt (ITFixed IT32))) False PTAny $ JsForeign "%0 % %1 |0"


### PR DESCRIPTION
@melted  merged #3829 too early...

Changes:

- Call specialization.
- Remove unnecessary "|0" in native-precision integer manipulations.
- Unify nullary datas with other arity.