### PR TITLE
Add discriminate tactic to Pruviloj

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,7 @@
 
 + Added `Text.Literate`, a module for working with literate source files.
 + Added `Data.IORef`, for working with mutable references in `IO`.
++ Added `discriminate` tactic to Pruviloj.
 
 ## Tool Updates
 + Private functions are no longer visible in the REPL except for modules

--- a/CONTRIBUTORS
+++ b/CONTRIBUTORS
@@ -121,6 +121,7 @@ John Wiegley
 Jon Atack
 Jonas Westerlund
 Jonathan Sterling
+Joomy Korkut
 Joseph Huang
 Josh Vera
 JP Smith


### PR DESCRIPTION
A port of the `discriminate` tactic from Coq is added to Pruviloj.