### PR TITLE
Fix #4020: Fix duplication in output of `--hightlight`.

### DIFF
--- a/src/Idris/Output.hs
+++ b/src/Idris/Output.hs
@@ -234,14 +234,15 @@ sendParserHighlighting =
 
 sendHighlighting :: [(FC, OutputAnnotation)] -> Idris ()
 sendHighlighting highlights =
-  do ist <- getIState
+  do let highlights_uniq = nub highlights
+     ist <- getIState
      case idris_outputmode ist of
        RawOutput _ -> updateIState $
                       \ist -> ist { idris_highlightedRegions =
-                                      highlights ++ idris_highlightedRegions ist }
+                                      highlights_uniq ++ idris_highlightedRegions ist }
        IdeMode n h ->
          let fancier = [ toSExp (fc, fancifyAnnots ist False annot)
-                       | (fc, annot) <- highlights, fullFC fc
+                       | (fc, annot) <- highlights_uniq, fullFC fc
                        ]
          in case fancier of
               [] -> return ()


### PR DESCRIPTION
When adding to the list of highlighted regions ensure that there are
no duplicates. While not a principled fix for the deduplication of
highlighted regions, it is a fix nonetheless.

We also add a test to stop regressions happening.