### PR TITLE
Add do-rewrite construction

### DIFF
--- a/src/Idris/AbsSyntaxTree.hs
+++ b/src/Idris/AbsSyntaxTree.hs
@@ -1177,6 +1177,7 @@ mapPTermFC f g (PDoBlock dos) = PDoBlock (map mapPDoFC dos)
           DoBindP (f fc) (mapPTermFC f g t1) (mapPTermFC f g t2) (map (\(l,r)-> (mapPTermFC f g l, mapPTermFC f g r)) alts)
         mapPDoFC (DoLet fc n nfc t1 t2) = DoLet (f fc) n (g nfc) (mapPTermFC f g t1) (mapPTermFC f g t2)
         mapPDoFC (DoLetP fc t1 t2) = DoLetP (f fc) (mapPTermFC f g t1) (mapPTermFC f g t2)
+        mapPDoFC (DoRewrite fc h) = DoRewrite (f fc) (mapPTermFC f g h)
 mapPTermFC f g (PIdiom fc t)                  = PIdiom (f fc) (mapPTermFC f g t)
 mapPTermFC f g (PMetavar fc n)                = PMetavar (g fc) n
 mapPTermFC f g (PProof tacs)                  = PProof (map (fmap (mapPTermFC f g)) tacs)
@@ -1301,6 +1302,7 @@ data PDo' t = DoExp  FC t
             | DoBindP FC t t [(t,t)]
             | DoLet  FC Name FC t t   -- ^ second FC is precise name location
             | DoLetP FC t t
