### PR TITLE
Text.Lexer: case-insensitive variants of `is` and `exact`.

### DIFF
--- a/libs/contrib/Text/Lexer.idr
+++ b/libs/contrib/Text/Lexer.idr
@@ -70,6 +70,14 @@ export
 isNot : Char -> Lexer
 isNot x = Pred (/=x)
 
+||| Recognise a specific string
+export
+exact : String -> Lexer
+exact str with (unpack str)
+  exact str | [] = Fail -- Not allowed, Lexer has to consume
+  exact str | (x :: xs)
+      = foldl SeqEmpty (is x) (map is xs)
+
 ||| Recognise a lexer or recognise no input. This is not guaranteed
 ||| to consume input
 export
@@ -189,14 +197,6 @@ digit = pred isDigit
 export
 digits : Lexer
 digits = some digit
-
-||| Recognise a specific string
-export
-exact : String -> Lexer
-exact str with (unpack str)
-  exact str | [] = Fail -- Not allowed, Lexer has to consume
-  exact str | (x :: xs)
-      = foldl SeqEmpty (is x) (map is xs)
 
 ||| Recognise a single hexidecimal digit
 export

--- a/libs/contrib/Text/Lexer.idr
+++ b/libs/contrib/Text/Lexer.idr
@@ -70,6 +70,16 @@ export
 isNot : Char -> Lexer
 isNot x = Pred (/=x)
 
+||| Recognise a character case-insensitively
+export
+like : Char -> Lexer
+like x = Pred (\y => toUpper x == toUpper y)
+
+||| Recognise anything but the given character case-insensitively
+export
+notLike : Char -> Lexer
+notLike x = Pred (\y => toUpper x /= toUpper y)
+
 ||| Recognise a specific string
 export
 exact : String -> Lexer
@@ -77,6 +87,14 @@ exact str with (unpack str)
   exact str | [] = Fail -- Not allowed, Lexer has to consume
   exact str | (x :: xs)
       = foldl SeqEmpty (is x) (map is xs)
+
+||| Recognise a specific string case-insensitively
+export
+approx : String -> Lexer
+approx str with (unpack str)
+  approx str | [] = Fail -- Not allowed, Lexer has to consume
+  approx str | (x :: xs)
+      = foldl SeqEmpty (like x) (map like xs)
 
 ||| Recognise a lexer or recognise no input. This is not guaranteed
 ||| to consume input


### PR DESCRIPTION
I have named these `like` and `approx`, respectively, which I think reads nicely.