### PR TITLE
Fix locations of lhs expressions

### DIFF
--- a/src/Idris/AbsSyntaxTree.hs
+++ b/src/Idris/AbsSyntaxTree.hs
@@ -927,17 +927,6 @@ updateNs ns t = mapPT updateRef t
   where updateRef (PRef fc fcs f) = PRef fc fcs (updateN ns f)
         updateRef t = t
 
--- updateDNs :: [(Name, Name)] -> PDecl -> PDecl
--- updateDNs [] t = t
--- updateDNs ns (PTy s f n t)    | Just n' <- lookup n ns = PTy s f n' t
--- updateDNs ns (PClauses f n c) | Just n' <- lookup n ns = PClauses f n' (map updateCNs c)
---   where updateCNs ns (PClause n l ts r ds)
---             = PClause (updateN ns n) (fmap (updateNs ns) l)
---                                      (map (fmap (updateNs ns)) ts)
---                                      (fmap (updateNs ns) r)
---                                      (map (updateDNs ns) ds)
--- updateDNs ns c = c
-
 data PunInfo = IsType
              | IsTerm
              | TypeOrTerm

--- a/src/Idris/Elab/Clause.hs
+++ b/src/Idris/Elab/Clause.hs
@@ -662,8 +662,9 @@ elabClause info opts (cnum, PClause fc fname lhs_in_as withs rhs_in_as wherebloc
 
         -- Check if we have "with" patterns outside of "with" block
         when (isOutsideWith lhs_in && (not $ null withs)) $
-            ierror (At fc (Elaborating "left hand side of " fname Nothing
-                          (Msg "unexpected patterns outside of \"with\" block")))
+            ierror (At (fromMaybe NoFC $ highestFC lhs_in_as)
+                       (Elaborating "left hand side of " fname Nothing
+                        (Msg "unexpected patterns outside of \"with\" block")))
 
         -- get the parameters first, to pass through to any where block
         let fn_ty = case lookupTy fname ctxt of
@@ -689,7 +690,8 @@ elabClause info opts (cnum, PClause fc fname lhs_in_as withs rhs_in_as wherebloc
         ((ElabResult lhs' dlhs [] ctxt' newDecls highlights newGName, probs, inj), _) <-
            tclift $ elaborate (constraintNS info) ctxt (idris_datatypes i) (idris_name i) (sMN 0 "patLHS") infP initEState
                     (do res <- errAt "left hand side of " fname Nothing
-                                 (erun fc (buildTC i info ELHS opts fname
+                                 (erun (fromMaybe NoFC $ highestFC lhs_in_as)
+                                       (buildTC i info ELHS opts fname
                                           (allNamesIn lhs_in)
                                           (infTerm lhs)))
                         probs <- get_probs
@@ -950,7 +952,8 @@ elabClause info opts (_, PWith fc fname lhs_in withs wval_in pn_in withblock)
         (ElabResult lhs' dlhs [] ctxt' newDecls highlights newGName, _) <-
             tclift $ elaborate (constraintNS info) ctxt (idris_datatypes i) (idris_name i) (sMN 0 "patLHS") infP initEState
               (errAt "left hand side of with in " fname Nothing
-                (erun fc (buildTC i info ELHS opts fname
+                (erun (fromMaybe NoFC $ highestFC lhs_in)
+                      (buildTC i info ELHS opts fname
                                   (allNamesIn lhs_in)
                                   (infTerm lhs))) )
         setContext ctxt'

--- a/src/Idris/Parser.hs
+++ b/src/Idris/Parser.hs
@@ -1144,11 +1144,11 @@ clause syn
            -- lhs application "with" clause or function clause
        <|> do pushIndent
               (n, nfc, capp, wargs) <- lhs
+              modify $ \ist -> ist { lastParse = Just n }
               (do (rs, fc) <- withExtent (rhs syn n)
                   let wsyn = syn { syn_namespace = [] }
                   (wheres, nmap) <-     whereBlock n wsyn <* popIndent
                                     <|> ([], []) <$ terminator
-                  modify $ \ist -> ist { lastParse = Just n }
                   return $ PClause fc n capp wargs rs wheres) <|> (do
                    popIndent
                    ((wval, pn), fc) <- withExtent $ do
@@ -1159,7 +1159,6 @@ clause syn
                    openBlock
                    ds <- some $ fnDecl syn
                    closeBlock
-                   modify $ \ist -> ist { lastParse = Just n }
                    let withs = map (fillLHSD n capp wargs) $ concat ds
                    return $ PWith fc n capp wargs wval pn withs)
       <?> "function clause"

--- a/test/error006/expected
+++ b/test/error006/expected
@@ -1,2 +1,2 @@
-WithPatsNoWith.idr:4:15-20:When checking left hand side of foo:
+WithPatsNoWith.idr:4:1-13:When checking left hand side of foo:
 unexpected patterns outside of "with" block

--- a/test/layout001/expected
+++ b/test/layout001/expected
@@ -14,7 +14,6 @@ Wrong indention: should be greater than context indentation
   |
 3 | 2
   | ^
-= is not a valid operator
 Wrong indention: should be greater than context indentation
 
 ./layout001e.idr:6:1:

--- a/test/regression002/expected
+++ b/test/regression002/expected
@@ -20,7 +20,7 @@ Specifically:
                 1
         and
                 0
-reg010.idr:5:28-31:
+reg010.idr:5:3-26:
 When checking left hand side of with block in usubst.unsafeSubst:
 Can't match on with block in usubst.unsafeSubst warg a P x x px
 reg018a.idr:16:1-18:
@@ -46,9 +46,9 @@ reg028a.idr:17:14-18:
 This style of tactic proof is deprecated. See %runElab for the replacement.
 reg028a.idr:11:1-14:
 tbad.qsort' is possibly not total due to: with block in tbad.qsort'
-reg034.idr:6:16-21:When checking left hand side of bar:
+reg034.idr:6:1-14:When checking left hand side of bar:
 Can't match on bar xs xs Refl
-reg034.idr:9:16-21:When checking left hand side of foo:
+reg034.idr:9:1-14:When checking left hand side of foo:
 Can't match on foo f x x Refl
 reg035b.idr:8:12-38:No such variable __pi_arg
 reg044.idr:4:6-10:
@@ -84,12 +84,12 @@ No such variable Bogus
   |                            ^
 unexpected Operator without known fixity: !!
 
-reg054.idr:18:19-24:When checking left hand side of inf:
+reg054.idr:18:1-17:When checking left hand side of inf:
 When checking an application of constructor Main.MkInfer:
         Attempting concrete match on polymorphic argument: 0
-reg054.idr:34:20-24:When checking left hand side of weird:
+reg054.idr:34:1-18:When checking left hand side of weird:
 No explicit types on left hand side: Char
-reg054.idr:37:32-34:When checking left hand side of weird':
+reg054.idr:37:1-30:When checking left hand side of weird':
 No explicit types on left hand side: Nat
 reg054.idr:40:1-7:When checking left hand side of tctrick:
 When checking an application of Main.tctrick:
@@ -97,14 +97,14 @@ When checking an application of Main.tctrick:
                 Maybe a1 (Type of Just x)
         and
                 a (Expected type)
-reg055.idr:5:9-11:When checking left hand side of g:
+reg055.idr:5:1-7:When checking left hand side of g:
 Can't match on g (f 0)
-reg055.idr:8:7-9:When checking left hand side of h:
+reg055.idr:8:1-5:When checking left hand side of h:
 Can't match on h x x
-reg055a.idr:8:20-23:When checking left hand side of foo:
+reg055a.idr:8:1-18:When checking left hand side of foo:
 When checking an application of constructor Foo.CAny:
         Attempting concrete match on polymorphic argument: Nothing
-reg055a.idr:13:25-27:When checking left hand side of Foo.apply:
+reg055a.idr:13:1-23:When checking left hand side of Foo.apply:
 Can't match on apply (\x, y => x) a
 reg056.idr:7:16-25:dodgy n m Refl is a valid case
 reg056.idr:10:11-20:nonk Refl is a valid case


### PR DESCRIPTION
Closes #4237

The `clauses` parser is somewhat cleaned up in the process, with duplication removed and one minor functional change to make the syntax consistent (Brackets weren't required on `with` expressions--but only when the left-hand side did not include the application expression.  They are now required in all cases.)