### PR TITLE
Text.Lexer: add quantified lexer combinators

### DIFF
--- a/libs/contrib/Text/Lexer.idr
+++ b/libs/contrib/Text/Lexer.idr
@@ -113,11 +113,11 @@ export
 many : Lexer -> Recognise False
 many l = opt (some l)
 
-||| Recognise the first matching lexer from a non-empty list.
+||| Recognise the first matching lexer from a Foldable. Always consumes input
+||| if one of the options succeeds. Fails if the foldable is empty.
 export
-choice : (xs : List Lexer) -> {auto ok : NonEmpty xs} -> Lexer
-choice (x :: [])          = x
-choice (x :: xs@(_ :: _)) = x <|> choice xs
+choice : Foldable t => t Lexer -> Lexer
+choice xs = foldr Alt Fail xs
 
 ||| Recognise many instances of `l` until an instance of `end` is
 ||| encountered.

--- a/libs/contrib/Text/Lexer.idr
+++ b/libs/contrib/Text/Lexer.idr
@@ -127,6 +127,34 @@ export
 manyTill : (l : Lexer) -> (end : Lexer) -> Recognise False
 manyTill l end = end <|> opt (l <+> manyTill l end)
 
+||| Recognise a sub-lexer at least `min` times. Consumes input unless
+||| min is zero.
+export
+atLeast : (min : Nat) -> (l : Lexer) -> Recognise (min > 0)
+atLeast Z l       = many l
+atLeast (S min) l = l <+> atLeast min l
+
+||| Recognise a sub-lexer at most `max` times. Not guaranteed to
+||| consume input.
+export
+atMost : (max : Nat) -> (l : Lexer) -> Recognise False
+atMost Z _     = Empty
+atMost (S k) l = atMost k l <+> opt l
+
+||| Recognise a sub-lexer repeated between `min` and `max` times. Fails
+||| if the inputs are out of order. Consumes input unless min is zero.
+export
+between : (min : Nat) -> (max : Nat) -> (l : Lexer) -> Recognise (min > 0)
+between Z max l           = atMost max l
+between (S min) Z _       = Fail
+between (S min) (S max) l = l <+> between min max l
+
+||| Recognise exactly `count` repeated occurrences of a sub-lexer.
+||| Consumes input unless count is zero.
+export
+exactly : (count : Nat) -> (l : Lexer) -> Recognise (count > 0)
+exactly n l = between n n l
+
 ||| Recognise any character
 export
 any : Lexer


### PR DESCRIPTION
Add new combinators for counted sub-lexer repetition.

This includes the combinators `atLeast`, `atMost`, `between`, and `exactly`.

The `choice` combinator was also generalized to accept empty lists.