### PR TITLE
Revert "Fix #4020: Fix duplication in output of `--hightlight`."

### DIFF
--- a/src/Idris/Output.hs
+++ b/src/Idris/Output.hs
@@ -234,15 +234,14 @@ sendParserHighlighting =
 
 sendHighlighting :: [(FC, OutputAnnotation)] -> Idris ()
 sendHighlighting highlights =
-  do let highlights_uniq = nub highlights
-     ist <- getIState
+  do ist <- getIState
      case idris_outputmode ist of
        RawOutput _ -> updateIState $
                       \ist -> ist { idris_highlightedRegions =
-                                      highlights_uniq ++ idris_highlightedRegions ist }
+                                      highlights ++ idris_highlightedRegions ist }
        IdeMode n h ->
          let fancier = [ toSExp (fc, fancifyAnnots ist False annot)
-                       | (fc, annot) <- highlights_uniq, fullFC fc
+                       | (fc, annot) <- highlights, fullFC fc
                        ]
          in case fancier of
               [] -> return ()


### PR DESCRIPTION
Reverts idris-lang/Idris-dev#4021

I've been noticing unhighlighted terms in output, so reverting until I can diagnose what is going wrong.