### PR TITLE
Remove long deprecated aspects of Idris' shipped libraries.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -55,6 +55,7 @@
 + `Prelude.Doubles.atan2` is now implemented as a primitive instead of
   being coded in Idris.
 + Added `Test.Unit` to `contrib` for simple unit testing.
++ Removed several deprecated items from the libraries shipped with Idris.
 
 ## Tool Updates
 

--- a/libs/effects/Effects.idr
+++ b/libs/effects/Effects.idr
@@ -306,11 +306,6 @@ toEff xs' = id
 pure : a -> EffM m a xs (\v => xs)
 pure = Value
 
-return : a -> EffM m a xs (\v => xs)
-return = pure
-
-%deprecate Effects.return "Please use `pure`."
-
 pureM : (val : a) -> EffM m a (xs val) xs
 pureM = Value
 

--- a/libs/prelude/Builtins.idr
+++ b/libs/prelude/Builtins.idr
@@ -130,14 +130,14 @@ data Delayed : DelayReason -> Type -> Type where
 Force : {t, a : _} -> Delayed t a -> a
 Force (Delay x) = x
 
-||| Lazily evaluated values. 
+||| Lazily evaluated values.
 ||| At run time, the delayed value will only be computed when required by
 ||| a case split.
 %error_reverse
 Lazy : Type -> Type
 Lazy t = Delayed LazyValue t
 
-||| Possibly infinite data. 
+||| Possibly infinite data.
 ||| A value which may be infinite is accepted by the totality checker if
 ||| it appears under a data constructor. At run time, the delayed value will
 ||| only be computed when required by a case split.
@@ -187,21 +187,15 @@ idris_crash : (msg : String) -> a
 
 ||| Subvert the type checker. This function is abstract, so it will not reduce in
 ||| the type checker. Use it with care - it can result in segfaults or worse!
-export 
+export
 believe_me : a -> b
 believe_me x = assert_total (prim__believe_me _ _ x)
 
 ||| Subvert the type checker. This function *will*  reduce in the type checker.
 ||| Use it with extreme care - it can result in segfaults or worse!
-public export 
+public export
 really_believe_me : a -> b
 really_believe_me x = assert_total (prim__believe_me _ _ x)
-
-||| Deprecated alias for `Double`, for the purpose of backwards
-||| compatibility. Idris does not support 32 bit floats at present.
-Float : Type
-Float = Double
-%deprecate Float
 
 -- Pointers as external primitive; there's no literals for these, so no
 -- need for them to be part of the compiler.

--- a/libs/prelude/Builtins.idr
+++ b/libs/prelude/Builtins.idr
@@ -51,14 +51,6 @@ namespace Builtins
   data DPair : (a : Type) -> (P : a -> Type) -> Type where
       MkDPair : .{P : a -> Type} -> (x : a) -> (pf : P x) -> DPair a P
 
-  Sigma : (a : Type) -> (P : a -> Type) -> Type
-  Sigma wit prf = DPair wit prf
-  %deprecate Sigma "This name is being deprecated in favour of `DPair`."
-
-  MkSigma : .{P : a -> Type} -> (x : a) -> (prf : P x) -> DPair a P
-  MkSigma wit prf = MkDPair wit prf
-  %deprecate MkSigma "This constructor is being deprecated in favour of `MkDPair`."
-
 ||| The empty type, also known as the trivially false proposition.
 |||
 ||| Use `void` or `absurd` to prove anything if you have a variable of type `Void` in scope.

--- a/libs/prelude/Language/Reflection.idr
+++ b/libs/prelude/Language/Reflection.idr
@@ -74,14 +74,6 @@ mutual
                    | MetaN TTName TTName
   %name SpecialName sn, sn'
 
-InstanceN : TTName -> (List String) -> SpecialName
-InstanceN = ImplementationN
-%deprecate InstanceN "`InstanceN` is deprecated, Please use `ImplementationN` instead."
-
-InstanceCtorN : TTName ->  SpecialName
-InstanceCtorN = ImplementationCtorN
-%deprecate InstanceCtorN "`InstanceCtorN` is deprecated, Please use `ImplementationCtorN` instead."
-
 -- Rather  than  implement  one-off  private functions,  we  make  the
 -- disjointness of  the constructors available to  all Idris programs,
 -- at the cost of a bit of scrolling here.
