### PR TITLE
Prefer to load imports from the current package

### DIFF
--- a/src/IRTS/Compiler.hs
+++ b/src/IRTS/Compiler.hs
@@ -76,7 +76,7 @@ compile codegen f mtm = do
         libs <- getLibs codegen
         flags <- getFlags codegen
         hdrs <- getHdrs codegen
-        impdirs <- allImportDirs
+        impdirs <- rankedImportDirs f
         ttDeclarations <- getDeclarations reachableNames
         defsIn <- mkDecls reachableNames
         -- if no 'main term' given, generate interface files

--- a/src/Idris/AbsSyntax.hs
+++ b/src/Idris/AbsSyntax.hs
@@ -1108,6 +1108,14 @@ allImportDirs = do i <- getIState
                    let optdirs = opt_importdirs (idris_options i)
                    return ("." : reverse optdirs)
 
+-- Like allImportDirs but the dirs that are a prefix of
+-- the files path first. This makes it look in the current
+-- package first.
+rankedImportDirs :: FilePath -> Idris [FilePath]
+rankedImportDirs fp = do ids <- allImportDirs
+                         let (prefixes, rest) = partition (`isPrefixOf`fp) ids
+                         return $ prefixes ++ rest
+
 addSourceDir :: FilePath -> Idris ()
 addSourceDir fp = do i <- getIState
                      let opts = idris_options i

--- a/src/Idris/Imports.hs
+++ b/src/Idris/Imports.hs
@@ -6,13 +6,14 @@ License     : BSD3
 Maintainer  : The Idris Community.
 -}
 module Idris.Imports(
-    IFileType(..), findImport, findInPath, findPkgIndex
+    IFileType(..), findIBC, findImport, findInPath, findPkgIndex
   , ibcPathNoFallback, installedPackages, pkgIndex
   ) where
 
 import Idris.AbsSyntax
 import Idris.Core.TT
 import Idris.Error
+import Idris.Output
 import IRTS.System (getIdrisLibDir)
 
 import Control.Applicative ((<$>))
@@ -76,6 +77,17 @@ findImport (d:ds) ibcsd fp = do let fp_full = d </> fp
                                   else if (idr || lidr)
                                        then return isrc
                                        else findImport ds ibcsd fp
+
+-- Only look for IBCs and not source
+findIBC :: [FilePath] -> FilePath -> FilePath -> Idris (Maybe FilePath)
+findIBC [] _ fp = return Nothing
+findIBC (d:ds) ibcsd fp = do let fp_full = d </> fp
+                             ibcp <- runIO $ ibcPathWithFallback ibcsd fp_full
+                             ibc <- runIO $ doesFileExist' ibcp
+                             if ibc
+                                then return $ Just ibcp
+                                else findIBC ds ibcsd fp
+
 
 -- find a specific filename somewhere in a path
 

--- a/src/Idris/Parser.hs
+++ b/src/Idris/Parser.hs
@@ -1664,7 +1664,7 @@ loadModule' f phase
    = do i <- getIState
         let file = takeWhile (/= ' ') f
         ibcsd <- valIBCSubDir i
-        ids <- allImportDirs
+        ids <- rankedImportDirs file
         fp <- findImport ids ibcsd file
         if file `elem` imported i
           then do logParser 1 $ "Already read " ++ file
@@ -1717,7 +1717,7 @@ loadSource lidr f toline
                   (mdocs, mname, imports_in, pos) <- parseImports f file
                   ai <- getAutoImports
                   let imports = map (\n -> ImportInfo True n Nothing [] NoFC NoFC) ai ++ imports_in
-                  ids <- allImportDirs
+                  ids <- rankedImportDirs f
                   ibcsd <- valIBCSubDir i
                   mapM_ (\(re, f, ns, nfc) ->
                                do fp <- findImport ids ibcsd f


### PR DESCRIPTION
This is done by moving import dirs that are prefixes to the current path to the front of the import dir list.

Also make a fuction that only looks for IBCs.

Both these changes should also be helpful for performance.

Fixes #3994