### PR TITLE
Prelude.Nat: make `fib` and `fact` tail-recursive

### DIFF
--- a/libs/prelude/Prelude/Nat.idr
+++ b/libs/prelude/Prelude/Nat.idr
@@ -326,15 +326,16 @@ pred (S n) = n
 --------------------------------------------------------------------------------
 
 ||| Fibonacci numbers
-total fib : Nat -> Nat
-fib Z         = Z
-fib (S Z)     = S Z
-fib (S (S n)) = fib (S n) + fib n
+total
+fib : {default Z a : Nat} -> {default (S Z) b : Nat} -> Nat -> Nat
+fib {a} {b} Z = a
+fib {a} {b} (S n) = fib {a=b} {b=a + b} n
 
 ||| Factorial function
-total fact : Nat -> Nat
-fact Z     = S Z
-fact (S n) = (S n) * fact n
+total
+fact : {default (S Z) acc : Nat} -> Nat -> Nat
+fact {acc} Z = acc
+fact {acc} (S n) = fact {acc=S n * acc} n
 
 --------------------------------------------------------------------------------
 -- Division and modulus

--- a/libs/prelude/Prelude/Stream.idr
+++ b/libs/prelude/Prelude/Stream.idr
@@ -8,6 +8,7 @@ import Prelude.Applicative
 import Prelude.Monad
 import Prelude.Nat
 import Prelude.List
+import Prelude.Interfaces
 
 %access public export
 %default total
@@ -108,6 +109,10 @@ cycle {a} (x :: xs) {ok = IsNonEmpty} = x :: cycle' xs
   where cycle' : List a -> Stream a
         cycle' []        = x :: cycle' xs
         cycle' (y :: ys) = y :: cycle' ys
+
+||| Produce a stream of Fibonacci numbers
+fibs : {default Z a : Nat} -> {default (S Z) b : Nat} -> Stream Nat
+fibs {a} {b} = a :: fibs {a=b} {b=a + b}
 
 Applicative Stream where
   pure = repeat


### PR DESCRIPTION
Uses default implicits as accumulators.

The performance of `fib` in particular is drastically improved.