### PR TITLE
--interface for node backend

### DIFF
--- a/codegen/idris-codegen-node/Main.hs
+++ b/codegen/idris-codegen-node/Main.hs
@@ -10,10 +10,12 @@ import IRTS.Compiler
 
 import Paths_idris
 
+import Control.Monad
 import System.Environment
 import System.Exit
 
 data Opts = Opts { inputs :: [FilePath]
+                 , interface :: Bool
                  , output :: FilePath
                  }
 
@@ -23,17 +25,20 @@ showUsage = do putStrLn "A code generator which is intended to be called by the 
 
 getOpts :: IO Opts
 getOpts = do xs <- getArgs
-             return $ process (Opts [] "main.js") xs
+             return $ process (Opts [] False "main.js") xs
   where
     process opts ("-o":o:xs) = process (opts { output = o }) xs
+    process opts ("--interface":xs) = process (opts { interface = True }) xs
     process opts (x:xs) = process (opts { inputs = x:inputs opts }) xs
     process opts [] = opts
 
 jsMain :: Opts -> Idris ()
 jsMain opts = do elabPrims
                  loadInputs (inputs opts) Nothing
-                 mainProg <- elabMain
-                 ir <- compile (Via IBCFormat "node") (output opts) (Just mainProg)
+                 mainProg <- if interface opts
+                                then return Nothing
+                                else liftM Just elabMain
+                 ir <- compile (Via IBCFormat "node") (output opts) mainProg
                  runIO $ codegenNode ir
 
 main :: IO ()

--- a/src/IRTS/CodegenJavaScript.hs
+++ b/src/IRTS/CodegenJavaScript.hs
@@ -55,8 +55,15 @@ codegenJavaScript ci =
 
 codegenNode :: CodeGenerator
 codegenNode ci =
-  do
-    if outputType ci == Executable then
+  if interfaces ci then
+    codegenJs (CGConf { header = ""
+                      , footer = ""
+                      , jsbnPath = "jsbn/jsbn-browser.js"
+                      , extraRunTime = "Runtime-node.js"
+                      }
+              )
+              ci
+    else
       do
         codegenJs (CGConf { header = "#!/usr/bin/env node\n"
                           , footer = ""
@@ -69,11 +76,3 @@ codegenNode ci =
                                                          , executable = True
                                                          , writable   = True
                                                          })
-      else
-        codegenJs (CGConf { header = ""
-                          , footer = ""
-                          , jsbnPath = "jsbn/jsbn-browser.js"
-                          , extraRunTime = "Runtime-node.js"
-                          }
-                  )
-                  ci

--- a/src/IRTS/CodegenJavaScript.hs
+++ b/src/IRTS/CodegenJavaScript.hs
@@ -56,14 +56,24 @@ codegenJavaScript ci =
 codegenNode :: CodeGenerator
 codegenNode ci =
   do
-    codegenJs (CGConf { header = "#!/usr/bin/env node\n"
-                      , footer = ""
-                      , jsbnPath = "jsbn/jsbn-browser.js"
-                      , extraRunTime = "Runtime-node.js"
-                      }
-              )
-              ci
-    setPermissions (outputFile ci) (emptyPermissions { readable   = True
-                                                     , executable = True
-                                                     , writable   = True
-                                                     })
+    if outputType ci == Executable then
+      do
+        codegenJs (CGConf { header = "#!/usr/bin/env node\n"
+                          , footer = ""
+                          , jsbnPath = "jsbn/jsbn-browser.js"
+                          , extraRunTime = "Runtime-node.js"
+                          }
+                  )
+                  ci
+        setPermissions (outputFile ci) (emptyPermissions { readable   = True
+                                                         , executable = True
+                                                         , writable   = True
+                                                         })
+      else
+        codegenJs (CGConf { header = ""
+                          , footer = ""
+                          , jsbnPath = "jsbn/jsbn-browser.js"
+                          , extraRunTime = "Runtime-node.js"
+                          }
+                  )
+                  ci

