### PR TITLE
Prelude.Nat: add IsSucc predicate type

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,6 +14,7 @@
 + Added `Text.Literate`, a module for working with literate source files.
 + Added `Data.IORef`, for working with mutable references in `IO` and `JS_IO`.
 + Added `discriminate` and `construct` tactics to Pruviloj.
++ Added `IsSucc` type to `Prelude`, which proves that a `Nat` is a successor.
 
 ## Tool Updates
 + Private functions are no longer visible in the REPL except for modules

--- a/libs/prelude/Prelude/Nat.idr
+++ b/libs/prelude/Prelude/Nat.idr
@@ -38,6 +38,11 @@ total isSucc : Nat -> Bool
 isSucc Z     = False
 isSucc (S n) = True
 
+
+||| Proof that `n` is not equal to Z
+data IsSucc : (n : Nat) -> Type where
+  ItIsSucc : IsSucc (S n)
+
 --------------------------------------------------------------------------------
 -- Basic arithmetic functions
 --------------------------------------------------------------------------------

--- a/libs/prelude/Prelude/Nat.idr
+++ b/libs/prelude/Prelude/Nat.idr
@@ -43,6 +43,14 @@ isSucc (S n) = True
 data IsSucc : (n : Nat) -> Type where
   ItIsSucc : IsSucc (S n)
 
+Uninhabited (IsSucc Z) where
+  uninhabited ItIsSucc impossible
+
+||| A decision procedure for `IsSucc`
+isItSucc : (n : Nat) -> Dec (IsSucc n)
+isItSucc Z = No absurd
+isItSucc (S n) = Yes ItIsSucc
+
 --------------------------------------------------------------------------------
 -- Basic arithmetic functions
 --------------------------------------------------------------------------------


### PR DESCRIPTION
By popular demand.

If this should be moved to `Data.Nat` in `base`, say the word. There is no
such module at the moment, however.