### PR TITLE
WIP: Add Package Description to IdrisDoc

### DIFF
--- a/idris.cabal
+++ b/idris.cabal
@@ -48,6 +48,8 @@ Tested-With:    GHC == 7.10.3, GHC == 8.0.1
 
 Data-files:            idrisdoc/styles.css
                        idrisdoc/reset.css
+                       idrisdoc/idrisdoc-logo.svg
+                       idrisdoc/script.js
                        jsrts/jsbn/jsbn-browser.js
                        jsrts/jsbn/jsbn-node.js
                        jsrts/Runtime-common.js

--- a/idris.cabal
+++ b/idris.cabal
@@ -47,6 +47,7 @@ Build-type:     Custom
 Tested-With:    GHC == 7.10.3, GHC == 8.0.1
 
 Data-files:            idrisdoc/styles.css
+                       idrisdoc/reset.css
                        jsrts/jsbn/jsbn-browser.js
                        jsrts/jsbn/jsbn-node.js
                        jsrts/Runtime-common.js

--- a/idrisdoc/idrisdoc-logo.svg
+++ b/idrisdoc/idrisdoc-logo.svg
@@ -1,0 +1,24 @@
+<?xml version="1.0" encoding="utf-8"?>
+<!-- Generator: Adobe Illustrator 21.1.0, SVG Export Plug-In . SVG Version: 6.00 Build 0)  -->
+<svg version="1.1"
+	 id="svg2" inkscape:version="0.91 r13725" sodipodi:docname="logo2.svg" xmlns:cc="http://creativecommons.org/ns#" xmlns:dc="http://purl.org/dc/elements/1.1/" xmlns:inkscape="http://www.inkscape.org/namespaces/inkscape" xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#" xmlns:sodipodi="http://sodipodi.sourceforge.net/DTD/sodipodi-0.dtd" xmlns:svg="http://www.w3.org/2000/svg"
+	 xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink" x="0px" y="0px" viewBox="0 0 310.7 570.5"
+	 style="enable-background:new 0 0 310.7 570.5;" xml:space="preserve">
+<style type="text/css">
+	.st0{fill:#8A0819;}
+</style>
+<sodipodi:namedview  bordercolor="#666666" borderopacity="1" gridtolerance="10" guidetolerance="10" id="namedview7" inkscape:current-layer="" inkscape:cx="52.74404" inkscape:cy="241.68009" inkscape:pageopacity="0" inkscape:pageshadow="2" inkscape:window-height="1598" inkscape:window-maximized="0" inkscape:window-width="1198" inkscape:window-x="1280" inkscape:window-y="0" inkscape:zoom="0.56123662" objecttolerance="10" pagecolor="#ffffff" showgrid="false">
+	</sodipodi:namedview>
+<g inkscape:groupmode="layer" inkscape:label="">
+	<g id="g3353" transform="translate(22,0)">
+		<path id="path3345" inkscape:connector-curvature="0" class="st0" d="M79.3,84.9c73.1,22.1,91.8,40.3,117.5,106.4
+			C191.8,110.7,159.5,77.1,79.3,84.9C98.1,17,79.3,84.9,79.3,84.9z"/>
+		<path id="path3343" inkscape:connector-curvature="0" class="st0" d="M-22,211.5c47.4,14.6,102.5,26.3,122.9,116.9
+			C109.3,215.3,55.8,209.6-22,211.5C68.6-90.7-22,211.5-22,211.5z"/>
+		<path id="path3341" inkscape:connector-curvature="0" class="st0" d="M10.1,139.4c71.3,14.7,116.7,34.1,143.3,126.1
+			C159.4,146.8,94.3,134.9,10.1,139.4C88.4,8.2,10.1,139.4,10.1,139.4z"/>
+		<path id="path5" inkscape:connector-curvature="0" class="st0" d="M103.5,0c389,253.7-86.4,258.1,17,552.6l61.2,17.8
+			C13.1,341.8,557.1,224.3,103.5,0L103.5,0z"/>
+	</g>
+</g>
+</svg>

--- a/idrisdoc/reset.css
+++ b/idrisdoc/reset.css
@@ -1,0 +1,48 @@
+/* http://meyerweb.com/eric/tools/css/reset/ 
+   v2.0 | 20110126
+   License: none (public domain)
+*/
+
+html, body, div, span, applet, object, iframe,
+h1, h2, h3, h4, h5, h6, p, blockquote, pre,
+a, abbr, acronym, address, big, cite, code,
+del, dfn, em, img, ins, kbd, q, s, samp,
+small, strike, strong, sub, sup, tt, var,
+b, u, i, center,
+dl, dt, dd, ol, ul, li,
+fieldset, form, label, legend,
+table, caption, tbody, tfoot, thead, tr, th, td,
+article, aside, canvas, details, embed, 
+figure, figcaption, footer, header, hgroup, 
+menu, nav, output, ruby, section, summary,
+time, mark, audio, video {
+	margin: 0;
+	padding: 0;
+	border: 0;
+	font-size: 100%;
+	font: inherit;
+	vertical-align: baseline;
+}
+/* HTML5 display-role reset for older browsers */
+article, aside, details, figcaption, figure, 
+footer, header, hgroup, menu, nav, section {
+	display: block;
+}
+body {
+	line-height: 1;
+}
+ol, ul {
+	list-style: none;
+}
+blockquote, q {
+	quotes: none;
+}
+blockquote:before, blockquote:after,
+q:before, q:after {
+	content: '';
+	content: none;
+}
+table {
+	border-collapse: collapse;
+	border-spacing: 0;
+}

--- a/idrisdoc/script.js
+++ b/idrisdoc/script.js
@@ -1,0 +1,35 @@
+/**
+ * Toggles a listing of idris package attributes and a shorter, nicer
+ * presentation using a button group.
+ */
+(function() {
+	function makeSwitch(switches) {
+		for(var i = 0; i < switches.length; ++i) {
+			switches[i].button.addEventListener("click", (function(self) {
+				return function() {
+					for(var i = 0; i < switches.length; ++i) {
+						if(self === i) {
+							switches[i].controls.classList.remove("hidden");
+							switches[i].button.classList.add("is-active");
+						} else {
+							switches[i].controls.classList.add("hidden");
+							switches[i].button.classList.remove("is-active");
+						}
+					}
+				};
+			})(i));
+		}
+	}
+
+	var buttongroup = document.getElementById("pkginfo-switch").getElementsByTagName("a");
+
+	var panel_rendered = document.getElementById("pkginfo-rendered");
+	var panel_listing  = document.getElementById("pkginfo-list");
+
+	makeSwitch([
+		{ button: buttongroup[0], controls: panel_rendered },
+		{ button: buttongroup[1], controls: panel_listing },
+	]);
+
+	buttongroup[0].click();
+})();

--- a/idrisdoc/styles.css
+++ b/idrisdoc/styles.css
@@ -1,320 +1,202 @@
-html, body {
-
-  margin: 0;
-  padding: 0;
-  border: 0;
-  
-  height: 100%;
-
-  font-family: "Trebuchet MS", Helvetica, sans-serif;
-  font-size: 11pt;
-
-  background-color: #FFF;
+.idrisdoc-logo {
+	font-weight: bold;
+	font-size: 1.4em;
+	padding: .5em;
 }
 
-a, a:active, a:visited {
-
-  text-decoration: none;
-  color: inherit;
+.idrisdoc-logo:before {
+	content: url(idrisdoc-logo.svg);
+	display: inline-block;
+	width: .5em;
+	vertical-align: middle;
+	margin-right: .5em;
 }
 
-a:hover {
-
-  text-decoration: underline;
+body {
+	font-family: "Trebuchet MS", Helvetica, sans-serif;
 }
 
 header {
-
-  padding: 5px 11px;
-
-  border-bottom: 3px solid #659FDB;
-  box-shadow: 0 -8px 22px 0px;
-  
-  background-color: #252525;
-  color: white;
-  
-  font-size: 9pt;
+	background-color: #252525;
+	color: white;
 }
 
-.wrapper {
-
-  min-height: 100%;
+header nav,
+header,
+dl,
+#pkginfo-rendered ul,
+.button-group,
+.box {
+	display: flex;
+	flex-wrap: wrap;
+	justify-content: center;
 }
 
-header nav, header strong {
-
-  font-size: 11pt;
+header > *,
+header nav > *,
+#pkginfo-rendered ul > *,
+dl > *,
+.box > * {
+	flex-grow: 1; 
 }
 
-header nav {
-
-  float: right;
+.idrisdoc-logo,
+header nav,
+.is-narrow {
+	flex-grow: 0;
 }
 
-footer {
+nav a:link,
+nav a:visited,
+.button-group a
+{
+	padding: 1em;
+	display: block;
+	text-decoration: none;
+	color: white;
+}
 
-  height: 30px;
-  width: 100%;
-  border-top: 1px solid #AAAAAA;
-  
-  margin-top: -31px;
-  
-  text-align: center;
-  color: #666;
-  line-height: 30px;
-  font-size: 9pt;
-  
-  background: none repeat scroll 0 0 #DDDDDD;
+nav a:hover {
+	background: #AAA;
 }
 
 .container {
-  
-  padding: 10px 10px 41px 20px;
+	max-width: 50em;
+	padding: 1em;
+	margin: 0 auto;
 }
 
-body.index .container a:visited {
-
-  color: #666;
+.nsname {
+	padding: 1em;
 }
 
-body.index .container a:hover {
+.nsname span:before {
+	content: "/";
+	color: #AAA;
+}
 
-  color: #04819E;
+.nsname span:first-child:before {
+	content: "";
 }
 
 h1 {
-
-  margin: 0;
-  margin-bottom: 5px;
-  font-size: 14pt;
-  
-  font-family: "Trebuchet MS", Helvetica, sans-serif;
+	font-size: 2em;
+	margin-top: 1em;
 }
 
-body.namespace h1 {
-
-  border-bottom: 1px solid #BBB;
-  padding-bottom: 2px;
+dd {
+	width: 60%;
+	margin-left: auto;
 }
 
-ul {
-
-  list-style-type: none;
-
-  margin: 0;
-  padding: 0;
+dt {
+	width: 39.9%;
+	font-weight: bold;
 }
 
-hr {
-
-  margin: 0;
-  padding: 0;
-  border: 0;
-  
-  border-bottom: 1px solid #BBB;
+dd,dt {
+	box-sizing: border-box;
+	padding: .5em;
 }
 
-p {
-
-  margin: 0;
-  padding: 0;
+#pkginfo-switch {
+	float: right;
+	font-size: .8em;
 }
 
-.code {
-
-  font-family: "Lucida Console", Monaco, monospace;
-  font-size: 10pt;
+.button-group {
+	border-radius: .5em;
+	overflow: hidden;
+	background: #E6E6E6;
+	box-shadow: .1em .1em .1em rgba(0,0,0,.5);
 }
 
-.decls {
-
-  margin-top: 15px;
+.button-group a {
+	color: #333;
+	padding: .8em;
+	border-right: 1px solid #BBB;
+	background-image: linear-gradient(transparent,rgba(0,0,0,.05) 45%,rgba(0,0,0,.1));
+}
+.button-group a:hover {
+	background-color: #DDD;
+	border-right: 1px solid #AAA;
+}
+.button-group a:first-child {
+	border-radius: .5em 0 0 .5em;
 }
 
-.decls > dt {
-
-  font-family: "Lucida Console", Monaco, monospace;
-  font-size: 10pt;
-  line-height: 20px;
-  
-  padding: 2px 0;
-  
-  border: 1px solid #CCC;
-  background-color: #F0F0F0;
-  
-  display: table;
-  width: 100%;
+.button-group a:last-child {
+	border-radius: 0 .5em .5em 0;
+	border-right: 0;
 }
 
-.decls > dt > :first-child {
-
-  padding-left: 6px;
+.button-group .is-active,
+.button-group .is-active:hover
+{
+	background-color: #D0D0FF;
 }
 
-.decls > dt > :last-child {
-
-  padding-right: 6px;
+#info h1 span {
+	font-weight: bold;
+	text-transform: uppercase;
 }
 
-.decls > dd {
-
-  margin: 10px 0 10px 20px;
-  
-  font-family: Arial, sans-serif;
-  font-size: 10pt;
+#pkginfo-rendered {
+	font-size: 1.2em;
+	line-height: 1.2;
 }
 
-.decls > dd > p {
-
-  margin-bottom: 8px;
+.hidden {
+	display: none;
 }
 
-.decls > dd > dl:not(.decls):not(:first-child) {
-  
-  padding-top: 5px;
-  border-top: 1px solid #EEE;
+#pkginfo-list {
+	margin-top: 1em;
+	border: 1px solid #CCC;
 }
 
-.decls > dd > dl:not(.decls) > dt {
-
-  display: block;
-  min-width: 70px;
-  
-  float: left;
-  
-  font-weight: bold;
+#pkginfo-list dt:nth-child(4n+1),
+#pkginfo-list dd:nth-child(4n+2)
+{
+	background: #EEE;
 }
 
-.decls > dd > dl:not(.decls) > dd {
-
-  margin-bottom: 2px;
+.important-facts * {
+	display: inline;
+	font-size: .6em;
+	padding: 0;
 }
 
-.fixity {
-
-  font-style: italic;
-  font-weight: normal !important;
+.important-facts dt:after {
+	content: ": ";
 }
 
-dd.fixity {
-
-  cursor: default;
+.important-facts dd:after {
+	content: " | ";
+	color: #CCC;
 }
 
-.word {
-
-  display: table-cell;
-  white-space: nowrap;
-  width: 0;
+.important-facts dd:last-child:after {
+	content: "";
 }
 
-.signature {
-
-  display: table-cell;
-  width: 100%;
+#pkginfo-rendered p {
+	margin-top: 1em;
 }
 
-.name {
-  
-  display: table-cell;
-  white-space: nowrap;
-  width: 0;
+#pkginfo-rendered a {
+	text-align: center;
+	display: block;
+	padding: 1em;
+	margin: 1em;
+	margin-left: 0;
+	background: #EEE;
+	font-size: .8em;
+}
+#pkginfo-rendered li:last-child a {
+	margin-right: 0;
 }
 
-.documented, .name {
-
-  cursor: default;
-}
-
-.documented {
-
-  font-weight: bold;
-}
-
-a.function {
-
-  color: #00BA00;
-}
-
-.function {
-
-  color: #007C21;
-}
-
-a.constructor {
-
-  color: #FF0000;
-}
-
-.constructor {
-
-  color: #BF3030;
-}
-
-a.type {
-
-  color: #0000FF;
-}
-
-.type {
-
-  color: #050599;
-}
-
-.keyword {
-
-  color: inherit;
-}
-
-.boundvar {
-
-  color: #BF30BF; /* Too much colour makes it hard to differ the rest of the colours */
-  color: inherit;
-}
-
-.boundvar.implicit {
-
-  text-decoration: underline;
-}
-
-/******************* Old colours
-
-a {
-
-  color: #04819E;
-}
-
-a:visited {
-
-  color: #26A3BF;
-}
-
-********************/
-
-ul.names {
-
-  border: 1px solid #666;
-}
-
-ul.names li:nth-child(odd) {
-
-  background-color: #EEEEEF;
-}
-
-ul.names li:nth-child(even) {
-
-  background-color: white;
-}
-
-ul.names li {
-
-  padding-left: 5px;
-}
-
-ul.names li a {
-
-  display: inline-block;
-  width: 100%;
-  
-  padding: 2px 0;
+#pkginfo-rendered a:hover {
+	background: #DDD;
 }

--- a/src/Idris/IdrisDoc.hs
+++ b/src/Idris/IdrisDoc.hs
@@ -683,7 +683,8 @@ wrapper :: Maybe NsName -- ^ Namespace name, unless it is the index
 wrapper ns inner =
   let (index, str) = extract ns
       base       = if index then "" else "../"
-      styles     = base ++ "styles.css" :: String
+      css_reset  = base ++ "reset.css" :: String
+      css_main   = base ++ "styles.css" :: String
       indexPage  = base ++ "index.html" :: String
   in  H.docTypeHtml $ do
     H.head $ do
@@ -695,7 +696,9 @@ wrapper ns inner =
           ": "
           toHtml str
       H.link ! type_ "text/css" ! rel "stylesheet"
-             ! href (toValue styles)
+             ! href (toValue css_reset)
+      H.link ! type_ "text/css" ! rel "stylesheet"
+             ! href (toValue css_main)
     H.body ! class_ (if index then "index" else "namespace") $ do
       H.div ! class_ "wrapper" $ do
         H.header $ do
@@ -747,5 +750,8 @@ copyDependencies :: FilePath -- ^ The base directory to which
                              --   dependencies should be written
                  -> IO ()
 copyDependencies dir =
-  do styles <- getIdrisDataFileByName $ "idrisdoc" </> "styles.css"
-     copyFile styles (dir </> "styles.css")
+  let copyDependency filename = do
+          src <- getIdrisDataFileByName $ "idrisdoc" </> filename
+          copyFile src (dir </> filename)
+  in
+  mapM_ copyDependency ["styles.css", "reset.css"]

--- a/src/Idris/Package.hs
+++ b/src/Idris/Package.hs
@@ -233,7 +233,7 @@ documentPkg copts (install,fp) = do
           when install $ do
               putStrLn $ unwords ["Attempting to install IdrisDocs for", show $ pkgname pkgdesc, "in:", out_dir]
 
-          docRes <- generateDocs ist mods out_dir
+	  docRes <- generateDocs ist pkgdesc mods out_dir
           case docRes of
             Right _  -> return ()
             Left msg -> do

--- a/src/Idris/Package.hs
+++ b/src/Idris/Package.hs
@@ -233,7 +233,7 @@ documentPkg copts (install,fp) = do
           when install $ do
               putStrLn $ unwords ["Attempting to install IdrisDocs for", show $ pkgname pkgdesc, "in:", out_dir]
 
-	  docRes <- generateDocs ist pkgdesc mods out_dir
+	  docRes <- generateDocs ist (Just pkgdesc) mods out_dir
           case docRes of
             Right _  -> return ()
             Left msg -> do

--- a/src/Idris/REPL.hs
+++ b/src/Idris/REPL.hs
@@ -71,6 +71,7 @@ import Idris.Interactive
 import Idris.ModeCommon
 import Idris.Options
 import Idris.Output
+import Idris.Package.Common
 import Idris.Parser hiding (indent)
 import Idris.Prover
 import Idris.REPL.Browse (namesInNS, namespacesInNS)
@@ -1434,7 +1435,7 @@ process fn (MakeDoc s) =
              (bad, nss) = partitionEithers $ map parse names
          cd            <- runIO getCurrentDirectory
          let outputDir  = cd </> "doc"
-         result        <- if null bad then runIO $ generateDocs istate nss outputDir
+	 result        <- if null bad then runIO $ generateDocs istate defaultPkg nss outputDir
                                       else return . Left $ "Illegal name: " ++ head bad
          case result of Right _   -> iputStrLn "IdrisDoc generated"
                         Left  err -> iPrintError err

--- a/src/Idris/REPL.hs
+++ b/src/Idris/REPL.hs
@@ -1435,7 +1435,7 @@ process fn (MakeDoc s) =
              (bad, nss) = partitionEithers $ map parse names
          cd            <- runIO getCurrentDirectory
          let outputDir  = cd </> "doc"
-	 result        <- if null bad then runIO $ generateDocs istate defaultPkg nss outputDir
+	 result        <- if null bad then runIO $ generateDocs istate Nothing nss outputDir
                                       else return . Left $ "Illegal name: " ++ head bad
          case result of Right _   -> iputStrLn "IdrisDoc generated"
                         Left  err -> iPrintError err


### PR DESCRIPTION
*This is a work in progress. I am posting this early, as I hope someone wants to continue working on it. I am new to Idris and Haskell, so this might be rubbish.*

---

Adds information collected from the `.ipkg` file to IdrisDoc. An example package-file and rendering:

```
package Elm-Make-Adobe

modules = Main
brief = "Allows you to write Extensions for Adobe Photoshop, Illustrator, Indesign and other products using the Elm programming language."
author = Reiner Dolp
license = BSD
maintainer = Reiner Dolp
version = 0.1.0
homepage = reinerdolp.com
sourceloc = github.com/reiner-dolp/elm-adobe
bugtracker = github.com/reiner-dolp/elm-adobe/issues
```

![image](https://user-images.githubusercontent.com/770508/32340464-f85e64dc-bffa-11e7-83db-826b57fff4f8.png)

![image](https://user-images.githubusercontent.com/770508/32340620-64f7f25c-bffb-11e7-852b-90538d024a22.png)
