### PR TITLE
Fix's to Text.PrettyPrint.WL

### DIFF
--- a/libs/contrib/Text/PrettyPrint/WL/Characters.idr
+++ b/libs/contrib/Text/PrettyPrint/WL/Characters.idr
@@ -69,8 +69,8 @@ bang = char '!'
 tick : Doc
 tick = char '`'
 
-tilda : Doc
-tilda = char '~'
+tilde : Doc
+tilde = char '~'
 
 hash : Doc
 hash = char '#'

--- a/libs/contrib/Text/PrettyPrint/WL/Core.idr
+++ b/libs/contrib/Text/PrettyPrint/WL/Core.idr
@@ -128,10 +128,10 @@ showPrettyDoc : (doc : PrettyDoc) -> String
 showPrettyDoc doc = showPrettyDocS doc ""
   where
     showPrettyDocS : (doc : PrettyDoc) -> (acc : String) -> String
-    showPrettyDocS Empty               = id
-    showPrettyDocS (Chara c rest)      = strCons c . showPrettyDocS rest
-    showPrettyDocS (Text len str rest) = (str ++) . showPrettyDocS rest
-    showPrettyDocS (Line lvl rest)     = (('\n' `strCons` indentation lvl) ++) . showPrettyDocS rest
+    showPrettyDocS Empty               acc = acc
+    showPrettyDocS (Chara c rest)      acc = strCons c (showPrettyDocS rest acc)
+    showPrettyDocS (Text len str rest) acc = str ++ (showPrettyDocS rest acc)
+    showPrettyDocS (Line lvl rest)     acc = (strCons '\n' (indentation lvl)) ++ showPrettyDocS rest acc
 
 private
 fits : (w : Int) -> (x : PrettyDoc) -> Bool


### PR DESCRIPTION
Small changes.

+ Fix spelling error.
+ Rewrite a helper function to be more maintainable/readable.