### PR TITLE
add startWith function for prepending a finite number of elements to a Stream

### DIFF
--- a/libs/contrib/Data/Stream/Extra.idr
+++ b/libs/contrib/Data/Stream/Extra.idr
@@ -1,0 +1,10 @@
+module Data.Stream.Extra
+
+%access public export
+%default total
+
+||| Produce a Stream that is prefixed by elements from a Foldable
+||| @ pfx the Foldable containing elements to prepend
+||| @ stream the Stream to prepend the elements to
+startWith : Foldable t => (pfx : t a) -> (stream : Stream a) -> Stream a
+startWith pfx stream = foldr (\x, xs => x :: xs) stream pfx        

--- a/libs/contrib/Data/Stream/Extra.idr
+++ b/libs/contrib/Data/Stream/Extra.idr
@@ -3,7 +3,7 @@ module Data.Stream.Extra
 %access public export
 %default total
 
-||| Produce a Stream that is prefixed by elements from a Foldable
+||| Insert elements from a Foldable at the start of an existing Stream
 ||| @ pfx the Foldable containing elements to prepend
 ||| @ stream the Stream to prepend the elements to
 startWith : Foldable t => (pfx : t a) -> (stream : Stream a) -> Stream a

--- a/libs/contrib/contrib.ipkg
+++ b/libs/contrib/contrib.ipkg
@@ -22,7 +22,7 @@ modules = CFFI, CFFI.Types, CFFI.Memory,
           Data.Heap,
           Data.SortedMap, Data.SortedSet,
           Data.CoList, Data.Storable,
-	  Data.List.Zipper,
+          Data.List.Zipper,
 
           Decidable.Decidable, Decidable.Order,
 
@@ -39,4 +39,5 @@ modules = CFFI, CFFI.Types, CFFI.Memory,
 
           Text.Literate,
 
-          Data.Fin.Extra
+          Data.Fin.Extra,
+          Data.Stream.Extra

--- a/libs/prelude/Prelude/Stream.idr
+++ b/libs/prelude/Prelude/Stream.idr
@@ -8,6 +8,7 @@ import Prelude.Applicative
 import Prelude.Monad
 import Prelude.Nat
 import Prelude.List
+import Prelude.Foldable
 
 %access public export
 %default total
@@ -108,6 +109,12 @@ cycle {a} (x :: xs) {ok = IsNonEmpty} = x :: cycle' xs
   where cycle' : List a -> Stream a
         cycle' []        = x :: cycle' xs
         cycle' (y :: ys) = y :: cycle' ys
+
+||| Produce a Stream that is prefixed by elements from a Foldable
+||| @ pfx the Foldable containing elements to prepend
+||| @ stream the Stream to prepend the elements to
+startWith : Foldable t => (pfx : t a) -> (stream : Stream a) -> Stream a
+startWith pfx stream = foldr (\x, xs => x :: xs) stream pfx        
 
 Applicative Stream where
   pure = repeat

--- a/libs/prelude/Prelude/Stream.idr
+++ b/libs/prelude/Prelude/Stream.idr
@@ -8,7 +8,6 @@ import Prelude.Applicative
 import Prelude.Monad
 import Prelude.Nat
 import Prelude.List
-import Prelude.Foldable
 
 %access public export
 %default total
@@ -109,12 +108,6 @@ cycle {a} (x :: xs) {ok = IsNonEmpty} = x :: cycle' xs
   where cycle' : List a -> Stream a
         cycle' []        = x :: cycle' xs
         cycle' (y :: ys) = y :: cycle' ys
-
-||| Produce a Stream that is prefixed by elements from a Foldable
-||| @ pfx the Foldable containing elements to prepend
-||| @ stream the Stream to prepend the elements to
-startWith : Foldable t => (pfx : t a) -> (stream : Stream a) -> Stream a
-startWith pfx stream = foldr (\x, xs => x :: xs) stream pfx        
 
 Applicative Stream where
   pure = repeat


### PR DESCRIPTION
This function inserts elements from a Foldable at the beginning of a Stream.

I was going to name this `prefix`, but that's a keyword. The following names were also candidates:

* `prepend`
* `insert`
* `prefixBy`
* `beginWith`

Should I rearrange the imports? I was going to alphabetize them, but I wasn't sure that would be appropriate.