### PR TITLE
Package name abstraction & naming restrictions

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -23,6 +23,10 @@
 + The C backend now pass arguments to the C compiler in the same order
   as they were given in the source files.
 
+## Packaging Updates
++ Package names now only accept a restrictive charset of letters, numbers and the `-_` characters.
+  Package names are also case insensitive
+
 # New in 1.1.1
 
 + Erasure analysis is now faster thanks to a bit smarter constraint solving.

--- a/src/Idris/IBC.hs
+++ b/src/Idris/IBC.hs
@@ -144,9 +144,9 @@ loadIBC reexport phase fp
                             addImported reexport fp
 
 -- | Load an entire package from its index file
-loadPkgIndex :: String -> Idris ()
+loadPkgIndex :: PkgName -> Idris ()
 loadPkgIndex pkg = do ddir <- runIO getIdrisLibDir
-                      addImportDir (ddir </> pkg)
+                      addImportDir (ddir </> unPkgName pkg)
                       fp <- findPkgIndex pkg
                       loadIBC True IBC_Building fp
 

--- a/src/Idris/Imports.hs
+++ b/src/Idris/Imports.hs
@@ -18,7 +18,7 @@ import IRTS.System (getIdrisLibDir)
 
 import Control.Applicative ((<$>))
 import Control.Monad.State.Strict
-import Data.Char (isDigit, isAlpha, toLower)
+import Data.Char (isAlpha, isDigit, toLower)
 import Data.List (isSuffixOf)
 import System.Directory
 import System.FilePath

--- a/src/Idris/Imports.hs
+++ b/src/Idris/Imports.hs
@@ -18,7 +18,7 @@ import IRTS.System (getIdrisLibDir)
 
 import Control.Applicative ((<$>))
 import Control.Monad.State.Strict
-import Data.Char (isDigit, isLower)
+import Data.Char (isDigit, isAlpha, toLower)
 import Data.List (isSuffixOf)
 import System.Directory
 import System.FilePath
@@ -26,8 +26,15 @@ import System.FilePath
 data IFileType = IDR FilePath | LIDR FilePath | IBC FilePath IFileType
     deriving (Show, Eq)
 
-newtype PkgName = PkgName { unPkgName :: String }
-  deriving (Show, Eq)
+newtype PkgName = PkgName String
+
+unPkgName :: PkgName -> String
+unPkgName (PkgName s) = map toLower s
+
+instance Show PkgName where
+    show (PkgName pkg) = pkg
+instance Eq PkgName where
+    a == b = unPkgName a == unPkgName b
 
 unInitializedPkgName :: PkgName
 unInitializedPkgName = PkgName ""
@@ -35,10 +42,10 @@ unInitializedPkgName = PkgName ""
 pkgName :: String -> Either String PkgName
 pkgName ""      = Left "empty package name"
 pkgName s@(f:l)
-    | not $ isLower f =
-        Left "package name need to start by a lower alpha"
-    | not $ all (\c -> isLower c || isDigit c || c `elem` "-_") l =
-        Left "package name need to contain only lower alpha, digits, and -_"
+    | not $ isAlpha f =
+        Left "package name need to start by a letter"
+    | not $ all (\c -> isAlpha c || isDigit c || c `elem` "-_") l =
+        Left "package name need to contain only letter, digits, and -_"
     | otherwise = Right $ PkgName s
 
 -- | Get the index file name for a package name

--- a/src/Idris/Imports.hs
+++ b/src/Idris/Imports.hs
@@ -19,6 +19,7 @@ import IRTS.System (getIdrisLibDir)
 import Control.Applicative ((<$>))
 import Control.Monad.State.Strict
 import Data.List (isSuffixOf)
+import Data.Char (isLower, isDigit)
 import System.Directory
 import System.FilePath
 
@@ -31,8 +32,14 @@ newtype PkgName = PkgName { unPkgName :: String }
 unInitializedPkgName :: PkgName
 unInitializedPkgName = PkgName ""
 
-pkgName :: String -> PkgName
-pkgName = PkgName
+pkgName :: String -> Either String PkgName
+pkgName ""      = Left "empty package name"
+pkgName s@(f:l)
+    | not $ isLower f =
+        Left "package name need to start by a lower alpha"
+    | not $ all (\c -> isLower c || isDigit c || c `elem` "-_") l =
+        Left "package name need to contain only lower alpha, digits, and -_"
+    | otherwise = Right $ PkgName s
 
 -- | Get the index file name for a package name
 pkgIndex :: PkgName -> FilePath

