### PR TITLE
Fix LaTeX pretty printing of backslash, braces and percent

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -23,6 +23,8 @@
 + The --interface option now creates CommonJS modules on the node backend.
 + The C backend now pass arguments to the C compiler in the same order
   as they were given in the source files.
++ Backslash, braces and percent symbols are now correctly pretty printed
+  in LaTeX.
 
 # New in 1.1.1
 

--- a/src/Idris/AbsSyntaxTree.hs
+++ b/src/Idris/AbsSyntaxTree.hs
@@ -1697,6 +1697,9 @@ pprintPTerm ppo bnd docArgs infixes = prettySe (ppopt_depth ppo) startPrec bnd
   where
     startPrec = 0
     funcAppPrec = 10
+    lbrace = annotate (AnnSyntax "{") (text "{")
+    rbrace = annotate (AnnSyntax "}") (text "}")
+    percent = annotate (AnnSyntax "%") (text "%")
 
     prettySe :: Maybe Int -> Int -> [(Name, Bool)] -> PTerm -> Doc OutputAnnotation
     prettySe d p bnd (PQuote r) =
@@ -1709,7 +1712,8 @@ pprintPTerm ppo bnd docArgs infixes = prettySe (ppopt_depth ppo) startPrec bnd
     prettySe d p bnd (PLam fc n nfc ty sc) =
       let (ns, sc') = getLamNames [n] sc in
           depth d . bracket p startPrec . group . align . hang 2 $
-          text "\\" <> prettyBindingsOf ns False <+> text "=>" <$>
+          (annotate (AnnSyntax "\\") (text "\\"))
+          <> prettyBindingsOf ns False <+> text "=>" <$>
           prettySe (decD d) startPrec ((n, False):bnd) sc'
       where
         getLamNames acc (PLam fc n nfc ty sc) = getLamNames (n : acc) sc
@@ -1749,7 +1753,7 @@ pprintPTerm ppo bnd docArgs infixes = prettySe (ppopt_depth ppo) startPrec bnd
 
         st =
           case s of
-            Static -> text "%static" <> space
+            Static -> percent <> text "static" <> space
             _      -> empty
     prettySe d p bnd (PPi (Imp l s _ fa _ rig) n _ ty sc)
       | ppopt_impl ppo =
@@ -1769,7 +1773,7 @@ pprintPTerm ppo bnd docArgs infixes = prettySe (ppopt_depth ppo) startPrec bnd
 
         st =
           case s of
-            Static -> text "%static" <> space
+            Static -> percent <> text "static" <> space
             _      -> empty
     prettySe d p bnd (PPi (Constraint _ _ rig) n _ ty sc) =
       depth d . bracket p startPrec $
@@ -1876,7 +1880,7 @@ pprintPTerm ppo bnd docArgs infixes = prettySe (ppopt_depth ppo) startPrec bnd
         , kwd "else" <+> prettySe (decD d) startPrec bnd f
         ]
     prettySe d p bnd (PHidden tm)         = text "." <> prettySe (decD d) funcAppPrec bnd tm
-    prettySe d p bnd (PResolveTC _)       = kwd "%implementation"
+    prettySe d p bnd (PResolveTC _)       = percent <> kwd "implementation"
     prettySe d p bnd (PTrue _ IsType)     = annName unitTy $ text "()"
     prettySe d p bnd (PTrue _ IsTerm)     = annName unitCon $ text "()"
     prettySe d p bnd (PTrue _ TypeOrTerm) = text "()"
@@ -1981,7 +1985,7 @@ pprintPTerm ppo bnd docArgs infixes = prettySe (ppopt_depth ppo) startPrec bnd
             end = if res then "}" else "}}"
     prettySe d p bnd (PRunElab _ tm _)        =
       bracket p funcAppPrec . group . align . hang 2 $
-      text "%runElab" <$>
+      (percent <> text "runElab") <$>
       prettySe (decD d) funcAppPrec bnd tm
     prettySe d p bnd (PConstSugar fc tm)      = prettySe d p bnd tm -- should never occur, but harmless
     prettySe d p bnd _                        = text "missing pretty-printer for term"

--- a/src/Idris/Core/TT.hs
+++ b/src/Idris/Core/TT.hs
@@ -224,6 +224,7 @@ data OutputAnnotation = AnnName Name (Maybe NameOutput) (Maybe String) (Maybe St
                         -- from that file.
                       | AnnQuasiquote
                       | AnnAntiquote
+                      | AnnSyntax String -- ^ type of syntax element: backslash or braces etc.
   deriving (Show, Eq, Generic)
 
 -- | Used for error reflection

--- a/src/Idris/IdeMode.hs
+++ b/src/Idris/IdeMode.hs
@@ -172,6 +172,7 @@ instance SExpable OutputAnnotation where
              maybeProps [("source-file", file)]
   toSExp AnnQuasiquote = toSExp [(SymbolAtom "quasiquotation", True)]
   toSExp AnnAntiquote = toSExp [(SymbolAtom "antiquotation", True)]
+  toSExp (AnnSyntax c) = SexpList []
 
 encodeName :: Name -> String
 encodeName n = UTF8.toString . Base64.encode . Lazy.toStrict . Binary.encode $ n

--- a/src/Idris/Output.hs
+++ b/src/Idris/Output.hs
@@ -318,6 +318,7 @@ renderExternal fmt width doc
       \txt -> "<a href=\"" ++ url ++ "\">" ++ txt ++ "</a>"
     decorate HTMLOutput AnnQuasiquote = id
     decorate HTMLOutput AnnAntiquote = id
+    decorate HTMLOutput (AnnSyntax c) = \txt -> c
 
     decorate LaTeXOutput (AnnName _ (Just TypeOutput) _ _) =
       latex "IdrisType"
@@ -349,6 +350,13 @@ renderExternal fmt width doc
     decorate LaTeXOutput (AnnLink url) = (++ "(\\url{" ++ url ++ "})")
     decorate LaTeXOutput AnnQuasiquote = id
     decorate LaTeXOutput AnnAntiquote = id
+    decorate LaTeXOutput (AnnSyntax c) = \txt ->
+      case c of
+        "\\" -> "\\textbackslash"
+        "{" -> "\\{"
+        "}" -> "\\}"
+        "%" -> "\\%"
+        _ -> c
 
     tag cls docs str = "<span class=\""++cls++"\""++title++">" ++ str ++ "</span>"
       where title = maybe "" (\d->" title=\"" ++ d ++ "\"") docs


### PR DESCRIPTION
Resolves #1876.

I'm not sure about the `toSExp (AnnSyntax c) = SexpList []` part so I need feedback on that.