### PR TITLE
Text.Lexer: export a fail function

### DIFF
--- a/libs/contrib/Text/Lexer.idr
+++ b/libs/contrib/Text/Lexer.idr
@@ -39,6 +39,11 @@ export
 (<|>) : Recognise c1 -> Recognise c2 -> Recognise (c1 && c2)
 (<|>) = Alt
 
+||| A recogniser that always fails.
+export
+fail : Recognise c
+fail = Fail
+
 ||| Positive lookahead. Never consumes input.
 export
 expect : Recognise c -> Recognise False


### PR DESCRIPTION
Adds the function `fail`.

The expored API of this module currently allows the construction of
an always-failing `Lexer` in various ways. This function makes that
explicit.

The function `fail` has an implicit argument `{c}` like `Fail`, so it
can return both consuming and non-consuming recognisers.


I'm not certain an always-failing `Recognise False` is at all useful in a public
API, so let me know if I should change the return type to `Lexer`.

