### PR TITLE
Refactor stack-shell.nix to use buildStackProject

### DIFF
--- a/stack-shell.nix
+++ b/stack-shell.nix
@@ -1,9 +1,7 @@
+{ ghc }:
 with (import <nixpkgs> {});
 
 let
-  # MUST match GHC of resolver in stack.yaml
-  ghc = haskell.packages.ghc802.ghc;
-
   native_libs = [
     libffi
     zlib
@@ -15,17 +13,9 @@ let
     CoreServices
   ]);
 
-in stdenv.mkDerivation {
-
+in haskell.lib.buildStackProject {
+  inherit ghc;
+  buildInputs = native_libs;
   name = "idrisBuildEnv";
-
-  buildInputs = [ ghc ] ++ native_libs;
-
-  STACK_IN_NIX_EXTRA_ARGS = builtins.foldl'
-    (acc: lib:
-      " --extra-lib-dirs=${lib}/lib --extra-include-dirs=${lib}/include" + acc)
-    "" native_libs;
-
-  # Needed if one wants to use ghci, due to https://ghc.haskell.org/trac/ghc/ticket/11042
-  LD_LIBRARY_PATH = builtins.concatStringsSep ":" (map (lib: lib.out + "/lib") native_libs);
+  src = ./.;
 }


### PR DESCRIPTION
Simpler and more robust to future changes, see https://github.com/NixOS/nixpkgs/blob/master/pkgs/development/haskell-modules/generic-stack-builder.nix