### PR TITLE
Add export list to Idris.Parser

### DIFF
--- a/src/Idris/Parser.hs
+++ b/src/Idris/Parser.hs
@@ -12,11 +12,9 @@ Maintainer  : The Idris Community.
 -- FIXME: {-# OPTIONS_GHC -fwarn-incomplete-patterns #-}
 {-# OPTIONS_GHC -fwarn-unused-imports #-}
 
-module Idris.Parser(module Idris.Parser,
-                    module Idris.Parser.Expr,
-                    module Idris.Parser.Data,
-                    module Idris.Parser.Helpers,
-                    module Idris.Parser.Ops) where
+module Idris.Parser(IdrisParser(..), ImportInfo(..), addReplSyntax, clearParserWarnings,
+                    decl, fixColour, loadFromIFile, loadModule, name, opChars, parseElabShellStep, parseConst, parseExpr, parseImports, parseTactic,
+                    runparser) where
 
 import Idris.AbsSyntax hiding (namespace, params)
 import Idris.Core.Evaluate

--- a/src/Idris/REPL/Parser.hs
+++ b/src/Idris/REPL/Parser.hs
@@ -17,6 +17,10 @@ import Idris.Core.TT
 import Idris.Help
 import Idris.Options
 import qualified Idris.Parser as P
+import qualified Idris.Parser.Expr as P
+import qualified Idris.Parser.Helpers as P
+import qualified Idris.Parser.Ops as P
+
 import Idris.REPL.Commands
 
 import Control.Applicative


### PR DESCRIPTION
Let `REPL/Parser.hs` access the submodules directly as it uses lots of low-level parsing stuff