### PR TITLE
add ":version" REPL command

### DIFF
--- a/src/Idris/REPL.hs
+++ b/src/Idris/REPL.hs
@@ -601,6 +601,7 @@ splitName s = case reverse $ splitOn "." s of
         unparen str = str
 
 idemodeProcess :: FilePath -> Command -> Idris ()
+idemodeProcess fn ShowVersion = process fn ShowVersion
 idemodeProcess fn Warranty = process fn Warranty
 idemodeProcess fn Help = process fn Help
 idemodeProcess fn (RunShellCommand cmd) =
@@ -828,6 +829,7 @@ insertScript prf (x : xs) = x : insertScript prf xs
 
 process :: FilePath -> Command -> Idris ()
 process fn Help = iPrintResult displayHelp
+process fn ShowVersion = iPrintResult getIdrisVersion
 process fn Warranty = iPrintResult warranty
 process fn (RunShellCommand cmd) = runIO $ system cmd >> return ()
 process fn (ChangeDirectory f)

--- a/src/Idris/REPL/Commands.hs
+++ b/src/Idris/REPL/Commands.hs
@@ -71,6 +71,7 @@ data Command = Quit
              | CallsWho Name
              | Browse [String]
              | MakeDoc String -- IdrisDoc
+             | ShowVersion
              | Warranty
              | PrintDef Name
              | PPrint OutputFmt Int PTerm

--- a/src/Idris/REPL/Parser.hs
+++ b/src/Idris/REPL/Parser.hs
@@ -111,6 +111,7 @@ parserCommandsForHelp =
   , (["consolewidth"], ConsoleWidthArg, "Set the width of the console", cmd_consolewidth)
   , (["printerdepth"], OptionalArg NumberArg, "Set the maximum pretty-printer depth (no arg for infinite)", cmd_printdepth)
   , noArgCmd ["q", "quit"] Quit "Exit the Idris system"
+  , noArgCmd ["version"] ShowVersion "Display the Idris version"
   , noArgCmd ["warranty"] Warranty "Displays warranty information"
   , (["let"], ManyArgs DeclArg
     , "Evaluate a declaration, such as a function definition, instance implementation, or fixity declaration"


### PR DESCRIPTION
Outputs the current Idris version (produced by `getIdrisVersion`).