### PR TITLE
Add support for running tests on OpenBSD, fixes #3964

### DIFF
--- a/test/TestRun.hs
+++ b/test/TestRun.hs
@@ -65,7 +65,8 @@ test testName path = goldenVsFileDiff testName diff ref output
   where
     ref = path </> "expected"
     output = path </> "output"
-    diff ref new = ["diff", "-u", new, ref]
+    diff ref new | os == "openbsd" = ["diff", "-u", new, ref]
+                 | otherwise = ["diff", "--strip-trailing-cr", "-u", new, ref]
 
 -- Should always output a 3-charater string from a postive Int
 indexToString :: Int -> String

--- a/test/TestRun.hs
+++ b/test/TestRun.hs
@@ -65,7 +65,7 @@ test testName path = goldenVsFileDiff testName diff ref output
   where
     ref = path </> "expected"
     output = path </> "output"
-    diff ref new = ["diff", "--strip-trailing-cr", "-u", new, ref]
+    diff ref new = ["diff", "-u", new, ref]
 
 -- Should always output a 3-charater string from a postive Int
 indexToString :: Int -> String

--- a/test/base001/exit1.c
+++ b/test/base001/exit1.c
@@ -1,6 +1,10 @@
 #include <stdio.h>
 #include <stdlib.h>
 
+#ifdef __OpenBSD__
+#include <sys/wait.h>
+#endif
+
 void doSystem(const char cmd[]) {
   printf("exit1: Executing cmd '%s'\n", cmd);
   int exitStatus = system(cmd);

--- a/test/base001/sys.c
+++ b/test/base001/sys.c
@@ -2,6 +2,10 @@
 
 #include <stdlib.h>
 
+#ifdef __OpenBSD__
+#include <sys/wait.h>
+#endif
+
 int WIFEXITED_(int status) {
   return WIFEXITED(status);
 }


### PR DESCRIPTION
All tests now pass on OpenBSD 6.1-stable amd64.