### PR TITLE
Make UnmatchedCase errors lazy (#4049)

### DIFF
--- a/src/IRTS/Compiler.hs
+++ b/src/IRTS/Compiler.hs
@@ -527,7 +527,7 @@ irTree top args tree = do
 
 irSC :: Name -> Vars -> SC -> Idris LExp
 irSC top vs (STerm t) = irTerm top vs [] t
-irSC top vs (UnmatchedCase str) = return $ LError str
+irSC top vs (UnmatchedCase str) = return $ LLazyExp $ LError str
 
 irSC top vs (ProjCase tm alts) = do
     tm'   <- irTerm top vs [] tm


### PR DESCRIPTION
Failure in erasure analysis may lead to UnmatchedCase errors being included in the generated code. Such errors should be evaluated lazily.

This fixes #4049