### PR TITLE
Support trailing quotes in verbatim string literals

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -23,6 +23,9 @@
     uninhabited (MkDPair n prf) = absurd prf
   ```
   It is possible to use `using implementation uninhabltb` to add the implementation to the automated resolution, but if it fails to find the instance due to non-injectivity, one must pass it explicitly to target function, i.e. `absurd @{uninhabltb}`.
++ Verbatim strings now support trailing quote characters. All quote characters
+  until the final three are considered part of the string. Now a string such as
+  `""""hello""""` will parse, and is equivalent to `"\"hello\""`.
 
 ## Library Updates
 

--- a/src/Idris/Parser/Expr.hs
+++ b/src/Idris/Parser/Expr.hs
@@ -1461,7 +1461,7 @@ constant = P.choice [ do fc <- reservedFC name; return (ty, fc)
 
 @
 VerbatimString_t ::=
-  '\"\"\"' ~'\"\"\"' '\"\"\"'
+  '\"\"\"' ~'\"\"\"' '\"'* '\"\"\"'
 ;
 @
  -}
@@ -1469,8 +1469,9 @@ verbatimStringLiteral :: IdrisParser (String, FC)
 verbatimStringLiteral = token $ do (FC f start _) <- getFC
                                    P.try $ string "\"\"\""
                                    str <- P.manyTill P.anyChar $ P.try (string "\"\"\"")
+                                   moreQuotes <- P.many $ P.char '"'
                                    (FC _ _ end) <- getFC
-                                   return (str, FC f start end)
+                                   return (str ++ moreQuotes, FC f start end)
 
 {- | Parses a static modifier
 

--- a/test/primitives003/expected
+++ b/test/primitives003/expected
@@ -5,6 +5,10 @@ False
 True
 False
 True
+True
+True
+True
+True
 False
 True
 False

--- a/test/primitives003/test038.idr
+++ b/test/primitives003/test038.idr
@@ -1,4 +1,4 @@
-module Main 
+module Main
 
 import Data.Vect
 import Data.Fin
@@ -17,18 +17,22 @@ main = do
   putStrLn . show $ test "hello" "world"
   putStrLn . show $ test (the Char '\0') (the Char '\0')
   putStrLn . show $ test (the Char '\1') (the Char '\2')
+  putStrLn . show $ test """""" ""
+  putStrLn . show $ test """"hello"""" "\"hello\""
+  putStrLn . show $ test """""hello""""" "\"\"hello\"\""
+  putStrLn . show $ test """""""""" "\"\"\"\""
 -- Non-primitives
   -- Vect
-  putStrLn . show $ 
+  putStrLn . show $
     test (the (Vect _ Int) [1,2,3]) (the (Vect _ Int) [1,2,3])
-  putStrLn . show $ 
+  putStrLn . show $
     test (the (Vect _ Int) [1,2,3]) (the (Vect _ Int) [1,2,4])
   -- List
-  putStrLn . show $ 
+  putStrLn . show $
     test (the (List Int) [1,2,3]) (the (List Int) [1,2,3])
-  putStrLn . show $ 
+  putStrLn . show $
     test (the (List Int) [1,2,3]) (the (List Int) [1,2])
-  putStrLn . show $ 
+  putStrLn . show $
     test (the (List Int) [1,2,3]) (the (List Int) [1,2,4])
   -- Tuple
   putStrLn . show $
@@ -45,16 +49,16 @@ main = do
   putStrLn . show $ test (Just "hello") (Just "world")
   putStrLn . show $ test (Just "hello") Nothing
   -- Either
-  putStrLn . show $ test (the (Either String Bool) (Left "hello")) 
+  putStrLn . show $ test (the (Either String Bool) (Left "hello"))
                          (the (Either String Bool) (Left "hello"))
-  putStrLn . show $ test (the (Either String Bool) (Left "hello")) 
+  putStrLn . show $ test (the (Either String Bool) (Left "hello"))
                          (the (Either String Bool) (Left "world"))
   putStrLn . show $ test (Left "hello") (Right "world")
   putStrLn . show $ test (Left "hello") (Right False)
   -- Fin
-  putStrLn . show $ test (the (Fin (S (S (S (Z))))) (FS (FS (FZ)))) 
+  putStrLn . show $ test (the (Fin (S (S (S (Z))))) (FS (FS (FZ))))
                          (the (Fin (S (S (S (Z))))) (FS (FS (FZ))))
-  putStrLn . show $ test (the (Fin (S (S (S (Z))))) (FS (FS (FZ)))) 
+  putStrLn . show $ test (the (Fin (S (S (S (Z))))) (FS (FS (FZ))))
                          (the (Fin (S (S (S (Z))))) (FS (FZ)))
   -- Nat
   putStrLn . show $ test (S (S (S Z))) (S (S (S Z)))


### PR DESCRIPTION
Since verbatim strings in Idris don't support escapes, it seems appropriate
to have them consume all `'"'` characters before the closing `"\"\"\""`. This is
the approach taken by Scala.

This means the following verbatim strings now parse, and produce the parenthesized
values, which are expressed as standard strings.
* `"""""""` (`"\""`)
* `""""hello""""` (`"\"hello\""`)
* `"""""a"""""""` (`"\"\"a\"\"\"\""`)
* `"""trailing """"` (`"trailing \""`)