--- a/src/IRTS/Compiler.hs
+++ b/src/IRTS/Compiler.hs
@@ -152,7 +152,7 @@ generate codegen mainmod ir
                                         return fn
                        let cmd = "idris-codegen-" ++ cg
                            args = [input, "-o", outputFile ir] ++ compilerFlags ir
-                       exit <- rawSystem cmd args
+                       exit <- rawSystem cmd (if interfaces ir then "--interface" : args else args)
                        when (exit /= ExitSuccess) $
                             putStrLn ("FAILURE: " ++ show cmd ++ " " ++ show args)
        Bytecode -> dumpBC (simpleDecls ir) (outputFile ir)

--- a/src/IRTS/JavaScript/Codegen.hs
+++ b/src/IRTS/JavaScript/Codegen.hs
@@ -114,11 +114,10 @@ codegenJs conf ci =
     debug <- isYes <$> lookupEnv "IDRISJS_DEBUG"
     let defs' = Map.fromList $ liftDecls ci
     let defs = globlToCon defs'
-    let isExec = outputType ci == Executable
-    putStrLn $ show $ isExec
-    let used = if isExec then
-                  Map.elems $ removeDeadCode defs [sMN 0 "runMain"]
-                  else Map.elems $ removeDeadCode defs (getExpNames $ exportDecls ci)
+    let iface = interfaces ci
+    let used = if iface then
+                  Map.elems $ removeDeadCode defs (getExpNames $ exportDecls ci)
+                  else Map.elems $ removeDeadCode defs [sMN 0 "runMain"]
     when debug $ do
         writeFile (outputFile ci ++ ".LDeclsDebug") $ (unlines $ intersperse "" $ map show used) ++ "\n\n\n"
         putStrLn $ "Finished calculating used"
@@ -149,8 +148,8 @@ codegenJs conf ci =
                                              , doPartials (partialApplications stats), "\n"
                                              , doHiddenClasses (hiddenClasses stats), "\n"
                                              , out, "\n"
-                                             , if isExec then jsName (sMN 0 "runMain") `T.append` "();\n"
-                                                  else T.concat ["module.exports = {\n", T.intercalate ";\n" $ concatMap makeExportDecls (exportDecls ci), "\n};\n"]
+                                             , if iface then T.concat ["module.exports = {\n", T.intercalate ";\n" $ concatMap makeExportDecls (exportDecls ci), "\n};\n"]
+                                                  else jsName (sMN 0 "runMain") `T.append` "();\n"
                                              , "}.call(this))"
                                              , footer conf
                                              ]

--- a/src/Idris/REPL.hs
+++ b/src/Idris/REPL.hs
@@ -79,6 +79,7 @@ import Idris.Termination
 import Idris.TypeSearch (searchByType)
 import Idris.WhoCalls
 import IRTS.Compiler
+import IRTS.CodegenCommon
 import Network
 import Prelude hiding (id, (.), (<$>))
 import System.Console.Haskeline as H
@@ -1284,7 +1285,8 @@ process fn (Compile codegen f)
                                return (Just m')
                        ir <- compile codegen f m
                        i <- getIState
-                       runIO $ generate codegen (fst (head (idris_imported i))) ir
+                       let ir' = ir {interfaces = iface}
+                       runIO $ generate codegen (fst (head (idris_imported i))) ir'
   where fc = fileFC "main"
 process fn (LogLvl i) = setLogLevel i
 process fn (LogCategory cs) = setLogCats cs


### PR DESCRIPTION
To address #4055 This pr adds --interface option to node backend
Example 
```
$ cat tiface.idr
module Lib

export
ones : Int -> List Int
ones 0 = []
ones n = 1 :: (ones (n - 1))

lib : FFI_Export FFI_JS "" []
lib = Data (List Int) "List Int" $
      Fun ones "ones" $
      End
$ idris --codegen node --interface  tiface.idr -o lib.js
$ node
> l = require("./lib.js")
{ ones: [Function: Lib__ones] }
> l.ones(2)
$HC_2_1$Prelude__List___58__58_ {
  type: 1,
  '$1': 1,
  '$2': $HC_2_1$Prelude__List___58__58_ { type: 1, '$1': 1, '$2': { type: 0 } } }
> $ 
```