--- a/src/Idris/Imports.hs
+++ b/src/Idris/Imports.hs
@@ -18,8 +18,8 @@ import IRTS.System (getIdrisLibDir)
 
 import Control.Applicative ((<$>))
 import Control.Monad.State.Strict
+import Data.Char (isDigit, isLower)
 import Data.List (isSuffixOf)
-import Data.Char (isLower, isDigit)
 import System.Directory
 import System.FilePath
 

--- a/src/Idris/Imports.hs
+++ b/src/Idris/Imports.hs
@@ -8,6 +8,7 @@ Maintainer  : The Idris Community.
 module Idris.Imports(
     IFileType(..), findIBC, findImport, findInPath, findPkgIndex
   , ibcPathNoFallback, installedPackages, pkgIndex
+  , PkgName, pkgName, unPkgName, unInitializedPkgName
   ) where
 
 import Idris.AbsSyntax
@@ -24,9 +25,18 @@ import System.FilePath
 data IFileType = IDR FilePath | LIDR FilePath | IBC FilePath IFileType
     deriving (Show, Eq)
 
+newtype PkgName = PkgName { unPkgName :: String }
+  deriving (Show, Eq)
+
+unInitializedPkgName :: PkgName
+unInitializedPkgName = PkgName ""
+
+pkgName :: String -> PkgName
+pkgName = PkgName
+
 -- | Get the index file name for a package name
-pkgIndex :: String -> FilePath
-pkgIndex s = "00" ++ s ++ "-idx.ibc"
+pkgIndex :: PkgName -> FilePath
+pkgIndex s = "00" ++ unPkgName s ++ "-idx.ibc"
 
 srcPath :: FilePath -> FilePath
 srcPath fp = let (_, ext) = splitExtension fp in
@@ -96,7 +106,7 @@ findInPath (d:ds) fp = do let p = d </> fp
                           e <- doesFileExist' p
                           if e then return p else findInPath ds fp
 
-findPkgIndex :: String -> Idris FilePath
+findPkgIndex :: PkgName -> Idris FilePath
 findPkgIndex p = do let idx = pkgIndex p
                     ids <- allImportDirs
                     runIO $ findInPath ids idx

--- a/src/Idris/Package.hs
+++ b/src/Idris/Package.hs
@@ -231,7 +231,7 @@ documentPkg copts (install,fp) = do
           pkgDocDir <- makeAbsolute (iDocDir </> unPkgName (pkgname pkgdesc))
           let out_dir = if install then pkgDocDir else outputDir
           when install $ do
-              putStrLn $ unwords ["Attempting to install IdrisDocs for", unPkgName $ pkgname pkgdesc, "in:", out_dir]
+              putStrLn $ unwords ["Attempting to install IdrisDocs for", show $ pkgname pkgdesc, "in:", out_dir]
 
           docRes <- generateDocs ist mods out_dir
           case docRes of
@@ -367,7 +367,7 @@ testLib warn p f
          case e of
             ExitSuccess -> return True
             _ -> do if warn
-                       then do putStrLn $ "Not building " ++ unPkgName p ++
+                       then do putStrLn $ "Not building " ++ show p ++
                                           " due to missing library " ++ f
                                return False
                        else fail $ "Missing library " ++ f

--- a/src/Idris/Package/Common.hs
+++ b/src/Idris/Package/Common.hs
@@ -8,11 +8,12 @@ module Idris.Package.Common where
 
 import Idris.Core.TT (Name)
 import Idris.Options (Opt(..))
