### PR TITLE
uninhabited instance for (S n = Z)

### DIFF
--- a/libs/prelude/Prelude/Nat.idr
+++ b/libs/prelude/Prelude/Nat.idr
@@ -25,6 +25,9 @@ import Prelude.Uninhabited
 
 Uninhabited (Z = S n) where
   uninhabited Refl impossible
+  
+Uninhabited (S n = Z) where
+  uninhabited Refl impossible  
 
 --------------------------------------------------------------------------------
 -- Syntactic tests


### PR DESCRIPTION
So that no extra `sym`s are required.