### PR TITLE
Tiny fix in the tutorial on default implicits

### DIFF
--- a/docs/tutorial/miscellany.rst
+++ b/docs/tutorial/miscellany.rst
@@ -86,7 +86,7 @@ number as 0), we could write:
 
 	fibonacci : {default 0 lag : Nat} -> {default 1 lead : Nat} -> (n : Nat) -> Nat
 	fibonacci {lag} Z = lag
-	fibonacci {lag} {lead} (S Z) = fibonacci {lag=lead} {lead=lag+lead} n
+	fibonacci {lag} {lead} (S n) = fibonacci {lag=lead} {lead=lag+lead} n
 
 After this definition, ``fibonacci 5`` is equivalent to ``fibonacci {lag=0} {lead=1} 5``,
 and will return the 5th fibonacci number. Note that while this works, this is not the 


### PR DESCRIPTION
Fixed a tiny typo (`Z` => `n`)