### PR TITLE
Replace '-' with '_' in LHS of Node requires

### DIFF
--- a/src/IRTS/JavaScript/Codegen.hs
+++ b/src/IRTS/JavaScript/Codegen.hs
@@ -89,6 +89,7 @@ includeLibs =
     repl '\\' = '_'
     repl '/' = '_'
     repl '.' = '_'
+    repl '-' = '_'
     repl c   = c
   in
     concatMap (\lib -> "var " ++ (repl <$> lib) ++ " = require(\"" ++ lib ++"\");\n")


### PR DESCRIPTION
Currently, the following

```
module Main
%lib Node "node-pty"

main : JS_IO ()
main = pure ()
```

produces the invalid javascript `var node-pty = require("node-pty");`. This is a quick fix that matches the way we handle other invalid characters.