### PR TITLE
mark covering functions using `sizeAccessible` as `public export total`

### DIFF
--- a/libs/base/Data/List/Views.idr
+++ b/libs/base/Data/List/Views.idr
@@ -63,7 +63,7 @@ data SplitRec : List a -> Type where
 
 ||| Covering function for the `SplitRec` view
 ||| Constructs the view in O(n lg n)
-export total
+public export total
 splitRec : (xs : List a) -> SplitRec xs
 splitRec xs with (sizeAccessible xs)
   splitRec xs | acc with (split xs)
@@ -109,7 +109,7 @@ filteredROK p x xs = LTESucc (filterSmaller xs)
 
 ||| Covering function for the `Filtered` view
 ||| Constructs the view in O(n lg n)
-export
+public export total
 filtered : (p : a -> a -> Bool) -> (xs : List a) -> Filtered p xs
 filtered p inp with (sizeAccessible inp)
   filtered p [] | _ = FNil

--- a/libs/base/Data/Nat/Views.idr
+++ b/libs/base/Data/Nat/Views.idr
@@ -22,7 +22,7 @@ half (S k) with (half k)
                                            HalfEven {n=S n}
   half (S (n + n)) | HalfEven = HalfOdd
 
-export
+public export total
 halfRec : (n : Nat) -> HalfRec n
 halfRec n with (sizeAccessible n)
   halfRec  Z | acc = HalfRecZ

--- a/libs/base/Data/Vect/Views.idr
+++ b/libs/base/Data/Vect/Views.idr
@@ -71,7 +71,7 @@ smallerPlusR {m} {k} = rewrite sym (plusSuccRightSucc m k) in
 
 ||| Covering function for the `SplitRec` view
 ||| Constructs the view in O(n lg n)
-export
+public export total
 splitRec : (xs : Vect n a) -> SplitRec xs
 splitRec {n} input with (sizeAccessible n)
   splitRec input | acc with (split input)


### PR DESCRIPTION
(so that they reduce in proofs)