@@ -410,7 +402,7 @@ mutual
   private
   implementationNInj : (ImplementationN n xs = ImplementationN n' ys) -> (n = n', xs = ys)
   implementationNInj Refl = (Refl, Refl)
-  
+
   private
   parentNInj : (ParentN n x = ParentN n' y) -> (n = n', x = y)
   parentNInj Refl = (Refl, Refl)

--- a/libs/prelude/Language/Reflection/Elab.idr
+++ b/libs/prelude/Language/Reflection/Elab.idr
@@ -560,11 +560,6 @@ namespace Tactics
   addImplementation : (ifaceName, implName : TTName) -> Elab ()
   addImplementation ifaceName implName = Prim__AddImplementation ifaceName implName
 
-  export
-  addInstance : (ifaceName, implName : TTName) -> Elab ()
-  addInstance = addImplementation
-  %deprecate addInstance "`addInstance` is deprecated, Please use `addImplementation` instead."
-
   ||| Determine whether a name denotes an interface.
   |||
   ||| @ name a name that might denote an interface.
@@ -769,4 +764,3 @@ implementation Quotable Datatype Raw where
   quotedTy = `(Datatype)
   quote (MkDatatype name tyConArgs tyConRes constructors) =
     `(MkDatatype ~(quote name) ~(quote tyConArgs) ~(quote tyConRes) ~(quote constructors))
-

--- a/libs/prelude/Prelude/Bits.idr
+++ b/libs/prelude/Prelude/Bits.idr
@@ -111,28 +111,3 @@ b32ToBinString c = concatMap b8ToBinString (b32ToBytes c)
 ||| Encode `Bits64` as a 64-character binary string.
 b64ToBinString : Bits64 -> String
 b64ToBinString c = concatMap b8ToBinString (b64ToBytes c)
-
-
---------------------------------------------------------------------------------
--- Deprecated String Functions
---------------------------------------------------------------------------------
-
-||| Encode `Bits8` as a 2-character hex string.
-b8ToString : Bits8 -> String
-b8ToString = b8ToHexString
-%deprecate b8ToString "Please use `b8ToHexString` instead."
-
-||| Encode `Bits16` as a 4-character hex string.
-b16ToString : Bits16 -> String
-b16ToString = b16ToHexString
-%deprecate b16ToString "Please use `b16ToHexString` instead."
-
-||| Encode `Bits32` as a 8-character hex string.
-b32ToString : Bits32 -> String
-b32ToString = b32ToHexString
-%deprecate b32ToString "Please use `b32ToHexString` instead."
-
-||| Encode `Bits64` as a 16-character hex string.
-b64ToString : Bits64 -> String
-b64ToString = b64ToHexString
-%deprecate b64ToString "Please use `b64ToHexString` instead."

--- a/libs/prelude/Prelude/File.idr
+++ b/libs/prelude/Prelude/File.idr
@@ -27,7 +27,7 @@ data File : Type where
 ||| An error from a file operation
 -- This is built in idris_mkFileError() in rts/idris_stdfgn.c. Make sure
 -- the values correspond!
-               
+
 data FileError = GenericFileError Int -- errno
                | FileReadError
                | FileWriteError
@@ -102,10 +102,6 @@ validFile (FHandle h) = do x <- nullPtr h
 ||| Modes for opening files
 data Mode = Read | WriteTruncate | Append | ReadWrite | ReadWriteTruncate | ReadAppend
 
-Write : Mode
-Write = WriteTruncate
-%deprecate Write "Please use WriteTruncate instead."
-
 modeStr : Mode -> String
 modeStr Read              = "r"
 modeStr WriteTruncate     = "w"
@@ -142,12 +138,12 @@ do_getFileSize h = foreign FFI_C "fileSize" (Ptr -> IO Int) h
 
 ||| Return the size of a File
 ||| Returns an error if the File is not an ordinary file (e.g. a directory)
-||| Also note that this currently returns an Int, which may overflow if the 
+||| Also note that this currently returns an Int, which may overflow if the
 ||| file is very big
 export
 fileSize : File -> IO (Either FileError Int)
 fileSize (FHandle h) = do s <- do_getFileSize h
-                          if (s < 0) 
+                          if (s < 0)
                              then do err <- getFileError
                                      pure (Left err)
                              else pure (Right s)
@@ -187,21 +183,16 @@ export
 pclose : File -> IO ()
 pclose (FHandle h) = foreign FFI_C "pclose" (Ptr -> IO ()) h
 
