### PR TITLE
implement `Prelude.List.length` using `Nat` constructors

### DIFF
--- a/libs/prelude/Prelude/List.idr
+++ b/libs/prelude/Prelude/List.idr
@@ -95,8 +95,8 @@ inBounds (S k) (x :: xs) with (inBounds k xs)
 |||
 ||| Runs in linear time
 length : List a -> Nat
-length []      = 0
-length (x::xs) = 1 + length xs
+length []      = Z
+length (x::xs) = S (length xs)
 
 --------------------------------------------------------------------------------
 -- Indexing into lists


### PR DESCRIPTION
Unless there was a reason for implementing it with `0` and `(1 +)`,
it seems more "natural" to use `Z` and `S` since this function returns
a `Nat`.

This improves the output of the REPL command `:printdef Prelude.List.length`,
which previously showed as the following:
```
Idris> :printdef Prelude.List.length
length : List a -> Nat
length [] = PE_fromInteger_dc75de74 0
length (x :: xs) = PE_+_6b31ad5c (PE_fromInteger_dc75de74 1) (length xs)
```