### PR TITLE
Implement shebang handling

### DIFF
--- a/scripts/runidris
+++ b/scripts/runidris
@@ -1,0 +1,18 @@
+#!/bin/sh
+
+# This is a script that runs an idris program, suitable for use
+# in a shebang line. We cache the executables by naming them after
+# the SHA hash of the idris source and looking for it before
+# compiling
+RUNIDRIS_DIR="${TEMP:-/tmp}/runidris"
+if [ ! -d $RUNIDRIS_DIR ]; then
+    mkdir $RUNIDRIS_DIR
+    chmod 700 $RUNIDRIS_DIR
+fi
+TEMP_NAME="runidris-`sha1sum $1 | cut -c1-40`"
+FP="$RUNIDRIS_DIR/$TEMP_NAME"
+if [ ! -e $FP ]; then
+    "${IDRIS:-idris}" $1 --ibcsubdir "$RUNIDRIS_DIR" -i "." -o $FP
+fi
+shift
+"$FP" "$@"

--- a/scripts/runidris-node
+++ b/scripts/runidris-node
@@ -1,0 +1,18 @@
+#!/bin/sh
+
+# This is a script that runs an idris program, suitable for use
+# in a shebang line. We cache the executables by naming them after
+# the SHA hash of the idris source and looking for it before
+# compiling. This is the node version.
+RUNIDRIS_DIR="${TEMP:-/tmp}/runidris-node"
+if [ ! -d $RUNIDRIS_DIR ]; then
+    mkdir $RUNIDRIS_DIR
+    chmod 700 $RUNIDRIS_DIR
+fi
+TEMP_NAME="runidris-`sha1sum $1 | cut -c1-40`.js"
+FP="$RUNIDRIS_DIR/$TEMP_NAME"
+if [ ! -e $FP ]; then
+    "${IDRIS:-idris}" --codegen node --ibcsubdir "$RUNIDRIS_DIR" -i "." $1 -o $FP
+fi
+shift
+node "$FP" "$@"

--- a/src/Idris/Parser.hs
+++ b/src/Idris/Parser.hs
@@ -1569,7 +1569,8 @@ parseImports fname input
                                  [ImportInfo],
                                  Maybe Delta),
                                 [(FC, OutputAnnotation)], IState)
-        imports = do whiteSpace
+        imports = do optional shebang
+                     whiteSpace
                      (mdoc, mname, annots) <- moduleHeader
                      ps_exp        <- many import_
                      mrk           <- mark
@@ -1593,6 +1594,9 @@ parseImports fname input
         addPath ((fc, AnnNamespace ns Nothing) : annots) path =
            (fc, AnnNamespace ns (Just path)) : addPath annots path
         addPath (annot:annots) path = annot : addPath annots path
+
+        shebang :: IdrisParser ()
+        shebang = string "#!" *> many (satisfy $ not . isEol) *> eol *> pure ()
 
 -- | There should be a better way of doing this...
 findFC :: Doc -> (FC, String)

--- a/test/interactive017/TestMod.idr
+++ b/test/interactive017/TestMod.idr
@@ -1,0 +1,5 @@
+module TestMod
+
+export
+test : IO ()
+test = putStrLn "Hello from a module"

--- a/test/interactive017/expected
+++ b/test/interactive017/expected
@@ -1,0 +1,7 @@
+hello from C
+hello from C
+hello from node
+hello from node
+Hello ["aaa"]
+Hello ["bbb", "aaa"]
+Hello from a module

--- a/test/interactive017/run
+++ b/test/interactive017/run
@@ -1,0 +1,9 @@
+#!/bin/sh
+PATH="../../scripts:$PATH"
+./shebang.idr
+./shebang.idr
+./shebang-node.idr
+./shebang-node.idr
+./shebang-args.idr aaa
+./shebang-args.idr bbb aaa
+./shebang-import.idr

--- a/test/interactive017/shebang-args.idr
+++ b/test/interactive017/shebang-args.idr
@@ -1,0 +1,6 @@
+#!/usr/bin/env runidris
+
+main : IO () 
+main = do
+    args <- getArgs
+    putStrLn $ "Hello " ++ (show $ drop 1 args) 

--- a/test/interactive017/shebang-import.idr
+++ b/test/interactive017/shebang-import.idr
@@ -1,0 +1,6 @@
+#!/usr/bin/env runidris
+
+import TestMod
+
+main : IO ()
+main = TestMod.test

--- a/test/interactive017/shebang-node.idr
+++ b/test/interactive017/shebang-node.idr
@@ -1,0 +1,4 @@
+#!/usr/bin/env runidris-node
+
+main : IO ()
+main = putStrLn "hello from node"

--- a/test/interactive017/shebang.idr
+++ b/test/interactive017/shebang.idr
@@ -1,0 +1,4 @@
+#!/usr/bin/env runidris
+
+main : IO ()
+main = putStrLn "hello from C"


### PR DESCRIPTION
Add two scripts for running idris programs with the C and node backends and adds a test.

Fixes #2247 

Implementation cribbed from #2289