### PR TITLE
Ticked infix decls

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,10 +8,10 @@
 + The `LinearTypes` language extension has been revised. It implements the
   rules from Bob Atkey's draft "The Syntax and Semantics of Quantitative
   Type Theory" and now works with holes and case expressions.
-+ Backticked operators can appear in sections, e.g. `(\`LTE\` 42)` or
-  `(1 \`plus\`)`.
++ Backticked operators can appear in sections, e.g. ``(`LTE` 42)`` or
+  ``(1 `plus`)``.
 + Backticked operators can have their precendence and associativity set like
-  other operators, e.g. `infixr 8 \`cons\``.
+  other operators, e.g. ``infixr 8 `cons` ``.
 
 ## Library Updates
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,7 +11,9 @@
 + Backticked operators can appear in sections, e.g. ``(`LTE` 42)`` or
   ``(1 `plus`)``.
 + Backticked operators can have their precendence and associativity set like
-  other operators, e.g. ``infixr 8 `cons` ``.
+  other operators, e.g. ``infixr 8 `cons` ``.  Backticked operators with
+  undeclared fixity are treated as non-associative with precedence lower
+  than all declared operators.
 
 ## Library Updates
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,8 @@
   Type Theory" and now works with holes and case expressions.
 + Backticked operators can appear in sections, e.g. `(\`LTE\` 42)` or
   `(1 \`plus\`)`.
++ Backticked operators can have their precendence and associativity set like
+  other operators, e.g. `infixr 8 \`cons\``.
 
 ## Library Updates
 

--- a/src/Idris/Parser.hs
+++ b/src/Idris/Parser.hs
@@ -1181,7 +1181,7 @@ clause syn
        <|> do (l, op, nfc) <- try (do
                 pushIndent
                 l <- argExpr syn
-                (op, nfc) <- operatorFC
+                (op, nfc) <- symbolicOperatorFC
                 when (op == "=" || op == "?=" ) $
                      fail "infix clause definition with \"=\" and \"?=\" not supported "
                 return (l, op, nfc))

--- a/src/Idris/Parser.hs
+++ b/src/Idris/Parser.hs
@@ -1086,7 +1086,7 @@ RHSName ::= '{' FnName '}';
 -}
 rhs :: SyntaxInfo -> Name -> IdrisParser PTerm
 rhs syn n = do lchar '='
-               indentPropHolds gtProp
+               indentGt
                expr syn
         <|> do symbol "?=";
                fc <- getFC
