### PR TITLE
Make type of `withAlloc` more general

### DIFF
--- a/libs/contrib/CFFI/Memory.idr
+++ b/libs/contrib/CFFI/Memory.idr
@@ -40,10 +40,11 @@ free : CPtr -> IO ()
 free (CPt p _ ) = mfree p
 
 ||| Perform an IO action with memory that is freed afterwards
-withAlloc : Composite -> (CPtr -> IO ()) -> IO ()
+withAlloc : Composite -> (CPtr -> IO a) -> IO a
 withAlloc t f = do m <- alloc t
-                   f m
+                   r <- f m
                    free m
+                   pure r
 
 infixl 1 ~~>
 ||| Perform an IO action with memory that is freed afterwards

--- a/test/ffi008/ffi008.c
+++ b/test/ffi008/ffi008.c
@@ -1,5 +1,7 @@
-#include "ffi008.h"
 #include <stdio.h>
+#include <stdlib.h>
+
+#include "ffi008.h"
 
 int size1(void) {
     return sizeof(struct test1);
@@ -11,4 +13,13 @@ int size2(void) {
 
 void print_mystruct(void) {
     printf("a: %d b: %d\n", mystruct.a, mystruct.b);
+}
+
+struct test2* calc_struct(struct test1 *in)
+{
+    struct test2 *out = malloc(sizeof(struct test2));
+    out->a = in->a * in->a;
+    out->b = in->b & 0x0000FFFF;
+
+    return out;
 }

--- a/test/ffi008/ffi008.h
+++ b/test/ffi008/ffi008.h
@@ -15,3 +15,5 @@ struct test2 mystruct;
 int size1(void);
 int size2(void);
 void print_mystruct();
+
+struct test2* calc_struct(struct test1*);

--- a/test/ffi008/ffi008.idr
+++ b/test/ffi008/ffi008.idr
@@ -18,6 +18,9 @@ mystruct = foreign FFI_C "&mystruct" (IO Ptr)
 print_mystruct : IO ()
 print_mystruct = foreign FFI_C "print_mystruct" (IO ())
 
+calc_struct : Ptr -> IO Ptr
+calc_struct = foreign FFI_C "calc_struct" (Ptr -> IO Ptr)
+
 test1 : Composite
 test1 = STRUCT [I8, I64]
 
@@ -46,3 +49,10 @@ main = do
         print !(peek I32 f1)
     withAlloc PTR $ \p =>
         poke PTR p fms
+    res <- withAlloc test1 $ \p => do
+        let f1 = (test1 # 0) p
+        let f2 = (test1 # 1) p
+        poke I8 f1 42
+        poke I64 f2 1125899906842624
+        calc_struct p
+    free res


### PR DESCRIPTION
This change makes the whole `withAlloc` block return the same value of
the function given as a parameter.