### PR TITLE
Implenting Data.List.Permutations

### DIFF
--- a/libs/contrib/Data/List/Permutations.idr
+++ b/libs/contrib/Data/List/Permutations.idr
@@ -1,0 +1,10 @@
+module Permutations
+
+-- | All permutations of a list.
+permutations : List a -> List (List a)
+permutations [] = [[]]
+permutations xs = [y :: zs | (y, ys) <- select xs, zs <- permutations ys]
+  where
+    select : List a -> List (a, List a)
+    select []        = []
+    select (x :: xs) = (x, xs) :: [(y, x::ys) | (y,ys) <- select xs]


### PR DESCRIPTION
I noticed that theres no built-in implementation of  ```permutations``` so I'm attempting to implement it.

I would also like to know what you think about this, and hear some possible improvements that I'm sure there are.

Only in case it is not clear by now, ```permutations``` should have the type ```List a -> List (List a)``` and should return all possible rearrangements of a list. ```permutations [1,2] == [[1,2], [2,1]]```. Every element of the list would be treated as unique, even if there are two or more repeated: ```permutations [1,1] = [[1,1],[1,1]]```