### PR TITLE
Text.Lexer: fix `reject` behavior at end-of-input

### DIFF
--- a/libs/contrib/Text/Lexer.idr
+++ b/libs/contrib/Text/Lexer.idr
@@ -9,7 +9,7 @@ export
 data Recognise : (consumes : Bool) -> Type where
      Empty : Recognise False
      Fail : Recognise c
-     Expect : Recognise c -> Recognise False
+     Lookahead : (positive : Bool) -> Recognise c -> Recognise False
      Pred : (Char -> Bool) -> Recognise True
      SeqEat : Recognise True -> Inf (Recognise e) -> Recognise True
      SeqEmpty : Recognise e1 -> Recognise e2 -> Recognise (e1 || e2)
@@ -47,18 +47,12 @@ fail = Fail
 ||| Positive lookahead. Never consumes input.
 export
 expect : Recognise c -> Recognise False
-expect = Expect
+expect = Lookahead True
 
 ||| Negative lookahead. Never consumes input.
 export
 reject : Recognise c -> Recognise False
-reject Empty            = Fail
-reject Fail             = Empty
-reject (Expect x)       = reject x
-reject (Pred f)         = Expect (Pred (not . f))
-reject (SeqEat r1 r2)   = reject r1 <|> Expect (SeqEat r1 (reject r2))
-reject (SeqEmpty r1 r2) = reject r1 <|> Expect (SeqEmpty r1 (reject r2))
-reject (Alt r1 r2)      = reject r1 <+> reject r2
+reject = Lookahead False
 
 ||| Recognise a specific character
 export
@@ -175,10 +169,10 @@ strTail start (MkStrLen str len)
 scan : Recognise c -> Nat -> StrLen -> Maybe Nat
 scan Empty idx str = pure idx
 scan Fail idx str = Nothing
-scan (Expect r) idx str
-    = case scan r idx str of
-           Just _  => pure idx
-           Nothing => Nothing
+scan (Lookahead positive r) idx str
+    = if isJust (scan r idx str) == positive
+         then Just idx
+         else Nothing
 scan (Pred f) idx str
     = do c <- strIndex str idx
          if f c


### PR DESCRIPTION
Previously, `reject` was implemented using `expect`, and inverting the
predicate used with `Pred`. This means that `reject` would fail if it's the
final lexer in the input, instead of succeeding like it should.

To fix this, the constructor `Expect` was renamed to `Lookahead`, with a new
boolean argument indicating positive or negative lookahead. This boolean is
processed in `scan`. Now, `reject` succeeds if the sub-lexer fails for any
reason, including end of input.