### PR TITLE
Simplify LV/DV constructor by removing unused case

### DIFF
--- a/src/IRTS/Compiler.hs
+++ b/src/IRTS/Compiler.hs
@@ -214,7 +214,7 @@ build (n, d)
               Just (ar, op) ->
                   let args = map (\x -> sMN x "op") [0..] in
                       return (n, (LFun [] n (take ar args)
-                                         (LOp op (map (LV . Glob) (take ar args)))))
+                                         (LOp op (map LV (take ar args)))))
               _ -> do def <- mkLDecl n d
                       logCodeGen 3 $ "Compiled " ++ show n ++ " =\n\t" ++ show def
                       return (n, def)
@@ -398,7 +398,7 @@ irTerm top vs env tm@(App _ f a) = do
                 -> irTerm top vs env (head argsPruned)
 
                 | otherwise  -- not newtype, plain data ctor
-                -> buildApp (LV $ Glob n) argsPruned
+                -> buildApp (LV n) argsPruned
 
             -- not saturated, underapplied
             LT  | isNewtype               -- newtype
@@ -407,11 +407,11 @@ irTerm top vs env tm@(App _ f a) = do
                     <$> irTerm top vs env (head argsPruned)
 
                 | isNewtype  -- newtype but the value is not among args yet
-                -> return . padLams $ \[vn] -> LApp False (LV $ Glob n) [LV $ Glob vn]
+                -> return . padLams $ \[vn] -> LApp False (LV n) [LV vn]
 
                 -- not a newtype, just apply to a constructor
                 | otherwise
-                -> padLams . applyToNames <$> buildApp (LV $ Glob n) argsPruned
+                -> padLams . applyToNames <$> buildApp (LV n) argsPruned
 
     -- type constructor
     (P (TCon t a) n _, args) -> return LNothing
@@ -446,7 +446,7 @@ irTerm top vs env tm@(App _ f a) = do
 
     applyToNames :: LExp -> [Name] -> LExp
     applyToNames tm [] = tm
-    applyToNames tm ns = LApp False tm $ map (LV . Glob) ns
+    applyToNames tm ns = LApp False tm $ map LV ns
 
     padLambdas :: [Int] -> Int -> Int -> ([Name] -> LExp) -> LExp
     padLambdas used startIdx endSIdx mkTerm
@@ -457,7 +457,7 @@ irTerm top vs env tm@(App _ f a) = do
 
     applyName :: Name -> IState -> [Term] -> Idris LExp
     applyName n ist args =
-        LApp False (LV $ Glob n) <$> mapM (irTerm top vs env . erase) (zip [0..] args)
+        LApp False (LV n) <$> mapM (irTerm top vs env . erase) (zip [0..] args)
       where
         erase (i, x)
             | i >= arity || i `elem` used = x
@@ -479,9 +479,9 @@ irTerm top vs env tm@(App _ f a) = do
         used = maybe [] (map fst . usedpos) $ lookupCtxtExact uName (idris_callgraph ist)
         fst4 (x,_,_,_,_,_) = x
 
-irTerm top vs env (P _ n _) = return $ LV (Glob n)
+irTerm top vs env (P _ n _) = return $ LV n
 irTerm top vs env (V i)
-    | i >= 0 && i < length env = return $ LV (Glob (env!!i))
+    | i >= 0 && i < length env = return $ LV (env!!i)
     | otherwise = ifail $ "bad de bruijn index: " ++ show i
 
 irTerm top vs env (Bind n (Lam _ _) sc) = LLam [n'] <$> irTerm top vs (n':env) sc
