### PR TITLE
change extra-deps for idris 1.1.0 lts-9.0 resolver

### DIFF
--- a/stack.yaml
+++ b/stack.yaml
@@ -1,3 +1,4 @@
+#recheck extra-deps next on resolver or cabal file change
 resolver: lts-9.0
 
 packages:
@@ -9,7 +10,8 @@ flags:
     GMP: true
 
 extra-deps:
-  - libffi-0.1
+  - binary-0.8.5.1
+  - cheapskate-0.1.1
 
 nix:
   enable: false


### PR DESCRIPTION
stack.yaml extra-deps changed as resolver lts-9.0 doesn't have
the recently required versions of libs in the idris.cabal file.

note added to stack.yaml to re-examine extra-deps on resolver
or cabal file change.

note should probably be in the cabal file but I'm not sure where it
would be seen