### PR TITLE
WIP: parse RigCount for let-bindings

### DIFF
--- a/src/Idris/Parser/Expr.hs
+++ b/src/Idris/Parser/Expr.hs
@@ -939,7 +939,7 @@ rewriteTerm syn = do keyword "rewrite"
                      return (PRewrite fc using prf sc giving)
                   <?> "term rewrite expression"
 
--- | Parse a constant and its source span
+-- | Parse rig count for linear types
 rigCount :: Parsing m => m RigCount
 rigCount = P.option RigW $ do lchar '1'; return Rig1
                        <|> do lchar '0'; return Rig0


### PR DESCRIPTION
Solves https://github.com/idris-lang/Idris-dev/issues/4297. This seems to work for the original issue, should anything else be added? The new syntax simply allows to add `0`/`1` before the name in let, e.g.: 
```
bar : (1 x : Int) -> ((1 i : Int) -> String) -> String
bar x f = let 1 res = f x in
          res
```