### PR TITLE
Text.Lexer: fix behavior of `surround`

### DIFF
--- a/libs/contrib/Text/Lexer.idr
+++ b/libs/contrib/Text/Lexer.idr
@@ -261,7 +261,7 @@ symbols = some symbol
 ||| delimiting lexers
 export
 surround : (start : Lexer) -> (end : Lexer) -> (l : Lexer) -> Lexer
-surround start end l = start <+> manyTill l end
+surround start end l = start <+> many (reject end <+> l) <+> end
 
 ||| Recognise zero or more occurrences of a sub-lexer surrounded
 ||| by the same quote lexer on both sides (useful for strings)


### PR DESCRIPTION
`manyTill` is a `Recognise False`. It will recognise either nothing,
or any number of `l` followed by an `end`. This makes it unsuited for
`surround`, because the end character is required.