### PR TITLE
Try to make appveyor not be mad at warnings

### DIFF
--- a/appveyor.yml
+++ b/appveyor.yml
@@ -6,9 +6,9 @@ init:
     mkdir C:\ghc
 
     Invoke-WebRequest "http://downloads.haskell.org/~ghc/7.10.3/ghc-7.10.3-x86_64-unknown-mingw32.tar.xz" -OutFile C:\ghc\ghc.tar.xz -UserAgent "Curl"
-    
+
     7z x C:\ghc\ghc.tar.xz -oC:\ghc
-    
+
     7z x C:\ghc\ghc.tar -oC:\ghc
 
     $env:PATH="$env:PATH;c:\ghc\ghc-7.10.3\bin;$HOME\AppData\Roaming\cabal\bin"
@@ -21,6 +21,7 @@ environment:
   MSYSTEM: MINGW64
   MSYS2_PATH_TYPE: inherit
 build_script:
-- ps: c:\msys64\usr\bin\bash -l -c "cd $env:current_posix && cabal install -fffi -j4 --enable-tests"
+- ps: >-
+    c:\msys64\usr\bin\bash -l -c "cd $env:current_posix && cabal install -fffi --enable-tests 2>&1"
 test_script:
-- ps: c:\msys64\usr\bin\bash -l -c "cd $env:current_posix && make test_c"
+- ps: c:\msys64\usr\bin\bash -l -c "cd $env:current_posix && make test_c 2>&1"

--- a/idris.cabal
+++ b/idris.cabal
@@ -360,7 +360,7 @@ Test-suite regression-and-feature-tests
                , filepath
                , directory
                , haskeline >= 0.7
-               , optparse-applicative >= 0.11 && < 0.14
+               , optparse-applicative >= 0.13 && < 0.15
                , tagged
                , tasty >= 0.8
                , tasty-golden >= 2.0

--- a/rts/Makefile
+++ b/rts/Makefile
@@ -31,7 +31,7 @@ LIBTARGET = libidris_rts.a
 build: $(LIBTARGET) $(DYLIBTARGET)
 
 $(LIBTARGET) : $(OBJS)
-	$(AR) r $(LIBTARGET) $(OBJS)
+	$(AR) rc $(LIBTARGET) $(OBJS)
 	$(RANLIB) $(LIBTARGET)
 
 install :


### PR DESCRIPTION
It's the redirection of stderr to stdout that fixes the problem (appveyor apparently fails builds that prints to stderr now).

Fix a warning from ar.

Sync the test optparse-applicative bounds with idris,