### PR TITLE
Moved `abs` from the `Neg` interface into its own `Abs` interface.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -55,6 +55,8 @@
 + `Prelude.Doubles.atan2` is now implemented as a primitive instead of
   being coded in Idris.
 + Added `Test.Unit` to `contrib` for simple unit testing.
++ Moved `abs` from the `Neg` interface into its own `Abs` interface.  `Nat`
+  implements `Abs` with `abs = id`.
 
 ## Tool Updates
 

--- a/libs/base/Data/Complex.idr
+++ b/libs/base/Data/Complex.idr
@@ -70,16 +70,11 @@ implementation Neg a => Num (Complex a) where
     (*) (a:+b) (c:+d) = ((a*c-b*d):+(b*c+a*d))
     fromInteger x = (fromInteger x:+0)
 
--- We can't do "implementation Neg a => Neg (Complex a)" because
--- we need "abs" which needs "magnitude" which needs "sqrt" which needs Double
-implementation Neg (Complex Double) where
+implementation Neg a => Neg (Complex a) where
     negate = map negate
     (-) (a:+b) (c:+d) = ((a-c):+(b-d))
+
+-- Specific to Double because `abs` needs `magnitude` which needs `sqrt` which
+-- operates on Double.
+implementation Abs (Complex Double) where
     abs (a:+b) = (magnitude (a:+b):+0)
-
--- As soon as abs moves out of Neg (issue #3500), the following would become a
--- valid instance:
-
--- implementation Neg a => Neg (Complex a) where
---     negate = map negate
---     (-) (a:+b) (c:+d) = ((a-c):+(b-d))

--- a/libs/contrib/Data/Matrix/Numeric.idr
+++ b/libs/contrib/Data/Matrix/Numeric.idr
@@ -30,8 +30,10 @@ implementation Num a => Num (Vect n a) where
 
 implementation Neg a => Neg (Vect n a) where
   (-) = zipWith (-)
-  abs = map abs
   negate = map negate
+
+implementation Abs a => Abs (Vect n a) where
+  abs = map abs
 
 -----------------------------------------------------------------------
 --                        Vector functions

--- a/libs/contrib/Data/ZZ.idr
+++ b/libs/contrib/Data/ZZ.idr
@@ -77,6 +77,9 @@ implementation Num ZZ where
   (*) = multZ
   fromInteger = fromInt
 
+implementation Abs ZZ where
+    abs = cast . absZ
+
 mutual
   implementation Neg ZZ where
     negate (Pos Z)     = Pos Z
@@ -84,7 +87,6 @@ mutual
     negate (NegS n)    = Pos (S n)
 
     (-) = subZ
-    abs = cast . absZ
 
   ||| Subtract two `ZZ`s. Consider using `(-) {a=ZZ}`.
   subZ : ZZ -> ZZ -> ZZ

--- a/libs/prelude/Prelude/Interfaces.idr
+++ b/libs/prelude/Prelude/Interfaces.idr
@@ -203,22 +203,33 @@ interface Num ty => Neg ty where
     ||| The underlying of unary minus. `-5` desugars to `negate (fromInteger 5)`.
     negate : ty -> ty
     (-) : ty -> ty -> ty
-    ||| Absolute value
-    abs : ty -> ty
+
 
 Neg Integer where
     negate x = prim__subBigInt 0 x
     (-) = prim__subBigInt
-    abs x = if x < 0 then -x else x
 
 Neg Int where
     negate x = prim__subInt 0 x
     (-) = prim__subInt
-    abs x = if x < (prim__truncBigInt_Int 0) then -x else x
 
 Neg Double where
     negate x = prim__negFloat x
     (-) = prim__subFloat
+
+-- ---------------------------------------------------- [ Absolute Value Interface ]
+||| Numbers for which the absolute value is defined should implement `Abs`.
+interface Num ty => Abs ty where
+    ||| Absolute value
+    abs : ty -> ty
+
+Abs Integer where
+    abs x = if x < 0 then -x else x
+
+Abs Int where
+    abs x = if x < (prim__truncBigInt_Int 0) then -x else x
+
+Abs Double where
     abs x = if x < (prim__toFloatBigInt 0) then -x else x
 
 -- ------------------------------------------------------------

--- a/libs/prelude/Prelude/Nat.idr
+++ b/libs/prelude/Prelude/Nat.idr
@@ -25,9 +25,9 @@ import Prelude.Uninhabited
 
 Uninhabited (Z = S n) where
   uninhabited Refl impossible
-  
+
 Uninhabited (S n = Z) where
-  uninhabited Refl impossible  
+  uninhabited Refl impossible
 
 --------------------------------------------------------------------------------
 -- Syntactic tests
@@ -243,6 +243,9 @@ Num Nat where
   (*) = mult
 
   fromInteger = fromIntegerNat
+
+Abs Nat where
+  abs = id
 
 MinBound Nat where
   minBound = Z


### PR DESCRIPTION
Moved `abs` from the `Neg` interface into its own `Abs` interface.

This implements
https://github.com/idris-lang/Idris-dev/issues/3500
`Nat` now implements `Abs` with `abs=id`.

