### PR TITLE
Megaparsec prep

### DIFF
--- a/src/Idris/Core/TT.hs
+++ b/src/Idris/Core/TT.hs
@@ -1141,15 +1141,6 @@ isInjective (Bind _ (Pi _ _ _ _) sc) = True
 isInjective (App _ f a)        = isInjective f
 isInjective _                  = False
 
--- | Count the number of instances of a de Bruijn index in a term
-vinstances :: Int -> TT n -> Int
-vinstances i (V x) | i == x = 1
-vinstances i (App _ f a) = vinstances i f + vinstances i a
-vinstances i (Bind x b sc) = instancesB b + vinstances (i + 1) sc
-  where instancesB (Let c t v) = vinstances i v
-        instancesB _ = 0
-vinstances i t = 0
-
 -- | Replace the outermost (index 0) de Bruijn variable with the given term
 instantiate :: TT n -> TT n -> TT n
 instantiate e = subst 0 where

--- a/src/Idris/Main.hs
+++ b/src/Idris/Main.hs
@@ -47,7 +47,6 @@ import System.Exit
 import System.FilePath
 import System.IO
 import System.IO.CodePage (withCP65001)
-import qualified Text.Trifecta.Result as P
 
 -- | How to run Idris programs.
 runMain :: Idris () -> IO ()
@@ -196,8 +195,8 @@ idrisMain opts =
                      mapM_ (\str -> do ist <- getIState
                                        c <- colourise
                                        case parseExpr ist str of
-                                         Left (P.ErrInfo err _) -> do iputStrLn $ show (fixColour c err)
-                                                                      runIO $ exitWith (ExitFailure 1)
+                                         Left err -> do iputStrLn $ show (fixColour c err)
+                                                        runIO $ exitWith (ExitFailure 1)
                                          Right e -> process "" (Eval e))
                            exprs
                      runIO exitSuccess
@@ -273,8 +272,8 @@ execScript :: String -> Idris ()
 execScript expr = do i <- getIState
                      c <- colourise
                      case parseExpr i expr of
-                          Left (P.ErrInfo err _) -> do iputStrLn $ show (fixColour c err)
-                                                       runIO $ exitWith (ExitFailure 1)
+                          Left err -> do iputStrLn $ show (fixColour c err)
+                                         runIO $ exitWith (ExitFailure 1)
                           Right term -> do ctxt <- getContext
                                            (tm, _) <- elabVal (recinfo (fileFC "toplevel")) ERHS term
                                            res <- execute tm
@@ -300,7 +299,7 @@ initScript = do script <- runIO $ getIdrisInitScript
                            runInit h
           processLine i cmd input clr =
               case parseCmd i input cmd of
-                   Left (P.ErrInfo err _) -> runIO $ print (fixColour clr err)
+                   Left err -> runIO $ print (fixColour clr err)
                    Right (Right Reload) -> iPrintError "Init scripts cannot reload the file"
                    Right (Right (Load f _)) -> iPrintError "Init scripts cannot load files"
                    Right (Right (ModImport f)) -> iPrintError "Init scripts cannot import modules"

--- a/src/Idris/Main.hs
+++ b/src/Idris/Main.hs
@@ -25,7 +25,6 @@ import Idris.ModeCommon
 import Idris.Options
 import Idris.Output
 import Idris.Parser hiding (indent)
-import Idris.Parser.Helpers (parseErrorDoc)
 import Idris.REPL
 import Idris.REPL.Commands
 import Idris.REPL.Parser

--- a/src/Idris/Main.hs
+++ b/src/Idris/Main.hs
@@ -47,7 +47,7 @@ import System.Exit
 import System.FilePath
 import System.IO
 import System.IO.CodePage (withCP65001)
-import Text.Trifecta.Result (ErrInfo(..), Result(..))
+import qualified Text.Trifecta.Result as P
 
 -- | How to run Idris programs.
 runMain :: Idris () -> IO ()
@@ -196,9 +196,9 @@ idrisMain opts =
                      mapM_ (\str -> do ist <- getIState
                                        c <- colourise
                                        case parseExpr ist str of
-                                         Failure (ErrInfo err _) -> do iputStrLn $ show (fixColour c err)
-                                                                       runIO $ exitWith (ExitFailure 1)
-                                         Success e -> process "" (Eval e))
+                                         P.Failure (P.ErrInfo err _) -> do iputStrLn $ show (fixColour c err)
+                                                                           runIO $ exitWith (ExitFailure 1)
+                                         P.Success e -> process "" (Eval e))
                            exprs
                      runIO exitSuccess
 
@@ -273,12 +273,12 @@ execScript :: String -> Idris ()
 execScript expr = do i <- getIState
                      c <- colourise
                      case parseExpr i expr of
-                          Failure (ErrInfo err _) -> do iputStrLn $ show (fixColour c err)
-                                                        runIO $ exitWith (ExitFailure 1)
-                          Success term -> do ctxt <- getContext
-                                             (tm, _) <- elabVal (recinfo (fileFC "toplevel")) ERHS term
-                                             res <- execute tm
-                                             runIO $ exitSuccess
+                          P.Failure (P.ErrInfo err _) -> do iputStrLn $ show (fixColour c err)
+                                                            runIO $ exitWith (ExitFailure 1)
+                          P.Success term -> do ctxt <- getContext
+                                               (tm, _) <- elabVal (recinfo (fileFC "toplevel")) ERHS term
+                                               res <- execute tm
+                                               runIO $ exitSuccess
 
 -- | Run the initialisation script
 initScript :: Idris ()
@@ -300,12 +300,12 @@ initScript = do script <- runIO $ getIdrisInitScript
                            runInit h
           processLine i cmd input clr =
               case parseCmd i input cmd of
-                   Failure (ErrInfo err _) -> runIO $ print (fixColour clr err)
-                   Success (Right Reload) -> iPrintError "Init scripts cannot reload the file"
-                   Success (Right (Load f _)) -> iPrintError "Init scripts cannot load files"
-                   Success (Right (ModImport f)) -> iPrintError "Init scripts cannot import modules"
-                   Success (Right Edit) -> iPrintError "Init scripts cannot invoke the editor"
-                   Success (Right Proofs) -> proofs i
-                   Success (Right Quit) -> iPrintError "Init scripts cannot quit Idris"
-                   Success (Right cmd ) -> process [] cmd
-                   Success (Left err) -> runIO $ print err
+                   P.Failure (P.ErrInfo err _) -> runIO $ print (fixColour clr err)
+                   P.Success (Right Reload) -> iPrintError "Init scripts cannot reload the file"
+                   P.Success (Right (Load f _)) -> iPrintError "Init scripts cannot load files"
+                   P.Success (Right (ModImport f)) -> iPrintError "Init scripts cannot import modules"
+                   P.Success (Right Edit) -> iPrintError "Init scripts cannot invoke the editor"
+                   P.Success (Right Proofs) -> proofs i
+                   P.Success (Right Quit) -> iPrintError "Init scripts cannot quit Idris"
+                   P.Success (Right cmd ) -> process [] cmd
+                   P.Success (Left err) -> runIO $ print err

--- a/src/Idris/Main.hs
+++ b/src/Idris/Main.hs
@@ -196,9 +196,9 @@ idrisMain opts =
                      mapM_ (\str -> do ist <- getIState
                                        c <- colourise
                                        case parseExpr ist str of
-                                         P.Failure (P.ErrInfo err _) -> do iputStrLn $ show (fixColour c err)
-                                                                           runIO $ exitWith (ExitFailure 1)
-                                         P.Success e -> process "" (Eval e))
+                                         Left (P.ErrInfo err _) -> do iputStrLn $ show (fixColour c err)
+                                                                      runIO $ exitWith (ExitFailure 1)
+                                         Right e -> process "" (Eval e))
                            exprs
                      runIO exitSuccess
 
@@ -273,12 +273,12 @@ execScript :: String -> Idris ()
 execScript expr = do i <- getIState
                      c <- colourise
                      case parseExpr i expr of
-                          P.Failure (P.ErrInfo err _) -> do iputStrLn $ show (fixColour c err)
-                                                            runIO $ exitWith (ExitFailure 1)
-                          P.Success term -> do ctxt <- getContext
-                                               (tm, _) <- elabVal (recinfo (fileFC "toplevel")) ERHS term
-                                               res <- execute tm
-                                               runIO $ exitSuccess
+                          Left (P.ErrInfo err _) -> do iputStrLn $ show (fixColour c err)
+                                                       runIO $ exitWith (ExitFailure 1)
+                          Right term -> do ctxt <- getContext
+                                           (tm, _) <- elabVal (recinfo (fileFC "toplevel")) ERHS term
+                                           res <- execute tm
+                                           runIO $ exitSuccess
 
 -- | Run the initialisation script
 initScript :: Idris ()
@@ -300,12 +300,12 @@ initScript = do script <- runIO $ getIdrisInitScript
                            runInit h
           processLine i cmd input clr =
               case parseCmd i input cmd of
-                   P.Failure (P.ErrInfo err _) -> runIO $ print (fixColour clr err)
-                   P.Success (Right Reload) -> iPrintError "Init scripts cannot reload the file"
-                   P.Success (Right (Load f _)) -> iPrintError "Init scripts cannot load files"
-                   P.Success (Right (ModImport f)) -> iPrintError "Init scripts cannot import modules"
-                   P.Success (Right Edit) -> iPrintError "Init scripts cannot invoke the editor"
-                   P.Success (Right Proofs) -> proofs i
-                   P.Success (Right Quit) -> iPrintError "Init scripts cannot quit Idris"
-                   P.Success (Right cmd ) -> process [] cmd
-                   P.Success (Left err) -> runIO $ print err
+                   Left (P.ErrInfo err _) -> runIO $ print (fixColour clr err)
+                   Right (Right Reload) -> iPrintError "Init scripts cannot reload the file"
+                   Right (Right (Load f _)) -> iPrintError "Init scripts cannot load files"
+                   Right (Right (ModImport f)) -> iPrintError "Init scripts cannot import modules"
+                   Right (Right Edit) -> iPrintError "Init scripts cannot invoke the editor"
+                   Right (Right Proofs) -> proofs i
+                   Right (Right Quit) -> iPrintError "Init scripts cannot quit Idris"
+                   Right (Right cmd ) -> process [] cmd
+                   Right (Left err) -> runIO $ print err

--- a/src/Idris/Main.hs
+++ b/src/Idris/Main.hs
@@ -25,6 +25,7 @@ import Idris.ModeCommon
 import Idris.Options
 import Idris.Output
 import Idris.Parser hiding (indent)
+import Idris.Parser.Helpers (parseErrorDoc)
 import Idris.REPL
 import Idris.REPL.Commands
 import Idris.REPL.Parser
@@ -195,7 +196,7 @@ idrisMain opts =
                      mapM_ (\str -> do ist <- getIState
                                        c <- colourise
                                        case parseExpr ist str of
-                                         Left err -> do iputStrLn $ show (fixColour c err)
+                                         Left err -> do iputStrLn . show . fixColour c . parseErrorDoc $ err
                                                         runIO $ exitWith (ExitFailure 1)
                                          Right e -> process "" (Eval e))
                            exprs
@@ -272,7 +273,7 @@ execScript :: String -> Idris ()
 execScript expr = do i <- getIState
                      c <- colourise
                      case parseExpr i expr of
-                          Left err -> do iputStrLn $ show (fixColour c err)
+                          Left err -> do iputStrLn . show . fixColour c . parseErrorDoc $ err
                                          runIO $ exitWith (ExitFailure 1)
                           Right term -> do ctxt <- getContext
                                            (tm, _) <- elabVal (recinfo (fileFC "toplevel")) ERHS term
