### PR TITLE
Data.Morphisms: add casts between compatible morphisms

### DIFF
--- a/libs/base/Data/Morphisms.idr
+++ b/libs/base/Data/Morphisms.idr
@@ -40,3 +40,15 @@ infixr 1 ~>
 
 (~>) : Type -> Type -> Type
 a ~> b = Morphism a b
+
+Cast (Endomorphism a) (Morphism a a) where
+  cast (Endo f) = Mor f
+
+Cast (Morphism a a) (Endomorphism a) where
+  cast (Mor f) = Endo f
+
+Monad m => Cast (Morphism a (m b)) (Kleislimorphism m a b) where
+  cast (Mor f) = Kleisli f
+
+Cast (Kleislimorphism m a b) (Morphism a (m b)) where
+  cast (Kleisli f) = Mor f


### PR DESCRIPTION
Implementations of `Cast` between compatible morphism types. This code was added to `base` to be alongside the type definitions.

#### No longer included in this PR:

> The second commit adds bidirectional conversions for morphism types. There is support for implicitly casting using the above implementations, and also bidirectionally converting between a morphism and the function it wraps.
>
> Since each of these categories of conversions have the potential to interfere with one another in confusing ways, I've placed them in separate packages.
>
> * `Data.Morphisms.Implicit.To`: Conversions from a function to a morphism wrapping that function.
> * `Data.Morphisms.Implicit.From`: Conversions from a morphism to the function it wraps.
> * `Data.Morphisms.Implicit.Cast`: Bidirectional conversions between compatible morphisms.