### PR TITLE
More compact display of names

### DIFF
--- a/src/Idris/Core/TT.hs
+++ b/src/Idris/Core/TT.hs
@@ -536,17 +536,20 @@ instance Pretty [Name] OutputAnnotation where
 
 instance Show Name where
     show (UN n) = str n
-    show (NS n s) = showSep "." (map T.unpack (reverse s)) ++ "." ++ show n
+    show (NS n s) = show n
     show (MN _ u) | u == txt "underscore" = "_"
     show (MN i s) = "{" ++ str s ++ "_" ++ show i ++ "}"
     show (SN s) = show s
     show (SymRef i) = "##symbol" ++ show i ++ "##"
 
 instance Show SpecialName where
-    show (WhereN i p c) = show p ++ ", " ++ show c
+    show (WhereN i p c) = show p ++ "." ++ show c
     show (WithN i n) = "with block in " ++ show n
-    show (ImplementationN cl impl) = showSep ", " (map T.unpack impl) ++ " implementation of " ++ show cl
-    show (MethodN m) = "method " ++ show m
+    show (ImplementationN cl []) = "@{" ++ show cl ++ "}"
+    show (ImplementationN cl [impl]) = "@{" ++ show cl ++ " $ " ++ show impl ++ "}"
+    show (ImplementationN cl impl) = "@{" ++ show cl ++
+        showSep " " (map (("(" ++) . (++ ")") . show . T.unpack) impl) ++ "}"
+    show (MethodN m) = show m
     show (ParentN p c) = show p ++ "#" ++ T.unpack c
     show (CaseN fc n) = "case block in " ++ show n ++
                         if fc == FC' emptyFC then "" else " at " ++ show fc


### PR DESCRIPTION
The old way is quite verbose, and with that, quite unreadable. Currently,
it is displayed as:

```
aaaaa : (x : Vect n a) ->
        (g1 : a -> b) ->
        (g2 : b -> c) ->
        Data.Vect.Vect n implementation of Prelude.Functor.Functor, method map (\x1 => g2 (g1 x1)) x =
        Data.Vect.Vect n implementation of Prelude.Functor.Functor, method map g2 (Data.Vect.Vect n implementation of Prelude.Functor.Functor, method map g1 x)
```

With this update, this becomes:

```
aaaaa : (x : Vect n a) ->
        (g1 : a -> b) ->
        (g2 : b -> c) ->
        @{Functor $ Vect n}.map (\x1 => g2 (g1 x1)) x = @{Functor $ Vect n}.map g2 (@{Functor $ Vect n}.map g1 x)
```