@@ -299,7 +300,7 @@ initScript = do script <- runIO $ getIdrisInitScript
                            runInit h
           processLine i cmd input clr =
               case parseCmd i input cmd of
-                   Left err -> runIO $ print (fixColour clr err)
+                   Left err -> runIO . print . fixColour clr . parseErrorDoc $ err
                    Right (Right Reload) -> iPrintError "Init scripts cannot reload the file"
                    Right (Right (Load f _)) -> iPrintError "Init scripts cannot load files"
                    Right (Right (ModImport f)) -> iPrintError "Init scripts cannot import modules"

--- a/src/Idris/Package/Parser.hs
+++ b/src/Idris/Package/Parser.hs
@@ -11,9 +11,9 @@ module Idris.Package.Parser where
 import Idris.CmdOptions
 import Idris.Imports
 import Idris.Package.Common
-import Idris.Parser.Helpers (MonadicParsing, eol, iName,
-                             identifier, isEol, lchar, packageName,
-                             parseErrorDoc, reserved, runparser, someSpace')
+import Idris.Parser.Helpers (MonadicParsing, eol, iName, identifier, isEol,
+                             lchar, packageName, parseErrorDoc, reserved,
+                             runparser, someSpace')
 
 import Control.Applicative
 import Control.Monad.State.Strict

--- a/src/Idris/Package/Parser.hs
+++ b/src/Idris/Package/Parser.hs
@@ -80,16 +80,14 @@ pPkgName = (either fail pure . pkgName =<< packageName) <?> "PkgName"
 -- | Treated for now as an identifier or a double-quoted string.
 filename :: (MonadicParsing m) => m String
 filename = (do
-    filename <- P.token $
-        -- Treat a double-quoted string as a filename to support spaces.
-        -- This also moves away from tying filenames to identifiers, so
-        -- it will also accept hyphens
-        -- (https://github.com/idris-lang/Idris-dev/issues/2721)
-        P.stringLiteral
-        <|>
-        -- Through at least version 0.9.19.1, IPKG executable values were
-        -- possibly namespaced identifiers, like foo.bar.baz.
-        show <$> fst <$> iName []
+                -- Treat a double-quoted string as a filename to support spaces.
+                -- This also moves away from tying filenames to identifiers, so
+                -- it will also accept hyphens
+                -- (https://github.com/idris-lang/Idris-dev/issues/2721)
+    filename <- P.stringLiteral <* someSpace'
+                -- Through at least version 0.9.19.1, IPKG executable values were
+                -- possibly namespaced identifiers, like foo.bar.baz.
+            <|> show . fst <$> iName []
     case filenameErrorMessage filename of
       Just errorMessage -> fail errorMessage
       Nothing -> return filename)

--- a/src/Idris/Package/Parser.hs
+++ b/src/Idris/Package/Parser.hs
@@ -56,8 +56,8 @@ parseDesc fp = do
       then do
         p <- readFile fp
         case runparser pPkg defaultPkg fp p of
-          P.Failure (P.ErrInfo err _) -> fail (show $ PP.plain err)
-          P.Success x -> return x
+          Left (P.ErrInfo err _) -> fail (show $ PP.plain err)
+          Right x -> return x
       else do
         putStrLn $ unwords [ "The presented iPKG file does not exist:", show fp]
         exitWith (ExitFailure 1)

--- a/src/Idris/Package/Parser.hs
+++ b/src/Idris/Package/Parser.hs
@@ -11,7 +11,11 @@ module Idris.Package.Parser where
 import Idris.CmdOptions
 import Idris.Imports
 import Idris.Package.Common
-import Idris.Parser.Helpers hiding (stringLiteral)
+import Idris.Parser.Helpers (HasLastTokenSpan, IdrisInnerParser, MonadicParsing,
+                             eol, getLastTokenSpan, iName, identifier, isEol,
+                             lchar, multiLineComment, packageName,
+                             parseErrorDoc, reserved, runparser,
+                             simpleWhiteSpace, singleLineComment)
 
 import Control.Applicative
 import Control.Monad.State.Strict

--- a/src/Idris/Package/Parser.hs
+++ b/src/Idris/Package/Parser.hs
@@ -56,7 +56,7 @@ parseDesc fp = do
       then do
         p <- readFile fp
         case runparser pPkg defaultPkg fp p of
-          Left (P.ErrInfo err _) -> fail (show $ PP.plain err)
+          Left err -> fail (show $ PP.plain err)
           Right x -> return x
       else do
         putStrLn $ unwords [ "The presented iPKG file does not exist:", show fp]

--- a/src/Idris/Package/Parser.hs
+++ b/src/Idris/Package/Parser.hs
@@ -11,7 +11,7 @@ module Idris.Package.Parser where
 import Idris.CmdOptions
 import Idris.Imports
 import Idris.Package.Common
-import Idris.Parser.Helpers (IdrisInnerParser, MonadicParsing, eol, iName,
+import Idris.Parser.Helpers (MonadicParsing, eol, iName,
                              identifier, isEol, lchar, packageName,
                              parseErrorDoc, reserved, runparser, someSpace')
 
@@ -25,7 +25,7 @@ import qualified Text.PrettyPrint.ANSI.Leijen as PP
 import Text.Trifecta ((<?>))
 import qualified Text.Trifecta as P
 
-type PParser = StateT PkgDesc IdrisInnerParser
+type PParser = StateT PkgDesc P.Parser
 
 #if MIN_VERSION_base(4,9,0)
 instance {-# OVERLAPPING #-} P.DeltaParsing PParser where

--- a/src/Idris/Package/Parser.hs
+++ b/src/Idris/Package/Parser.hs
@@ -11,10 +11,9 @@ module Idris.Package.Parser where
 import Idris.CmdOptions
 import Idris.Imports
 import Idris.Package.Common
-import Idris.Parser.Helpers (HasLastTokenSpan, IdrisInnerParser, MonadicParsing,
-                             eol, getLastTokenSpan, iName, identifier, isEol,
-                             lchar, multiLineComment, packageName,
-                             parseErrorDoc, reserved, runparser,
+import Idris.Parser.Helpers (IdrisInnerParser, MonadicParsing, eol, iName,
+                             identifier, isEol, lchar, multiLineComment,
+                             packageName, parseErrorDoc, reserved, runparser,
                              simpleWhiteSpace, singleLineComment)
 
 import Control.Applicative
@@ -28,9 +27,6 @@ import Text.Trifecta ((<?>))
 import qualified Text.Trifecta as P
 
 type PParser = StateT PkgDesc IdrisInnerParser
-
-instance HasLastTokenSpan PParser where
-  getLastTokenSpan = return Nothing
 
 #if MIN_VERSION_base(4,9,0)
 instance {-# OVERLAPPING #-} P.DeltaParsing PParser where
@@ -83,7 +79,7 @@ pPkgName = (either fail pure . pkgName =<< packageName) <?> "PkgName"
 -- | Parses a filename.
 -- |
 -- | Treated for now as an identifier or a double-quoted string.
-filename :: (MonadicParsing m, HasLastTokenSpan m) => m String
+filename :: (MonadicParsing m) => m String
 filename = (do
     filename <- P.token $
         -- Treat a double-quoted string as a filename to support spaces.

--- a/src/Idris/Package/Parser.hs
+++ b/src/Idris/Package/Parser.hs
@@ -56,7 +56,7 @@ parseDesc fp = do
       then do
         p <- readFile fp
         case runparser pPkg defaultPkg fp p of
-          Left err -> fail (show $ PP.plain err)
+          Left err -> fail (show $ PP.plain $ parseErrorDoc err)
           Right x -> return x
       else do
         putStrLn $ unwords [ "The presented iPKG file does not exist:", show fp]

--- a/src/Idris/Package/Parser.hs
+++ b/src/Idris/Package/Parser.hs
@@ -123,6 +123,8 @@ filename = (do
                     checkThat (path == takeFileName path)
                         "filename must contain no directory component"
 
+textUntilEol :: MonadicParsing m => m String
+textUntilEol = many (P.satisfy (not . isEol)) <* eol <* P.someSpace
 
 pClause :: PParser ()
 pClause = do reserved "executable"; lchar '=';
@@ -189,40 +191,31 @@ pClause = do reserved "executable"; lchar '=';
 
       <|> do reserved "readme"
              lchar '='
-             rme <- many (P.satisfy (not . isEol))
-             eol
-             P.someSpace
+             rme <- textUntilEol
              st <- get
              put (st { pkgreadme = Just rme })
 
       <|> do reserved "license"
              lchar '='
-             lStr <- many (P.satisfy (not . isEol))
-             eol
+             lStr <- textUntilEol
              st <- get
              put st {pkglicense = Just lStr}
 
       <|> do reserved "homepage"
              lchar '='
-             www <- many (P.satisfy (not . isEol))
-             eol
-             P.someSpace
+             www <- textUntilEol
              st <- get
              put st {pkghomepage = Just www}
 
       <|> do reserved "sourceloc"
              lchar '='
-             srcpage <- many (P.satisfy (not . isEol))
-             eol
-             P.someSpace
+             srcpage <- textUntilEol
              st <- get
              put st {pkgsourceloc = Just srcpage}
 
       <|> do reserved "bugtracker"
              lchar '='
-             src <- many (P.satisfy (not . isEol))
-             eol
-             P.someSpace
+             src <- textUntilEol
              st <- get
              put st {pkgbugtracker = Just src}
 

--- a/src/Idris/Package/Parser.hs
+++ b/src/Idris/Package/Parser.hs
@@ -71,8 +71,7 @@ pPkg = do
     reserved "package"
     p <- pPkgName
     P.someSpace
-    st <- get
-    put (st { pkgname = p })
+    modify $ \st -> st { pkgname = p }
     some pClause
     st <- get
     P.eof

--- a/src/Idris/Package/Parser.hs
+++ b/src/Idris/Package/Parser.hs
@@ -127,7 +127,7 @@ textUntilEol :: MonadicParsing m => m String
 textUntilEol = many (P.satisfy (not . isEol)) <* eol <* P.someSpace
 
 clause          :: String -> PParser a -> (PkgDesc -> a -> PkgDesc) -> PParser ()
-clause name p f = do value <- reserved name *> lchar '=' *> p
+clause name p f = do value <- reserved name *> lchar '=' *> p <* P.someSpace
                      modify $ \st -> f st value
 
 commaSep   :: MonadicParsing m => m a -> m [a]
@@ -153,6 +153,6 @@ pClause = clause "executable" filename (\st v -> st { execout = Just v })
       <|> clause "homepage" textUntilEol (\st v -> st { pkghomepage = Just v })
       <|> clause "sourceloc" textUntilEol (\st v -> st { pkgsourceloc = Just v })
       <|> clause "bugtracker" textUntilEol (\st v -> st { pkgbugtracker = Just v })
-      <|> clause "brief" (P.stringLiteral <* P.someSpace) (\st v -> st { pkgbrief = Just v })
+      <|> clause "brief" P.stringLiteral (\st v -> st { pkgbrief = Just v })
       <|> clause "author" textUntilEol (\st v -> st { pkgauthor = Just v })
       <|> clause "maintainer" textUntilEol (\st v -> st { pkgmaintainer = Just v })

--- a/src/Idris/Parser.hs
+++ b/src/Idris/Parser.hs
@@ -14,7 +14,7 @@ Maintainer  : The Idris Community.
 
 module Idris.Parser(IdrisParser(..), ImportInfo(..), addReplSyntax, clearParserWarnings,
                     decl, fixColour, loadFromIFile, loadModule, name, opChars, parseElabShellStep, parseConst, parseExpr, parseImports, parseTactic,
-                    runparser) where
+                    runparser, ParseError, parseErrorDoc) where
 
 import Idris.AbsSyntax hiding (namespace, params)
 import Idris.Core.Evaluate

--- a/src/Idris/Parser.hs
+++ b/src/Idris/Parser.hs
@@ -1516,7 +1516,7 @@ parseElabShellStep ist = runparser (Right <$> do_ defaultSyntax <|> Left <$> ela
 parseImports :: FilePath -> String -> Idris (Maybe (Docstring ()), [String], [ImportInfo], Maybe P.Delta)
 parseImports fname input
     = do i <- getIState
-         case P.parseString (runInnerParser (evalStateT imports i)) (P.Directed (UTF8.fromString fname) 0 0 0 0) input of
+         case P.parseString (evalStateT imports i) (P.Directed (UTF8.fromString fname) 0 0 0 0) input of
               P.Failure (P.ErrInfo err _) -> ifail $ show err
               P.Success (x, annots, i) ->
                 do putIState i

--- a/src/Idris/Parser.hs
+++ b/src/Idris/Parser.hs
@@ -1578,14 +1578,14 @@ parseProg :: SyntaxInfo -> FilePath -> String -> Maybe P.Delta ->
 parseProg syn fname input mrk
     = do i <- getIState
          case runparser mainProg i fname input of
-            Left doc -> do -- FIXME: Get error location from trifecta
+            Left err -> do -- FIXME: Get error location from trifecta
                            -- this can't be the solution!
                            -- Issue #1575 on the issue tracker.
                            --    https://github.com/idris-lang/Idris-dev/issues/1575
-                           let (fc, msg) = findFC doc
+                           let (fc, msg) = findFC $ parseErrorDoc err
                            i <- getIState
                            case idris_outputmode i of
-                             RawOutput h  -> iputStrLn (show $ fixColour (idris_colourRepl i) doc)
+                             RawOutput h  -> iputStrLn (show . fixColour (idris_colourRepl i) . parseErrorDoc $ err)
                              IdeMode n h -> iWarn fc (Util.Pretty.text msg)
                            putIState (i { errSpan = Just fc })
                            return []

--- a/src/Idris/Parser.hs
+++ b/src/Idris/Parser.hs
@@ -36,7 +36,7 @@ import Idris.Parser.Ops
 import Idris.Termination
 import Idris.Unlit
 
-import qualified Util.Pretty as P
+import qualified Util.Pretty
 import Util.System (readSource)
 
 import Prelude hiding (pi)
@@ -59,9 +59,9 @@ import qualified System.Directory as Dir (makeAbsolute)
 import System.FilePath
 import Text.PrettyPrint.ANSI.Leijen (Doc, plain)
 import qualified Text.PrettyPrint.ANSI.Leijen as ANSI
-import Text.Trifecta hiding (Err, char, charLiteral, natural, span, string,
-                      stringLiteral, symbol, whiteSpace)
-import Text.Trifecta.Delta
+import Text.Trifecta ((<?>))
+import qualified Text.Trifecta as P
+import qualified Text.Trifecta.Delta as P
 
 {-
 @
@@ -84,17 +84,17 @@ import Text.Trifecta.Delta
 @
 -}
 moduleHeader :: IdrisParser (Maybe (Docstring ()), [String], [(FC, OutputAnnotation)])
-moduleHeader =     try (do docs <- optional docComment
-                           noArgs docs
-                           reservedHL "module"
-                           (i, ifc) <- identifier
-                           option ';' (lchar ';')
-                           let modName = moduleName i
-                           return (fmap fst docs,
-                                   modName,
-                                   [(ifc, AnnNamespace (map T.pack modName) Nothing)]))
-               <|> try (do lchar '%'; reserved "unqualified"
-                           return (Nothing, [], []))
+moduleHeader =     P.try (do docs <- optional docComment
+                             noArgs docs
+                             reservedHL "module"
+                             (i, ifc) <- identifier
+                             P.option ';' (lchar ';')
+                             let modName = moduleName i
+                             return (fmap fst docs,
+                                     modName,
+                                     [(ifc, AnnNamespace (map T.pack modName) Nothing)]))
+               <|> P.try (do lchar '%'; reserved "unqualified"
+                             return (Nothing, [], []))
                <|> return (Nothing, moduleName "Main", [])
   where moduleName x = case span (/='.') x of
                            (x, "")    -> [x]
@@ -119,12 +119,11 @@ data ImportInfo = ImportInfo { import_reexport :: Bool
 import_ :: IdrisParser ImportInfo
 import_ = do fc <- getFC
              reservedHL "import"
-             reexport <- option False (do reservedHL "public"
-                                          return True)
+             reexport <- P.option False (True <$ reservedHL "public")
              (id, idfc) <- identifier
              newName <- optional (do reservedHL "as"
                                      identifier)
-             option ';' (lchar ';')
+             P.option ';' (lchar ';')
              return $ ImportInfo reexport (toPath id)
                         (fmap (\(n, fc) -> (toPath n, fc)) newName)
                         (map T.pack $ ns id) fc idfc
@@ -143,7 +142,7 @@ prog syn = do whiteSpace
               decls <- many (decl syn)
               let c = concat decls
               case maxline syn of
-                   Nothing -> do notOpenBraces; eof
+                   Nothing -> do notOpenBraces; P.eof
                    _ -> return ()
               ist <- get
               fc <- getFC
@@ -172,7 +171,7 @@ Decl ::=
 @
 -}
 decl :: SyntaxInfo -> IdrisParser [PDecl]
-decl syn = try (externalDecl syn)
+decl syn = P.try (externalDecl syn)
            <|> internalDecl syn
            <?> "declaration"
 
@@ -195,13 +194,13 @@ internalDecl syn
               if continue then
                  do notEndBlock
                     declBody continue
-                else try (do notEndBlock
-                             declBody continue)
+                else P.try (do notEndBlock
+                               declBody continue)
                      <|> fail "End of readable input"
   where declBody :: Bool -> IdrisParser [PDecl]
         declBody b =
-                   try (implementation True syn)
-                   <|> try (openInterface syn)
+                   P.try (implementation True syn)
+                   <|> P.try (openInterface syn)
                    <|> declBody' b
                    <|> using_ syn
                    <|> params syn
@@ -276,9 +275,9 @@ declExtensions syn rules = declExtension syn [] (filter isDeclRule rules)
 declExtension :: SyntaxInfo -> [Maybe (Name, SynMatch)] -> [Syntax]
                  -> IdrisParser [PDecl]
 declExtension syn ns rules =
-  choice $ flip map (groupBy (ruleGroup `on` syntaxSymbols) rules) $ \rs ->
+  P.choice $ flip map (groupBy (ruleGroup `on` syntaxSymbols) rules) $ \rs ->
     case head rs of -- can never be []
-      DeclRule (symb:_) _ -> try $ do
+      DeclRule (symb:_) _ -> P.try $ do
         n <- extSymbol symb
         declExtension syn (n : ns) [DeclRule ss t | (DeclRule (_:ss) t) <- rs]
       -- If we have more than one Rule in this bucket, our grammar is
@@ -427,28 +426,28 @@ SyntaxSym ::=   '[' Name_t ']'
 -}
 syntaxRule :: SyntaxInfo -> IdrisParser Syntax
 syntaxRule syn
-    = do sty <- try (do
+    = do sty <- P.try (do
             pushIndent
-            sty <- option AnySyntax
-                          (do reservedHL "term"; return TermSyntax
-                           <|> do reservedHL "pattern"; return PatternSyntax)
+            sty <- P.option AnySyntax
+                            (TermSyntax <$ reservedHL "term"
+                             <|> PatternSyntax <$ reservedHL "pattern")
             reservedHL "syntax"
             return sty)
          syms <- some syntaxSym
-         when (all isExpr syms) $ unexpected "missing keywords in syntax rule"
+         when (all isExpr syms) $ P.unexpected "missing keywords in syntax rule"
          let ns = mapMaybe getName syms
          when (length ns /= length (nub ns))
-            $ unexpected "repeated variable in syntax rule"
+            $ P.unexpected "repeated variable in syntax rule"
          lchar '='
          tm <- typeExpr (allowImp syn) >>= uniquifyBinders [n | Binding n <- syms]
          terminator
          return (Rule (mkSimple syms) tm sty)
   <|> do reservedHL "decl"; reservedHL "syntax"
          syms <- some syntaxSym
-         when (all isExpr syms) $ unexpected "missing keywords in syntax rule"
+         when (all isExpr syms) $ P.unexpected "missing keywords in syntax rule"
          let ns = mapMaybe getName syms
          when (length ns /= length (nub ns))
-            $ unexpected "repeated variable in syntax rule"
+            $ P.unexpected "repeated variable in syntax rule"
          lchar '='
          openBlock
          dec <- some (decl syn)
@@ -544,10 +543,10 @@ SyntaxSym ::=   '[' Name_t ']'
 @
  -}
 syntaxSym :: IdrisParser SSymbol
-syntaxSym =    try (do lchar '['; n <- fst <$> name; lchar ']'
-                       return (Expr n))
-            <|> try (do lchar '{'; n <- fst <$> name; lchar '}'
-                        return (Binding n))
+syntaxSym =    P.try (do lchar '['; n <- fst <$> name; lchar ']'
+                         return (Expr n))
+            <|> P.try (do lchar '{'; n <- fst <$> name; lchar '}'
+                          return (Binding n))
             <|> do n <- fst <$> iName []
                    return (Keyword n)
             <|> do sym <- fmap fst stringLiteral
@@ -561,11 +560,11 @@ syntaxSym =    try (do lchar '['; n <- fst <$> name; lchar ']'
 @
 -}
 fnDecl :: SyntaxInfo -> IdrisParser [PDecl]
-fnDecl syn = try (do notEndBlock
-                     d <- fnDecl' syn
-                     i <- get
-                     let d' = fmap (desugar syn i) d
-                     return [d']) <?> "function declaration"
+fnDecl syn = P.try (do notEndBlock
+                       d <- fnDecl' syn
+                       i <- get
+                       let d' = fmap (desugar syn i) d
+                       return [d']) <?> "function declaration"
 
 {-| Parses a function declaration
 
@@ -580,7 +579,7 @@ fnDecl syn = try (do notEndBlock
 -}
 fnDecl' :: SyntaxInfo -> IdrisParser PDecl
 fnDecl' syn = checkDeclFixity $
-              do (doc, argDocs, fc, opts', n, nfc, acc) <- try (do
+              do (doc, argDocs, fc, opts', n, nfc, acc) <- P.try (do
                         pushIndent
                         (doc, argDocs) <- docstring syn
                         (opts, acc) <- fnOpts
@@ -658,41 +657,32 @@ NameTimesList ::=
 -}
 fnOpt :: IdrisParser FnOpt
 fnOpt = do reservedHL "total"; return TotalFn
-        <|> do reservedHL "partial"; return PartialFn
-        <|> do reservedHL "covering"; return CoveringFn
-        <|> do try (lchar '%' *> reserved "export"); c <- fmap fst stringLiteral;
-                    return $ CExport c
-        <|> do try (lchar '%' *> reserved "no_implicit");
-                    return NoImplicit
-        <|> do try (lchar '%' *> reserved "inline");
-                    return Inlinable
-        <|> do try (lchar '%' *> reserved "static");
-                    return StaticFn
-        <|> do try (lchar '%' *> reserved "assert_total");
+        <|> PartialFn <$ reservedHL "partial"
+        <|> CoveringFn <$ reservedHL "covering"
+        <|> do P.try (lchar '%' *> reserved "export"); c <- fmap fst stringLiteral;
+                      return $ CExport c
+        <|> NoImplicit <$ P.try (lchar '%' *> reserved "no_implicit")
+        <|> Inlinable <$ P.try (lchar '%' *> reserved "inline")
+        <|> StaticFn <$ P.try (lchar '%' *> reserved "static")
+        <|> do P.try (lchar '%' *> reserved "assert_total");
                fc <- getFC
                parserWarning fc Nothing (Msg "%assert_total is deprecated. Use the 'assert_total' function instead.")
                return AssertTotal
-        <|> do try (lchar '%' *> reserved "error_handler");
-                    return ErrorHandler
-        <|> do try (lchar '%' *> reserved "error_reverse");
-                    return ErrorReverse
-        <|> do try (lchar '%' *> reserved "error_reduce");
-                    return ErrorReduce
-        <|> do try (lchar '%' *> reserved "reflection");
-                    return Reflection
-        <|> do try (lchar '%' *> reserved "hint");
-                    return AutoHint
-        <|> do try (lchar '%' *> reserved "overlapping");
-                    return OverlappingDictionary
+        <|> ErrorHandler <$ P.try (lchar '%' *> reserved "error_handler")
+        <|> ErrorReverse <$ P.try (lchar '%' *> reserved "error_reverse")
+        <|> ErrorReduce  <$ P.try (lchar '%' *> reserved "error_reduce")
+        <|> Reflection   <$ P.try (lchar '%' *> reserved "reflection")
+        <|> AutoHint     <$ P.try (lchar '%' *> reserved "hint")
+        <|> OverlappingDictionary <$ P.try (lchar '%' *> reserved "overlapping")
         <|> do lchar '%'; reserved "specialise";
-               lchar '['; ns <- sepBy nameTimes (lchar ','); lchar ']';
+               lchar '['; ns <- P.sepBy nameTimes (lchar ','); lchar ']';
                return $ Specialise ns
-        <|> do reservedHL "implicit"; return Implicit
+        <|> Implicit <$ reservedHL "implicit"
         <?> "function modifier"
   where nameTimes :: IdrisParser (Name, Maybe Int)
         nameTimes = do n <- fst <$> fnName
-                       t <- option Nothing (do reds <- fmap fst natural
-                                               return (Just (fromInteger reds)))
+                       t <- P.option Nothing (do reds <- fmap fst natural
+                                                 return (Just (fromInteger reds)))
                        return (n, t)
 
 {-| Parses a postulate
@@ -705,10 +695,10 @@ Postulate ::=
 -}
 postulate :: SyntaxInfo -> IdrisParser PDecl
 postulate syn = do (doc, ext)
-                       <- try $ do (doc, _) <- docstring syn
-                                   pushIndent
-                                   ext <- ppostDecl
-                                   return (doc, ext)
+                       <- P.try $ do (doc, _) <- docstring syn
+                                     pushIndent
+                                     ext <- ppostDecl
+                                     return (doc, ext)
                    ist <- get
                    (opts, acc) <- fnOpts
                    (n_in, nfc) <- fnName
@@ -768,7 +758,7 @@ openInterface syn =
     do reservedHL "using"
        reservedHL "implementation"
        fc <- getFC
-       ns <- sepBy1 fnName (lchar ',')
+       ns <- P.sepBy1 fnName (lchar ',')
 
        openBlock
        ds <- many (decl syn)
@@ -848,14 +838,14 @@ InterfaceBlock ::=
 interfaceBlock :: SyntaxInfo -> IdrisParser (Maybe (Name, FC), Docstring (Either Err PTerm), [PDecl])
 interfaceBlock syn = do reservedHL "where"
                         openBlock
-                        (cn, cd) <- option (Nothing, emptyDocstring) $
-                                    try (do (doc, _) <- option noDocs docComment
-                                            n <- constructor
-                                            return (Just n, doc))
+                        (cn, cd) <- P.option (Nothing, emptyDocstring) $
+                                    P.try (do (doc, _) <- P.option noDocs docComment
+                                              n <- constructor
+                                              return (Just n, doc))
                         ist <- get
                         let cd' = annotate syn ist cd
 
-                        ds <- many (notEndBlock >> try (implementation True syn)
+                        ds <- many (notEndBlock >> P.try (implementation True syn)
                                                    <|> do x <- data_ syn
                                                           return [x]
                                                    <|> fnDecl syn)
@@ -886,24 +876,24 @@ Interface ::=
 -}
 interface_ :: SyntaxInfo -> IdrisParser [PDecl]
 interface_ syn = do (doc, argDocs, acc)
-                      <- try (do (doc, argDocs) <- docstring syn
-                                 acc <- accessibility
-                                 interfaceKeyword
-                                 return (doc, argDocs, acc))
+                      <- P.try (do (doc, argDocs) <- docstring syn
+                                   acc <- accessibility
+                                   interfaceKeyword
+                                   return (doc, argDocs, acc))
                     fc <- getFC
                     cons <- constraintList syn
                     let cons' = [(c, ty) | (_, c, _, ty) <- cons]
                     (n_in, nfc) <- fnName
                     let n = expandNS syn n_in
                     cs <- many carg
-                    fds <- option [(cn, NoFC) | (cn, _, _) <- cs] fundeps
-                    (cn, cd, ds) <- option (Nothing, fst noDocs, []) (interfaceBlock syn)
+                    fds <- P.option [(cn, NoFC) | (cn, _, _) <- cs] fundeps
+                    (cn, cd, ds) <- P.option (Nothing, fst noDocs, []) (interfaceBlock syn)
                     accData acc n (concatMap declared ds)
                     return [PInterface doc syn fc cons' n nfc cs argDocs fds ds cn cd]
                  <?> "interface declaration"
   where
     fundeps :: IdrisParser [(Name, FC)]
-    fundeps = do lchar '|'; sepBy name (lchar ',')
+    fundeps = do lchar '|'; P.sepBy name (lchar ',')
 
     interfaceKeyword :: IdrisParser ()
     interfaceKeyword = reservedHL "interface"
@@ -964,7 +954,7 @@ implementation kwopt syn
 
         implementationUsing :: IdrisParser [Name]
         implementationUsing = do reservedHL "using"
-                                 ns <- sepBy1 fnName (lchar ',')
+                                 ns <- P.sepBy1 fnName (lchar ',')
                                  return (map fst ns)
                               <|> return []
 
@@ -972,7 +962,7 @@ implementation kwopt syn
 docstring :: SyntaxInfo
           -> IdrisParser (Docstring (Either Err PTerm),
                           [(Name,Docstring (Either Err PTerm))])
-docstring syn = do (doc, argDocs) <- option noDocs docComment
+docstring syn = do (doc, argDocs) <- P.option noDocs docComment
                    ist <- get
                    let doc' = annotCode (tryFullExpr syn ist) doc
                        argDocs' = [ (n, annotCode (tryFullExpr syn ist) d)
@@ -1005,8 +995,8 @@ NameList ::=
 -}
 usingDeclList :: SyntaxInfo -> IdrisParser [Using]
 usingDeclList syn
-               = try (sepBy1 (usingDecl syn) (lchar ','))
-             <|> do ns <- sepBy1 (fst <$> name) (lchar ',')
+               = P.try (P.sepBy1 (usingDecl syn) (lchar ','))
+             <|> do ns <- P.sepBy1 (fst <$> name) (lchar ',')
                     lchar ':'
                     t <- typeExpr (disallowImp syn)
                     return (map (\x -> UImplicit x t) ns)
@@ -1022,10 +1012,10 @@ UsingDecl ::=
 @
 -}
 usingDecl :: SyntaxInfo -> IdrisParser Using
-usingDecl syn = try (do x <- fst <$> fnName
-                        lchar ':'
-                        t <- typeExpr (disallowImp syn)
-                        return (UImplicit x t))
+usingDecl syn = P.try (do x <- fst <$> fnName
+                          lchar ':'
+                          t <- typeExpr (disallowImp syn)
+                          return (UImplicit x t))
             <|> do c <- fst <$> fnName
                    xs <- many (fst <$> fnName)
                    return (UConstraint c xs)
@@ -1068,7 +1058,7 @@ ArgExpr ::= HSimpleExpr | {- In Pattern External (User-defined) Expression -};
 -}
 argExpr :: SyntaxInfo -> IdrisParser PTerm
 argExpr syn = let syn' = syn { inPattern = True } in
-                  try (hsimpleExpr syn') <|> simpleExternalExpr syn'
+                  P.try (hsimpleExpr syn') <|> simpleExternalExpr syn'
               <?> "argument expression"
 
 {-| Parse a right hand side of a function
@@ -1090,8 +1080,8 @@ rhs syn n = do lchar '='
                expr syn
         <|> do symbol "?=";
                fc <- getFC
-               name <- option n' (do symbol "{"; n <- fst <$> fnName; symbol "}";
-                                     return n)
+               name <- P.option n' (do symbol "{"; n <- fst <$> fnName; symbol "}";
+                                       return n)
                r <- expr syn
                return (addLet fc name r)
         <|> impossible
@@ -1135,7 +1125,7 @@ WhereOrTerminator ::= WhereBlock | Terminator;
 -}
 clause :: SyntaxInfo -> IdrisParser PClause
 clause syn
-         = do wargs <- try (do pushIndent; some (wExpr syn))
+         = do wargs <- P.try (do pushIndent; some (wExpr syn))
               fc <- getFC
               ist <- get
               n <- case lastParse ist of
@@ -1143,11 +1133,8 @@ clause syn
                         Nothing -> fail "Invalid clause"
               (do r <- rhs syn n
                   let wsyn = syn { syn_namespace = [], syn_toplevel = False }
-                  (wheres, nmap) <- choice [do x <- whereBlock n wsyn
-                                               popIndent
-                                               return x,
-                                            do terminator
-                                               return ([], [])]
+                  (wheres, nmap) <-     whereBlock n wsyn <* popIndent
+                                    <|> ([], []) <$ terminator
                   return $ PClauseR fc wargs r wheres) <|> (do
                   popIndent
                   reservedHL "with"
@@ -1158,19 +1145,16 @@ clause syn
                   let withs = concat ds
                   closeBlock
                   return $ PWithR fc wargs wval pn withs)
-       <|> do ty <- try (do pushIndent
-                            ty <- simpleExpr syn
-                            symbol "<=="
-                            return ty)
+       <|> do ty <- P.try (do pushIndent
+                              ty <- simpleExpr syn
+                              symbol "<=="
+                              return ty)
               fc <- getFC
               n_in <- fst <$> fnName; let n = expandNS syn n_in
               r <- rhs syn n
               let wsyn = syn { syn_namespace = [] }
-              (wheres, nmap) <- choice [do x <- whereBlock n wsyn
-                                           popIndent
-                                           return x,
-                                        do terminator
-                                           return ([], [])]
+              (wheres, nmap) <-   whereBlock n wsyn <* popIndent
+                                <|> ([], []) <$ terminator
               let capp = PLet fc RigW (sMN 0 "match") NoFC
                               ty
                               (PMatchApp fc n)
@@ -1178,7 +1162,7 @@ clause syn
               ist <- get
               put (ist { lastParse = Just n })
               return $ PClause fc n capp [] r wheres
-       <|> do (l, op, nfc) <- try (do
+       <|> do (l, op, nfc) <- P.try (do
                 pushIndent
                 l <- argExpr syn
                 (op, nfc) <- symbolicOperatorFC
@@ -1191,11 +1175,8 @@ clause syn
               wargs <- many (wExpr syn)
               (do rs <- rhs syn n
                   let wsyn = syn { syn_namespace = [] }
-                  (wheres, nmap) <- choice [do x <- whereBlock n wsyn
-                                               popIndent
-                                               return x,
-                                            do terminator
-                                               return ([], [])]
+                  (wheres, nmap) <-     whereBlock n wsyn <* popIndent
+                                    <|> ([], []) <$ terminator
                   ist <- get
                   let capp = PApp fc (PRef nfc [nfc] n) [pexp l, pexp r]
                   put (ist { lastParse = Just n })
@@ -1215,18 +1196,15 @@ clause syn
        <|> do pushIndent
               (n_in, nfc) <- fnName; let n = expandNS syn n_in
               fc <- getFC
-              args <- many (try (implicitArg (syn { inPattern = True } ))
-                            <|> try (constraintArg (syn { inPattern = True }))
+              args <- many (P.try (implicitArg (syn { inPattern = True } ))
+                            <|> P.try (constraintArg (syn { inPattern = True }))
                             <|> (fmap pexp (argExpr syn)))
               wargs <- many (wExpr syn)
               let capp = PApp fc (PRef nfc [nfc] n) args
               (do r <- rhs syn n
                   let wsyn = syn { syn_namespace = [] }
-                  (wheres, nmap) <- choice [do x <- whereBlock n wsyn
-                                               popIndent
-                                               return x,
-                                            do terminator
-                                               return ([], [])]
+                  (wheres, nmap) <-     whereBlock n wsyn <* popIndent
+                                    <|> ([], []) <$ terminator
                   ist <- get
                   put (ist { lastParse = Just n })
                   return $ PClause fc n capp wargs r wheres) <|> (do
@@ -1243,9 +1221,9 @@ clause syn
                    return $ PWith fc n capp wargs wval pn withs)
       <?> "function clause"
   where
-    optProof = option Nothing (do reservedHL "proof"
-                                  n <- fnName
-                                  return (Just n))
+    optProof = P.option Nothing (do reservedHL "proof"
+                                    n <- fnName
+                                    return (Just n))
 
     fillLHS :: Name -> PTerm -> [PTerm] -> PClause -> PClause
     fillLHS n capp owargs (PClauseR fc wargs v ws)
@@ -1336,74 +1314,74 @@ Directive' ::= 'lib'            CodeGen String_t
 @
 -}
 directive :: SyntaxInfo -> IdrisParser [PDecl]
-directive syn = do try (lchar '%' *> reserved "lib")
+directive syn = do P.try (lchar '%' *> reserved "lib")
                    cgn <- codegen_
                    lib <- fmap fst stringLiteral
                    return [PDirective (DLib cgn lib)]
-             <|> do try (lchar '%' *> reserved "link")
+             <|> do P.try (lchar '%' *> reserved "link")
                     cgn <- codegen_; obj <- fst <$> stringLiteral
                     return [PDirective (DLink cgn obj)]
-             <|> do try (lchar '%' *> reserved "flag")
+             <|> do P.try (lchar '%' *> reserved "flag")
                     cgn <- codegen_; flag <- fst <$> stringLiteral
                     return [PDirective (DFlag cgn flag)]
-             <|> do try (lchar '%' *> reserved "include")
+             <|> do P.try (lchar '%' *> reserved "include")
                     cgn <- codegen_
                     hdr <- fst <$> stringLiteral
                     return [PDirective (DInclude cgn hdr)]
-             <|> do try (lchar '%' *> reserved "hide"); n <- fst <$> fnName
+             <|> do P.try (lchar '%' *> reserved "hide"); n <- fst <$> fnName
                     return [PDirective (DHide n)]
-             <|> do try (lchar '%' *> reserved "freeze"); n <- fst <$> iName []
+             <|> do P.try (lchar '%' *> reserved "freeze"); n <- fst <$> iName []
                     return [PDirective (DFreeze n)]
-             <|> do try (lchar '%' *> reserved "thaw"); n <- fst <$> iName []
+             <|> do P.try (lchar '%' *> reserved "thaw"); n <- fst <$> iName []
                     return [PDirective (DThaw n)]
              -- injectivity assertins are intended for debugging purposes
              -- only, and won't be documented/could be removed at any point
-             <|> do try (lchar '%' *> reserved "assert_injective"); n <- fst <$> fnName
+             <|> do P.try (lchar '%' *> reserved "assert_injective"); n <- fst <$> fnName
                     return [PDirective (DInjective n)]
              -- Assert totality of something after definition. This is
              -- here as a debugging aid, so commented out...
---              <|> do try (lchar '%' *> reserved "assert_set_total"); n <- fst <$> fnName
+--              <|> do P.try (lchar '%' *> reserved "assert_set_total"); n <- fst <$> fnName
 --                     return [PDirective (DSetTotal n)]
-             <|> do try (lchar '%' *> reserved "access")
+             <|> do P.try (lchar '%' *> reserved "access")
                     acc <- accessibility
                     ist <- get
                     put ist { default_access = acc }
                     return [PDirective (DAccess acc)]
-             <|> do try (lchar '%' *> reserved "default"); tot <- totality
+             <|> do P.try (lchar '%' *> reserved "default"); tot <- totality
                     i <- get
                     put (i { default_total = tot } )
                     return [PDirective (DDefault tot)]
-             <|> do try (lchar '%' *> reserved "logging")
+             <|> do P.try (lchar '%' *> reserved "logging")
                     i <- fst <$> natural
                     return [PDirective (DLogging i)]
-             <|> do try (lchar '%' *> reserved "dynamic")
-                    libs <- sepBy1 (fmap fst stringLiteral) (lchar ',')
+             <|> do P.try (lchar '%' *> reserved "dynamic")
+                    libs <- P.sepBy1 (fmap fst stringLiteral) (lchar ',')
                     return [PDirective (DDynamicLibs libs)]
-             <|> do try (lchar '%' *> reserved "name")
+             <|> do P.try (lchar '%' *> reserved "name")
                     (ty, tyFC) <- fnName
-                    ns <- sepBy1 name (lchar ',')
+                    ns <- P.sepBy1 name (lchar ',')
                     return [PDirective (DNameHint ty tyFC ns)]
-             <|> do try (lchar '%' *> reserved "error_handlers")
+             <|> do P.try (lchar '%' *> reserved "error_handlers")
                     (fn, nfc) <- fnName
                     (arg, afc) <- fnName
-                    ns <- sepBy1 name (lchar ',')
+                    ns <- P.sepBy1 name (lchar ',')
                     return [PDirective (DErrorHandlers fn nfc arg afc ns) ]
-             <|> do try (lchar '%' *> reserved "language"); ext <- pLangExt;
+             <|> do P.try (lchar '%' *> reserved "language"); ext <- pLangExt;
                     return [PDirective (DLanguage ext)]
-             <|> do try (lchar '%' *> reserved "deprecate")
+             <|> do P.try (lchar '%' *> reserved "deprecate")
                     n <- fst <$> fnName
-                    alt <- option "" (fst <$> stringLiteral)
+                    alt <- P.option "" (fst <$> stringLiteral)
                     return [PDirective (DDeprecate n alt)]
-             <|> do try (lchar '%' *> reserved "fragile")
+             <|> do P.try (lchar '%' *> reserved "fragile")
                     n <- fst <$> fnName
-                    alt <- option "" (fst <$> stringLiteral)
+                    alt <- P.option "" (fst <$> stringLiteral)
                     return [PDirective (DFragile n alt)]
              <|> do fc <- getFC
-                    try (lchar '%' *> reserved "used")
+                    P.try (lchar '%' *> reserved "used")
                     fn <- fst <$> fnName
                     arg <- fst <$> iName []
                     return [PDirective (DUsed fc fn arg)]
-             <|> do try (lchar '%' *> reserved "auto_implicits")
+             <|> do P.try (lchar '%' *> reserved "auto_implicits")
                     b <- on_off
                     return [PDirective (DAutoImplicits b)]
              <?> "directive"
@@ -1440,12 +1418,12 @@ ProviderWhat ::= 'proof' | 'term' | 'type' | 'postulate'
 @
  -}
 provider :: SyntaxInfo -> IdrisParser [PDecl]
-provider syn = do doc <- try (do (doc, _) <- docstring syn
-                                 fc1 <- getFC
-                                 lchar '%'
-                                 fc2 <- reservedFC "provide"
-                                 highlightP (spanFC fc1 fc2) AnnKeyword
-                                 return doc)
+provider syn = do doc <- P.try (do (doc, _) <- docstring syn
+                                   fc1 <- getFC
+                                   lchar '%'
+                                   fc2 <- reservedFC "provide"
+                                   highlightP (spanFC fc1 fc2) AnnKeyword
+                                   return doc)
                   provideTerm doc <|> providePostulate doc
                <?> "type provider"
   where provideTerm doc =
@@ -1469,7 +1447,7 @@ Transform ::= '%' 'transform' Expr '==>' Expr
 @
 -}
 transform :: SyntaxInfo -> IdrisParser [PDecl]
-transform syn = do try (lchar '%' *> reserved "transform")
+transform syn = do P.try (lchar '%' *> reserved "transform")
                     -- leave it unchecked, until we work out what this should
                     -- actually mean...
 --                     safety <- option True (do reserved "unsafe"
@@ -1489,10 +1467,10 @@ RunElabDecl ::= '%' 'runElab' Expr
 -}
 runElabDecl :: SyntaxInfo -> IdrisParser PDecl
 runElabDecl syn =
-  do kwFC <- try (do fc <- getFC
-                     lchar '%'
-                     fc' <- reservedFC "runElab"
-                     return (spanFC fc fc'))
+  do kwFC <- P.try (do fc <- getFC
+                       lchar '%'
+                       fc' <- reservedFC "runElab"
+                       return (spanFC fc fc'))
      script <- expr syn <?> "elaborator script"
      highlightP kwFC AnnKeyword
      return $ PRunElabDecl kwFC script (syn_namespace syn)
@@ -1500,19 +1478,19 @@ runElabDecl syn =
 
 {- * Loading and parsing -}
 {-| Parses an expression from input -}
-parseExpr :: IState -> String -> Result PTerm
+parseExpr :: IState -> String -> P.Result PTerm
 parseExpr st = runparser (fullExpr defaultSyntax) st "(input)"
 
 {-| Parses a constant form input -}
-parseConst :: IState -> String -> Result Const
+parseConst :: IState -> String -> P.Result Const
 parseConst st = runparser (fmap fst constant) st "(input)"
 
 {-| Parses a tactic from input -}
-parseTactic :: IState -> String -> Result PTactic
+parseTactic :: IState -> String -> P.Result PTactic
 parseTactic st = runparser (fullTactic defaultSyntax) st "(input)"
 
 {-| Parses a do-step from input (used in the elab shell) -}
-parseElabShellStep :: IState -> String -> Result (Either ElabShellCmd PDo)
+parseElabShellStep :: IState -> String -> P.Result (Either ElabShellCmd PDo)
 parseElabShellStep ist = runparser (fmap Right (do_ defaultSyntax) <|> fmap Left elabShellCmd) ist "(input)"
   where elabShellCmd = char ':' >>
                        (reserved "qed"     >> pure EQED       ) <|>
@@ -1525,7 +1503,7 @@ parseElabShellStep ist = runparser (fmap Right (do_ defaultSyntax) <|> fmap Left
                        (expressionTactic ["search"] ESearch   ) <|>
                        (do reserved "doc"
                            doc <- (Right . fst <$> constant) <|> (Left . fst <$> fnName)
-                           eof
+                           P.eof
                            return (EDocStr doc))
                        <?> "elab command"
         expressionTactic cmds tactic =
@@ -1536,26 +1514,26 @@ parseElabShellStep ist = runparser (fmap Right (do_ defaultSyntax) <|> fmap Left
         spaced parser = indentGt *> parser
 
 -- | Parse module header and imports
-parseImports :: FilePath -> String -> Idris (Maybe (Docstring ()), [String], [ImportInfo], Maybe Delta)
+parseImports :: FilePath -> String -> Idris (Maybe (Docstring ()), [String], [ImportInfo], Maybe P.Delta)
 parseImports fname input
     = do i <- getIState
-         case parseString (runInnerParser (evalStateT imports i)) (Directed (UTF8.fromString fname) 0 0 0 0) input of
-              Failure (ErrInfo err _) -> ifail $ show err
-              Success (x, annots, i) ->
+         case P.parseString (runInnerParser (evalStateT imports i)) (P.Directed (UTF8.fromString fname) 0 0 0 0) input of
+              P.Failure (P.ErrInfo err _) -> ifail $ show err
+              P.Success (x, annots, i) ->
                 do putIState i
                    fname' <- runIO $ Dir.makeAbsolute fname
                    sendHighlighting $ addPath annots fname'
                    return x
   where imports :: IdrisParser ((Maybe (Docstring ()), [String],
                                  [ImportInfo],
-                                 Maybe Delta),
+                                 Maybe P.Delta),
                                 [(FC, OutputAnnotation)], IState)
         imports = do optional shebang
                      whiteSpace
                      (mdoc, mname, annots) <- moduleHeader
                      ps_exp        <- many import_
-                     mrk           <- mark
-                     isEof         <- lookAheadMatches eof
+                     mrk           <- P.mark
+                     isEof         <- lookAheadMatches P.eof
                      let mrk' = if isEof
                                    then Nothing
                                    else Just mrk
@@ -1572,7 +1550,7 @@ parseImports fname input
         addPath (annot:annots) path = annot : addPath annots path
 
         shebang :: IdrisParser ()
-        shebang = string "#!" *> many (satisfy $ not . isEol) *> eol *> pure ()
+        shebang = string "#!" *> many (P.satisfy $ not . isEol) *> eol *> pure ()
 
 -- | There should be a better way of doing this...
 findFC :: Doc -> (FC, String)
@@ -1596,12 +1574,12 @@ fixColour True doc  = doc
 
 -- | A program is a list of declarations, possibly with associated
 -- documentation strings.
-parseProg :: SyntaxInfo -> FilePath -> String -> Maybe Delta ->
+parseProg :: SyntaxInfo -> FilePath -> String -> Maybe P.Delta ->
              Idris [PDecl]
 parseProg syn fname input mrk
     = do i <- getIState
          case runparser mainProg i fname input of
-            Failure (ErrInfo doc _)     -> do -- FIXME: Get error location from trifecta
+            P.Failure (P.ErrInfo doc _)     -> do -- FIXME: Get error location from trifecta
                                   -- this can't be the solution!
                                   -- Issue #1575 on the issue tracker.
                                   --    https://github.com/idris-lang/Idris-dev/issues/1575
@@ -1609,17 +1587,17 @@ parseProg syn fname input mrk
                                   i <- getIState
                                   case idris_outputmode i of
                                     RawOutput h  -> iputStrLn (show $ fixColour (idris_colourRepl i) doc)
-                                    IdeMode n h -> iWarn fc (P.text msg)
+                                    IdeMode n h -> iWarn fc (Util.Pretty.text msg)
                                   putIState (i { errSpan = Just fc })
                                   return []
-            Success (x, i)  -> do putIState i
-                                  reportParserWarnings
-                                  return $ collect x
+            P.Success (x, i)  -> do putIState i
+                                    reportParserWarnings
+                                    return $ collect x
   where mainProg :: IdrisParser ([PDecl], IState)
         mainProg = case mrk of
                         Nothing -> do i <- get; return ([], i)
                         Just mrk -> do
-                          release mrk
+                          P.release mrk
                           ds <- prog syn
                           i' <- get
                           return (ds, i')

--- a/src/Idris/Parser/Expr.hs
+++ b/src/Idris/Parser/Expr.hs
@@ -18,6 +18,7 @@ import Idris.Parser.Ops
 
 import Prelude hiding (pi)
 
+import Control.Arrow (left)
 import Control.Applicative
 import Control.Monad
 import Control.Monad.State.Strict
@@ -58,10 +59,7 @@ fullExpr syn = do x <- expr syn
                   return $ debindApp syn (desugar syn i x)
 
 tryFullExpr :: SyntaxInfo -> IState -> String -> Either Err PTerm
-tryFullExpr syn st input =
-  case runparser (fullExpr syn) st "" input of
-    P.Success tm -> Right tm
-    P.Failure e -> Left (Msg (show e))
+tryFullExpr syn st = left (Msg . show) . runparser (fullExpr syn) st ""
 
 {- | Parses an expression
 @

--- a/src/Idris/Parser/Expr.hs
+++ b/src/Idris/Parser/Expr.hs
@@ -59,7 +59,7 @@ fullExpr syn = do x <- expr syn
                   return $ debindApp syn (desugar syn i x)
 
 tryFullExpr :: SyntaxInfo -> IState -> String -> Either Err PTerm
-tryFullExpr syn st = left (Msg . show) . runparser (fullExpr syn) st ""
+tryFullExpr syn st = left (Msg . show . parseErrorDoc) . runparser (fullExpr syn) st ""
 
 {- | Parses an expression
 @

--- a/src/Idris/Parser/Expr.hs
+++ b/src/Idris/Parser/Expr.hs
@@ -18,8 +18,8 @@ import Idris.Parser.Ops
 
 import Prelude hiding (pi)
 
-import Control.Arrow (left)
 import Control.Applicative
+import Control.Arrow (left)
 import Control.Monad
 import Control.Monad.State.Strict
 import Data.Function (on)

--- a/src/Idris/Parser/Helpers.hs
+++ b/src/Idris/Parser/Helpers.hs
@@ -288,12 +288,12 @@ lcharFC ch = do (FC file (l, c) _) <- getFC
                 return $ FC file (l, c) (l, c+1)
 
 -- | Parses string as a token
-symbol :: MonadicParsing m => String -> m String
-symbol = Tok.symbol
+symbol :: MonadicParsing m => String -> m ()
+symbol = void . Tok.symbol
 
 symbolFC :: MonadicParsing m => String -> m FC
 symbolFC str = do (FC file (l, c) _) <- getFC
-                  Tok.symbol str
+                  symbol str
                   return $ FC file (l, c) (l, c + length str)
 
 -- | Parses a reserved identifier

--- a/src/Idris/Parser/Helpers.hs
+++ b/src/Idris/Parser/Helpers.hs
@@ -59,7 +59,6 @@ instance {-# OVERLAPPING #-} P.DeltaParsing IdrisParser where
   {-# INLINE rend #-}
   restOfLine = lift P.restOfLine
   {-# INLINE restOfLine #-}
-
 #endif
 
 instance {-# OVERLAPPING #-} P.TokenParsing IdrisParser where
@@ -72,8 +71,9 @@ instance {-# OVERLAPPING #-} P.TokenParsing IdrisParser where
                whiteSpace
                put (s { lastTokenSpan = Just (FC fn (sl, sc) (el, ec)) })
                return r
+
 -- | Generalized monadic parsing constraint type
-type MonadicParsing m = (P.DeltaParsing m, LookAheadParsing m, P.TokenParsing m, Monad m)
+type MonadicParsing m = (P.DeltaParsing m, LookAheadParsing m, Monad m)
 
 class HasLastTokenSpan m where
   getLastTokenSpan :: m (Maybe FC)
@@ -335,13 +335,11 @@ identifier = P.try $ do
   return (ident, FC f (l, c) (l, c + length ident))
 
 -- | Parses an identifier with possible namespace as a name
-iName :: (MonadicParsing m, HasLastTokenSpan m) => [String] -> m (Name, FC)
-iName bad = do (n, fc) <- maybeWithNS identifier False bad
-               return (n, fc)
-            <?> "name"
+iName :: (MonadicParsing m) => [String] -> m (Name, FC)
+iName bad = maybeWithNS identifier False bad <?> "name"
 
 -- | Parses an string possibly prefixed by a namespace
-maybeWithNS :: (MonadicParsing m, HasLastTokenSpan m) => m (String, FC) -> Bool -> [String] -> m (Name, FC)
+maybeWithNS :: (MonadicParsing m) => m (String, FC) -> Bool -> [String] -> m (Name, FC)
 maybeWithNS parser ascend bad = do
   fc <- getFC
   i <- P.option "" (lookAhead (fst <$> identifier))

--- a/src/Idris/Parser/Helpers.hs
+++ b/src/Idris/Parser/Helpers.hs
@@ -61,8 +61,11 @@ instance {-# OVERLAPPING #-} P.DeltaParsing IdrisParser where
   {-# INLINE restOfLine #-}
 #endif
 
+someSpace' :: MonadicParsing m => m ()
+someSpace' = many (simpleWhiteSpace <|> singleLineComment <|> multiLineComment) *> pure ()
+
 instance {-# OVERLAPPING #-} P.TokenParsing IdrisParser where
-  someSpace = many (simpleWhiteSpace <|> singleLineComment <|> multiLineComment) *> pure ()
+  someSpace = someSpace'
   token p = do s <- get
                (FC fn (sl, sc) _) <- getFC --TODO: Update after fixing getFC
                                            -- See Issue #1594
@@ -206,7 +209,7 @@ docComment = do dc <- pushIndent *> docCommentLine
                                    contents <- P.option "" (do first <- P.satisfy (\c -> not (isEol c || c == '@'))
                                                                res <- many (P.satisfy (not . isEol))
                                                                return $ first:res)
-                                   eol ; P.someSpace
+                                   eol ; someSpace'
                                    return contents)
                         <?> ""
 
@@ -217,7 +220,7 @@ docComment = do dc <- pushIndent *> docCommentLine
                                n <- fst <$> name
                                many (P.satisfy isSpace)
                                docs <- many (P.satisfy (not . isEol))
-                               eol ; P.someSpace
+                               eol ; someSpace'
                                return (n, docs)
 
 -- | Parses some white space

--- a/src/Idris/Parser/Helpers.hs
+++ b/src/Idris/Parser/Helpers.hs
@@ -40,12 +40,7 @@ import qualified Text.Trifecta as P
 import qualified Text.Trifecta.Delta as P
 
 -- | Idris parser with state used during parsing
-type IdrisParser = StateT IState IdrisInnerParser
-
-newtype IdrisInnerParser a = IdrisInnerParser { runInnerParser :: P.Parser a }
-  deriving (Monad, Functor, MonadPlus, Applicative, Alternative, P.CharParsing, LookAheadParsing, P.DeltaParsing, P.MarkParsing P.Delta, Monoid, P.TokenParsing)
-
-deriving instance P.Parsing IdrisInnerParser
+type IdrisParser = StateT IState P.Parser
 
 #if MIN_VERSION_base(4,9,0)
 instance {-# OVERLAPPING #-} P.DeltaParsing IdrisParser where
@@ -87,9 +82,9 @@ instance HasLastTokenSpan IdrisParser where
 newtype ParseError = ParseError { parseErrorDoc :: PP.Doc }
 
 -- | Helper to run Idris inner parser based stateT parsers
-runparser :: StateT st IdrisInnerParser res -> st -> String -> String -> Either ParseError res
+runparser :: StateT st P.Parser res -> st -> String -> String -> Either ParseError res
 runparser p i inputname s =
-  case P.parseString (runInnerParser (evalStateT p i))
+  case P.parseString (evalStateT p i)
                      (P.Directed (UTF8.fromString inputname) 0 0 0 0) s of
     P.Failure (P.ErrInfo doc _) -> Left (ParseError doc)
     P.Success value -> Right value

--- a/src/Idris/Parser/Helpers.hs
+++ b/src/Idris/Parser/Helpers.hs
@@ -82,14 +82,14 @@ class HasLastTokenSpan m where
 instance HasLastTokenSpan IdrisParser where
   getLastTokenSpan = lastTokenSpan <$> get
 
-type ParseError = PP.Doc
+newtype ParseError = ParseError { parseErrorDoc :: PP.Doc }
 
 -- | Helper to run Idris inner parser based stateT parsers
 runparser :: StateT st IdrisInnerParser res -> st -> String -> String -> Either ParseError res
 runparser p i inputname s =
   case P.parseString (runInnerParser (evalStateT p i))
                      (P.Directed (UTF8.fromString inputname) 0 0 0 0) s of
-    P.Failure (P.ErrInfo doc _) -> Left doc
+    P.Failure (P.ErrInfo doc _) -> Left (ParseError doc)
     P.Success value -> Right value
 
 highlightP :: FC -> OutputAnnotation -> IdrisParser ()

--- a/src/Idris/Parser/Helpers.hs
+++ b/src/Idris/Parser/Helpers.hs
@@ -82,10 +82,12 @@ instance HasLastTokenSpan IdrisParser where
   getLastTokenSpan = lastTokenSpan <$> get
 
 -- | Helper to run Idris inner parser based stateT parsers
-runparser :: StateT st IdrisInnerParser res -> st -> String -> String -> P.Result res
-runparser p i inputname =
-  P.parseString (runInnerParser (evalStateT p i))
-                (P.Directed (UTF8.fromString inputname) 0 0 0 0)
+runparser :: StateT st IdrisInnerParser res -> st -> String -> String -> Either P.ErrInfo res
+runparser p i inputname s =
+  case P.parseString (runInnerParser (evalStateT p i))
+                     (P.Directed (UTF8.fromString inputname) 0 0 0 0) s of
+    P.Failure errInfo -> Left errInfo
+    P.Success result -> Right result
 
 highlightP :: FC -> OutputAnnotation -> IdrisParser ()
 highlightP fc annot = do ist <- get

--- a/src/Idris/Prover.hs
+++ b/src/Idris/Prover.hs
@@ -34,7 +34,6 @@ import qualified Idris.IdeMode as IdeMode
 import Idris.Options
 import Idris.Output
 import Idris.Parser hiding (params)
-import Idris.Parser.Helpers (parseErrorDoc)
 import Idris.TypeSearch (searchByType)
 
 import Util.Pretty

--- a/src/Idris/Prover.hs
+++ b/src/Idris/Prover.hs
@@ -43,7 +43,7 @@ import Control.Monad.State.Strict
 import System.Console.Haskeline
 import System.Console.Haskeline.History
 import System.IO (Handle, hPutStrLn, stdin, stdout)
-import Text.Trifecta.Result (ErrInfo(..), Result(..))
+import qualified Text.Trifecta.Result as P
 
 -- | Launch the proof shell
 prover :: ElabInfo -> Bool -> Bool -> Name -> Idris ()
@@ -312,15 +312,15 @@ elabloop info fn d prompt prf e prev h env
 
        -- if we're abandoning, it has to be outside the scope of the catch
        case cmd of
-         Success (Left EAbandon) -> do iPrintError ""; ifail "Abandoned"
+         P.Success (Left EAbandon) -> do iPrintError ""; ifail "Abandoned"
          _ -> return ()
 
        (d, prev', st, done, prf', env', res) <-
          idrisCatch
            (case cmd of
-              Failure (ErrInfo err _) ->
+              P.Failure (P.ErrInfo err _) ->
                 return (False, prev, e, False, prf, env, Left . Msg . show . fixColour (idris_colourRepl ist) $ err)
-              Success (Left cmd') ->
+              P.Success (Left cmd') ->
                 case cmd' of
                   EQED -> do hs <- lifte e get_holes
                              unless (null hs) $ ifail "Incomplete proof"
@@ -345,7 +345,7 @@ elabloop info fn d prompt prf e prev h env
                                    return (d', prev, st', done, prf', env, go)
                   EDocStr d -> do (d', st', done, prf', go) <- docStr e prf d
                                   return (d', prev, st', done, prf', env, go)
-              Success (Right cmd') ->
+              P.Success (Right cmd') ->
                 case cmd' of
                   DoLetP  {} -> ifail "Pattern-matching let not supported here"
                   DoRewrite  {} -> ifail "Pattern-matching do-rewrite not supported here"
@@ -430,27 +430,27 @@ ploop fn d prompt prf e h
             Nothing -> do iPrintError ""; ifail "Abandoned"
             Just input -> return (parseTactic i input, input)
          case cmd of
-            Success Abandon -> do iPrintError ""; ifail "Abandoned"
+            P.Success Abandon -> do iPrintError ""; ifail "Abandoned"
             _ -> return ()
          (d, st, done, prf', res) <- idrisCatch
            (case cmd of
-              Failure (ErrInfo err _) -> return (False, e, False, prf, Left . Msg . show . fixColour (idris_colourRepl i) $ err)
-              Success Undo -> do (_, st) <- elabStep e loadState
-                                 return (True, st, False, init prf, Right $ iPrintResult "")
-              Success ProofState -> return (True, e, False, prf, Right $ iPrintResult "")
-              Success ProofTerm -> do tm <- lifte e get_term
-                                      iputStrLn $ "TT: " ++ show tm ++ "\n"
-                                      return (False, e, False, prf, Right $ iPrintResult "")
-              Success Qed -> do hs <- lifte e get_holes
-                                unless (null hs) $ ifail "Incomplete proof"
-                                iputStrLn "Proof completed!"
-                                return (False, e, True, prf, Right $ iPrintResult "")
-              Success (TCheck (PRef _ _ n)) -> checkNameType e prf n
-              Success (TCheck t) -> checkType e prf t
-              Success (TEval t)  -> evalTerm e prf t
-              Success (TDocStr x) -> docStr e prf x
-              Success (TSearch t) -> search e prf t
-              Success tac ->
+              P.Failure (P.ErrInfo err _) -> return (False, e, False, prf, Left . Msg . show . fixColour (idris_colourRepl i) $ err)
+              P.Success Undo -> do (_, st) <- elabStep e loadState
+                                   return (True, st, False, init prf, Right $ iPrintResult "")
+              P.Success ProofState -> return (True, e, False, prf, Right $ iPrintResult "")
+              P.Success ProofTerm -> do tm <- lifte e get_term
+                                        iputStrLn $ "TT: " ++ show tm ++ "\n"
+                                        return (False, e, False, prf, Right $ iPrintResult "")
+              P.Success Qed -> do hs <- lifte e get_holes
+                                  unless (null hs) $ ifail "Incomplete proof"
+                                  iputStrLn "Proof completed!"
+                                  return (False, e, True, prf, Right $ iPrintResult "")
+              P.Success (TCheck (PRef _ _ n)) -> checkNameType e prf n
+              P.Success (TCheck t) -> checkType e prf t
+              P.Success (TEval t)  -> evalTerm e prf t
+              P.Success (TDocStr x) -> docStr e prf x
+              P.Success (TSearch t) -> search e prf t
+              P.Success tac ->
                 do (_, e) <- elabStep e saveState
                    (_, st) <- elabStep e (runTac autoSolve i (Just proverFC) fn tac)
                    return (True, st, False, prf ++ [step], Right $ iPrintResult ""))

--- a/src/Idris/Prover.hs
+++ b/src/Idris/Prover.hs
@@ -318,7 +318,7 @@ elabloop info fn d prompt prf e prev h env
        (d, prev', st, done, prf', env', res) <-
          idrisCatch
            (case cmd of
-              Left (P.ErrInfo err _) ->
+              Left err ->
                 return (False, prev, e, False, prf, env, Left . Msg . show . fixColour (idris_colourRepl ist) $ err)
               Right (Left cmd') ->
                 case cmd' of
@@ -434,7 +434,7 @@ ploop fn d prompt prf e h
             _ -> return ()
          (d, st, done, prf', res) <- idrisCatch
            (case cmd of
-              Left (P.ErrInfo err _) -> return (False, e, False, prf, Left . Msg . show . fixColour (idris_colourRepl i) $ err)
+              Left err -> return (False, e, False, prf, Left . Msg . show . fixColour (idris_colourRepl i) $ err)
               Right Undo -> do (_, st) <- elabStep e loadState
                                return (True, st, False, init prf, Right $ iPrintResult "")
               Right ProofState -> return (True, e, False, prf, Right $ iPrintResult "")

--- a/src/Idris/Prover.hs
+++ b/src/Idris/Prover.hs
@@ -34,6 +34,7 @@ import qualified Idris.IdeMode as IdeMode
 import Idris.Options
 import Idris.Output
 import Idris.Parser hiding (params)
+import Idris.Parser.Helpers (parseErrorDoc)
 import Idris.TypeSearch (searchByType)
 
 import Util.Pretty
@@ -43,7 +44,6 @@ import Control.Monad.State.Strict
 import System.Console.Haskeline
 import System.Console.Haskeline.History
 import System.IO (Handle, hPutStrLn, stdin, stdout)
-import qualified Text.Trifecta.Result as P
 
 -- | Launch the proof shell
 prover :: ElabInfo -> Bool -> Bool -> Name -> Idris ()
@@ -319,7 +319,7 @@ elabloop info fn d prompt prf e prev h env
          idrisCatch
            (case cmd of
               Left err ->
-                return (False, prev, e, False, prf, env, Left . Msg . show . fixColour (idris_colourRepl ist) $ err)
+                return (False, prev, e, False, prf, env, Left . Msg . show . fixColour (idris_colourRepl ist) . parseErrorDoc $ err)
               Right (Left cmd') ->
                 case cmd' of
                   EQED -> do hs <- lifte e get_holes
@@ -434,7 +434,7 @@ ploop fn d prompt prf e h
             _ -> return ()
          (d, st, done, prf', res) <- idrisCatch
            (case cmd of
-              Left err -> return (False, e, False, prf, Left . Msg . show . fixColour (idris_colourRepl i) $ err)
+              Left err -> return (False, e, False, prf, Left . Msg . show . fixColour (idris_colourRepl i) . parseErrorDoc $ err)
               Right Undo -> do (_, st) <- elabStep e loadState
                                return (True, st, False, init prf, Right $ iPrintResult "")
               Right ProofState -> return (True, e, False, prf, Right $ iPrintResult "")

--- a/src/Idris/REPL.hs
+++ b/src/Idris/REPL.hs
@@ -93,7 +93,7 @@ import System.FSNotify (watchDir, withManager)
 import System.FSNotify.Devel (allEvents, doAllEvents)
 import System.IO
 import System.Process
-import Text.Trifecta.Result (ErrInfo(..), Result(..))
+import qualified Text.Trifecta.Result as P
 import Util.DynamicLinker
 import Util.Net (listenOnLocalhost, listenOnLocalhostAnyPort)
 import Util.Pretty hiding ((</>))
@@ -177,9 +177,9 @@ processNetCmd :: IState -> IState -> Handle -> FilePath -> String ->
                  IO (IState, FilePath)
 processNetCmd orig i h fn cmd
     = do res <- case parseCmd i "(net)" cmd of
-                  Failure (ErrInfo err _) -> return (Left (Msg " invalid command"))
-                  Success (Right c) -> runExceptT $ evalStateT (processNet fn c) i
-                  Success (Left err) -> return (Left (Msg err))
+                  P.Failure (P.ErrInfo err _) -> return (Left (Msg " invalid command"))
+                  P.Success (Right c) -> runExceptT $ evalStateT (processNet fn c) i
+                  P.Success (Left err) -> return (Left (Msg err))
          case res of
               Right x -> return x
               Left err -> do hPutStrLn h (show err)
@@ -295,8 +295,8 @@ runIdeModeCommand h id orig fn mods (IdeMode.Interpret cmd) =
   do c <- colourise
      i <- getIState
      case parseCmd i "(input)" cmd of
-       Failure (ErrInfo err _) -> iPrintError $ show (fixColour False err)
-       Success (Right (Prove mode n')) ->
+       P.Failure (P.ErrInfo err _) -> iPrintError $ show (fixColour False err)
+       P.Success (Right (Prove mode n')) ->
          idrisCatch
            (do process fn (Prove mode n')
                isetPrompt (mkPrompt mods)
@@ -315,10 +315,10 @@ runIdeModeCommand h id orig fn mods (IdeMode.Interpret cmd) =
                            IdeMode.convSExp "abandon-proof" "Abandoned" n
                        _ -> return ()
                      iRenderError $ pprintErr ist e)
-       Success (Right cmd) -> idrisCatch
+       P.Success (Right cmd) -> idrisCatch
                         (idemodeProcess fn cmd)
                         (\e -> getIState >>= iRenderError . flip pprintErr e)
-       Success (Left err) -> iPrintError err
+       P.Success (Left err) -> iPrintError err
 runIdeModeCommand h id orig fn mods (IdeMode.REPLCompletions str) =
   do (unused, compls) <- replCompletion (reverse str, "")
      let good = IdeMode.SexpList [IdeMode.SymbolAtom "ok",
@@ -353,8 +353,8 @@ runIdeModeCommand h id orig fn mods (IdeMode.TypeOf name) =
                  (Check (PRef (FC "(idemode)" (0,0) (0,0)) [] n))
 runIdeModeCommand h id orig fn mods (IdeMode.DocsFor name w) =
   case parseConst orig name of
-    Success c -> process "(idemode)" (DocStr (Right c) (howMuch w))
-    Failure _ ->
+    P.Success c -> process "(idemode)" (DocStr (Right c) (howMuch w))
+    P.Failure _ ->
      case splitName name of
        Left err -> iPrintError err
        Right n -> process "(idemode)" (DocStr (Left n) (howMuch w))
@@ -727,11 +727,10 @@ processInput cmd orig inputs efile
          let fn = fromMaybe "" (listToMaybe inputs)
          c <- colourise
          case parseCmd i "(input)" cmd of
-            Failure (ErrInfo err _) ->   do iputStrLn $ show (fixColour c err)
-                                            return (Just inputs)
-            Success (Right Reload) ->
+            P.Failure (P.ErrInfo err _) -> Just inputs <$ iputStrLn (show (fixColour c err))
+            P.Success (Right Reload) ->
                 reload orig inputs
-            Success (Right Watch) ->
+            P.Success (Right Watch) ->
                 if null inputs then
                   do iputStrLn "No loaded files to watch."
                      return (Just inputs)
@@ -739,7 +738,7 @@ processInput cmd orig inputs efile
                   do iputStrLn efile
                      iputStrLn $ "Watching for .idr changes in " ++ show inputs ++ ", press enter to cancel."
                      watch orig inputs
-            Success (Right (Load f toline)) ->
+            P.Success (Right (Load f toline)) ->
                 -- The $!! here prevents a space leak on reloading.
                 -- This isn't a solution - but it's a temporary stopgap.
                 -- See issue #2386
@@ -749,22 +748,20 @@ processInput cmd orig inputs efile
                    clearErr
                    mod <- loadInputs [f] toline
                    return (Just mod)
-            Success (Right (ModImport f)) ->
+            P.Success (Right (ModImport f)) ->
                 do clearErr
                    fmod <- loadModule f (IBC_REPL True)
                    return (Just (inputs ++ maybe [] (:[]) fmod))
-            Success (Right Edit) -> do -- takeMVar stvar
+            P.Success (Right Edit) -> do -- takeMVar stvar
                                edit efile orig
                                return (Just inputs)
-            Success (Right Proofs) -> do proofs orig
+            P.Success (Right Proofs) -> Just inputs <$ proofs orig
+            P.Success (Right Quit) -> Nothing <$ when (not quiet) (iputStrLn "Bye bye")
+            P.Success (Right cmd ) -> do idrisCatch (process fn cmd)
+                                            (\e -> do msg <- showErr e ; iputStrLn msg)
                                          return (Just inputs)
-            Success (Right Quit) -> do when (not quiet) (iputStrLn "Bye bye")
-                                       return Nothing
-            Success (Right cmd ) -> do idrisCatch (process fn cmd)
-                                          (\e -> do msg <- showErr e ; iputStrLn msg)
+            P.Success (Left err) -> do runIO $ putStrLn err
                                        return (Just inputs)
-            Success (Left err) -> do runIO $ putStrLn err
-                                     return (Just inputs)
 
 resolveProof :: Name -> Idris Name
 resolveProof n'
@@ -1429,7 +1426,7 @@ process fn (Browse ns) =
 process fn (MakeDoc s) =
   do     istate        <- getIState
          let names      = words s
-             parse n    | Success x <- runparser (fmap fst name) istate fn n = Right x
+             parse n    | P.Success x <- runparser (fmap fst name) istate fn n = Right x
              parse n    = Left n
              (bad, nss) = partitionEithers $ map parse names
          cd            <- runIO getCurrentDirectory

--- a/src/Idris/REPL.hs
+++ b/src/Idris/REPL.hs
@@ -72,6 +72,7 @@ import Idris.ModeCommon
 import Idris.Options
 import Idris.Output
 import Idris.Parser hiding (indent)
+import Idris.Parser.Helpers (parseErrorDoc)
 import Idris.Prover
 import Idris.REPL.Browse (namesInNS, namespacesInNS)
 import Idris.REPL.Commands
@@ -294,7 +295,7 @@ runIdeModeCommand h id orig fn mods (IdeMode.Interpret cmd) =
   do c <- colourise
      i <- getIState
      case parseCmd i "(input)" cmd of
-       Left err -> iPrintError $ show (fixColour False err)
+       Left err -> iPrintError . show . fixColour False . parseErrorDoc $ err
        Right (Right (Prove mode n')) ->
          idrisCatch
            (do process fn (Prove mode n')
@@ -726,7 +727,7 @@ processInput cmd orig inputs efile
          let fn = fromMaybe "" (listToMaybe inputs)
          c <- colourise
          case parseCmd i "(input)" cmd of
-            Left err -> Just inputs <$ iputStrLn (show (fixColour c err))
+            Left err -> Just inputs <$ iputStrLn (show . fixColour c . parseErrorDoc $ err)
             Right (Right Reload) ->
                 reload orig inputs
             Right (Right Watch) ->

--- a/src/Idris/REPL.hs
+++ b/src/Idris/REPL.hs
@@ -93,7 +93,6 @@ import System.FSNotify (watchDir, withManager)
 import System.FSNotify.Devel (allEvents, doAllEvents)
 import System.IO
 import System.Process
-import qualified Text.Trifecta.Result as P
 import Util.DynamicLinker
 import Util.Net (listenOnLocalhost, listenOnLocalhostAnyPort)
 import Util.Pretty hiding ((</>))
@@ -177,7 +176,7 @@ processNetCmd :: IState -> IState -> Handle -> FilePath -> String ->
                  IO (IState, FilePath)
 processNetCmd orig i h fn cmd
     = do res <- case parseCmd i "(net)" cmd of
-                  Left (P.ErrInfo err _) -> return (Left (Msg " invalid command"))
+                  Left err -> return (Left (Msg " invalid command"))
                   Right (Right c) -> runExceptT $ evalStateT (processNet fn c) i
                   Right (Left err) -> return (Left (Msg err))
          case res of
@@ -295,7 +294,7 @@ runIdeModeCommand h id orig fn mods (IdeMode.Interpret cmd) =
   do c <- colourise
      i <- getIState
      case parseCmd i "(input)" cmd of
-       Left (P.ErrInfo err _) -> iPrintError $ show (fixColour False err)
+       Left err -> iPrintError $ show (fixColour False err)
        Right (Right (Prove mode n')) ->
          idrisCatch
            (do process fn (Prove mode n')
@@ -727,7 +726,7 @@ processInput cmd orig inputs efile
          let fn = fromMaybe "" (listToMaybe inputs)
          c <- colourise
          case parseCmd i "(input)" cmd of
-            Left (P.ErrInfo err _) -> Just inputs <$ iputStrLn (show (fixColour c err))
+            Left err -> Just inputs <$ iputStrLn (show (fixColour c err))
             Right (Right Reload) ->
                 reload orig inputs
             Right (Right Watch) ->

--- a/src/Idris/REPL.hs
+++ b/src/Idris/REPL.hs
@@ -72,7 +72,6 @@ import Idris.ModeCommon
 import Idris.Options
 import Idris.Output
 import Idris.Parser hiding (indent)
-import Idris.Parser.Helpers (parseErrorDoc)
 import Idris.Prover
 import Idris.REPL.Browse (namesInNS, namespacesInNS)
 import Idris.REPL.Commands

--- a/src/Idris/REPL/Parser.hs
+++ b/src/Idris/REPL/Parser.hs
@@ -33,7 +33,6 @@ import System.Console.ANSI (Color(..))
 import System.FilePath ((</>))
 import Text.Parser.Char (anyChar, oneOf)
 import Text.Parser.Combinators
-import qualified Text.Trifecta as P
 
 parseCmd :: IState -> String -> String -> Either IP.ParseError (Either String Command)
 parseCmd i inputname = IP.runparser pCmd i inputname . trim

--- a/src/Idris/REPL/Parser.hs
+++ b/src/Idris/REPL/Parser.hs
@@ -35,7 +35,7 @@ import Text.Parser.Char (anyChar, oneOf)
 import Text.Parser.Combinators
 import qualified Text.Trifecta as P
 
-parseCmd :: IState -> String -> String -> P.Result (Either String Command)
+parseCmd :: IState -> String -> String -> Either P.ErrInfo (Either String Command)
 parseCmd i inputname = IP.runparser pCmd i inputname . trim
     where trim = f . f
               where f = reverse . dropWhile isSpace

--- a/src/Idris/REPL/Parser.hs
+++ b/src/Idris/REPL/Parser.hs
@@ -35,7 +35,7 @@ import Text.Parser.Char (anyChar, oneOf)
 import Text.Parser.Combinators
 import qualified Text.Trifecta as P
 
-parseCmd :: IState -> String -> String -> Either P.ErrInfo (Either String Command)
+parseCmd :: IState -> String -> String -> Either IP.ParseError (Either String Command)
 parseCmd i inputname = IP.runparser pCmd i inputname . trim
     where trim = f . f
               where f = reverse . dropWhile isSpace


### PR DESCRIPTION
This PR is refactoring prep-work for switching to Megaparsec as discussed in #3443.  (TL;DR better performance, better error messages, more recently maintained, and no dependency on lens to break builds.)

Nothing in here should change the operation of Idris, and it does not yet add megaparsec as a dependency or switch anything over.

Mostly, it is switching to qualified imports for the parser, and making functions use megaparsecs types where possible (`Either` instead of `P.ParseResult` for parse results, making our own `ParseError` type).  And removing unneeded dependencies and constraints between the package parser and `Idris.Parser.Helpers`.

My process has been: try to use megaparsec in a big commit, see some small dependency that can be done pre-switch, stash, do that thing, run tests, pop stash, continue on big commit.  This has left the trail of small commits that became this PR.
