### PR TITLE
Drop support for GHC <= 7.8.4, Cabal <= 1.20

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -14,12 +14,6 @@ matrix:
     - os: osx
       env: CABALVER="1.24" GHCVER="8.0.1" TESTS="test_c"
       compiler: ": #GHC 8.0.1"
-    - env: CABALVER="1.20" GHCVER="7.6.3" TESTS="test_c"
-      compiler: ": #GHC 7.6.3"
-      addons: {apt: {packages: [cabal-install-1.20,ghc-7.6.3,cppcheck,hscolour], sources: [hvr-ghc]}}
-    - env: CABALVER="1.20" GHCVER="7.8.4" TESTS="test_c"
-      compiler: ": #GHC 7.8.4"
-      addons: {apt: {packages: [cabal-install-1.20,ghc-7.8.4,cppcheck,hscolour], sources: [hvr-ghc]}}
     - env: CABALVER="1.22" GHCVER="7.10.3" TESTS="lib_doc doc"
       compiler: ": #GHC 7.10.3"
       addons: {apt: {packages: [cabal-install-1.22,ghc-7.10.3,cppcheck,hscolour], sources: [hvr-ghc]}}

--- a/Setup.hs
+++ b/Setup.hs
@@ -274,26 +274,15 @@ idrisInstall verbosity copy pkg local = unless (execOnly (configFlags local)) $ 
 -- -----------------------------------------------------------------------------
 -- Test
 
--- FIXME: We use the __GLASGOW_HASKELL__ macro because MIN_VERSION_cabal seems
--- to be broken !
-
 -- There are two "dataDir" in cabal, and they don't relate to each other.
 -- When fetching modules, idris uses the second path (in the pkg record),
 -- which by default is the root folder of the project.
 -- We want it to be the install directory where we put the idris libraries.
 fixPkg pkg target = pkg { dataDir = target }
 
--- The "Args" argument of the testHooks has been added in cabal 1.22.0,
--- and should therefore be ignored for prior versions.
-#if __GLASGOW_HASKELL__ < 710
-originalTestHook _ = testHook simpleUserHooks
-#else
-originalTestHook = testHook simpleUserHooks
-#endif
-
 idrisTestHook args pkg local hooks flags = do
   let target = datadir $ L.absoluteInstallDirs pkg local NoCopyDest
-  originalTestHook args (fixPkg pkg target) local hooks flags
+  testHook simpleUserHooks args (fixPkg pkg target) local hooks flags
 
 -- -----------------------------------------------------------------------------
 -- Main
@@ -314,9 +303,5 @@ main = defaultMainWithHooks $ simpleUserHooks
    , preSDist = idrisPreSDist
    , sDistHook = idrisSDist (sDistHook simpleUserHooks)
    , postSDist = idrisPostSDist
-#if __GLASGOW_HASKELL__ < 710
-   , testHook = idrisTestHook ()
-#else
    , testHook = idrisTestHook
-#endif
    }

--- a/idris.cabal
+++ b/idris.cabal
@@ -279,7 +279,7 @@ Library
                 , ieee754 >= 0.7 && <= 0.8.0
                 , mtl >= 2.1 && < 2.3
                 , network < 2.7
-                , optparse-applicative >= 0.11 && < 0.14
+                , optparse-applicative >= 0.13 && < 0.14
                 , parsers >= 0.9 && < 0.13
                 , pretty < 1.2
                 , regex-tdfa >= 1.2

--- a/src/Idris/CmdOptions.hs
+++ b/src/Idris/CmdOptions.hs
@@ -28,9 +28,7 @@ import Control.Monad.Trans.Except (throwE)
 import Control.Monad.Trans.Reader (ask)
 import Data.Char
 import Data.Maybe
-#if MIN_VERSION_optparse_applicative(0,13,0)
 import Data.Monoid ((<>))
-#endif
 import Options.Applicative
 import Options.Applicative.Arrows
 import Options.Applicative.Types (ReadM(..))

--- a/src/Idris/Package/Parser.hs
+++ b/src/Idris/Package/Parser.hs
@@ -6,9 +6,6 @@ License     : BSD3
 Maintainer  : The Idris Community.
 -}
 {-# LANGUAGE CPP, ConstraintKinds #-}
-#if !(MIN_VERSION_base(4,8,0))
-{-# LANGUAGE OverlappingInstances #-}
-#endif
 module Idris.Package.Parser where
 
 import Idris.AbsSyntaxTree
@@ -50,11 +47,7 @@ instance {-# OVERLAPPING #-} DeltaParsing PParser where
   {-# INLINE restOfLine #-}
 #endif
 
-#if MIN_VERSION_base(4,8,0)
 instance {-# OVERLAPPING #-} TokenParsing PParser where
-#else
-instance TokenParsing PParser where
-#endif
   someSpace = many (simpleWhiteSpace <|> singleLineComment <|> multiLineComment) *> pure ()
 
 

--- a/src/Idris/Parser/Helpers.hs
+++ b/src/Idris/Parser/Helpers.hs
@@ -7,9 +7,6 @@ Maintainer  : The Idris Community.
 -}
 {-# LANGUAGE CPP, ConstraintKinds, GeneralizedNewtypeDeriving, PatternGuards,
              StandaloneDeriving #-}
-#if !(MIN_VERSION_base(4,8,0))
-{-# LANGUAGE OverlappingInstances #-}
-#endif
 module Idris.Parser.Helpers where
 
 import Idris.AbsSyntax
@@ -69,11 +66,7 @@ instance {-# OVERLAPPING #-} DeltaParsing IdrisParser where
 
 #endif
 
-#if MIN_VERSION_base(4,8,0)
 instance {-# OVERLAPPING #-} TokenParsing IdrisParser where
-#else
-instance TokenParsing IdrisParser where
-#endif
   someSpace = many (simpleWhiteSpace <|> singleLineComment <|> multiLineComment) *> pure ()
   token p = do s <- get
                (FC fn (sl, sc) _) <- getFC --TODO: Update after fixing getFC

--- a/src/Idris/Reflection.hs
+++ b/src/Idris/Reflection.hs
@@ -21,11 +21,6 @@ import Idris.AbsSyntaxTree (ArgOpt(..), ElabD, Fixity(..), IState(idris_datatype
                             initEState, pairCon, pairTy)
 import Idris.Delaborate (delab)
 
-#if __GLASGOW_HASKELL__ < 710
-import Control.Applicative (pure, (<$>), (<*>))
-import Data.Traversable (mapM)
-import Prelude hiding (mapM)
-#endif
 import Control.Monad (liftM, liftM2, liftM4)
 import Control.Monad.State.Strict (lift)
 import Data.List (findIndex, (\\))

--- a/test/TestRun.hs
+++ b/test/TestRun.hs
@@ -7,9 +7,7 @@ import Control.Monad
 import Data.Char (isLetter)
 import qualified Data.IntMap as IMap
 import Data.List
-#if MIN_VERSION_optparse_applicative(0,13,0)
 import Data.Monoid ((<>))
-#endif
 import Data.Proxy
 import Data.Typeable
 import Options.Applicative


### PR DESCRIPTION
Closes  #3918.

Also upgrades `optparse-applicative` so that we can remove conditional compilation.