### PR TITLE
changed js backend to look for includes also in getIdrisLibDir

### DIFF
--- a/docs/tutorial/miscellany.rst
+++ b/docs/tutorial/miscellany.rst
@@ -467,6 +467,15 @@ And for use in the browser:
       %include JavaScript "path/to/external.js"
 
 The given files will be added to the top of the generated code.
+For library packages you can also use the ipkg objs option to include the
+js file in the installation, and use
+
+.. code-block:: idris
+
+      %include Node "package/external.js"
+
+This javascript and node backends idris will also lookup for the file on
+on that location.
 
 Including *NodeJS* modules
 --------------------------

--- a/src/IRTS/JavaScript/Codegen.hs
+++ b/src/IRTS/JavaScript/Codegen.hs
@@ -64,7 +64,14 @@ data CGConf = CGConf { header :: Text
 
 
 getInclude :: FilePath -> IO Text
-getInclude p = TIO.readFile p
+getInclude p =
+  do
+    libs <- getIdrisLibDir
+    let libPath = libs </> p
+    exitsInLib <- doesFileExist libPath
+    if exitsInLib then
+      TIO.readFile libPath
+      else TIO.readFile p
 
 getIncludes :: [FilePath] -> IO Text
 getIncludes l = do


### PR DESCRIPTION
 Changed js backend to look for includes also in getIdrisLibDir. This is useful to use with objs ipkg option when making libraries. Without this I don't know any other way to include javascript parts on idris libraries. 