### PR TITLE
Fix code typo in "Composing State Machines" documentation

### DIFF
--- a/docs/st/composing.rst
+++ b/docs/st/composing.rst
@@ -437,7 +437,7 @@ using the SDL bindings as follows:
 
 .. code-block:: idris
 
-  interface Draw IO where
+  implementation Draw IO where
     Surface = State SDLSurface
 
     initWindow x y = do Just srf <- lift (startSDL x y)


### PR DESCRIPTION
Really enjoying this tutorial btw - thanks!