### PR TITLE
Rename `contrib:Data.String`, was shadowing `base:Data.String`

### DIFF
--- a/libs/contrib/Data/String/Extra.idr
+++ b/libs/contrib/Data/String/Extra.idr
@@ -1,4 +1,4 @@
-module Data.String
+module Data.String.Extra
 
 infixl 5 +>
 infixr 5 <+

--- a/libs/contrib/contrib.ipkg
+++ b/libs/contrib/contrib.ipkg
@@ -38,6 +38,7 @@ modules = CFFI
         , Data.SortedSet
         , Data.Storable
         , Data.Stream.Extra
+        , Data.String.Extra
         , Data.ZZ
         , Decidable.Decidable
         , Decidable.Order


### PR DESCRIPTION
Also add the resulting `Data.String.Extra` to `contrib.ipkg`, as the module was never actually listed and was thus inaccessible outside of `contrib` itself.