### PR TITLE
adjust fixities of several common operators

### DIFF
--- a/libs/contrib/Interfaces/Correlative.idr
+++ b/libs/contrib/Interfaces/Correlative.idr
@@ -5,7 +5,7 @@ import Data.Vect
 %access public export
 %default total
 
-infixl 2 </>
+infixl 3 </>
 
 ||| A Correlative functor is a functor where, given `(xs, ys : Correlative f)`,
 ||| certain elements from xs and ys can be paired with one another due to some
@@ -13,11 +13,11 @@ infixl 2 </>
 interface Functor f => Correlative (f : Type -> Type) where
   (</>) : f (a -> b) -> f a -> f b
 
-infixl 2 </
+infixl 3 </
 (</) : Correlative f => f a -> f b -> f a
 x </ y = map const x </> y
 
-infixl 2 />
+infixl 3 />
 (/>) : Correlative f => f a -> f b -> f b
 x /> y = map (const id) x </> y
 

--- a/libs/effects/Effects.idr
+++ b/libs/effects/Effects.idr
@@ -303,8 +303,6 @@ staticEff = id
 toEff : .(xs' : List EFFECT) -> EffM m a xs (\v => xs') -> EffM m a xs (\v => xs')
 toEff xs' = id
 
-infixl 2 <*>
-
 pure : a -> EffM m a xs (\v => xs)
 pure = Value
 

--- a/libs/prelude/Prelude/Applicative.idr
+++ b/libs/prelude/Prelude/Applicative.idr
@@ -12,17 +12,17 @@ import Prelude.Functor
 
 ---- Applicative functors/Idioms
 
-infixl 2 <*>
+infixl 3 <*>
 
 interface Functor f => Applicative (f : Type -> Type) where
     pure  : a -> f a
     (<*>) : f (a -> b) -> f a -> f b
 
-infixl 2 <*
+infixl 3 <*
 (<*) : Applicative f => f a -> f b -> f a
 a <* b = map const a <*> b
 
-infixl 2 *>
+infixl 3 *>
 (*>) : Applicative f => f a -> f b -> f b
 a *> b = map (const id) a <*> b
 
@@ -38,7 +38,7 @@ liftA2 f a b = (map f a) <*> b
 liftA3 : Applicative f => (a -> b -> c -> d) -> f a -> f b -> f c -> f d
 liftA3 f a b c = (map f a) <*> b <*> c
 
-infixr 3 <|>
+infixr 2 <|>
 interface Applicative f => Alternative (f : Type -> Type) where
     empty : f a
     (<|>) : f a -> f a -> f a

--- a/libs/prelude/Prelude/Basics.idr
+++ b/libs/prelude/Prelude/Basics.idr
@@ -29,7 +29,7 @@ fst (x, y) = x
 snd : (a, b) -> b
 snd (x, y) = y
 
-infixl 9 .
+infixr 9 .
 
 ||| Function composition
 (.) : (b -> c) -> (a -> b) -> a -> c
@@ -58,4 +58,3 @@ data Dec : Type -> Type where
   ||| The case where the property holding would be a contradiction
   ||| @ contra a demonstration that prop would be a contradiction
   No  : (contra : prop -> Void) -> Dec prop
-

--- a/libs/prelude/Prelude/Functor.idr
+++ b/libs/prelude/Prelude/Functor.idr
@@ -6,15 +6,15 @@ import Prelude.Basics
 %access public export
 
 ||| Functors allow a uniform action over a parameterised type.
-||| @ f a parameterised type 
+||| @ f a parameterised type
 interface Functor (f : Type -> Type) where
-    ||| Apply a function across everything of type 'a' in a 
+    ||| Apply a function across everything of type 'a' in a
     ||| parameterised type
     ||| @ f the parameterised type
     ||| @ func the function to apply
     map : (func : a -> b) -> f a -> f b
 
-infixl 4 <$>
+infixr 4 <$>
 
 ||| An infix alias for `map`, applying a function across everything of
 ||| type 'a' in a parameterised type

--- a/libs/prelude/Prelude/Monad.idr
+++ b/libs/prelude/Prelude/Monad.idr
@@ -11,7 +11,7 @@ import IO
 
 %access public export
 
-infixl 5 >>=
+infixl 1 >>=
 
 interface Applicative m => Monad (m : Type -> Type) where
     ||| Also called `bind`.


### PR DESCRIPTION
Corrects several fixity problems throughout the standard library. Most notably, `<|>` had a higher precedence than `<*>`, and `>>=` had a higher precedence than both.