### PR TITLE
A revised Idris port of the Wadler-Leijen pretty-printer.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,9 @@
 
 ## Library Updates
 
++ Added `Text.PrettyPrint.WL` an implementation of the Wadler-Leijen
+  Pretty-Print algorithm.  Useful for those wishing to pretty print
+  things.
 + Added `Text.Lexer` and `Text.Parser` to `contrib`. These are small libraries
   for implementing total lexical analysers and parsers.
 + New instances:

--- a/libs/contrib/Text/PrettyPrint/WL.idr
+++ b/libs/contrib/Text/PrettyPrint/WL.idr
@@ -1,0 +1,18 @@
+||| A revised Idris port of the Wadler-Leijen pretty-printer.
+|||
+||| This port of the Wadler-Leijen Pretty-Printer is based upon the
+||| port originally created by Shayan Najd [1]. We have changed the
+||| render function to be total using a technique based on
+||| continuations proposed by gallais [2], and fix minor errors in the
+||| original Idris port.
+|||
+||| [1] https://github.com/shayan-najd/wl-pprint
+||| [2] https://gallais.github.io/blog/termination-tricks.html
+module Text.PrettyPrint.WL
+
+import public Text.PrettyPrint.WL.Core
+import public Text.PrettyPrint.WL.Characters
+import public Text.PrettyPrint.WL.Combinators
+
+%default total
+%access export

--- a/libs/contrib/Text/PrettyPrint/WL/Characters.idr
+++ b/libs/contrib/Text/PrettyPrint/WL/Characters.idr
@@ -1,0 +1,103 @@
+||| Commonly used characters
+module Text.PrettyPrint.WL.Characters
+
+import Text.PrettyPrint.WL.Core
+
+%default total
+%access export
+
+lparen : Doc
+lparen = char '('
+
+rparen : Doc
+rparen = char ')'
+
+langle : Doc
+langle = char '<'
+
+rangle : Doc
+rangle = char '>'
+
+lbrace : Doc
+lbrace = char '{'
+
+rbrace : Doc
+rbrace = char '}'
+
+lbracket : Doc
+lbracket = char '['
+
+rbracket : Doc
+rbracket = char ']'
+
+squote : Doc
+squote = char '\''
+
+dquote : Doc
+dquote = char '"'
+
+semi : Doc
+semi = char ';'
+
+colon : Doc
+colon = char ':'
+
+comma : Doc
+comma = char ','
+
+space : Doc
+space = char ' '
+
+dot : Doc
+dot = char '.'
+
+backslash : Doc
+backslash = char '\\'
+
+forwardslash : Doc
+forwardslash = char '/'
+
+equals : Doc
+equals = char '='
+
+pipe : Doc
+pipe = char '|'
+
+bang : Doc
+bang = char '!'
+
+tick : Doc
+tick = char '`'
+
+tilda : Doc
+tilda = char '~'
+
+hash : Doc
+hash = char '#'
+
+asterix : Doc
+asterix = char '*'
+
+ampersand : Doc
+ampersand = char '&'
+
+dash : Doc
+dash = char '-'
+
+question : Doc
+question = char '?'
+
+dollar : Doc
+dollar = char '$'
+
+pound : Doc
+pound = char '£'
+
+euro : Doc
+euro = char '€'
+
+caret : Doc
+caret = char '^'
+
+percent : Doc
+percent = char '%'