--- mkForeign (FFun "idris_readStr" [FPtr, FPtr] (FAny String))
---                        prim__vm h
-
-export
-fread : File -> IO (Either FileError String)
-fread (FHandle h) = do str <- do_fread h
-                       if !(ferror (FHandle h))
-                          then pure (Left FileReadError)
-                          else pure (Right str)
 
 ||| Read a line from a file
 ||| @h a file handle which must be open for reading
 export
 fGetLine : (h : File) -> IO (Either FileError String)
-fGetLine = fread
+fGetLine (FHandle h) = do
+  str <- do_fread h
+  if !(ferror (FHandle h))
+    then pure (Left FileReadError)
+    else pure (Right str)
 
 ||| Read up to a number of characters from a file
 ||| @h a file handle which must be open for reading
@@ -212,7 +203,6 @@ fGetChars (FHandle h) len = do str <- do_freadChars h len
                                   then pure (Left FileReadError)
                                   else pure (Right str)
 
-%deprecate fread "Use fGetLine instead"
 
 private
 do_fwrite : Ptr -> String -> IO (Either FileError ())
@@ -225,10 +215,6 @@ do_fwrite h s = do res <- prim_fwrite h s
                                          pure (Left err)
                       else pure (Right ())
 
-export
-fwrite : File -> String -> IO (Either FileError ())
-fwrite (FHandle h) s = do_fwrite h s
-
 ||| Write a line to a file
 ||| @h a file handle which must be open for writing
 ||| @str the line to write to the file
@@ -240,8 +226,6 @@ export
 fPutStrLn : File -> String -> IO (Either FileError ())
 fPutStrLn (FHandle h) s = do_fwrite h (s ++ "\n")
 
-%deprecate fwrite "Use fPutStr instead"
-
 private
 do_feof : Ptr -> IO Int
 do_feof h = foreign FFI_C "fileEOF" (Ptr -> IO Int) h
@@ -251,13 +235,6 @@ export
 fEOF : File -> IO Bool
 fEOF (FHandle h) = do eof <- do_feof h
                       pure (not (eof == 0))
-
-||| Check if a file handle has reached the end
-export
-feof : File -> IO Bool
-feof = fEOF
-
-%deprecate feof "Use fEOF instead"
 
 export
 fpoll : File -> IO Bool

--- a/libs/prelude/Prelude/Monad.idr
+++ b/libs/prelude/Prelude/Monad.idr
@@ -1,6 +1,5 @@
+||| Monads and Functors
 module Prelude.Monad
-
--- Monads and Functors
 
 import Builtins
 import Prelude.Functor
@@ -28,11 +27,7 @@ interface Applicative m => Monad (m : Type -> Type) where
 ||| define `return` and `pure` differently!
 return : Monad m => a -> m a
 return = pure
-%deprecate return "Please use `pure`, which is equivalent."
-
-flatten : Monad m => m (m a) -> m a
-flatten = join
-%deprecate flatten "Please use `join`, which is the standard name."
+%fragile return "`return` is provided for those coming from Haskell. Please use `pure` instead, which is equivalent."
 
 ||| Similar to `foldl`, but uses a function wrapping its result in a `Monad`.
 ||| Consequently, the final value is wrapped in the same `Monad`.

--- a/libs/prelude/Prelude/Pairs.idr
+++ b/libs/prelude/Prelude/Pairs.idr
@@ -41,13 +41,5 @@ using (a : Type, P : a -> Type)
     snd : (x : DPair a P) -> P (fst x)
     snd (x ** pf) = pf
 
-    getWitness : DPair a P -> a
-    getWitness = fst
-    %deprecate DPair.getWitness "This is being deprecated in favour of `fst`."
-
-    getProof : (x : DPair a P) -> P (fst x)
-    getProof = snd
-    %deprecate DPair.getProof "This is being deprecated in favour of `snd`."
-
   -- Polymorphic (interface-based) projections have been removed
   -- because type-directed name disambiguation works better.


### PR DESCRIPTION
Several releases ago we decided to deprecate the use of `Float` in
favour of `Double` to describe 64bit floating point numbers. For the
rationale please see our FAQs [1].

Given that the decision was made several releases ago I think it is
time that we remove the type alias that point's `Float` to `Double`.

There has been enough time for people to move on.

[1] http://idris.readthedocs.io/en/latest/faq/faq.html#why-does-idris-use-double-instead-of-float64

I've updated the PR to remove other deprecated parts of idris' libraries that have been deprecated for several releases.