@@ -1533,7 +1533,7 @@ parseElabShellStep ist = runparser (fmap Right (do_ defaultSyntax) <|> fmap Left
               t <- spaced (expr defaultSyntax)
               i <- get
               return $ tactic (desugar defaultSyntax i t)
-        spaced parser = indentPropHolds gtProp *> parser
+        spaced parser = indentGt *> parser
 
 -- | Parse module header and imports
 parseImports :: FilePath -> String -> Idris (Maybe (Docstring ()), [String], [ImportInfo], Maybe Delta)

--- a/src/Idris/Parser/Expr.hs
+++ b/src/Idris/Parser/Expr.hs
@@ -468,8 +468,7 @@ bracketed' open syn =
                lchar ')'
                return $ PTrue (spanFC open (FC f start (l, c+1))) TypeOrTerm
         <|> try (dependentPair TypeOrTerm [] open syn)
-        <|> try (do fc <- getFC
-                    opName <- operatorName
+        <|> try (do (opName, fc) <- operatorName
                     guardNotPrefix opName
 
                     e <- expr syn
@@ -478,7 +477,7 @@ bracketed' open syn =
                       (PApp fc (PRef fc [] opName) [pexp (PRef fc [] (sMN 1000 "ARG")),
                                                     pexp e]))
         <|> try (simpleExpr syn >>= \l ->
-                     try (do opName <- operatorName
+                     try (do (opName, _) <- operatorName
                              lchar ')'
                              fc <- getFC
                              return $ PLam fc (sMN 1000 "ARG") NoFC Placeholder
@@ -488,10 +487,6 @@ bracketed' open syn =
         <|> do l <- expr (allowConstr syn)
                bracketedExpr (allowConstr syn) open l
   where
-    operatorName :: IdrisParser Name
-    operatorName =     sUN <$> operator
-                   <|> fst <$> backtickOperator
-
     justPrefix                          :: FixDecl -> Maybe Name
     justPrefix (Fix (PrefixN _) opName) = Just (sUN opName)
     justPrefix _                        = Nothing

--- a/src/Idris/Parser/Expr.hs
+++ b/src/Idris/Parser/Expr.hs
@@ -1558,8 +1558,8 @@ tactics =
           imps <- many imp
           return $ Refine n imps)
   , (["claim"], Nothing, \syn ->
-       do n <- indentPropHolds gtProp *> (fst <$> name)
-          goal <- indentPropHolds gtProp *> expr syn
+       do n <- indentGt *> (fst <$> name)
+          goal <- indentGt *> expr syn
           return $ Claim n goal)
   , (["mrefine"], Just ExprTArg, const $
        do n <- spaced (fst <$> fnName)
@@ -1569,15 +1569,15 @@ tactics =
   , expressionTactic ["induction"] Induction
   , expressionTactic ["equiv"] Equiv
   , (["let"], Nothing, \syn -> -- FIXME syntax for let
-       do n <- (indentPropHolds gtProp *> (fst <$> name))
-          (do indentPropHolds gtProp *> lchar ':'
-              ty <- indentPropHolds gtProp *> expr' syn
-              indentPropHolds gtProp *> lchar '='
-              t <- indentPropHolds gtProp *> expr syn
+       do n <- (indentGt *> (fst <$> name))
+          (do indentGt *> lchar ':'
+              ty <- indentGt *> expr' syn
+              indentGt *> lchar '='
+              t <- indentGt *> expr syn
               i <- get
               return $ LetTacTy n (desugar syn i ty) (desugar syn i t))
-            <|> (do indentPropHolds gtProp *> lchar '='
-                    t <- indentPropHolds gtProp *> expr syn
+            <|> (do indentGt *> lchar '='
+                    t <- indentGt *> expr syn
                     i <- get
                     return $ LetTac n (desugar syn i t)))
 
@@ -1628,7 +1628,7 @@ tactics =
         i <- get
         return $ tactic (desugar syn i t))
   noArgs names tactic = (names, Nothing, const (return tactic))
-  spaced parser = indentPropHolds gtProp *> parser
+  spaced parser = indentGt *> parser
   imp :: IdrisParser Bool
   imp = do lchar '?'; return False
     <|> do lchar '_'; return True

--- a/src/Idris/Parser/Expr.hs
+++ b/src/Idris/Parser/Expr.hs
@@ -490,7 +490,7 @@ bracketed' open syn =
   where
     operatorName :: IdrisParser Name
     operatorName =     sUN <$> operator
-                   <|> fst <$> between (lchar '`') (lchar '`') fnName
+                   <|> fst <$> backtickOperator
 
     justPrefix                          :: FixDecl -> Maybe Name
     justPrefix (Fix (PrefixN _) opName) = Just (sUN opName)

--- a/src/Idris/Parser/Helpers.hs
+++ b/src/Idris/Parser/Helpers.hs
@@ -415,10 +415,10 @@ symbolicOperator = do op <- token . some $ operatorLetter
                       return op
 
 -- | Parses an operator
-operatorFC :: MonadicParsing m => m (String, FC)
-operatorFC = do (FC f (l, c) _) <- getFC
-                op <- symbolicOperator
-                return (op, FC f (l, c) (l, c + length op))
+symbolicOperatorFC :: MonadicParsing m => m (String, FC)
+symbolicOperatorFC = do (FC f (l, c) _) <- getFC
+                        op <- symbolicOperator
+                        return (op, FC f (l, c) (l, c + length op))
 
 {- * Position helpers -}
 {- | Get filename from position (returns "(interactive)" when no source file is given)  -}

--- a/src/Idris/Parser/Helpers.hs
+++ b/src/Idris/Parser/Helpers.hs
@@ -590,36 +590,11 @@ notEndBlock = do ist <- get
                                           when (i < lvl || isParen) (fail "end of block")
                       _ -> return ()
 
--- | Representation of an operation that can compare the current indentation with the last indentation, and an error message if it fails
-data IndentProperty = IndentProperty (Int -> Int -> Bool) String
-
--- | Allows comparison of indent, and fails if property doesn't hold
-indentPropHolds :: IndentProperty -> IdrisParser ()
-indentPropHolds (IndentProperty op msg) = do
+indentGt :: IdrisParser ()
+indentGt = do
   li <- lastIndent
   i <- indent
-  when (not $ op i li) $ fail ("Wrong indention: " ++ msg)
-
--- | Greater-than indent property
-gtProp :: IndentProperty
-gtProp = IndentProperty (>) "should be greater than context indentation"
-
--- | Greater-than or equal to indent property
-gteProp :: IndentProperty
-gteProp = IndentProperty (>=) "should be greater than or equal context indentation"
-
--- | Equal indent property
-eqProp :: IndentProperty
-eqProp = IndentProperty (==) "should be equal to context indentation"
-
--- | Less-than indent property
-ltProp :: IndentProperty
-ltProp = IndentProperty (<) "should be less than context indentation"
-
--- | Less-than or equal to indent property
-lteProp :: IndentProperty
-lteProp = IndentProperty (<=) "should be less than or equal to context indentation"
-
+  when (i <= li) $ fail "Wrong indention: should be greater than context indentation"
 
 -- | Checks that there are no braces that are not closed
 notOpenBraces :: IdrisParser ()

--- a/src/Idris/Parser/Helpers.hs
+++ b/src/Idris/Parser/Helpers.hs
@@ -408,16 +408,16 @@ invalidOperators :: [String]
 invalidOperators = [":", "=>", "->", "<-", "=", "?=", "|", "**", "==>", "\\", "%", "~", "?", "!", "@"]
 
 -- | Parses an operator
-operator :: MonadicParsing m => m String
-operator = do op <- token . some $ operatorLetter
-              when (op `elem` (invalidOperators ++ commentMarkers)) $
-                   fail $ op ++ " is not a valid operator"
-              return op
+symbolicOperator :: MonadicParsing m => m String
+symbolicOperator = do op <- token . some $ operatorLetter
+                      when (op `elem` (invalidOperators ++ commentMarkers)) $
+                           fail $ op ++ " is not a valid operator"
+                      return op
 
 -- | Parses an operator
 operatorFC :: MonadicParsing m => m (String, FC)
 operatorFC = do (FC f (l, c) _) <- getFC
-                op <- operator
+                op <- symbolicOperator
                 return (op, FC f (l, c) (l, c + length op))
 
 {- * Position helpers -}

--- a/src/Idris/Parser/Ops.hs
+++ b/src/Idris/Parser/Ops.hs
@@ -71,13 +71,15 @@ table fixes
 
     binary :: String -> (FC -> PTerm -> PTerm -> PTerm) -> Assoc -> Operator IdrisParser PTerm
     binary name f
-      | isBacktick name = Infix (do (n, fc) <- backtickOperator
-                                    guard (show (nsroot n) == name)
-                                    return (f fc))
-      | otherwise       = Infix (do indentGt
-                                    fc <- reservedOpFC name
-                                    indentGt
-                                    return (f fc))
+      | isBacktick name = Infix $ do
+                            (n, fc) <- backtickOperator
+                            guard $ show (nsroot n) == name
+                            return $ f fc
+      | otherwise       = Infix $ do
+                            indentGt
+                            fc <- reservedOpFC name
+                            indentGt
+                            return $ f fc
 
     prefix :: String -> (FC -> PTerm -> PTerm) -> Operator IdrisParser PTerm
     prefix name f = Prefix (do reservedOp name

--- a/src/Idris/Parser/Ops.hs
+++ b/src/Idris/Parser/Ops.hs
@@ -30,7 +30,7 @@ table :: [FixDecl] -> OperatorTable IdrisParser PTerm
 table fixes
    = [[prefix "-" (\fc x -> PApp fc (PRef fc [fc] (sUN "negate")) [pexp x])]] ++
       toTable (reverse fixes) ++
-     [[backtick],
+     [[noFixityBacktickOperator],
       [binary "$" (\fc x y -> flatten $ PApp fc x [pexp y]) AssocRight],
       [binary "="  (\fc x y -> PApp fc (PRef fc [fc] eqTy) [pexp x, pexp y]) AssocLeft],
       [nofixityoperator]]
@@ -39,10 +39,10 @@ table fixes
     flatten (PApp fc (PApp _ f as) bs) = flatten (PApp fc f (as ++ bs))
     flatten t = t
 
-    -- | Backtick operator
-    backtick :: Operator IdrisParser PTerm
-    backtick = Infix (do (n, fc) <- backtickOperator
-                         return (\x y -> PApp fc (PRef fc [fc] n) [pexp x, pexp y])) AssocNone
+    noFixityBacktickOperator :: Operator IdrisParser PTerm
+    noFixityBacktickOperator =
+      Infix (do (n, fc) <- backtickOperator
+                return (\x y -> PApp fc (PRef fc [fc] n) [pexp x, pexp y])) AssocNone
 
 
 -- | Calculates table for fixity declarations

--- a/src/Idris/Parser/Ops.hs
+++ b/src/Idris/Parser/Ops.hs
@@ -106,7 +106,7 @@ backtickOperator = between (indentGt *> lchar '`') (indentGt *> lchar '`') name
 @
 -}
 operatorName :: IdrisParser (Name, FC)
-operatorName =     first sUN <$> operatorFC
+operatorName =     first sUN <$> symbolicOperatorFC
                <|> backtickOperator
 
 {- | Parses an operator in function position i.e. enclosed by `()', with an

--- a/src/Idris/Parser/Ops.hs
+++ b/src/Idris/Parser/Ops.hs
@@ -15,8 +15,8 @@ import Idris.Parser.Helpers
 
 import Prelude hiding (pi)
 
-import Control.Arrow (first)
 import Control.Applicative
+import Control.Arrow (first)
 import Control.Monad
 import Control.Monad.State.Strict
 import Data.Char (isAlpha)

--- a/src/Idris/Parser/Ops.hs
+++ b/src/Idris/Parser/Ops.hs
@@ -65,10 +65,8 @@ table fixes
     assoc (InfixN _) = AssocNone
 
     isBacktick :: String -> Bool
-    isBacktick (c : _)
-      | isAlpha c = True
-      | c == '_'  = True
-      | otherwise = False
+    isBacktick (c : _) = c == '_' || isAlpha c
+    isBacktick _       = False
 
     binary :: String -> Assoc -> (FC -> Name -> PTerm -> PTerm -> PTerm) -> Operator IdrisParser PTerm
     binary name assoc f

--- a/src/Idris/Parser/Ops.hs
+++ b/src/Idris/Parser/Ops.hs
@@ -46,7 +46,7 @@ table fixes
 
     -- | Operator without fixity (throws an error)
     noFixityOperator :: Operator IdrisParser PTerm
-    noFixityOperator = Infix (do indentPropHolds gtProp
+    noFixityOperator = Infix (do indentGt
                                  op <- try operator
                                  unexpected $ "Operator without known fixity: " ++ op) AssocNone
 
@@ -73,15 +73,15 @@ table fixes
       | isBacktick name = Infix (do (n, fc) <- backtickOperator
                                     guard (show (nsroot n) == name)
                                     return (f fc))
-      | otherwise       = Infix (do indentPropHolds gtProp
+      | otherwise       = Infix (do indentGt
                                     fc <- reservedOpFC name
-                                    indentPropHolds gtProp
+                                    indentGt
                                     return (f fc))
 
     prefix :: String -> (FC -> PTerm -> PTerm) -> Operator IdrisParser PTerm
     prefix name f = Prefix (do reservedOp name
                                fc <- getFC
-                               indentPropHolds gtProp
+                               indentGt
                                return (f fc))
 
 {- | Parses a function used as an operator -- enclosed in backticks
@@ -93,8 +93,7 @@ table fixes
 @
  -}
 backtickOperator :: IdrisParser (Name, FC)
-backtickOperator =
-  between (indentPropHolds gtProp *> lchar '`') (lchar '`' <* indentPropHolds gtProp) name
+backtickOperator = between (indentGt *> lchar '`') (lchar '`' <* indentGt) name
 
 {- | Parses an operator in function position i.e. enclosed by `()', with an
  optional namespace

--- a/src/Idris/Parser/Ops.hs
+++ b/src/Idris/Parser/Ops.hs
@@ -36,20 +36,21 @@ table fixes
       [binary "=" AssocLeft  $ \fc _ x y -> PApp fc (PRef fc [fc] eqTy) [pexp x, pexp y]],
       [noFixityOperator]]
   where
-    flatten :: PTerm -> PTerm -- flatten application
+    flatten                            :: PTerm -> PTerm -- flatten application
     flatten (PApp fc (PApp _ f as) bs) = flatten (PApp fc f (as ++ bs))
-    flatten t = t
+    flatten t                          = t
 
     noFixityBacktickOperator :: Operator IdrisParser PTerm
-    noFixityBacktickOperator =
-      Infix (do (n, fc) <- backtickOperator
-                return (\x y -> PApp fc (PRef fc [fc] n) [pexp x, pexp y])) AssocNone
+    noFixityBacktickOperator = flip Infix AssocNone $ do
+                                 (n, fc) <- backtickOperator
+                                 return $ \x y -> PApp fc (PRef fc [fc] n) [pexp x, pexp y]
 
     -- | Operator without fixity (throws an error)
     noFixityOperator :: Operator IdrisParser PTerm
-    noFixityOperator = Infix (do indentGt
-                                 op <- try symbolicOperator
-                                 unexpected $ "Operator without known fixity: " ++ op) AssocNone
+    noFixityOperator = flip Infix AssocNone $ do
+                         indentGt
+                         op <- try symbolicOperator
+                         unexpected $ "Operator without known fixity: " ++ op
 
     -- | Calculates table for fixity declarations
     toTable    :: [FixDecl] -> OperatorTable IdrisParser PTerm

--- a/src/Idris/Parser/Ops.hs
+++ b/src/Idris/Parser/Ops.hs
@@ -48,7 +48,7 @@ table fixes
     -- | Operator without fixity (throws an error)
     noFixityOperator :: Operator IdrisParser PTerm
     noFixityOperator = Infix (do indentGt
-                                 op <- try operator
+                                 op <- try symbolicOperator
                                  unexpected $ "Operator without known fixity: " ++ op) AssocNone
 
     -- | Calculates table for fixity declarations
@@ -125,7 +125,7 @@ operatorFront = try (do (FC f (l, c) _) <- getFC
                         op <- lchar '(' *> reservedOp "="  <* lchar ')'
                         return (eqTy, FC f (l, c) (l, c+3)))
             <|> maybeWithNS (do (FC f (l, c) _) <- getFC
-                                op <- lchar '(' *> operator
+                                op <- lchar '(' *> symbolicOperator
                                 (FC _ _ (l', c')) <- getFC
                                 lchar ')'
                                 return (op, (FC f (l, c) (l', c' + 1)))) False []

--- a/src/Idris/Parser/Ops.hs
+++ b/src/Idris/Parser/Ops.hs
@@ -65,7 +65,7 @@ table fixes
     assoc (Infixr _) = AssocRight
     assoc (InfixN _) = AssocNone
 
-    isBacktick :: String -> Bool
+    isBacktick         :: String -> Bool
     isBacktick (c : _) = c == '_' || isAlpha c
     isBacktick _       = False
 

--- a/src/Idris/Parser/Ops.hs
+++ b/src/Idris/Parser/Ops.hs
@@ -93,7 +93,7 @@ table fixes
 @
  -}
 backtickOperator :: IdrisParser (Name, FC)
-backtickOperator = between (indentGt *> lchar '`') (lchar '`' <* indentGt) name
+backtickOperator = between (indentGt *> lchar '`') (indentGt *> lchar '`') name
 
 {- | Parses an operator in function position i.e. enclosed by `()', with an
  optional namespace

--- a/src/Idris/REPL/Parser.hs
+++ b/src/Idris/REPL/Parser.hs
@@ -234,7 +234,7 @@ exprArg cmd name = do
           return $ Left ("Usage is :" ++ name ++ " <expression>")
 
     let justOperator = do
-          (op, fc) <- P.operatorFC
+          (op, fc) <- P.symbolicOperatorFC
           eof
           return $ Right $ cmd (PRef fc [] (sUN op))
 

--- a/src/Util/DynamicLinker.hs
+++ b/src/Util/DynamicLinker.hs
@@ -21,7 +21,7 @@ import System.FilePath.Windows ((</>))
 import System.Win32.DLL
 import System.Win32.Types
 #else
-import Control.Exception (IOException, try, throwIO)
+import Control.Exception (IOException, throwIO, try)
 import Foreign.Ptr (FunPtr, nullFunPtr, nullPtr)
 #ifdef linux_HOST_OS
 import Data.Array (bounds, inRange, (!))

--- a/test/basic023/expected
+++ b/test/basic023/expected
@@ -5,3 +5,4 @@ True
 True
 True
 True
+True

--- a/test/basic023/expected
+++ b/test/basic023/expected
@@ -6,3 +6,5 @@ True
 True
 True
 True
+True
+True

--- a/test/basic023/sections.idr
+++ b/test/basic023/sections.idr
@@ -5,6 +5,15 @@ infixr 8 `cons`
 cons : Int -> List Int -> List Int
 cons = (::)
 
+namespace A
+  infixr 8 `nmul`
+  nmul : Nat -> Nat -> Nat
+  nmul = (*)
+
+namespace B
+  nmul : Nat -> Nat -> Nat
+  nmul _ y = y
+
 prefix 1 :/
 (:/) : Nat -> Nat
 (:/) = (1 `plus`)
@@ -21,3 +30,5 @@ main = do
   printLn $ (! io) == 9         -- prefix, not section
   printLn $ (:/ 3) == 4         -- custom prefix operator (#2571)
   printLn $ 1 `cons` 2 `cons` [3] == [1,2,3]
+  printLn $ 2 `A.nmul` 3 `B.nmul` 5 == 10
+  printLn $ 2 `B.nmul` 3 `A.nmul` 5 == 15

--- a/test/basic023/sections.idr
+++ b/test/basic023/sections.idr
@@ -1,7 +1,7 @@
 postInc : Nat -> Nat
 postInc = (`plus` 1)
 
-infixr 4 `cons`
+infixr 8 `cons`
 cons : Int -> List Int -> List Int
 cons = (::)
 
@@ -20,3 +20,4 @@ main = do
   let io : IO Integer = pure 9
   printLn $ (! io) == 9         -- prefix, not section
   printLn $ (:/ 3) == 4         -- custom prefix operator (#2571)
+  printLn $ 1 `cons` 2 `cons` [3] == [1,2,3]

--- a/test/basic023/sections.idr
+++ b/test/basic023/sections.idr
@@ -1,6 +1,7 @@
 postInc : Nat -> Nat
 postInc = (`plus` 1)
 
+infixr 4 `cons`
 cons : Int -> List Int -> List Int
 cons = (::)
 


### PR DESCRIPTION
Allows for declaring the fixity and precedence of backtick-quoted words.

Closes #1811