### PR TITLE
Add notLTImpliesGTE to Prelude

### DIFF
--- a/libs/prelude/Prelude/Nat.idr
+++ b/libs/prelude/Prelude/Nat.idr
@@ -160,6 +160,11 @@ lteAddRight : (n : Nat) -> LTE n (plus n m)
 lteAddRight Z = LTEZero
 lteAddRight (S k) = LTESucc (lteAddRight k)
 
+||| If a number is not less than another, it is greater than or equal to it
+ifNotLtThenGte : Not (LT a b) -> GTE a b
+ifNotLtThenGte {b = Z} _ = LTEZero
+ifNotLtThenGte {a = Z} {b = S k} notLt = absurd (notLt (LTESucc LTEZero))
+ifNotLtThenGte {a = S k} {b = S j} notLt = LTESucc (ifNotLtThenGte (notLt . LTESucc))
 
 ||| Boolean test than one Nat is less than or equal to another
 total lte : Nat -> Nat -> Bool

--- a/libs/prelude/Prelude/Nat.idr
+++ b/libs/prelude/Prelude/Nat.idr
@@ -161,10 +161,10 @@ lteAddRight Z = LTEZero
 lteAddRight (S k) = LTESucc (lteAddRight k)
 
 ||| If a number is not less than another, it is greater than or equal to it
-ifNotLtThenGte : Not (LT a b) -> GTE a b
-ifNotLtThenGte {b = Z} _ = LTEZero
-ifNotLtThenGte {a = Z} {b = S k} notLt = absurd (notLt (LTESucc LTEZero))
-ifNotLtThenGte {a = S k} {b = S j} notLt = LTESucc (ifNotLtThenGte (notLt . LTESucc))
+notLTImpliesGTE : Not (LT a b) -> GTE a b
+notLTImpliesGTE {b = Z} _ = LTEZero
+notLTImpliesGTE {a = Z} {b = S k} notLt = absurd (notLt (LTESucc LTEZero))
+notLTImpliesGTE {a = S k} {b = S j} notLt = LTESucc (notLTImpliesGTE (notLt . LTESucc))
 
 ||| Boolean test than one Nat is less than or equal to another
 total lte : Nat -> Nat -> Bool


### PR DESCRIPTION
Adds a proof that `Not (LT a b)` implies `GTE a b` to the Prelude. I needed this step in proofs more than once and I think it is useful enough for being in the standard library.

Let me know if you prefer it somewhere else or if you prefer some arguments implicit or explicit :)
