### PR TITLE
Text.Lexer: positive and negative lookahead

### DIFF
--- a/libs/contrib/Text/Lexer.idr
+++ b/libs/contrib/Text/Lexer.idr
@@ -101,6 +101,10 @@ export
 any : Lexer
 any = Pred (const True)
 
+||| Recognise any character if the sub-lexer `l` fails.
+non : (l : Lexer) -> Lexer
+non l = reject l <+> any
+
 ||| Recognise no input (doesn't consume any input)
 export
 empty : Recognise False


### PR DESCRIPTION
This required a new constructor for `Recognise`, called `Look`.

Exports new functions `look` and `unlook`.
