### PR TITLE
Tidy up iPKG module listings.

### DIFF
--- a/libs/base/base.ipkg
+++ b/libs/base/base.ipkg
@@ -7,12 +7,14 @@ modules = Control.Arrow
         , Control.Category
         , Control.IOExcept
         , Control.Isomorphism
+
         , Control.Monad.Identity
         , Control.Monad.Reader
         , Control.Monad.RWS
         , Control.Monad.State
         , Control.Monad.Trans
         , Control.Monad.Writer
+
         , Data.Bits
         , Data.Buffer
         , Data.Complex
@@ -20,23 +22,31 @@ modules = Control.Arrow
         , Data.Fin
         , Data.HVect
         , Data.IORef
+
         , Data.List
         , Data.List.Quantifiers
         , Data.List.Views
+
         , Data.Mod2
         , Data.Morphisms
         , Data.Nat.Views
         , Data.Primitives.Views
         , Data.So
+
         , Data.String
         , Data.String.Views
+
         , Data.Vect
         , Data.Vect.Quantifiers
         , Data.Vect.Views
+
         , Debug.Error
         , Debug.Trace
+
         , Language.Reflection.Utils
+
         , Syntax.PreorderReasoning
+
         , System
         , System.Concurrency.Channels
         , System.Concurrency.Raw

--- a/libs/contrib/contrib.ipkg
+++ b/libs/contrib/contrib.ipkg
@@ -33,11 +33,14 @@ modules = CFFI
         , Data.Heap
         , Data.IOArray
         , Data.List.Zipper
+
         , Data.Matrix
         , Data.Matrix.Algebraic
         , Data.Matrix.Numeric
+
         , Data.Nat.DivMod
         , Data.Nat.DivMod.IteratedSubtraction
+
         , Data.Pairs.Implicit
         , Data.Rel
         , Data.Sign
@@ -63,7 +66,9 @@ modules = CFFI
 
         , Text.Lexer
         , Text.Lexer.Core
+
         , Text.Literate
+
         , Text.Parser
         , Text.Parser.Core
 

--- a/libs/effects/effects.ipkg
+++ b/libs/effects/effects.ipkg
@@ -2,12 +2,16 @@ package effects
 
 opts = "--nobasepkgs --partial-eval --typeintype -i ../prelude -i ../base"
 
-modules = Effect.Default
+modules = Effects
+
+        , Effect.Default
         , Effect.Exception
         , Effect.File
+
         , Effect.Logging.Category
         , Effect.Logging.Default
         , Effect.Logging.Level
+
         , Effect.Memory
         , Effect.Monad
         , Effect.Perf
@@ -17,4 +21,3 @@ modules = Effect.Default
         , Effect.StdIO
         , Effect.System
         , Effect.Trans
-        , Effects

--- a/libs/prelude/prelude.ipkg
+++ b/libs/prelude/prelude.ipkg
@@ -3,12 +3,17 @@ package prelude
 opts = "--nobuiltins --total --no-elim-deprecation-warnings --partial-eval"
 
 modules = Builtins
+
         , Decidable.Equality
+
         , IO
+
         , Language.Reflection
         , Language.Reflection.Elab
         , Language.Reflection.Errors
+
         , Prelude
+
         , Prelude.Algebra
         , Prelude.Applicative
         , Prelude.Basics

--- a/libs/pruviloj/pruviloj.ipkg
+++ b/libs/pruviloj/pruviloj.ipkg
@@ -3,12 +3,17 @@ package pruviloj
 opts = "--nobasepkgs --partial-eval -i ../prelude -i ../base"
 
 modules = Pruviloj
+
         , Pruviloj.Core
+
         , Pruviloj.Derive.DecEq
         , Pruviloj.Derive.Eliminators
+
         , Pruviloj.Disjoint
         , Pruviloj.Induction
         , Pruviloj.Injective
+
         , Pruviloj.Internals
         , Pruviloj.Internals.TyConInfo
+
         , Pruviloj.Renamers


### PR DESCRIPTION
Whitespace is free, so let's use it to break long lists down into readable pieces.