### PR TITLE
IdrisDoc, set charset and viewport

### DIFF
--- a/src/Idris/IdrisDoc.hs
+++ b/src/Idris/IdrisDoc.hs
@@ -641,6 +641,8 @@ wrapper ns inner =
       indexPage  = base ++ "index.html" :: String
   in  H.docTypeHtml $ do
     H.head $ do
+      H.meta ! charset "utf-8"
+      H.meta ! name "viewport" ! content "width=device-width, initial-scale=1, shrink-to-fit=no"
       H.title $ do
         "IdrisDoc"
         if index then " Index" else do


### PR DESCRIPTION
- The meta-viewport tag makes the documentation work on mobile devices and
tablets.
- The meta-charset tag ensures that the charset is correctly detected even
if the HTTP Server is misconfigured or BOMs stripped.

---
Just for reference, these two lines in some popular frameworks:
- [Bootstrap](https://getbootstrap.com/docs/4.0/getting-started/introduction/#starter-template)
- [HTML5 Boilerplate](https://github.com/h5bp/html5-boilerplate/blob/master/src/index.html#L8)