### PR TITLE
rename primitive types and add aliases

### DIFF
--- a/libs/prelude/Builtins.idr
+++ b/libs/prelude/Builtins.idr
@@ -78,38 +78,47 @@ void : Void -> a
 ||| Arbitrary-precision integers
 Integer : Type
 Integer = prim__Integer
+%used Integer
 
 ||| Fixed-precision integers of undefined size
 Int : Type
 Int = prim__Int
+%used Int
 
 ||| Characters in some unspecified encoding
 Char : Type
 Char = prim__Char
+%used Char
 
 ||| Double-precision floating-point numbers
 Double : Type
 Double = prim__Double
+%used Double
 
 ||| Strings in some unspecified encoding
 String : Type
 String = prim__String
+%used String
 
 ||| Eight bits (unsigned)
 Bits8 : Type
 Bits8 = prim__Bits8
+%used Bits8
 
 ||| Sixteen bits (unsigned)
 Bits16 : Type
 Bits16 = prim__Bits16
+%used Bits16
 
 ||| Thirty-two bits (unsigned)
 Bits32 : Type
 Bits32 = prim__Bits32
+%used Bits32
 
 ||| Sixty-four bits (unsigned)
 Bits64 : Type
 Bits64 = prim__Bits64
+%used Bits64
 
 ||| For 'symbol syntax. 'foo becomes Symbol_ "foo"
 data Symbol_ : String -> Type where

--- a/libs/prelude/Builtins.idr
+++ b/libs/prelude/Builtins.idr
@@ -73,6 +73,44 @@ void : Void -> a
 -- it, Prelude.Nat depends on Prelude.Uninhabited, and Language.Reflection.Elab
 -- depends on Prelude.Nat. Instead, void is defined in Prelude.idr
 
+-- Aliases for primitive types, facilitating lookup by name
+
+||| Arbitrary-precision integers
+Integer : Type
+Integer = prim__Integer
+
+||| Fixed-precision integers of undefined size
+Int : Type
+Int = prim__Int
+
+||| Characters in some unspecified encoding
+Char : Type
+Char = prim__Char
+
+||| Double-precision floating-point numbers
+Double : Type
+Double = prim__Double
+
+||| Strings in some unspecified encoding
+String : Type
+String = prim__String
+
+||| Eight bits (unsigned)
+Bits8 : Type
+Bits8 = prim__Bits8
+
+||| Sixteen bits (unsigned)
+Bits16 : Type
+Bits16 = prim__Bits16
+
+||| Thirty-two bits (unsigned)
+Bits32 : Type
+Bits32 = prim__Bits32
+
+||| Sixty-four bits (unsigned)
+Bits64 : Type
+Bits64 = prim__Bits64
+
 ||| For 'symbol syntax. 'foo becomes Symbol_ "foo"
 data Symbol_ : String -> Type where
 
@@ -130,14 +168,14 @@ data Delayed : DelayReason -> Type -> Type where
 Force : {t, a : _} -> Delayed t a -> a
 Force (Delay x) = x
 
-||| Lazily evaluated values. 
+||| Lazily evaluated values.
 ||| At run time, the delayed value will only be computed when required by
 ||| a case split.
 %error_reverse
 Lazy : Type -> Type
 Lazy t = Delayed LazyValue t
 
-||| Possibly infinite data. 
+||| Possibly infinite data.
 ||| A value which may be infinite is accepted by the totality checker if
 ||| it appears under a data constructor. At run time, the delayed value will
 ||| only be computed when required by a case split.
@@ -187,20 +225,20 @@ idris_crash : (msg : String) -> a
 
 ||| Subvert the type checker. This function is abstract, so it will not reduce in
 ||| the type checker. Use it with care - it can result in segfaults or worse!
-export 
+export
 believe_me : a -> b
 believe_me x = assert_total (prim__believe_me _ _ x)
 
 ||| Subvert the type checker. This function *will*  reduce in the type checker.
 ||| Use it with extreme care - it can result in segfaults or worse!
-public export 
+public export
 really_believe_me : a -> b
 really_believe_me x = assert_total (prim__believe_me _ _ x)
 
 ||| Deprecated alias for `Double`, for the purpose of backwards
 ||| compatibility. Idris does not support 32 bit floats at present.
 Float : Type
-Float = Double
+Float = prim__Double
 %deprecate Float
 
 -- Pointers as external primitive; there's no literals for these, so no

--- a/libs/prelude/Prelude/Providers.idr
+++ b/libs/prelude/Prelude/Providers.idr
@@ -1,5 +1,6 @@
 module Prelude.Providers
 
+import Builtins
 import Prelude.Basics
 import Prelude.Functor
 import Prelude.Applicative

--- a/src/Idris/Parser/Expr.hs
+++ b/src/Idris/Parser/Expr.hs
@@ -1412,15 +1412,17 @@ idiom syn
 
 @
 Constant ::=
-    'Integer'
-  | 'Int'
-  | 'Char'
-  | 'Double'
-  | 'String'
-  | 'Bits8'
-  | 'Bits16'
-  | 'Bits32'
-  | 'Bits64'
+    'prim__Integer'
+  | 'prim__Int'
+  | 'prim__Char'
+  | 'prim__Double'
+  | 'prim__String'
+  | 'prim__WorldType'
+  | 'prim__TheWorld'
+  | 'prim__Bits8'
+  | 'prim__Bits16'
+  | 'prim__Bits32'
+  | 'prim__Bits64'
   | Float_t
   | Natural_t
   | VerbatimString_t
@@ -1432,17 +1434,17 @@ Constant ::=
 
 constants :: [(String, Idris.Core.TT.Const)]
 constants =
-  [ ("Integer",            AType (ATInt ITBig))
-  , ("Int",                AType (ATInt ITNative))
-  , ("Char",               AType (ATInt ITChar))
-  , ("Double",             AType ATFloat)
-  , ("String",             StrType)
+  [ ("prim__Integer",      AType (ATInt ITBig))
+  , ("prim__Int",          AType (ATInt ITNative))
+  , ("prim__Char",         AType (ATInt ITChar))
+  , ("prim__Double",       AType ATFloat)
+  , ("prim__String",       StrType)
   , ("prim__WorldType",    WorldType)
   , ("prim__TheWorld",     TheWorld)
-  , ("Bits8",              AType (ATInt (ITFixed IT8)))
-  , ("Bits16",             AType (ATInt (ITFixed IT16)))
-  , ("Bits32",             AType (ATInt (ITFixed IT32)))
-  , ("Bits64",             AType (ATInt (ITFixed IT64)))
+  , ("prim__Bits8",        AType (ATInt (ITFixed IT8)))
+  , ("prim__Bits16",       AType (ATInt (ITFixed IT16)))
+  , ("prim__Bits32",       AType (ATInt (ITFixed IT32)))
+  , ("prim__Bits64",       AType (ATInt (ITFixed IT64)))
   ]
 
 -- | Parse a constant and its source span


### PR DESCRIPTION
Fixes #4175.

They all highlight green now, so maybe this isn't the best idea...