### PR TITLE
Reorder the type parameters on BoundedList.

### DIFF
--- a/libs/base/Data/BoundedList.idr
+++ b/libs/base/Data/BoundedList.idr
@@ -4,12 +4,12 @@ module Data.BoundedList
 %default total
 
 ||| A list with an upper bound on its length.
-data BoundedList : Type -> Nat -> Type where
-  Nil : BoundedList a n
-  (::) : a -> BoundedList a n -> BoundedList a (S n)
+data BoundedList : Nat -> Type -> Type where
+  Nil : BoundedList n a
+  (::) : a -> BoundedList n a -> BoundedList (S n) a
 
 ||| Compute the length of a list.
-length : BoundedList a n -> Fin (S n)
+length : BoundedList n a -> Fin (S n)
 length [] = fZ
 length (x :: xs) = fS (length xs)
 
@@ -17,7 +17,7 @@ length (x :: xs) = fS (length xs)
 -- Indexing into bounded lists
 --------------------------------------------------------------------------------
 
-index : Fin (S n) -> BoundedList a n -> Maybe a
+index : Fin (S n) -> BoundedList n a -> Maybe a
 index _      []        = Nothing
 index fZ     (x :: _)  = Just x
 index (fS f) (_ :: xs) = index f xs
@@ -27,7 +27,7 @@ index (fS f) (_ :: xs) = index f xs
 --------------------------------------------------------------------------------
 
 ||| Loosen the bounds on a list's length.
-weaken : BoundedList a n -> BoundedList a (n + m)
+weaken : BoundedList n a -> BoundedList (n + m) a
 weaken []        = []
 weaken (x :: xs) = x :: weaken xs
 
@@ -35,16 +35,16 @@ weaken (x :: xs) = x :: weaken xs
 -- Conversions to and from list
 --------------------------------------------------------------------------------
 
-take : (n : Nat) -> List a -> BoundedList a n
+take : (n : Nat) -> List a -> BoundedList n a
 take _ [] = []
 take Z _ = []
 take (S n') (x :: xs) = x :: take n' xs
 
-toList : BoundedList a n -> List a
+toList : BoundedList n a -> List a
 toList [] = []
-toList (x :: xs) = x :: toList xs
+toList (x :: xs) = x :: Data.BoundedList.toList xs
 
-fromList : (xs : List a) -> BoundedList a (length xs)
+fromList : (xs : List a) -> BoundedList (length xs) a
 fromList [] = []
 fromList (x :: xs) = x :: fromList xs
 
@@ -52,7 +52,7 @@ fromList (x :: xs) = x :: fromList xs
 -- Building (bigger) bounded lists
 --------------------------------------------------------------------------------
 
-replicate : (n : Nat) -> a -> BoundedList a n
+replicate : (n : Nat) -> a -> BoundedList n a
 replicate Z _ = []
 replicate (S n) x = x :: replicate n x
 
@@ -60,28 +60,26 @@ replicate (S n) x = x :: replicate n x
 -- Folds
 --------------------------------------------------------------------------------
 
-foldl : (a -> b -> a) -> a -> BoundedList b n -> a
-foldl f e []      = e
-foldl f e (x::xs) = foldl f (f e x) xs
-
-foldr : (a -> b -> b) -> b -> BoundedList a n -> b
-foldr f e []      = e
-foldr f e (x::xs) = f x (foldr f e xs)
+instance Foldable (BoundedList n) where
+  foldr f e []      = e
+  foldr f e (x::xs) = f x (foldr f e xs)
+  foldl f e []      = e
+  foldl f e (x::xs) = foldl f (f e x) xs
 
 --------------------------------------------------------------------------------
 -- Maps
 --------------------------------------------------------------------------------
 
-map : (a -> b) -> BoundedList a n -> BoundedList b n
-map f [] = []
-map f (x :: xs) = f x :: map f xs
+instance Functor (BoundedList n) where
+  map f [] = []
+  map f (x :: xs) = f x :: map f xs
 
 --------------------------------------------------------------------------------
 -- Misc
 --------------------------------------------------------------------------------
 
 ||| Extend a bounded list to the maximum size by padding on the left.
-pad : (xs : BoundedList a n) -> (padding : a) -> BoundedList a n
+pad : BoundedList n a -> a -> BoundedList n a
 pad {n=Z}    []        _       = []
 pad {n=S n'} []        padding = padding :: (pad {n=n'} [] padding)
 pad {n=S n'} (x :: xs) padding = x :: pad {n=n'} xs padding
@@ -91,6 +89,6 @@ pad {n=S n'} (x :: xs) padding = x :: pad {n=n'} xs padding
 -- Simple properties
 --------------------------------------------------------------------------------
 
-zeroBoundIsEmpty : (xs : BoundedList a 0) -> xs = the (BoundedList a 0) []
+zeroBoundIsEmpty : (xs : BoundedList 0 a) -> xs = the (BoundedList 0 a) []
 zeroBoundIsEmpty [] = refl
 zeroBoundIsEmpty (_ :: _) impossible

--- a/libs/prelude/Prelude/Fin.idr
+++ b/libs/prelude/Prelude/Fin.idr
@@ -123,6 +123,12 @@ f - fZ = f
 (*) {n=S n} {m=S m} fZ     f' = fZ
 (*) {n=S n} {m=S m} (fS f) f' = f' + (f * f')
 
+mod : Fin n -> Fin n -> Fin n
+mod left   fZ      = left
+mod fZ     _       = fZ
+mod _      (fS fZ) = fZ
+mod (fS p) (fS m)  = fS (mod p m)
+
 -- Construct a Fin from an integer literal which must fit in the given Fin
 
 natToFin : Nat -> (n : Nat) -> Maybe (Fin n)

--- a/libs/prelude/Prelude/Fin.idr
+++ b/libs/prelude/Prelude/Fin.idr
@@ -123,12 +123,6 @@ f - fZ = f
 (*) {n=S n} {m=S m} fZ     f' = fZ
 (*) {n=S n} {m=S m} (fS f) f' = f' + (f * f')
 
-mod : Fin n -> Fin n -> Fin n
-mod left   fZ      = left
-mod fZ     _       = fZ
-mod _      (fS fZ) = fZ
-mod (fS p) (fS m)  = fS (mod p m)
-
 -- Construct a Fin from an integer literal which must fit in the given Fin
 
 natToFin : Nat -> (n : Nat) -> Maybe (Fin n)

--- a/libs/prelude/Prelude/Foldable.idr
+++ b/libs/prelude/Prelude/Foldable.idr
@@ -10,9 +10,8 @@ import Prelude.Algebra
 
 class Foldable (t : Type -> Type) where
   foldr : (elt -> acc -> acc) -> acc -> t elt -> acc
-
-foldl : Foldable t => (acc -> elt -> acc) -> acc -> t elt -> acc
-foldl f z t = foldr (flip (.) . flip f) id t z
+  foldl : Foldable t => (acc -> elt -> acc) -> acc -> t elt -> acc
+  foldl f z t = foldr (flip (.) . flip f) id t z
 
 concat : (Foldable t, Monoid a) => t a -> a
 concat = foldr (<+>) neutral


### PR DESCRIPTION
Now we can have Functor and Foldable instances, rather than just defining overloaded versions.

Also, I don’t know how I’ve had these changes just sitting on my fork for over three years.