--- a/libs/contrib/Text/PrettyPrint/WL/Combinators.idr
+++ b/libs/contrib/Text/PrettyPrint/WL/Combinators.idr
@@ -1,0 +1,259 @@
+||| Common combinators.
+module Text.PrettyPrint.WL.Combinators
+
+import Text.PrettyPrint.WL.Core
+import Text.PrettyPrint.WL.Characters
+
+%default total
+%access export
+
+-- --------------------------------------------------- [ Alignment Combinators ]
+
+||| The document `(align x)` renders document `x` with the nesting
+||| level set to the current column. It is used for example to
+||| implement 'hang'.
+align : Doc -> Doc
+align d = column (\k => nesting (\i => nest (k - i) d))
+
+||| The hang combinator implements hanging indentation. The document
+||| `(hang i x)` renders document `x` with a nesting level set to the
+||| current column plus `i`.
+hang : Int -> Doc -> Doc
+hang i d = align (nest i d)
+
+||| The document `(indent i x)` indents document `x` with `i` spaces.
+indent : Int -> Doc -> Doc
+indent i d = hang i (text (spaces i) <+> d)
+
+-- -------------------------------------------------- [ High-Level Combinators ]
+
+||| The document `softLine` behaves like `space` if the resulting
+||| output fits the page, otherwise it behaves like `line`.
+softLine : Doc
+softLine = group line
+
+||| The document `softbreak` behaves like `empty` if the resulting
+||| output fits the page, otherwise it behaves like 'line'.
+softBreak : Doc
+softBreak = group breakLine
+
+infixr 5 |/|, |//|, |$|, |$$|
+infixr 6 |+|, |++|
+
+private
+concatDoc : Doc -> Doc -> Doc -> Doc
+concatDoc sep x y = x `beside` (sep `beside` y)
+
+||| The document `(x |+| y)` concatenates document `x` and document
+||| `y`. It is an associative operation having 'empty' as a left and
+||| right unit.
+(|+|) : Doc -> Doc -> Doc
+(|+|) = (<+>)
+
+||| The document `(x |++| y)` concatenates document `x` and `y` with a
+||| `space` in between.
+(|++|) : Doc -> Doc -> Doc
+(|++|) = concatDoc space
+
+||| The document `(x |/| y)` concatenates document `x` and `y` with a
+||| 'softline' in between. This effectively puts `x` and `y` either
+||| next to each other (with a `space` in between) or underneath each
+||| other.
+(|/|) : Doc -> Doc -> Doc
+(|/|) = concatDoc softLine
+
+||| The document `(x |//| y)` concatenates document `x` and `y` with
+||| a 'softbreak' in between. This effectively puts `x` and `y` either
+||| right next to each other or underneath each other.
+(|//|) : Doc -> Doc -> Doc
+(|//|) = concatDoc softBreak
+
+||| The document `(x |$| y)` concatenates document `x` and `y` with a
+||| `line` in between.
+(|$|) : Doc -> Doc -> Doc
+(|$|) = concatDoc line
+
+||| The document `(x |$$| y)` concatenates document `x` and `y` with
+||| a `linebreak` in between.
+(|$$|) : Doc -> Doc -> Doc
+(|$$|) = concatDoc breakLine
+
+||| The document `(vsep xs)` concatenates all documents `xs`
+||| vertically with `(|$|)`. If a 'group' undoes the line breaks
+||| inserted by `vsep`, all documents are separated with a space.
+vsep : List Doc -> Doc
+vsep = fold (|$|)
+
+||| The document `(sep xs)` concatenates all documents `xs` either
+||| horizontally with `(|++|)`, if it fits the page, or vertically with
+||| `(|$|)`.
+sep : List Doc -> Doc
+sep = group . vsep
+
+
+||| The document `(fillSep xs)` concatenates documents `xs`
+||| horizontally with `(|++|)` as long as its fits the page, than
+||| inserts a `line` and continues doing that for all documents in
+||| `xs`.
+fillSep : List Doc -> Doc
+fillSep = fold (|/|)
+
+||| The document `(hsep xs)` concatenates all documents `xs`
+||| horizontally with `(|++|)`.
+hsep : List Doc -> Doc
+hsep = fold (|++|)
+
+||| The document `(hcat xs)` concatenates all documents `xs`
+||| horizontally with `(|+|)`.
+hcat : List Doc -> Doc
+hcat = fold (<+>)
+
+||| The document `(vcat xs)` concatenates all documents `xs`
+||| vertically with `(|$$|)`. If a `group` undoes the line breaks
+||| inserted by `vcat`, all documents are directly concatenated.
+vcat : List Doc -> Doc
+vcat = fold (|$$|)
+
+||| The document `(cat xs)` concatenates all documents `xs` either
+||| horizontally with `(|+|)`, if it fits the page, or vertically with
+||| `(|$$|)`.
+cat : List Doc -> Doc
+cat = group . vcat
+
+||| The document `(fillCat xs)` concatenates documents `xs`
+||| horizontally with `(|+|)` as long as its fits the page, than inserts
+||| a `linebreak` and continues doing that for all documents in `xs`.
+fillCat : List Doc -> Doc
+fillCat = fold (|//|)
+
+||| The document `(enclose l r x)` encloses document `x` between
+||| documents `l` and `r` using `(|+|)`.
+enclose : Doc -> Doc -> Doc -> Doc
+enclose l r x = concatDoc x l r
+
+squotes : Doc -> Doc
+squotes = enclose squote squote
+
+dquotes : Doc -> Doc
+dquotes = enclose dquote dquote
+
+braces : Doc -> Doc
+braces = enclose lbrace rbrace
+
+parens : Doc -> Doc
+parens = enclose lparen rparen
+
+angles : Doc -> Doc
+angles = enclose langle rangle
+
+brackets : Doc -> Doc
+brackets = enclose lbracket rbracket
+
+-- ----------------------------------------------------- [ Lists, Sets, Tuples ]
+
+||| The document `(encloseSep l r sep xs)` concatenates the documents
+||| `xs` separated by `sep` and encloses the resulting document by `l`
+||| and `r`. The documents are rendered horizontally if that fits the
+||| page. Otherwise they are aligned vertically. All separators are put
+||| in front of the elements.
+encloseSep : (l   : Doc)
+          -> (r   : Doc)
+          -> (sep : Doc)
+          -> (xs  : List Doc)
+          -> Doc
+encloseSep l r s []  = l <+> r
+encloseSep l r s [x] = l <+> x <+> r
+encloseSep l r s xs  = align (cat (zipWith (<+>) (l :: replicate (length xs) s) xs) <+> r)
+
+||| The document `(list xs)` comma separates the documents `xs` and
+||| encloses them in square brackets. The documents are rendered
+||| horizontally if that fits the page. Otherwise they are aligned
+||| vertically. All comma separators are put in front of the
+||| elements.
+list : List Doc -> Doc
+list = encloseSep lbracket rbracket comma
+
+||| The document `(tupled xs)` comma separates the documents `xs`
+||| and encloses them in parenthesis. The documents are rendered
+||| horizontally if that fits the page. Otherwise they are aligned
+||| vertically. All comma separators are put in front of the
+||| elements.
+tupled : List Doc -> Doc
+tupled = encloseSep lparen rparen comma
+
+||| The document `(set xs)` separates the documents `xs` with
+||| commas and encloses them in braces. The documents are
+||| rendered horizontally if that fits the page. Otherwise they are
+||| aligned vertically. All comma's are put in front of the
+||| elements.
+set : List Doc -> Doc
+set = encloseSep lbrace rbrace comma
+
+||| The document `(semiBraces xs)` separates the documents `xs` with
+||| semi-colon and encloses them in braces. The documents are
+||| rendered horizontally if that fits the page. Otherwise they are
+||| aligned vertically. All semi-colons's are put in front of the
+||| elements.
+semiBrace : List Doc -> Doc
+semiBrace = encloseSep lbrace rbrace semi
+
+||| `(punctuate p xs)` concatenates all documents in `xs` with
+||| document `p` except for the last document.
+punctuate : Doc -> List Doc -> List Doc
+punctuate p []  = []
+punctuate p [x] = [x]
+punctuate p (x :: xs) = (x <+> p) :: punctuate p xs
+
+-- ------------------------------------------------------------------- [ Fills ]
+
+width : Doc -> (Int -> Doc) -> Doc
+width doc f = column (\k => doc <+> column (\k' => f (k' - k)))
+
+||| The document `(fillBreak i x)` first renders document `x`. It
+||| than appends `space`s until the width is equal to `i`. If the
+||| width of `x` is already larger than `i`, the nesting level is
+||| increased by `i` and a `line` is appended.
+fillBreak : (i : Int) -> (x : Doc) -> Doc
+fillBreak f x =
+  width x (\w => if (w > f)
+                  then nest f breakLine
+                  else text (spaces (f - w)))
+
+||| The document `(fill i x)` renders document `x`. It than appends
+||| `space`s until the width is equal to `i`. If the width of `x` is
+||| already larger, nothing is appended. This combinator is quite
+||| useful in practice to output a list of bindings.
+fill : (i : Int) -> (x : Doc) -> Doc
+fill f d =
+  width d (\w => if (w >= f)
+                    then empty
+                    else text (spaces (f - w)))
+
+-- -------------------------------------------------------------- [ Primatives ]
+
+||| The document `(literal s)` concatenates all characters in `s`
+||| using `line` for newline characters and `char` for all other
+||| characters. It is used instead of 'text' whenever the text contains
+||| newline characters.
+literal : (str : String) -> Doc
+literal str = mkLiteral (unpack str)
+  where
+    mkLiteral : List Char -> Doc
+    mkLiteral Nil         = empty
+    mkLiteral ('\n':: ss) = line <+> mkLiteral ss
+    mkLiteral (c :: ss)   = char c <+> mkLiteral ss
+
+bool : Bool -> Doc
+bool b = text (show b)
+
+nat : Nat -> Doc
+nat n = text (show n)
+
+int : Int -> Doc
+int i = text (show i)
+
+integer : Integer -> Doc
+integer i = text (show i)
+
+double : Double -> Doc
+double d = text (show d)

--- a/libs/contrib/Text/PrettyPrint/WL/Core.idr
+++ b/libs/contrib/Text/PrettyPrint/WL/Core.idr
@@ -1,0 +1,225 @@
+||| Core definitions and primitives.
+module Text.PrettyPrint.WL.Core
+
+%default total
+%access export
+
+-- -------------------------------------------------------------------- [ Core ]
+
+||| The abstract data type `Doc` represents pretty documents.
+|||
+data Doc : Type where
+  Empty : Doc
+  Chara : (c : Char) -> Doc
+  Text  : (len : Int) -> (str : String) -> Doc
+  Line : (undone : Bool) -> Doc
+
+  Cat     : (x : Doc) -> (y : Doc) -> Doc
+  Nest    : (lvl : Int) -> (x : Doc) -> Doc
+  Union   : (x : Doc) -> (y : Doc) -> Doc
+
+  Column  : (f : Int -> Doc) -> Doc
+  Nesting : (f : Int -> Doc) -> Doc
+
+-- -------------------------------------------------------------- [ Primitives ]
+
+||| The empty document is, indeed, empty.
+empty : Doc
+empty = Empty
+
+||| The `line` document advances to the next line and indents to the
+||| current nesting level. Document `line` behaves like `(text " ")`
+||| if the line break is undone by 'group'.
+line : Doc
+line = Line False
+
+||| The document `(char c)` contains the literal character `c`. If the
+||| character is a newline (`'\n'`) the function returns a line
+||| document. Ideally, the function 'line' should be used for line
+||| breaks.
+char : (c : Char) -> Doc
+char '\n' = line
+char c    = Chara c
+
+||| The document `(text s)` contains the literal string `s`. The
+||| string shouldn't contain any newline (`'\n'`) characters. If the
+||| string contains newline characters, the function 'literal' should be
+||| used.
+text : (str : String) -> Doc
+text ""  = empty
+text str = Text (cast $ length str) str
+
+||| The `breakLine` document advances to the next line and indents to
+||| the current nesting level. Document `breakLine` behaves like
+||| 'empty' if the line break is undone by 'group'.
+breakLine : Doc
+breakLine = Line True
+
+||| Horizontal concatenation of documents
+beside : Doc -> Doc -> Doc
+beside = Cat
+
+||| The document `(nest lvl x)` renders document `x` with the current
+||| indentation level increased by lvl.
+nest : (lvl : Int)
+    -> (x   : Doc)
+    -> Doc
+nest = Nest
+
+column : (f : Int -> Doc) -> Doc
+column = Column
+
+nesting : (f : Int -> Doc) -> Doc
+nesting = Nesting
+
+private %inline
+flatten : Doc -> Doc
+flatten (Line break)  = if break then Empty else Text 1 " "
+
+flatten (Cat x y)    = Cat (flatten x) (flatten y)
+flatten (Nest lvl x) = Nest lvl (flatten x)
+flatten (Union x _)  = flatten x
+flatten (Column f)   = Column  (\i => flatten $ f i)
+flatten (Nesting f)  = Nesting (\i => flatten $ f i)
+
+flatten other = other
+
+||| The `group` combinator is used to specify alternative
+||| layouts. The document `(group x)` undoes all line breaks in
+||| document `x`. The resulting line is added to the current line if
+||| that fits the page. Otherwise, the document `x` is rendered without
+||| any changes.
+group : Doc -> Doc
+group x = Union (flatten x) x
+
+Semigroup Doc where
+  (<+>) x y = beside x y
+
+Monoid Doc where
+  neutral = empty
+
+fold : (f : Doc -> Doc -> Doc) -> (ds : List Doc) -> Doc
+fold _ Nil     = empty
+fold f (x::xs) = foldl f x xs
+
+-- --------------------------------------------------------------- [ Renderers ]
+
+namespace PrettyDoc
+
+  ||| The data type `PrettyDoc` represents rendered documents and is
+  ||| used by the display functions.
+  data PrettyDoc : Type where
+    Empty : PrettyDoc
+    Chara : (c : Char) -> (rest : PrettyDoc) -> PrettyDoc
+    Text  : (len : Int) -> (str : String) -> (rest : PrettyDoc) -> PrettyDoc
+    Line  : (lvl : Int) -> (rest : PrettyDoc) -> PrettyDoc
+
+||| Helper function to construct spaces.
+spaces : (n : Int) -> String
+spaces n = if n <= 0 then "" else pack $ replicate (cast n) ' '
+
+private
+indentation : Int -> String
+indentation n = spaces n
+
+||| `(showPrettyDoc doc)` takes the output `PrettyDoc` from a
+||| rendering function and transforms it to a String for printing.
+showPrettyDoc : (doc : PrettyDoc) -> String
+showPrettyDoc doc = showPrettyDocS doc ""
+  where
+    showPrettyDocS : (doc : PrettyDoc) -> (acc : String) -> String
+    showPrettyDocS Empty               = id
+    showPrettyDocS (Chara c rest)      = strCons c . showPrettyDocS rest
+    showPrettyDocS (Text len str rest) = (str ++) . showPrettyDocS rest
+    showPrettyDocS (Line lvl rest)     = (('\n' `strCons` indentation lvl) ++) . showPrettyDocS rest
+
+private
+fits : (w : Int) -> (x : PrettyDoc) -> Bool
+fits w Empty               = if w < 0 then False else True
+fits w (Chara c rest)      = if w < 0 then False else fits (w - 1) rest
+
+fits w (Text len str rest) = if w < 0 then False else fits (w - len) rest
+
+fits w (Line _ _)          = if w < 0 then False else True
+
+
+||| Use the Wadler-Leijen algorithm to pretty print the `doc`.
+||| The algorithm uses a page width of `width` and a ribbon
+||| width of `(ribbonfrac * width)` characters. The ribbon width is
+||| the maximal amount of non-indentation characters on a line. The
+||| parameter `ribbonfrac` should be between `0.0` and `1.0`. If it is
+||| lower or higher, the ribbon width will be 0 or `width`
+||| respectively.
+render : (rfrac : Double)
+      -> (width : Int)
+      -> (doc : Doc)
+      -> PrettyDoc
+render rfrac w doc = best w 0 0 doc (const Empty)
+  where
+    rwidth : Int
+    rwidth = max 0 $ min w (cast (cast w * rfrac))
+
+    nicest : (lvl : Int)
+          -> (col : Int)
+          -> (x : PrettyDoc)
+          -> (y : PrettyDoc)
+          -> PrettyDoc
+    nicest n k x y =
+      let width = min (w - k) (rwidth - k + n)
+       in if fits width x then x else y
+
+    best : (lvl : Int)
+        -> (col : Int)
+        -> (curr : Int)
+        -> (doc  : Doc)
+        -> (k : Int -> PrettyDoc)
+        -> PrettyDoc
+    best lvl col curr Empty          k = k col
+    best lvl col curr (Chara c)      k = Chara c $ k (col + 1)
+    best lvl col curr (Text len str) k = Text len str $ k (col + len)
+    best lvl col curr (Line undone)  k = Line curr $ k curr
+
+    best lvl col curr (Cat x y) k =
+        best lvl col curr x (\curr' => best lvl curr' curr y k)
+
+    best lvl col curr (Nest x y) k = best lvl col (curr+x) y k
+
+    best lvl col curr (Union x y) k =
+        nicest lvl col (best lvl col curr x k)
+                       (best lvl col curr y k)
+
+    best lvl col curr (Column f)  k = best lvl col curr (f col) k
+    best lvl col curr (Nesting f) k = best lvl col curr (f curr) k
+
+||| Print the document to a string using the given ribbon fraction
+||| and page width.
+toString : (rfrac : Double)
+        -> (width : Int)
+        -> (doc : Doc)
+        -> String
+toString rfrac width doc = showPrettyDoc (render rfrac width doc)
+
+writeDoc : (fname : String)
+        -> (rfrac : Double)
+        -> (width : Int)
+        -> (doc : Doc)
+        -> IO (Either FileError ())
+writeDoc fname rfrac width doc = writeFile fname $ toString rfrac width doc
+
+namespace Default
+
+  ||| Render the document with a default ribbon fraction of 0.4 and page width of 120 characters.
+  render : (doc : Doc) -> PrettyDoc
+  render = render 0.4 120
+
+  ||| Print the document to a string using a default ribbon fraction
+  ||| of 0.4 and page width of 120 characters.
+  toString : (doc : Doc) -> String
+  toString = toString 0.4 120
+
+  ||| Write the doc to `fname` using a default ribbon fraction of 0.4
+  ||| and page width of 120 characters.
+  writeDoc : (fname : String)
+          -> (doc : Doc)
+          -> IO (Either FileError ())
+  writeDoc fname doc = writeFile fname $ Default.toString doc

--- a/libs/contrib/contrib.ipkg
+++ b/libs/contrib/contrib.ipkg
@@ -32,4 +32,9 @@ modules = CFFI, CFFI.Types, CFFI.Memory,
 
           Text.Lexer, Text.Parser,
 
+          Text.PrettyPrint.WL,
+          Text.PrettyPrint.WL.Core,
+          Text.PrettyPrint.WL.Characters,
+          Text.PrettyPrint.WL.Combinators,
+
           Data.Fin.Extra


### PR DESCRIPTION
This port of the Wadler-Leijen Pretty-Printer is based upon the
port originally created by Shayan Najd [1]. We have changed the
render function to be total using a technique based on
continuations proposed by gallais [2], and fix minor errors in the
original Idris port.

[1] https://github.com/shayan-najd/wl-pprint
[2] https://gallais.github.io/blog/termination-tricks.html