### PR TITLE
Set environment with Idris flags while running `make`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -109,7 +109,10 @@
 ## Packaging Updates
 
 + Package names now only accept a restrictive charset of letters, numbers and the `-_` characters.
-  Package names are also case insensitive
+  Package names are also case insensitive.
++ When building makefiles for the FFI, the environment variables
+  `IDRIS_INCLUDES` and `IDRIS_LDFLAGS` are now set with the correct C
+  flags.
 
 # New in 1.1.1
 

--- a/docs/reference/packages.rst
+++ b/docs/reference/packages.rst
@@ -91,7 +91,10 @@ external ``C`` libraries, the following options are available:
 
 + ``makefile = <file>``, which specifies a ``Makefile``, to be built
   before the Idris modules, for example to support linking with a
-  ``C`` library.
+  ``C`` library. When building, Idris sets the environment variables
+  ``IDRIS_INCLUDES`` (with C include flags) and ``IDRIS_LDFLAGS``
+  (with C linking flags) so they can be used from inside the
+  ``Makefile``.
 
 + ``libs = <libs>``, which takes a comma separated list of libraries
   which must be present for the package to be usable.


### PR DESCRIPTION
When building a package with foreign code and a makefile, the makefile
itself must find the compilation flags that Idris already knows
about. Moreover, the `idris` executable found by the makefile may not
be the same used to build the package. This change passes the build
flags to the makefile though environment variables.