### PR TITLE
Add styling for metavariables in LaTeX and HTML pretty printer

### DIFF
--- a/src/Idris/Output.hs
+++ b/src/Idris/Output.hs
@@ -362,6 +362,7 @@ renderExternal fmt width doc
                     [".idris-data { color: red; } ",
                      ".idris-type { color: blue; }",
                      ".idris-function {color: green; }",
+                     ".idris-metavar {color: turquoise; }",
                      ".idris-keyword { font-weight: bold; }",
                      ".idris-bound { color: purple; }",
                      ".idris-implicit { font-style: italic; }",
@@ -375,7 +376,8 @@ renderExternal fmt width doc
                "\\newcommand{\\"++ cmd ++
                "}[1]{\\textcolor{"++ color ++"}{#1}}")
              [("IdrisData", "red"), ("IdrisType", "blue"),
-              ("IdrisBound", "magenta"), ("IdrisFunction", "green")] ++
+              ("IdrisBound", "magenta"), ("IdrisFunction", "green"),
+              ("IdrisMetavar", "cyan")] ++
         ["\\newcommand{\\IdrisKeyword}[1]{{\\underline{#1}}}",
          "\\newcommand{\\IdrisImplicit}[1]{{\\itshape \\IdrisBound{#1}}}",
          "\n",


### PR DESCRIPTION
The metavariable styling case is missing in the pretty printer for LaTeX and HTML, which means `\IdrisMetavar` command is undefined in LaTeX, which means the pretty printer can return buggy LaTeX. This PR fixes that.