### PR TITLE
Add Paths_idris to other-modules of codegen executables

### DIFF
--- a/idris.cabal
+++ b/idris.cabal
@@ -375,6 +375,7 @@ Test-suite regression-and-feature-tests
 
 Executable idris-codegen-c
   Main-is:        Main.hs
+  other-modules:  Paths_idris
   hs-source-dirs: codegen/idris-codegen-c
 
   Build-depends:  idris
@@ -389,6 +390,7 @@ Executable idris-codegen-c
 
 Executable idris-codegen-javascript
   Main-is:        Main.hs
+  other-modules:  Paths_idris
   hs-source-dirs: codegen/idris-codegen-javascript
 
   Build-depends:  idris
@@ -403,6 +405,7 @@ Executable idris-codegen-javascript
 
 Executable idris-codegen-node
   Main-is:        Main.hs
+  other-modules:  Paths_idris
   hs-source-dirs: codegen/idris-codegen-node
 
   Build-depends:  idris


### PR DESCRIPTION
When compiling Idris with GHC 8.2, several warnings of a similar variety pop up:

```
Preprocessing executable 'idris-codegen-c' for idris-1.1.1..
Building executable 'idris-codegen-c' for idris-1.1.1..

<no location info>: warning: [-Wmissing-home-modules]
    These modules are needed for compilation but not listed in your .cabal file's other-modules: Paths_idris
[1 of 2] Compiling Paths_idris      ( dist/build/idris-codegen-c/autogen/Paths_idris.hs, dist/build/idris-codegen-c/idris-codegen-c-tmp/Paths_idris.o )
[2 of 2] Compiling Main             ( codegen/idris-codegen-c/Main.hs, dist/build/idris-codegen-c/idris-codegen-c-tmp/Main.o )

<no location info>: warning: [-Wmissing-home-modules]
    These modules are needed for compilation but not listed in your .cabal file's other-modules: Paths_idris
Linking dist/build/idris-codegen-c/idris-codegen-c ...
Preprocessing executable 'idris-codegen-javascript' for idris-1.1.1..
Building executable 'idris-codegen-javascript' for idris-1.1.1..

<no location info>: warning: [-Wmissing-home-modules]
    These modules are needed for compilation but not listed in your .cabal file's other-modules: Paths_idris
[1 of 2] Compiling Paths_idris      ( dist/build/idris-codegen-javascript/autogen/Paths_idris.hs, dist/build/idris-codegen-javascript/idris-codegen-javascript-tmp/Paths_idris.o )
[2 of 2] Compiling Main             ( codegen/idris-codegen-javascript/Main.hs, dist/build/idris-codegen-javascript/idris-codegen-javascript-tmp/Main.o )

<no location info>: warning: [-Wmissing-home-modules]
    These modules are needed for compilation but not listed in your .cabal file's other-modules: Paths_idris
Linking dist/build/idris-codegen-javascript/idris-codegen-javascript ...
Preprocessing executable 'idris-codegen-node' for idris-1.1.1..
Building executable 'idris-codegen-node' for idris-1.1.1..

<no location info>: warning: [-Wmissing-home-modules]
    These modules are needed for compilation but not listed in your .cabal file's other-modules: Paths_idris
[1 of 2] Compiling Paths_idris      ( dist/build/idris-codegen-node/autogen/Paths_idris.hs, dist/build/idris-codegen-node/idris-codegen-node-tmp/Paths_idris.o )
[2 of 2] Compiling Main             ( codegen/idris-codegen-node/Main.hs, dist/build/idris-codegen-node/idris-codegen-node-tmp/Main.o )

<no location info>: warning: [-Wmissing-home-modules]
    These modules are needed for compilation but not listed in your .cabal file's other-modules: Paths_idris
Linking dist/build/idris-codegen-node/idris-codegen-node ...
```

As the warning suggests, these can be resolved by adding `Paths_idris` to `other-modules` in the right places in `idris.cabal`, which this PR accomplishes.