### PR TITLE
Add the Vect version of dropElem.

### DIFF
--- a/CONTRIBUTORS
+++ b/CONTRIBUTORS
@@ -34,6 +34,7 @@ Brent Yorgey
 Brian Koropoff
 Brian McKenna
 Bryn Keller
+Caleb Case
 Calvin Beck
 Carsten König
 Carter Charbonneau

--- a/libs/base/Data/Vect.idr
+++ b/libs/base/Data/Vect.idr
@@ -634,6 +634,14 @@ mapElem : {xs : Vect k t} -> {f : t -> u} -> Elem x xs -> Elem (f x) (map f xs)
 mapElem Here = Here
 mapElem (There e) = There (mapElem e)
 
+||| Remove the element at the given position.
+|||
+||| @xs The vector to be removed from
+||| @p A proof that the element to be removed is in the vector
+dropElem : (xs : Vect (S k) t) -> (p : Elem x xs) -> Vect k t
+dropElem (x :: ys) Here = ys
+dropElem {k = (S k)} (x :: ys) (There later) = x :: dropElem ys later
+
 -- Some convenience functions for testing lengths
 
 ||| If the given Vect is the required length, return a Vect with that


### PR DESCRIPTION
Inspired by the request from Kevin Meredith in the Idris mailing list for an
implementation of [removeElem][1]. This borrows directly from the existing work
in the List implementation and the work in 'Type-Driven Development with Idris'
by Edwin Brady.

[1]: https://groups.google.com/d/msg/idris-lang/UKhvTKS6TfE/MEK9akzYBwAJ