### PR TITLE
No longer need transformers-compat

### DIFF
--- a/idris.cabal
+++ b/idris.cabal
@@ -298,8 +298,7 @@ Library
                 , terminal-size < 0.4
                 , text >=1.2.1.0 && < 1.3
                 , time >= 1.4 && < 1.9
-                , transformers < 0.6
-                , transformers-compat >= 0.3
+                , transformers >= 0.5 && < 0.6
                 , uniplate >=1.6 && < 1.7
                 , unordered-containers < 0.3
                 , utf8-string < 1.1


### PR DESCRIPTION
This seems to be a shim for using strict transformers with pre-0.3 transformers.