### PR TITLE
Simplify JS code generation

### DIFF
--- a/CONTRIBUTORS
+++ b/CONTRIBUTORS
@@ -200,6 +200,7 @@ Sven Koschnicke
 tdidriksen
 Tenor Biel
 Thomas Cooper
+Thomas Scholtes
 Tim Dysinger
 Tim McGilchrist
 Timo Petteri Sinnemäki

--- a/src/IRTS/JavaScript/Codegen.hs
+++ b/src/IRTS/JavaScript/Codegen.hs
@@ -25,10 +25,12 @@ import IRTS.System
 
 import Control.Monad
 import Control.Monad.Trans.State
+import Data.Foldable (foldMap)
 import Data.List (nub)
 import Data.Map.Strict (Map)
 import qualified Data.Map.Strict as Map
 import Data.Maybe (fromJust)
+import Data.Monoid
 import Data.Set (Set)
 import qualified Data.Set as Set
 import Data.Text (Text)
@@ -45,16 +47,26 @@ import Data.Generics.Uniplate.Data
 import Data.List
 import GHC.Generics (Generic)
 
+-- | Code generation stats hold information about the generated user
+-- code. Based on that information we add additional code to make
+-- things work.
 data CGStats = CGStats { usedBigInt :: Bool
                        , partialApplications :: Set Partial
                        , hiddenClasses :: Set HiddenClass
                        }
 
