### PR TITLE
Data.Fuel: move `Fuel` data type from Control.ST to its own module

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -51,6 +51,7 @@
   * Lowered the precedence of `>>=` to be below that of `<|>`.
 + Added some useful string manipulation functions to `Data.String.Extra`.
 + Added `Control.Delayed`, a module for conditionally making a type `Inf` or `Lazy`.
++ Added `Data.Fuel`, which implements the `Fuel` data type and the partial `forever` function.
 + Added `Data.Bool.Extra`, a module with properties of boolean operations.
 + Moved core of `Text.Lexer` to `Text.Lexer.Core`. Added several new combinators
   and lexers to `Text.Lexer`.

--- a/libs/contrib/Control/ST.idr
+++ b/libs/contrib/Control/ST.idr
@@ -1,7 +1,9 @@
 module Control.ST
 
-import Language.Reflection.Utils
 import Control.IOExcept
+import Language.Reflection.Utils
+
+import public Data.Fuel
 
 %default total
 
@@ -394,13 +396,6 @@ runST env (Call prog res_prf) k
 runST env (Read lbl prf) k = k (lookupEnv prf env) env
 runST env (Write lbl prf val) k = k () (updateEnv prf env val)
 
-export
-data Fuel = Empty | More (Lazy Fuel)
-
-export partial
-forever : Fuel
-forever = More forever
-
 runSTLoop : Fuel -> Env invars -> STransLoop m a invars outfn ->
             (k : (x : a) -> Env (outfn x) -> m b) ->
             (onDry : m b) -> m b
@@ -589,10 +584,10 @@ run prog = runST [] prog (\res, env' => pure res)
 
 export
 runLoop : Applicative m => Fuel -> STLoop m a [] ->
-          (onEmpty : m a) ->
+          (onDry : m a) ->
           m a
-runLoop fuel prog onEmpty
-    = runSTLoop fuel [] prog (\res, env' => pure res) onEmpty
+runLoop fuel prog onDry
+    = runSTLoop fuel [] prog (\res, env' => pure res) onDry
 
 ||| runWith allows running an STrans program with an initial environment,
 ||| which must be consumed.

--- a/libs/contrib/Data/Fuel.idr
+++ b/libs/contrib/Data/Fuel.idr
@@ -1,0 +1,18 @@
+module Data.Fuel
+
+%access public export
+%default total
+
+||| Fuel for running total operations potentially indefinitely.
+data Fuel = Dry | More (Lazy Fuel)
+
+||| Provide `n` units of fuel.
+limit : Nat -> Fuel
+limit Z = Dry
+limit (S n) = More (limit n)
+
+||| Provide fuel indefinitely.
+||| This function is fundamentally partial.
+partial
+forever : Fuel
+forever = More forever

--- a/libs/contrib/contrib.ipkg
+++ b/libs/contrib/contrib.ipkg
@@ -28,6 +28,7 @@ modules = CFFI
         , Data.Combinators.Applicative
         , Data.Combinators.Arrow
         , Data.Fin.Extra
+        , Data.Fuel
         , Data.Fun
         , Data.Hash
         , Data.Heap


### PR DESCRIPTION
This data type is used multiple times in TDDWI.