### PR TITLE
Fix issue where relative paths aren't parsed correctly for JS %lib in…

### DIFF
--- a/src/IRTS/JavaScript/Codegen.hs
+++ b/src/IRTS/JavaScript/Codegen.hs
@@ -84,8 +84,11 @@ includeLibs =
     repl '\\' = '_'
     repl '/' = '_'
     repl c   = c
+
+    trimPeriod ('.' : xs) = '_' : xs
+    trimPeriod s = s
   in
-    concatMap (\lib -> "var " ++ (repl <$> lib) ++ " = require(\"" ++ lib ++"\");\n")
+    concatMap (\lib -> "var " ++ (trimPeriod $ repl <$> lib) ++ " = require(\"" ++ lib ++"\");\n")
 
 isYes :: Maybe String -> Bool
 isYes (Just "Y") = True

--- a/src/IRTS/JavaScript/Codegen.hs
+++ b/src/IRTS/JavaScript/Codegen.hs
@@ -83,12 +83,10 @@ includeLibs =
   let
     repl '\\' = '_'
     repl '/' = '_'
+    repl '.' = '_'
     repl c   = c
-
-    trimPeriod ('.' : xs) = '_' : xs
-    trimPeriod s = s
   in
-    concatMap (\lib -> "var " ++ (trimPeriod $ repl <$> lib) ++ " = require(\"" ++ lib ++"\");\n")
+    concatMap (\lib -> "var " ++ (repl <$> lib) ++ " = require(\"" ++ lib ++"\");\n")
 
 isYes :: Maybe String -> Bool
 isYes (Just "Y") = True


### PR DESCRIPTION
…cludes

The issue is that if you write something like:

```idris
%lib Node "./ex.js"
```

Then the js/node codegen will parse the result as:

```js
var ._ex.js = require("./ex.js");
```

Which isn't valid syntax and would cause a runtime parse error
This commit fixes this issue by parsing the result as:

```js
var __ex.js = require("./ex.js");
```