### PR TITLE
add Data.Pairs.Implicit for converting erased pairs

### DIFF
--- a/libs/contrib/Data/Pairs/Implicit.idr
+++ b/libs/contrib/Data/Pairs/Implicit.idr
@@ -1,0 +1,13 @@
+||| Implicit conversions for erased dependent pairs.
+module Data.Pairs.Implicit
+
+%access public export
+%default total
+
+||| Convert an Evidence to its proof.
+implicit evidence : (x : Exists p) -> p (getWitness x)
+evidence = getProof
+
+||| Convert an Element to its value (a.k.a. witness).
+implicit element : Subset a p -> a
+element = getWitness

--- a/libs/contrib/contrib.ipkg
+++ b/libs/contrib/contrib.ipkg
@@ -24,6 +24,7 @@ modules = CFFI, CFFI.Types, CFFI.Memory,
           Data.SortedMap, Data.SortedSet,
           Data.CoList, Data.Storable,
           Data.List.Zipper,
+          Data.Pairs.Implicit,
 
           Decidable.Decidable, Decidable.Order,
 


### PR DESCRIPTION
The conversions are performed by the functions `evidence` and `element`.