### PR TITLE
Replace splitPair with construct tactic

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,7 +13,7 @@
 
 + Added `Text.Literate`, a module for working with literate source files.
 + Added `Data.IORef`, for working with mutable references in `IO`.
-+ Added `discriminate` and `splitPair` tactics to Pruviloj.
++ Added `discriminate` and `construct` tactics to Pruviloj.
 
 ## Tool Updates
 + Private functions are no longer visible in the REPL except for modules

--- a/libs/pruviloj/Pruviloj/Core.idr
+++ b/libs/pruviloj/Pruviloj/Core.idr
@@ -256,21 +256,6 @@ unproduct tm =
        try (unproduct (Var n1))
        try (unproduct (Var n2))
 
-||| If the goal is a tuple or a dependent pair, then split it into
-||| two goals and return the new goal names.
-||| It fails if the goal is neither a `Pair` nor a `DPair`.
-splitPair : Elab (TTName, TTName)
-splitPair =
-  let bug = [TextPart "Splitting created wrong number of holes"] in
-  case !goalType of
-    `(Pair ~A ~B)   => do [x, y] <- apply `(MkPair {A=~A} {B=~B}) [False, False]
-                                | _ => fail bug
-                          solve ; pure (x, y)
-    `(DPair ~A ~Pr) => do [x, y] <- apply `(MkDPair {a=~A} {P=~Pr}) [False, False]
-                              | _ => fail bug
-                          solve ; pure (x, y)
-    _ => fail [TextPart "Goal is not a pair"]
-
 ||| Try to apply the constructors of the goal data type one by one,
 ||| and apply the first one that works.
 ||| Similar to `constructor` in Coq.

--- a/test/pruviloj001/expected
+++ b/test/pruviloj001/expected
@@ -1,6 +1,6 @@
-pruviloj001.idr:74:9:
+pruviloj001.idr:73:9:
 Main.evenZ has a name which may be implicitly bound.
 This is likely to lead to problems!
-pruviloj001.idr:75:10:
+pruviloj001.idr:74:10:
 Main.evenSS has a name which may be implicitly bound.
 This is likely to lead to problems!

--- a/test/pruviloj001/expected
+++ b/test/pruviloj001/expected
@@ -1,0 +1,6 @@
+pruviloj001.idr:74:9:
+Main.evenZ has a name which may be implicitly bound.
+This is likely to lead to problems!
+pruviloj001.idr:75:10:
+Main.evenSS has a name which may be implicitly bound.
+This is likely to lead to problems!

--- a/test/pruviloj001/expected
+++ b/test/pruviloj001/expected
@@ -1,6 +1,0 @@
-pruviloj001.idr:73:9:
-Main.evenZ has a name which may be implicitly bound.
-This is likely to lead to problems!
-pruviloj001.idr:74:10:
-Main.evenSS has a name which may be implicitly bound.
-This is likely to lead to problems!

--- a/test/pruviloj001/pruviloj001.idr
+++ b/test/pruviloj001/pruviloj001.idr
@@ -70,8 +70,8 @@ pair : a -> b -> (a, b)
 pair = %runElab (do intros ; construct ; hypothesis ; hypothesis)
 
 data Even : Nat -> Type where
-  evenZ : Even Z
-  evenSS : Even n -> Even (S (S n))
+  EvenZ : Even Z
+  EvenSS : Even n -> Even (S (S n))
 
 even6 : Even 6
 even6 = %runElab (do construct ; construct ; construct ; construct ; skip)

--- a/test/pruviloj001/pruviloj001.idr
+++ b/test/pruviloj001/pruviloj001.idr
@@ -66,6 +66,19 @@ appendNilRightId : (l : List a) ->
                    l ++ [] = l
 appendNilRightId = %runElab mush
 
+pair : a -> b -> (a, b)
+pair = %runElab (do intros ; construct ; hypothesis ; hypothesis)
+
+data Even : Nat -> Type where
+  evenZ : Even Z
+  evenSS : Even n -> Even (S (S n))
+
+even6 : Even 6
+even6 = %runElab (do construct ; construct ; construct ; construct ; skip)
+
+even6' : Even 6
+even6' = %runElab (repeatUntilFail (ignore construct))
+
 -- Local Variables:
 -- idris-load-packages: ("pruviloj")
 -- End:


### PR DESCRIPTION
As @david-christiansen suggested in the comment thread of #4094, this is a generalized version of `splitPair`. It behaves like `constructor` in Coq.

Now we can do this:
```idris
data Even : Nat -> Type where
  evenZ : Even Z
  evenSS : Even n -> Even (S (S n))

even6 : Even 6
even6 = %runElab (repeatUntilFail (ignore construct))
```