### PR TITLE
Fix undeclared variable in node runtime

### DIFF
--- a/jsrts/Runtime-node.js
+++ b/jsrts/Runtime-node.js
@@ -22,7 +22,7 @@ $JSRTS.prim_readStr = function () {
         }
         i++;
         if (i == b.length) {
-            nb = new Buffer(b.length * 2);
+            var nb = new Buffer(b.length * 2);
             b.copy(nb)
             b = nb;
         }


### PR DESCRIPTION
This PR fixes an undeclared variable error occuring when optimising node.js outout with the closure compiler.