### PR TITLE
Add missing patterns for a REPL function (#3883)

### DIFF
--- a/src/Idris/REPL.hs
+++ b/src/Idris/REPL.hs
@@ -1474,6 +1474,17 @@ process fn (PPrint fmt width t)
             ty' = normaliseC ctxt [] ty
         iPrintResult =<< renderExternal fmt width (pprintDelab ist tm)
 
+
+process fn Quit = iPrintError "Unimplemented pattern for command Quit"
+process fn Reload = iPrintError "Unimplemented pattern for command Reload"
+process fn Watch = iPrintError "Unimplemented pattern for command Watch"
+process fn (Load _ _) = iPrintError "Unimplemented pattern for command Load"
+process fn Edit = iPrintError "Unimplemented pattern for command Edit"
+process fn Proofs = iPrintError "Unimplemented pattern for command Proofs"
+process fn (Verbosity _)
+   = iPrintError "Unimplemented pattern for command Verbosity"
+
+
 showTotal :: Totality -> IState -> Doc OutputAnnotation
 showTotal t@(Partial (Other ns)) i
    = text "possibly not total due to:" <$>

--- a/src/Idris/REPL.hs
+++ b/src/Idris/REPL.hs
@@ -1475,14 +1475,14 @@ process fn (PPrint fmt width t)
         iPrintResult =<< renderExternal fmt width (pprintDelab ist tm)
 
 
-process fn Quit = iPrintError "Unimplemented pattern for command Quit"
-process fn Reload = iPrintError "Unimplemented pattern for command Reload"
-process fn Watch = iPrintError "Unimplemented pattern for command Watch"
-process fn (Load _ _) = iPrintError "Unimplemented pattern for command Load"
-process fn Edit = iPrintError "Unimplemented pattern for command Edit"
-process fn Proofs = iPrintError "Unimplemented pattern for command Proofs"
+process fn Quit = iPrintError "Command ':quit' is currently unsupported"
+process fn Reload = iPrintError "Command ':reload' is currently unsupported"
+process fn Watch = iPrintError "Command ':watch' is currently unsupported"
+process fn (Load _ _) = iPrintError "Command ':load' is currently unsupported"
+process fn Edit = iPrintError "Command ':edit' is currently unsupported"
+process fn Proofs = iPrintError "Command ':proofs' is currently unsupported"
 process fn (Verbosity _)
-   = iPrintError "Unimplemented pattern for command Verbosity"
+   = iPrintError "Command ':verbosity' is currently unsupported"
 
 
 showTotal :: Totality -> IState -> Doc OutputAnnotation


### PR DESCRIPTION
Seven missing patterns for the `process` function (`src/Idris/REPL.hs`) were
added. This makes patterns in the function exhaustive.