### PR TITLE
add precedence for infix `div` and `mod`

### DIFF
--- a/libs/prelude/Prelude/Interfaces.idr
+++ b/libs/prelude/Prelude/Interfaces.idr
@@ -12,6 +12,8 @@ infixl 7 <<, >> -- unused
 infixl 8 +, -
 infixl 9 *, /
 
+infixl 9 `div`, `mod`
+
 -- ------------------------------------------------------------- [ Boolean Ops ]
 intToBool : Int -> Bool
 intToBool 0 = False

--- a/test/views001/views001.idr
+++ b/test/views001/views001.idr
@@ -26,7 +26,7 @@ mergeSort xs with (splitRec xs)
 testList : Int -> Int -> List Int -> List Int
 testList 0 seed acc = acc
 -- Need to explicitly mod since different back ends overflow differently
-testList x seed acc = let seed' = seed * 12345 + 768 `mod` 65536 in
+testList x seed acc = let seed' = (seed * 12345 + 768) `mod` 65536 in
                           testList (x - 1) seed' 
                                ((seed' `mod` 100) :: acc)
 

--- a/test/views001/views001a.idr
+++ b/test/views001/views001a.idr
@@ -13,7 +13,7 @@ mergeSort xs with (splitRec xs)
 testList : Int -> Int -> List Int -> List Int
 testList 0 seed acc = acc
 -- Need to explicitly mod since different back ends overflow differently
-testList x seed acc = let seed' = seed * 12345 + 768 `mod` 65536 in
+testList x seed acc = let seed' = (seed * 12345 + 768) `mod` 65536 in
                           testList (x - 1) seed' 
                                ((seed' `mod` 100) :: acc)
 

--- a/test/views002/views002.idr
+++ b/test/views002/views002.idr
@@ -11,7 +11,7 @@ qsort inp with (filtered (<) inp)
 testList : Int -> Int -> List Int -> List Int
 testList 0 seed acc = acc
 -- Need to explicitly mod since different back ends overflow differently
-testList x seed acc = let seed' = seed * 12345 + 768 `mod` 65536 in
+testList x seed acc = let seed' = (seed * 12345 + 768) `mod` 65536 in
                           testList (x - 1) seed' 
                                ((seed' `mod` 100) :: acc)
 


### PR DESCRIPTION
These functions have the same precedence as `/`.