### PR TITLE
Change eqPtr to use the primitive

### DIFF
--- a/libs/prelude/Prelude.idr
+++ b/libs/prelude/Prelude.idr
@@ -280,8 +280,7 @@ namespace JSNull
 
 ||| Pointer equality
 eqPtr : Ptr -> Ptr -> IO Bool
-eqPtr x y = do eq <- foreign FFI_C "idris_eqPtr" (Ptr -> Ptr -> IO Int) x y
-               pure (eq /= 0)
+eqPtr x y = pure $ prim__eqPtr x y /= 0
 
 ||| Loop while some test is true
 |||

--- a/rts/idris_stdfgn.c
+++ b/rts/idris_stdfgn.c
@@ -103,10 +103,6 @@ int isNull(void* ptr) {
     return ptr==NULL;
 }
 
-int idris_eqPtr(void* x, void* y) {
-    return x==y;
-}
-
 void* idris_stdin() {
     return (void*)stdin;
 }

--- a/rts/idris_stdfgn.h
+++ b/rts/idris_stdfgn.h
@@ -29,8 +29,6 @@ VAL idris_getString(VM* vm, void* buffer);
 void* do_popen(const char* cmd, const char* mode);
 int fpoll(void* h);
 
-
-int idris_eqPtr(void* x, void* y);
 int isNull(void* ptr);
 void* idris_stdin();
 


### PR DESCRIPTION
Maybe eqPtr isn't needed, Ptr has an == instance.