+            | DoRewrite FC t          -- rewrite in do block
     deriving (Eq, Ord, Functor, Data, Generic, Typeable)
 {-!
 deriving instance Binary PDo'
@@ -1312,6 +1314,7 @@ instance Sized a => Sized (PDo' a) where
   size (DoBindP fc l r alts)  = 1 + size fc + size l  + size r   + size alts
   size (DoLet fc nm nfc l r)  = 1 + size fc + size nm + size l   + size r
   size (DoLetP fc l r)        = 1 + size fc + size l  + size r
+  size (DoRewrite fc h)       = 1 + size fc + size h
 
 type PDo = PDo' PTerm
 
@@ -1407,6 +1410,7 @@ highestFC (PDoBlock lines) =
     getDoFC (DoBindP fc l r alts) = fc
     getDoFC (DoLet fc nm nfc l r) = fc
     getDoFC (DoLetP fc l r)       = fc
+    getDoFC (DoRewrite fc h)      = fc
 
 highestFC (PIdiom fc _)           = Just fc
 highestFC (PMetavar fc _)         = Just fc
@@ -2079,6 +2083,9 @@ pprintPTerm ppo bnd docArgs infixes = prettySe (ppopt_depth ppo) startPrec bnd
                 group (align (hang 2 (prettySe (decD d) startPrec bnd v)))) :
                ppdo ((ln, False):bnd) dos
              ppdo bnd (DoLetP _ _ _ : dos) = -- ok because never made by delab
+               text "no pretty printer for pattern-matching do binding" :
+               ppdo bnd dos
+             ppdo bnd (DoRewrite _ _ : dos) = -- ok because never made by delab
                text "no pretty printer for pattern-matching do binding" :
                ppdo bnd dos
              ppdo _ [] = []

--- a/src/Idris/DSL.hs
+++ b/src/Idris/DSL.hs
@@ -109,6 +109,8 @@ expandSugar dsl (PDoBlock ds)
         = PLet fc n nfc ty tm (block b rest)
     block b (DoLetP fc p tm : rest)
         = PCase fc tm [(p, block b rest)]
+    block b (DoRewrite fc h : rest)
+        = PRewrite fc Nothing h (block b rest) Nothing
     block b (DoExp fc tm : rest)
         = PApp fc b
             [pexp tm,

--- a/src/Idris/Elab/Quasiquote.hs
+++ b/src/Idris/Elab/Quasiquote.hs
@@ -75,6 +75,7 @@ extractDoUnquotes d (DoLet  fc n nfc v b)
        (b', ex2) <- extractUnquotes d b
        return (DoLet fc n nfc v' b', ex1 ++ ex2)
 extractDoUnquotes d (DoLetP fc t t') = fail "Pattern-matching lets cannot be quasiquoted"
+extractDoUnquotes d (DoRewrite fc h) = fail "Rewrites in Do block cannot be quasiquoted"
 
 
 extractUnquotes :: Int -> PTerm -> Elab' aux (PTerm, [(Name, PTerm)])

--- a/src/Idris/Error.hs
+++ b/src/Idris/Error.hs
@@ -138,6 +138,7 @@ warnDisamb ist (PDoBlock steps) = mapM_ wStep steps
                                    mapM_ (\(x,y) -> warnDisamb ist x >> warnDisamb ist y) cs
         wStep (DoLet _ _ _ x y) = warnDisamb ist x >> warnDisamb ist y
         wStep (DoLetP _ x y) = warnDisamb ist x >> warnDisamb ist y
+        wStep (DoRewrite _ h) = warnDisamb ist h
 warnDisamb ist (PIdiom _ x) = warnDisamb ist x
 warnDisamb ist (PMetavar _ _) = return ()
 warnDisamb ist (PProof tacs) = mapM_ (Foldable.mapM_ (warnDisamb ist)) tacs

--- a/src/Idris/IBC.hs
+++ b/src/Idris/IBC.hs
@@ -2292,7 +2292,7 @@ instance (Binary t) => Binary (PDo' t) where
                                       put x1
                                       put x2
                                       put x3
-                DoRewrite x1 x2 -> do putWord8 3
+                DoRewrite x1 x2 -> do putWord8 5
                                       put x1
                                       put x2
         get

--- a/src/Idris/IBC.hs
+++ b/src/Idris/IBC.hs
@@ -2292,6 +2292,9 @@ instance (Binary t) => Binary (PDo' t) where
                                       put x1
                                       put x2
                                       put x3
+                DoRewrite x1 x2 -> do putWord8 3
+                                      put x1
+                                      put x2
         get
           = do i <- getWord8
                case i of
@@ -2318,6 +2321,10 @@ instance (Binary t) => Binary (PDo' t) where
                            x2 <- get
                            x3 <- get
                            return (DoLetP x1 x2 x3)
+                   5 -> do
+                           x1 <- get
+                           x2 <- get
+                           return (DoRewrite x1 x2)
                    _ -> error "Corrupted binary data for PDo'"
 
 

--- a/src/Idris/IBC.hs
+++ b/src/Idris/IBC.hs
@@ -47,7 +47,7 @@ import System.Directory
 import System.FilePath
 
 ibcVersion :: Word16
-ibcVersion = 160
+ibcVersion = 161 
 
 -- | When IBC is being loaded - we'll load different things (and omit
 -- different structures/definitions) depending on which phase we're in.

--- a/src/Idris/IBC.hs
+++ b/src/Idris/IBC.hs
@@ -47,7 +47,7 @@ import System.Directory
 import System.FilePath
 
 ibcVersion :: Word16
-ibcVersion = 161 
+ibcVersion = 161
 
 -- | When IBC is being loaded - we'll load different things (and omit
 -- different structures/definitions) depending on which phase we're in.

--- a/src/Idris/IdrisDoc.hs
+++ b/src/Idris/IdrisDoc.hs
@@ -343,6 +343,7 @@ extractPDo (DoBindP _ p1 p2 ps)  = let (ps1, ps2) = unzip ps
                                    in  concatMap extract (p1 : p2 : ps')
 extractPDo (DoLet   _ n _ p1 p2) = n : concatMap extract [p1, p2]
 extractPDo (DoLetP  _ p1 p2)     = concatMap extract [p1, p2]
+extractPDo (DoRewrite  _ p)      = extract p
 
 -- | Helper function for extractPTermNames
 extractPTactic :: PTactic -> [Name]

--- a/src/Idris/Parser/Expr.hs
+++ b/src/Idris/Parser/Expr.hs
@@ -233,6 +233,7 @@ updateSynMatch = update
                     = DoBindP fc (update ns i) (update ns t)
                                  (map (\(l,r) -> (update ns l, update ns r)) ts)
             upd ns (DoLetP fc i t) = DoLetP fc (update ns i) (update ns t)
+            upd ns (DoRewrite fc h) = DoRewrite fc (update ns h)
     update ns (PIdiom fc t) = PIdiom fc $ update ns t
     update ns (PMetavar fc n) = uncurry (flip PMetavar) $ updateB ns (n, fc)
     update ns (PProof tacs) = PProof $ map (updTactic ns) tacs
@@ -1342,6 +1343,7 @@ doBlock syn
 Do ::=
     'let' Name  TypeSig'?      '=' Expr
   | 'let' Expr'                '=' Expr
+  | 'rewrite Expr
   | Name  '<-' Expr
   | Expr' '<-' Expr
   | Expr
@@ -1366,6 +1368,11 @@ do_ syn
                sc <- expr syn
                highlightP kw AnnKeyword
                return (DoLetP fc i sc))
+   <|> try (do kw <- reservedFC "rewrite"
+               fc <- getFC
+               sc <- expr syn
+               highlightP kw AnnKeyword
+               return (DoRewrite fc sc))
    <|> try (do (i, ifc) <- name
                symbol "<-"
                fc <- getFC

--- a/src/Idris/Prover.hs
+++ b/src/Idris/Prover.hs
@@ -349,6 +349,7 @@ elabloop info fn d prompt prf e prev h env
               Success (Right cmd') ->
                 case cmd' of
                   DoLetP  {} -> ifail "Pattern-matching let not supported here"
+                  DoRewrite  {} -> ifail "Pattern-matching do-rewrite not supported here"
                   DoBindP {} -> ifail "Pattern-matching <- not supported here"
                   DoLet fc i ifc Placeholder expr ->
                     do (tm, ty) <- elabVal (recinfo proverfc) ERHS (inLets ist env expr)


### PR DESCRIPTION
A fix for #3840.

Syntax:

```idris
do { rewrite H; ... }
```

Definition

```idris
do { rewrite H; ... } =====> rewrite H in do {...}
```