+import Idris.Imports
 
 -- | Description of an Idris package.
 data PkgDesc = PkgDesc {
-    pkgname       :: String       -- ^ Name associated with a package.
-  , pkgdeps       :: [String]     -- ^ List of packages this package depends on.
+    pkgname       :: PkgName      -- ^ Name associated with a package.
+  , pkgdeps       :: [PkgName]    -- ^ List of packages this package depends on.
   , pkgbrief      :: Maybe String -- ^ Brief description of the package.
   , pkgversion    :: Maybe String -- ^ Version string to associate with the package.
   , pkgreadme     :: Maybe String -- ^ Location of the README file.
@@ -35,6 +36,6 @@ data PkgDesc = PkgDesc {
 
 -- | Default settings for package descriptions.
 defaultPkg :: PkgDesc
-defaultPkg = PkgDesc "" [] Nothing Nothing Nothing Nothing
+defaultPkg = PkgDesc unInitializedPkgName [] Nothing Nothing Nothing Nothing
                         Nothing Nothing Nothing Nothing
                         Nothing [] [] Nothing [] "" [] Nothing Nothing []

--- a/src/Idris/Package/Common.hs
+++ b/src/Idris/Package/Common.hs
@@ -7,8 +7,8 @@ Maintainer  : The Idris Community.
 module Idris.Package.Common where
 
 import Idris.Core.TT (Name)
-import Idris.Options (Opt(..))
 import Idris.Imports
+import Idris.Options (Opt(..))
 
 -- | Description of an Idris package.
 data PkgDesc = PkgDesc {

--- a/src/Idris/Package/Parser.hs
+++ b/src/Idris/Package/Parser.hs
@@ -145,7 +145,7 @@ pClause = do reserved "executable"; lchar '=';
       <|> do reserved "pkgs"; lchar '=';
              ps <- sepBy1 (pPkgName <* someSpace) (lchar ',')
              st <- get
-             let pkgs = pureArgParser $ concatMap (\x -> ["-p", unPkgName x]) ps
+             let pkgs = pureArgParser $ concatMap (\x -> ["-p", show x]) ps
 
              put (st { pkgdeps    = ps `union` (pkgdeps st)
                      , idris_opts = pkgs ++ idris_opts st})

--- a/src/Idris/Package/Parser.hs
+++ b/src/Idris/Package/Parser.hs
@@ -9,9 +9,9 @@ Maintainer  : The Idris Community.
 module Idris.Package.Parser where
 
 import Idris.CmdOptions
+import Idris.Imports
 import Idris.Package.Common
 import Idris.Parser.Helpers hiding (stringLiteral)
-import Idris.Imports
 
 import Control.Applicative
 import Control.Monad.State.Strict

--- a/src/Idris/Package/Parser.hs
+++ b/src/Idris/Package/Parser.hs
@@ -75,7 +75,7 @@ pPkg = do
     return st
 
 pPkgName :: PParser PkgName
-pPkgName = (pkgName <$> packageName) <?> "PkgName"
+pPkgName = (either fail pure . pkgName =<< packageName) <?> "PkgName"
 
 -- | Parses a filename.
 -- |

--- a/src/Idris/Parser/Helpers.hs
+++ b/src/Idris/Parser/Helpers.hs
@@ -395,6 +395,11 @@ opChars = ":!#$%&*+./<=>?@\\^|-~"
 operatorLetter :: MonadicParsing m => m Char
 operatorLetter = oneOf opChars
 
+-- | Parse a package name
+packageName :: MonadicParsing m => m String
+packageName = (:) <$> oneOf firstChars <*> many (oneOf remChars)
+  where firstChars = ['a'..'z']
+        remChars = ['a'..'z'] ++ ['0'..'9'] ++ ['-','_']
 
 commentMarkers :: [String]
 commentMarkers = [ "--", "|||" ]

--- a/src/Idris/Parser/Helpers.hs
+++ b/src/Idris/Parser/Helpers.hs
@@ -398,8 +398,8 @@ operatorLetter = oneOf opChars
 -- | Parse a package name
 packageName :: MonadicParsing m => m String
 packageName = (:) <$> oneOf firstChars <*> many (oneOf remChars)
-  where firstChars = ['a'..'z']
-        remChars = ['a'..'z'] ++ ['0'..'9'] ++ ['-','_']
+  where firstChars = ['a'..'z'] ++ ['A'..'Z']
+        remChars = ['a'..'z'] ++ ['A'..'Z'] ++ ['0'..'9'] ++ ['-','_']
 
 commentMarkers :: [String]
 commentMarkers = [ "--", "|||" ]

--- a/src/Idris/REPL.hs
+++ b/src/Idris/REPL.hs
@@ -65,6 +65,7 @@ import Idris.Help
 import Idris.IBC
 import qualified Idris.IdeMode as IdeMode
 import Idris.IdrisDoc
+import Idris.Imports
 import Idris.Info
 import Idris.Inliner
 import Idris.Interactive
@@ -1373,7 +1374,7 @@ process fn (SetPrinterDepth d) = setDepth d
 process fn (Apropos pkgs a) =
   do orig <- getIState
      when (not (null pkgs)) $
-       iputStrLn $ "Searching packages: " ++ showSep ", " pkgs
+       iputStrLn $ "Searching packages: " ++ showSep ", " (map unPkgName pkgs)
      mapM_ loadPkgIndex pkgs
      ist <- getIState
      let mods = aproposModules ist (T.pack a)

--- a/src/Idris/REPL.hs
+++ b/src/Idris/REPL.hs
@@ -65,7 +65,6 @@ import Idris.Help
 import Idris.IBC
 import qualified Idris.IdeMode as IdeMode
 import Idris.IdrisDoc
-import Idris.Imports
 import Idris.Info
 import Idris.Inliner
 import Idris.Interactive
@@ -1374,7 +1373,7 @@ process fn (SetPrinterDepth d) = setDepth d
 process fn (Apropos pkgs a) =
   do orig <- getIState
      when (not (null pkgs)) $
-       iputStrLn $ "Searching packages: " ++ showSep ", " (map unPkgName pkgs)
+       iputStrLn $ "Searching packages: " ++ showSep ", " (map show pkgs)
      mapM_ loadPkgIndex pkgs
      ist <- getIState
      let mods = aproposModules ist (T.pack a)

--- a/src/Idris/REPL/Commands.hs
+++ b/src/Idris/REPL/Commands.hs
@@ -3,8 +3,8 @@ module Idris.REPL.Commands where
 import Idris.AbsSyntaxTree
 import Idris.Colours
 import Idris.Core.TT
-import Idris.Options
 import Idris.Imports
+import Idris.Options
 
 -- | REPL commands
 data Command = Quit

--- a/src/Idris/REPL/Commands.hs
+++ b/src/Idris/REPL/Commands.hs
@@ -4,6 +4,7 @@ import Idris.AbsSyntaxTree
 import Idris.Colours
 import Idris.Core.TT
 import Idris.Options
+import Idris.Imports
 
 -- | REPL commands
 data Command = Quit
@@ -43,7 +44,7 @@ data Command = Quit
              | DynamicLink FilePath
              | ListDynamic
              | Pattelab PTerm
-             | Search [String] PTerm
+             | Search [PkgName] PTerm
              | CaseSplitAt Bool Int Name
              | AddClauseFrom Bool Int Name
              | AddProofClauseFrom Bool Int Name
@@ -65,7 +66,7 @@ data Command = Quit
              | ListErrorHandlers
              | SetConsoleWidth ConsoleWidth
              | SetPrinterDepth (Maybe Int)
-             | Apropos [String] String
+             | Apropos [PkgName] String
              | WhoCalls Name
              | CallsWho Name
              | Browse [String]

--- a/src/Idris/REPL/Parser.hs
+++ b/src/Idris/REPL/Parser.hs
@@ -512,12 +512,14 @@ packageBasedCmd :: P.IdrisParser a -> ([PkgName] -> a -> Command)
                 -> String -> P.IdrisParser (Either String Command)
 packageBasedCmd valParser cmd name =
   try (do P.lchar '('
-          pkgs <- sepBy (pkgName <$> some idChar) (P.lchar ',')
+          pkgs <- sepBy (pkg <* P.whiteSpace) (P.lchar ',')
           P.lchar ')'
           val <- valParser
           return (Right (cmd pkgs val)))
    <|> do val <- valParser
           return (Right (cmd [] val))
+  where
+    pkg = either fail pure . pkgName =<< P.packageName
 
 cmd_search :: String -> P.IdrisParser (Either String Command)
 cmd_search = packageBasedCmd

--- a/src/Idris/REPL/Parser.hs
+++ b/src/Idris/REPL/Parser.hs
@@ -16,6 +16,7 @@ import Idris.Colours
 import Idris.Core.TT
 import Idris.Help
 import Idris.Options
+import Idris.Imports
 import qualified Idris.Parser as P
 import qualified Idris.Parser.Expr as P
 import qualified Idris.Parser.Helpers as P
@@ -507,11 +508,11 @@ idChar = oneOf (['a'..'z'] ++ ['A'..'Z'] ++ ['0'..'9'] ++ ['_'])
 cmd_apropos :: String -> P.IdrisParser (Either String Command)
 cmd_apropos = packageBasedCmd (some idChar) Apropos
 
-packageBasedCmd :: P.IdrisParser a -> ([String] -> a -> Command)
+packageBasedCmd :: P.IdrisParser a -> ([PkgName] -> a -> Command)
                 -> String -> P.IdrisParser (Either String Command)
 packageBasedCmd valParser cmd name =
   try (do P.lchar '('
-          pkgs <- sepBy (some idChar) (P.lchar ',')
+          pkgs <- sepBy (pkgName <$> some idChar) (P.lchar ',')
           P.lchar ')'
           val <- valParser
           return (Right (cmd pkgs val)))

--- a/src/Idris/REPL/Parser.hs
+++ b/src/Idris/REPL/Parser.hs
@@ -15,8 +15,8 @@ import Idris.AbsSyntax
 import Idris.Colours
 import Idris.Core.TT
 import Idris.Help
-import Idris.Options
 import Idris.Imports
+import Idris.Options
 import qualified Idris.Parser as P
 import qualified Idris.Parser.Expr as P
 import qualified Idris.Parser.Helpers as P

--- a/src/Idris/TypeSearch.hs
+++ b/src/Idris/TypeSearch.hs
@@ -26,6 +26,7 @@ import Idris.Delaborate (delabTy)
 import Idris.Docstrings (noDocs, overview)
 import Idris.Elab.Type (elabType)
 import Idris.IBC
+import Idris.Imports (PkgName, unPkgName)
 import Idris.Output (iPrintResult, iRenderError, iRenderOutput, iRenderResult,
                      iputStrLn, prettyDocumentedIst)
 
@@ -48,11 +49,11 @@ import qualified Data.Set as S
 import qualified Data.Text as T (isPrefixOf, pack)
 import Data.Traversable (traverse)
 
-searchByType :: [String] -> PTerm -> Idris ()
+searchByType :: [PkgName] -> PTerm -> Idris ()
 searchByType pkgs pterm = do
   i <- getIState -- save original
   when (not (null pkgs)) $
-     iputStrLn $ "Searching packages: " ++ showSep ", " pkgs
+     iputStrLn $ "Searching packages: " ++ showSep ", " (map unPkgName pkgs)
 
   mapM_ loadPkgIndex pkgs
   pterm' <- addUsingConstraints syn emptyFC pterm

--- a/src/Idris/TypeSearch.hs
+++ b/src/Idris/TypeSearch.hs
@@ -26,7 +26,7 @@ import Idris.Delaborate (delabTy)
 import Idris.Docstrings (noDocs, overview)
 import Idris.Elab.Type (elabType)
 import Idris.IBC
-import Idris.Imports (PkgName, unPkgName)
+import Idris.Imports (PkgName)
 import Idris.Output (iPrintResult, iRenderError, iRenderOutput, iRenderResult,
                      iputStrLn, prettyDocumentedIst)
 
@@ -53,7 +53,7 @@ searchByType :: [PkgName] -> PTerm -> Idris ()
 searchByType pkgs pterm = do
   i <- getIState -- save original
   when (not (null pkgs)) $
-     iputStrLn $ "Searching packages: " ++ showSep ", " (map unPkgName pkgs)
+     iputStrLn $ "Searching packages: " ++ showSep ", " (map show pkgs)
 
   mapM_ loadPkgIndex pkgs
   pterm' <- addUsingConstraints syn emptyFC pterm

--- a/test/pkg001/test-pkg.ipkg
+++ b/test/pkg001/test-pkg.ipkg
@@ -1,4 +1,4 @@
-package "test-pkg"
+package test-pkg
 
 pkgs = effects
 


### PR DESCRIPTION
I was looking at the package code and strenghtening the package name from a `String` seems to be a good idea. This PR changes the following:

* Introduce a `PkgName` newtype on `String`
* only accept package name to be `[a-z][-_a-z0-9]*`
* change the ipkg parser to not accept a `filename` for package name, removing the support for quoted string that seems only used in one of the test suite (also fixed).

The choice of supported package name is very conservative since package name are used as filename in multiple places. it's conservative for the following reasons:

* avoid filesystem case insensitive issues by only supporting lowercase
* avoid filesystem unicode normalization issues by not supporting any unicode

Since it brings new restrictions, it could break existing code/package, so this is more for RFC for package naming than a finished PR.