@@ -546,7 +546,7 @@ irSC top vs (ProjCase tm alts) = do
 irSC top vs (Case up n [ConCase (UN delay) i [_, _, n'] sc])
     | delay == txt "Delay"
     = do sc' <- irSC top vs sc -- mkForce n' n sc
-         return $ lsubst n' (LForce (LV (Glob n))) sc'
+         return $ lsubst n' (LForce (LV n)) sc'
 
 -- There are two transformations in this case:
 --
@@ -583,10 +583,10 @@ irSC top vs (Case up n [alt]) = do
     case replacement of
         Just sc -> irSC top vs sc
         _ -> do
-            alt' <- irAlt top vs (LV (Glob n)) alt
+            alt' <- irAlt top vs (LV n) alt
             return $ case namesBoundIn alt' `usedIn` subexpr alt' of
                 [] -> subexpr alt'  -- strip the unused top-most case
-                _  -> LCase up (LV (Glob n)) [alt']
+                _  -> LCase up (LV n) [alt']
   where
     namesBoundIn :: LAlt -> [Name]
     namesBoundIn (LConCase cn i ns sc) = ns
@@ -618,7 +618,7 @@ irSC top vs (Case up n alts@[ConCase cn a ns sc, DefaultCase sc']) = do
     detag <- fgetState (opt_detaggable . ist_optimisation cn)
     if detag
         then irSC top vs (Case up n [ConCase cn a ns sc])
-        else LCase up (LV (Glob n)) <$> mapM (irAlt top vs (LV (Glob n))) alts
+        else LCase up (LV n) <$> mapM (irAlt top vs (LV n)) alts
 
 irSC top vs sc@(Case up n alts) = do
     -- check that neither alternative needs the newtype optimisation,
@@ -628,7 +628,7 @@ irSC top vs sc@(Case up n alts) = do
         $ ifail ("irSC: non-trivial case-match on detaggable data: " ++ show sc)
 
     -- everything okay
-    LCase up (LV (Glob n)) <$> mapM (irAlt top vs (LV (Glob n))) alts
+    LCase up (LV n) <$> mapM (irAlt top vs (LV n)) alts
   where
     isDetaggable (ConCase cn _ _ _) = fgetState $ opt_detaggable . ist_optimisation cn
     isDetaggable  _                 = return False

--- a/src/IRTS/Defunctionalise.hs
+++ b/src/IRTS/Defunctionalise.hs
@@ -34,12 +34,12 @@ import Data.List
 import Data.Maybe
 import Debug.Trace
 
-data DExp = DV LVar
+data DExp = DV Name
           | DApp Bool Name [DExp] -- True = tail call
           | DLet Name DExp DExp -- name just for pretty printing
           | DUpdate Name DExp -- eval expression, then update var with it
           | DProj DExp Int
-          | DC (Maybe LVar) Int Name [DExp]
+          | DC (Maybe Name) Int Name [DExp]
           | DCase CaseType DExp [DAlt]
           | DChkCase DExp [DAlt] -- a case where the type is unknown (for EVAL/APPLY)
           | DConst Const
@@ -90,27 +90,27 @@ addApps defs (n, LFun _ _ args e)
          return (n, DFun n args e')
   where
     aa :: [Name] -> LExp -> State ([Name], [(Name, Int)]) DExp
-    aa env (LV (Glob n)) | n `elem` env = return $ DV (Glob n)
-                         | otherwise = aa env (LApp False (LV (Glob n)) [])
-    aa env (LApp tc (LV (Glob n)) args)
+    aa env (LV n) | n `elem` env = return $ DV n
+                         | otherwise = aa env (LApp False (LV n) [])
+    aa env (LApp tc (LV n) args)
        = do args' <- mapM (aa env) args
             case lookupCtxtExact n defs of
                 Just (LConstructor _ i ar) -> return $ DApp tc n args'
                 Just (LFun _ _ as _) -> let arity = length as in
                                                fixApply tc n args' arity
-                Nothing -> return $ chainAPPLY (DV (Glob n)) args'
+                Nothing -> return $ chainAPPLY (DV n) args'
     aa env (LLazyApp n args)
        = do args' <- mapM (aa env) args
             case lookupCtxtExact n defs of
                 Just (LConstructor _ i ar) -> return $ DApp False n args'
                 Just (LFun _ _ as _) -> let arity = length as in
                                            fixLazyApply n args' arity
-                Nothing -> return $ chainAPPLY (DV (Glob n)) args'
-    aa env (LForce (LLazyApp n args)) = aa env (LApp False (LV (Glob n)) args)
+                Nothing -> return $ chainAPPLY (DV n) args'
+    aa env (LForce (LLazyApp n args)) = aa env (LApp False (LV n) args)
     aa env (LForce e) = liftM eEVAL (aa env e)
     aa env (LLet n v sc) = liftM2 (DLet n) (aa env v) (aa (n : env) sc)
     aa env (LCon loc i n args) = liftM (DC loc i n) (mapM (aa env) args)
-    aa env (LProj t@(LV (Glob n)) i)
+    aa env (LProj t@(LV n) i)
         | n `elem` env = do t' <- aa env t
                             return $ DProj (DUpdate n t') i
     aa env (LProj t i) = do t' <- aa env t
@@ -170,7 +170,7 @@ addApps defs (n, LFun _ _ args e)
 
     preEval [] t = t
     preEval (x : xs) t
-       | needsEval x t = DLet x (DV (Glob x)) (preEval xs t)
+       | needsEval x t = DLet x (DV x) (preEval xs t)
        | otherwise = preEval xs t
 
     needsEval x (DApp _ _ args) = any (needsEval x) args
@@ -188,7 +188,7 @@ addApps defs (n, LFun _ _ args e)
           | otherwise = needsEval x v || needsEval x e
     needsEval x (DForeign _ _ args) = any (needsEval x) (map snd args)
     needsEval x (DOp op args) = any (needsEval x) args
-    needsEval x (DProj (DV (Glob x')) _) = x == x'
+    needsEval x (DProj (DV x') _) = x == x'
     needsEval x _ = False
 
 eEVAL x = DApp False (sMN 0 "EVAL") [x]
@@ -207,7 +207,7 @@ toCons ns (n, i)
           EvalCase (\tlarg ->
             (DConCase (-1) (mkFnCon n) (take i (genArgs 0))
               (dupdate tlarg
-                (DApp False n (map (DV . Glob) (take i (genArgs 0))))))))
+                (DApp False n (map DV (take i (genArgs 0))))))))
           : [] -- mkApplyCase n 0 i
     | otherwise = []
   where dupdate tlarg x = DUpdate tlarg x
@@ -219,7 +219,7 @@ toConsA ns (n, i)
 --           EvalCase (\tlarg ->
 --             (DConCase (-1) (mkFnCon n) (take i (genArgs 0))
 --               (dupdate tlarg
---                 (DApp False n (map (DV . Glob) (take i (genArgs 0))))))))
+--                 (DApp False n (map DV (take i (genArgs 0))))))))
           = mkApplyCase n ar i
     | otherwise = []
   where dupdate tlarg x = x
@@ -229,13 +229,13 @@ mkApplyCase fname n ar
         = let nm = mkUnderCon fname (ar - n) in
               (nm, n, ApplyCase (DConCase (-1) nm (take n (genArgs 0))
                   (DApp False (mkUnderCon fname (ar - (n + 1)))
-                       (map (DV . Glob) (take n (genArgs 0) ++
+                       (map DV (take n (genArgs 0) ++
                          [sMN 0 "arg"])))))
                             :
               if (ar - (n + 2) >=0 )
                  then (nm, n, Apply2Case (DConCase (-1) nm (take n (genArgs 0))
                       (DApp False (mkUnderCon fname (ar - (n + 2)))
-                       (map (DV . Glob) (take n (genArgs 0) ++
+                       (map DV (take n (genArgs 0) ++
                          [sMN 0 "arg0", sMN 0 "arg1"])))))
                             :
                             mkApplyCase fname (n + 1) ar
@@ -243,9 +243,9 @@ mkApplyCase fname n ar
 
 mkEval :: [(Name, Int, EvalApply DAlt)] -> (Name, DDecl)
 mkEval xs = (sMN 0 "EVAL", DFun (sMN 0 "EVAL") [sMN 0 "arg"]
-               (mkBigCase (sMN 0 "EVAL") 256 (DV (Glob (sMN 0 "arg")))
+               (mkBigCase (sMN 0 "EVAL") 256 (DV (sMN 0 "arg"))
                   (mapMaybe evalCase xs ++
-                      [DDefaultCase (DV (Glob (sMN 0 "arg")))])))
+                      [DDefaultCase (DV (sMN 0 "arg"))])))
   where
     evalCase (n, t, EvalCase x) = Just (x (sMN 0 "arg"))
     evalCase _ = Nothing
@@ -256,7 +256,7 @@ mkApply xs = (sMN 0 "APPLY", DFun (sMN 0 "APPLY") [sMN 0 "fn", sMN 0 "arg"]
                                 [] -> DNothing
                                 cases ->
                                     mkBigCase (sMN 0 "APPLY") 256
-                                               (DV (Glob (sMN 0 "fn")))
+                                               (DV (sMN 0 "fn"))
                                               (cases ++
                                     [DDefaultCase DNothing])))
   where
@@ -269,14 +269,14 @@ mkApply2 xs = (sMN 0 "APPLY2", DFun (sMN 0 "APPLY2") [sMN 0 "fn", sMN 0 "arg0", 
                                 [] -> DNothing
                                 cases ->
                                     mkBigCase (sMN 0 "APPLY") 256
-                                               (DV (Glob (sMN 0 "fn")))
+                                               (DV (sMN 0 "fn"))
                                               (cases ++
                                     [DDefaultCase
                                        (DApp False (sMN 0 "APPLY")
                                        [DApp False (sMN 0 "APPLY")
-                                              [DV (Glob (sMN 0 "fn")),
-                                               DV (Glob (sMN 0 "arg0"))],
-                                               DV (Glob (sMN 0 "arg1"))])
+                                              [DV (sMN 0 "fn"),
+                                               DV (sMN 0 "arg0")],
+                                               DV (sMN 0 "arg1")])
                                                ])))
   where
     applyCase (n, t, Apply2Case x) = Just x
@@ -297,8 +297,7 @@ mkUnderCon n missing = sMN missing ("U_" ++ show n)
 
 instance Show DExp where
    show e = show' [] e where
-     show' env (DV (Loc i)) = "var " ++ env!!i
-     show' env (DV (Glob n)) = "GLOB " ++ show n
+     show' env (DV n) = show n
      show' env (DApp _ e args) = show e ++ "(" ++
                                    showSep ", " (map (show' env) args) ++")"
      show' env (DLet n v e) = "let " ++ show n ++ " = " ++ show' env v ++ " in " ++

--- a/src/IRTS/JavaScript/Codegen.hs
+++ b/src/IRTS/JavaScript/Codegen.hs
@@ -345,15 +345,15 @@ cgBody rt expr =
     expr -> cgBody' rt expr
 
 cgBody' :: BodyResTarget -> LExp -> State CGBodyState ([JsStmt], JsStmt)
-cgBody' rt (LV (Glob n)) =
+cgBody' rt (LV n) =
   do
     argsFn <- getArgList n
     case argsFn of
-      Just a -> cgBody' rt (LApp False (LV (Glob n)) [])
+      Just a -> cgBody' rt (LApp False (LV n) [])
       Nothing -> do
         n' <- cgName n
         pure $ ([], addRT rt n')
-cgBody' rt (LApp tailcall (LV (Glob fn)) args) =
+cgBody' rt (LApp tailcall (LV fn) args) =
   do
     let fname = jsName fn
     st <- get
@@ -372,10 +372,10 @@ cgBody' rt (LApp tailcall (LV (Glob fn)) args) =
         app <- formApp fn argVals
         pure (preDecs, addRT rt app)
 
-cgBody' rt (LForce (LLazyApp n args)) = cgBody rt (LApp False (LV (Glob n)) args)
+cgBody' rt (LForce (LLazyApp n args)) = cgBody rt (LApp False (LV n) args)
 cgBody' rt (LLazyApp n args) =
   do
-    (d,v) <- cgBody ReturnBT (LApp False (LV (Glob n)) args)
+    (d,v) <- cgBody ReturnBT (LApp False (LV n) args)
     pure ([], addRT rt $ jsLazy $ jsStmt2Expr $ JsSeq (seqJs d) v)
 cgBody' rt (LForce e) =
   do

--- a/src/IRTS/JavaScript/LangTransforms.hs
+++ b/src/IRTS/JavaScript/LangTransforms.hs
@@ -57,7 +57,7 @@ mapMapListKeys f (t:r) x = mapMapListKeys f r $ Map.adjust f t x
 extractGlobs :: Map Name LDecl -> LDecl -> [Name]
 extractGlobs defs (LConstructor _ _ _) = []
 extractGlobs defs (LFun _ _ _ e) =
-  let f (LV (Glob x)) = Just x
+  let f (LV x) = Just x
       f (LLazyApp x _) = Just x
       f _ = Nothing
   in [x | Just x <- map f $ universe e, Map.member x defs]
@@ -102,7 +102,7 @@ globlToCon x =
   transformBi (f x) x
   where
     f :: Map Name LDecl -> LExp -> LExp
-    f y x@(LV (Glob n)) =
+    f y x@(LV n) =
       case Map.lookup n y of
         Just (LConstructor _ conId arity) -> LCon Nothing conId n []
         _ -> x

--- a/src/IRTS/Lang.hs
+++ b/src/IRTS/Lang.hs
@@ -28,7 +28,7 @@ data LVar = Loc Int | Glob Name
 
 -- ASSUMPTION: All variable bindings have unique names here
 -- Constructors commented as lifted are not present in the LIR provided to the different backends.
-data LExp = LV LVar
+data LExp = LV Name
           | LApp Bool LExp [LExp]    -- True = tail call
           | LLazyApp Name [LExp]     -- True = tail call
           | LLazyExp LExp            -- lifted out before compiling
@@ -36,7 +36,7 @@ data LExp = LV LVar
           | LLet Name LExp LExp      -- name just for pretty printing
           | LLam [Name] LExp         -- lambda, lifted out before compiling
           | LProj LExp Int           -- projection
-          | LCon (Maybe LVar)        -- Location to reallocate, if available
+          | LCon (Maybe Name)        -- Location to reallocate, if available
                  Int Name [LExp]
           | LCase CaseType LExp [LAlt]
           | LConst Const
@@ -168,13 +168,13 @@ addFn fn d = do LS n i ds <- get
 
 lift :: [Name] -> LExp -> State LiftState LExp
 lift env (LV v) = return (LV v) -- Lifting happens before these can exist...
-lift env (LApp tc (LV (Glob n)) args) = do args' <- mapM (lift env) args
-                                           return (LApp tc (LV (Glob n)) args')
+lift env (LApp tc (LV n) args) = do args' <- mapM (lift env) args
+                                    return (LApp tc (LV n) args')
 lift env (LApp tc f args) = do f' <- lift env f
                                fn <- getNextName
                                addFn fn (LFun [Inline] fn env f')
                                args' <- mapM (lift env) args
-                               return (LApp tc (LV (Glob fn)) (map (LV . Glob) env ++ args'))
+                               return (LApp tc (LV fn) (map LV env ++ args'))
 lift env (LLazyApp n args) = do args' <- mapM (lift env) args
                                 return (LLazyApp n args')
 lift env (LLazyExp (LConst c)) = return (LConst c)
@@ -184,7 +184,7 @@ lift env (LLazyExp e) = do e' <- lift env e
                            let usedArgs = nub $ usedIn env e'
                            fn <- getNextName
                            addFn fn (LFun [NoInline] fn usedArgs e')
-                           return (LLazyApp fn (map (LV . Glob) usedArgs))
+                           return (LLazyApp fn (map LV usedArgs))
 lift env (LForce e) = do e' <- lift env e
                          return (LForce e')
 lift env (LLet n v e) = do v' <- lift env v
@@ -194,7 +194,7 @@ lift env (LLam args e) = do e' <- lift (env ++ args) e
                             let usedArgs = nub $ usedIn env e'
                             fn <- getNextName
                             addFn fn (LFun [Inline] fn (usedArgs ++ args) e')
-                            return (LApp False (LV (Glob fn)) (map (LV . Glob) usedArgs))
+                            return (LApp False (LV fn) (map LV usedArgs))
 lift env (LProj t i) = do t' <- lift env t
                           return (LProj t' i)
 lift env (LCon loc i n args) = do args' <- mapM (lift env) args
@@ -229,11 +229,11 @@ allocUnique defs (n, LFun opts fn args e)
     -- Keep track of 'updatable' names in the state, i.e. names whose heap
     -- entry may be reused, along with the arity which was there
     findUp :: LExp -> State [(Name, Int)] LExp
-    findUp (LApp t (LV (Glob n)) as)
+    findUp (LApp t (LV n) as)
        | Just (LConstructor _ i ar) <- lookupCtxtExact n defs,
          ar == length as
           = findUp (LCon Nothing i n as)
-    findUp (LV (Glob n))
+    findUp (LV n)
        | Just (LConstructor _ i 0) <- lookupCtxtExact n defs
           = return $ LCon Nothing i n [] -- nullary cons are global, no need to update
     findUp (LApp t f as) = LApp t <$> findUp f <*> mapM findUp as
@@ -253,7 +253,7 @@ allocUnique defs (n, LFun opts fn args e)
            = LForeign t s <$> mapM (\ (t, e) -> do e' <- findUp e
                                                    return (t, e')) es
     findUp (LOp o es) = LOp o <$> mapM findUp es
-    findUp (LCase Updatable e@(LV (Glob n)) as)
+    findUp (LCase Updatable e@(LV n) as)
            = LCase Updatable e <$> mapM (doUpAlt n) as
     findUp (LCase t e as)
            = LCase t <$> findUp e <*> mapM findUpAlt as
@@ -277,7 +277,7 @@ allocUnique defs (n, LFun opts fn args e)
 
     findVar _ [] i = return Nothing
     findVar acc ((n, l) : ns) i | l == i = do put (reverse acc ++ ns)
-                                              return (Just (Glob n))
+                                              return (Just n)
     findVar acc (n : ns) i = findVar (n : acc) ns i
 
 
@@ -287,7 +287,7 @@ usedArg env n | n `elem` env = [n]
               | otherwise = []
 
 usedIn :: [Name] -> LExp -> [Name]
-usedIn env (LV (Glob n)) = usedArg env n
+usedIn env (LV n) = usedArg env n
 usedIn env (LApp _ e args) = usedIn env e ++ concatMap (usedIn env) args
 usedIn env (LLazyApp n args) = concatMap (usedIn env) args ++ usedArg env n
 usedIn env (LLazyExp e) = usedIn env e
@@ -297,7 +297,7 @@ usedIn env (LLam ns e) = usedIn (env \\ ns) e
 usedIn env (LCon v i n args) = let rest = concatMap (usedIn env) args in
                                    case v of
                                       Nothing -> rest
-                                      Just (Glob n) -> usedArg env n ++ rest
+                                      Just n -> usedArg env n ++ rest
 usedIn env (LProj t i) = usedIn env t
 usedIn env (LCase up e alts) = usedIn env e ++ concatMap (usedInA env) alts
   where usedInA env (LConCase i n ns e) = usedIn env e
@@ -308,7 +308,7 @@ usedIn env (LOp f args) = concatMap (usedIn env) args
 usedIn env _ = []
 
 lsubst :: Name -> LExp -> LExp -> LExp
-lsubst n new (LV (Glob x)) | n == x = new
+lsubst n new (LV x) | n == x = new
 lsubst n new (LApp t e args) = let e' = lsubst n new e
                                    args' = map (lsubst n new) args in
                                    LApp t e' args'
@@ -333,8 +333,7 @@ lsubst n new tm = tm
 
 instance Show LExp where
    show e = show' [] "" e where
-     show' env ind (LV (Loc i)) = env!!i
-     show' env ind (LV (Glob n)) = show n
+     show' env ind (LV n) = show n
 
      show' env ind (LLazyApp e args)
         = show e ++ "|(" ++ showSep ", " (map (show' env ind) args) ++")"

--- a/src/IRTS/Simplified.hs
+++ b/src/IRTS/Simplified.hs
@@ -53,8 +53,7 @@ ldefs = do (l, h) <- get
 -- The boolean parameter indicates whether the expression is at tail
 -- call position.
 simplify :: Bool -> DExp -> State (DDefs, Int) SExp
-simplify tl (DV (Loc i)) = return (SV (Loc i))
-simplify tl (DV (Glob x))
+simplify tl (DV x)
     = do ctxt <- ldefs
          case lookupCtxtExact x ctxt of
               Just (DConstructor _ t 0) -> return $ SCon Nothing t x []
@@ -68,7 +67,7 @@ simplify tl (DLet n v e) = do v' <- simplify False v
                               return (SLet (Glob n) v' e')
 simplify tl (DUpdate n e) = do e' <- simplify False e
                                return (SUpdate (Glob n) e')
-simplify tl (DC loc i n args) = bindExprs args (SCon loc i n)
+simplify tl (DC loc i n args) = bindExprs args (SCon (Glob <$> loc) i n)
 simplify tl (DProj t i) = bindExpr t (\var -> SProj var i)
 simplify tl (DCase up e alts)
     = do alts' <- mapM (sAlt tl) alts
@@ -97,12 +96,11 @@ bindExpr :: DExp -> (LVar -> SExp) -> State (DDefs, Int) SExp
 bindExpr e f = bindExprM e (return . f)
 
 bindExprM :: DExp -> (LVar -> State (DDefs, Int) SExp) -> State (DDefs, Int) SExp
-bindExprM (DV (Glob x)) f
+bindExprM (DV x) f
     = do ctxt <- ldefs
          case lookupCtxtExact x ctxt of
               Just (DConstructor _ t 0) -> bindExprM (DC Nothing t x []) f
               _ -> f (Glob x)
-bindExprM (DV var) f = f var
 bindExprM e f =
     do e' <- simplify False e
        var <- freshVar


### PR DESCRIPTION
`LV` and `DB` were always called with a `Glob` construtor for the `LVar` datatype. We eliminate this indirection.