### PR TITLE
Update win32 bounds

### DIFF
--- a/idris.cabal
+++ b/idris.cabal
@@ -314,7 +314,7 @@ Library
 
   if os(windows)
      build-depends: mintty >= 0.1 && < 0.2
-                  , Win32 < 2.4
+                  , Win32 < 2.7
   else
      build-depends: unix < 2.8
   if flag(FFI)


### PR DESCRIPTION
The win32-notify package that clashed has been fixed.