-emptyStats :: CGStats
-emptyStats = CGStats { partialApplications = Set.empty
-                     , hiddenClasses = Set.empty
-                     , usedBigInt = False
-                     }
+-- If we generate code for two declarations we want to merge their code
+-- generation stats.
+instance Monoid CGStats where
+  mempty = CGStats { partialApplications = Set.empty
+                   , hiddenClasses = Set.empty
+                   , usedBigInt = False
+                   }
+  mappend x y = CGStats { partialApplications = partialApplications x `Set.union` partialApplications y
+                        , hiddenClasses = hiddenClasses x `Set.union` hiddenClasses y
+                        , usedBigInt = usedBigInt x || usedBigInt y
+                        }
+
 
 data CGConf = CGConf { header :: Text
                      , footer :: Text
@@ -101,11 +113,9 @@ codegenJs conf ci =
     let defs' = Map.fromList $ liftDecls ci
     let defs = globlToCon defs'
     let used = Map.elems $ removeDeadCode defs [sMN 0 "runMain"]
-    if debug then
-      do
+    when debug $ do
         writeFile (outputFile ci ++ ".LDeclsDebug") $ (unlines $ intersperse "" $ map show used) ++ "\n\n\n"
         putStrLn $ "Finished calculating used"
-      else pure ()
 
     let (out, stats) = doCodegen conf defs used
 
@@ -160,20 +170,21 @@ doHiddenClasses x =
              JsFun (jsNameHiddenClass p) vars $ JsSeq (JsSet (JsProp JsThis "type") (JsInt id)) $ seqJs
                $ map (\tv -> JsSet (JsProp JsThis tv) (JsVar tv)) vars
 
-doCodegen :: CGConf -> Map Name LDecl -> [LDecl] -> (Text, CGStats)
-doCodegen conf defs decls =
-  let xs = map (doCodegenDecl conf defs) decls
-      groupCGStats x y = CGStats { partialApplications = partialApplications x `Set.union` partialApplications y
-                                 , hiddenClasses = hiddenClasses x `Set.union` hiddenClasses y
-                                 , usedBigInt = usedBigInt x || usedBigInt y
-                                 }
-  in (T.intercalate "\n" $ map fst xs, foldl' groupCGStats emptyStats (map snd xs) )
 
-doCodegenDecl :: CGConf -> Map Name LDecl -> LDecl -> (Text, CGStats)
-doCodegenDecl conf defs (LFun _ n args def) =
-  let (ast, stats) = cgFun conf defs n args def
-  in (T.concat [jsStmt2Text (JsComment $ T.pack $ show n), "\n", jsStmt2Text ast], stats)
-doCodegenDecl conf defs (LConstructor n i sz) = ("", emptyStats)
+-- | Generate code for each declaration and collect stats.
+-- LFunctions are turned into JS function declarations. They are
+-- preceded by a comment that gives their name. Constructor
+-- declarations are ignored.
+doCodegen :: CGConf -> Map Name LDecl -> [LDecl] -> (Text, CGStats)
+doCodegen conf defs decls = foldMap (doCodegenDecl conf defs) decls
+  where
+    doCodegenDecl :: CGConf -> Map Name LDecl -> LDecl -> (Text, CGStats)
+    doCodegenDecl conf defs (LFun _ name args def) =
+      let (ast, stats) = cgFun conf defs name args def
+          fnComment = jsStmt2Text (JsComment $ T.pack $ show name)
+      in (T.concat [fnComment, "\n", jsStmt2Text ast, "\n"], stats)
+    doCodegenDecl conf defs (LConstructor n i sz) = ("", mempty)
+
 
 seqJs :: [JsStmt] -> JsStmt
 seqJs [] = JsEmpty

--- a/src/IRTS/JavaScript/Codegen.hs
+++ b/src/IRTS/JavaScript/Codegen.hs
@@ -222,10 +222,6 @@ addUsedArgsTailCallOptim :: Set (Text, Text) -> State CGBodyState ()
 addUsedArgsTailCallOptim p =
   modify (\s -> s {usedArgsTailCallOptim = Set.union p (usedArgsTailCallOptim s) })
 
-getNewCGNames :: Int -> State CGBodyState [Text]
-getNewCGNames n =
-  mapM (\_ -> getNewCGName) [1..n]
-
 getConsId :: Name -> State CGBodyState (Int, Int)
 getConsId n =
     do
@@ -272,16 +268,6 @@ cgFun dfs n args def = do
                        , usedBigInt = usedITBig st
                        }
   (fn, state')
-
-getSwitchJs :: JsExpr -> [LAlt] -> JsExpr
-getSwitchJs x alts =
-  if any conCase alts then JsArrayProj (JsInt 0) x
-    else if any constBigIntCase alts then JsForeign "%0.toString()" [x]
-            else x
-  where conCase (LConCase _ _ _ _) = True
-        conCase _ = False
-        constBigIntCase (LConstCase (BI _) _) = True
-        constBigIntCase _ = False
 
 addRT :: BodyResTarget -> JsExpr -> JsStmt
 addRT ReturnBT x = JsReturn x

--- a/src/IRTS/JavaScript/Codegen.hs
+++ b/src/IRTS/JavaScript/Codegen.hs
@@ -20,17 +20,16 @@ import IRTS.JavaScript.Name
 import IRTS.JavaScript.PrimOp
 import IRTS.JavaScript.Specialize
 import IRTS.Lang
-import IRTS.LangOpts
 import IRTS.System
 
+import Control.Applicative (pure, (<$>))
 import Control.Monad
 import Control.Monad.Trans.State
 import Data.Foldable (foldMap)
-import Data.List (nub)
+import Data.Generics.Uniplate.Data
+import Data.List
 import Data.Map.Strict (Map)
 import qualified Data.Map.Strict as Map
-import Data.Maybe (fromJust)
-import Data.Monoid
 import Data.Set (Set)
 import qualified Data.Set as Set
 import Data.Text (Text)
@@ -40,12 +39,6 @@ import System.Directory (doesFileExist)
 import System.Environment
 import System.FilePath
 
-import Control.Applicative (pure, (<$>))
-import Data.Char
-import Data.Data
-import Data.Generics.Uniplate.Data
-import Data.List
-import GHC.Generics (Generic)
 
 -- | Code generation stats hold information about the generated user
 -- code. Based on that information we add additional code to make


### PR DESCRIPTION
This PR simplifies some code in `src/IRTS/JavaScript/Codegen.hs`.

* Remove redundant imports.
* Remove two unused functions `getNewCGNames` and `genSwitchJS`
* Removed unused `GConf` argument and data field
* Add a Monoid instance for `CGStats`. Allows us to express code generation more concisely