### PR TITLE
Set C language standard to C99 in runtime and codegen

### DIFF
--- a/config.mk
+++ b/config.mk
@@ -14,7 +14,7 @@ RANLIB          ?=ranlib
 CABAL           :=cabal
 # IDRIS_ENABLE_STATS should not be set in final release
 # Any flags defined here which alter the RTS API must also be added to src/IRTS/CodegenC.hs
-CFLAGS          :=-O2 -Wall -DHAS_PTHREAD -DIDRIS_ENABLE_STATS $(CFLAGS)
+CFLAGS          :=-O2 -Wall -std=c99 -D_POSIX_C_SOURCE=200809L -DHAS_PTHREAD -DIDRIS_ENABLE_STATS $(CFLAGS)
 
 # CABALFLAGS	:=
 CABALFLAGS      += --enable-tests

--- a/libs/base/System.idr
+++ b/libs/base/System.idr
@@ -93,9 +93,9 @@ time : IO Integer
 time = do MkRaw t <- foreign FFI_C "idris_time" (IO (Raw Integer))
           pure t
 
-||| Specify interval to sleep for, must be in range [0, 1000000]
-usleep : (i : Int) -> { auto prf : So (i >= 0 && i <= 1000000) } -> IO ()
-usleep i = foreign FFI_C "usleep" (Int -> IO ()) i
+||| Specify interval to sleep for in microseconds, must be nonnegative
+usleep : (i : Int) -> { auto prf : So (i >= 0) } -> IO ()
+usleep i = foreign FFI_C "idris_usleep" (Int -> IO ()) i
 
 ||| Execute a program and returns its exit status code.
 system : String -> IO Int

--- a/libs/effects/Effect/System.idr
+++ b/libs/effects/Effect/System.idr
@@ -15,7 +15,7 @@ data System : Effect where
      Time : sig System Integer
      GetEnv : String -> sig System (Maybe String)
      CSystem : String -> sig System Int
-     Usleep : (i : Int) -> (inbounds : So (i >= 0 && i <= 1000000)) -> sig System ()
+     Usleep : (i : Int) -> (inbounds : So (i >= 0)) -> sig System ()
 
 implementation Handler System IO where
     handle () Args k = do x <- getArgs; k x ()
@@ -48,5 +48,5 @@ getEnv s = call $ GetEnv s
 system : String -> Eff Int [SYSTEM]
 system s = call $ CSystem s
 
-usleep : (i : Int) -> { auto prf : So (i >= 0 && i <= 1000000) } -> Eff () [SYSTEM]
+usleep : (i : Int) -> { auto prf : So (i >= 0) } -> Eff () [SYSTEM]
 usleep i {prf} = call $ Usleep i prf

--- a/rts/idris_main.c
+++ b/rts/idris_main.c
@@ -4,8 +4,11 @@
 #include "idris_stats.h"
 
 void _idris__123_runMain_95_0_125_(VM* vm, VAL* oldbase);
-#if defined(WIN32) || defined(__WIN32) || defined(__WIN32__)
+
+#ifdef _WIN32
+
 #include <Windows.h>
+
 int win32_get_argv_utf8(int *argc_ptr, char ***argv_ptr)
 {
     int argc;
@@ -26,6 +29,7 @@ int win32_get_argv_utf8(int *argc_ptr, char ***argv_ptr)
     *argv_ptr = argv;
     return 0;
 }
+
 #endif
 
 // The default options should give satisfactory results under many circumstances.
@@ -35,7 +39,7 @@ RTSOpts opts = {
     .show_summary   = 0
 };
 
-#if defined(WIN32) || defined(__WIN32) || defined(__WIN32__)
+#ifdef _WIN32
 int main() {
     int argc;
     char **argv;

--- a/rts/idris_net.c
+++ b/rts/idris_net.c
@@ -8,7 +8,7 @@
 #include <stdio.h>
 #include <string.h>
 
-#ifndef WIN32
+#ifndef _WIN32
 #include <netinet/in.h>
 #include <arpa/inet.h>
 #else
@@ -58,7 +58,7 @@ void idrnet_free(void* ptr) {
 
 
 int idrnet_socket(int domain, int type, int protocol) {
-#ifdef WIN32
+#ifdef _WIN32
     if (!check_init()) {
         return -1;
     }

--- a/rts/idris_net.h
+++ b/rts/idris_net.h
@@ -2,7 +2,7 @@
 #define IDRISNET_H
 
 // Includes used by the idris-file.
-#ifdef WIN32
+#ifdef _WIN32
 #include <winsock2.h>
 #include <Ws2tcpip.h>
 #else

--- a/rts/idris_rts.c
+++ b/rts/idris_rts.c
@@ -1225,6 +1225,14 @@ void idris_disableBuffering(void) {
   setvbuf(stdout, NULL, _IONBF, 0);
 }
 
+int idris_usleep(int usec) {
+    struct timespec t;
+    t.tv_sec = usec / 1000000;
+    t.tv_nsec = (usec % 1000000) * 1000;
+
+    return nanosleep(&t, NULL);
+}
+
 void stackOverflow(void) {
   fprintf(stderr, "Stack overflow");
   exit(-1);

--- a/rts/idris_rts.h
+++ b/rts/idris_rts.h
@@ -442,6 +442,8 @@ const char *idris_getArg(int i);
 // disable stdin/stdout buffering
 void idris_disableBuffering(void);
 
+int idris_usleep(int usec);
+
 // Handle stack overflow.
 // Just reports an error and exits.
 

--- a/rts/idris_stdfgn.c
+++ b/rts/idris_stdfgn.c
@@ -10,7 +10,7 @@
 #include <time.h>
 #include <dirent.h>
 
-#if defined(WIN32) || defined(__WIN32) || defined(__WIN32__)
+#ifdef _WIN32
 int win_fpoll(void* h);
 FILE *win32_u8fopen(const char *path, const char *mode);
 FILE *win32_u8popen(const char *path, const char *mode);
@@ -25,7 +25,7 @@ void putStr(char* str) {
 }
 
 void *fileOpen(char *name, char *mode) {
-#if defined(WIN32) || defined(__WIN32) || defined(__WIN32__)
+#ifdef _WIN32
     FILE *f = win32_u8fopen(name, mode);
 #else
     FILE *f = fopen(name, mode);
@@ -97,7 +97,7 @@ char* idris_nextDirEntry(void* h) {
 }
 
 int idris_mkdir(char* dname) {
-#if defined(WIN32) || defined(__WIN32) || defined(__WIN32__)
+#ifdef _WIN32
     return mkdir(dname);
 #else
     return mkdir(dname, S_IRWXU | S_IRGRP | S_IROTH);
@@ -119,7 +119,7 @@ int idris_writeStr(void* h, char* str) {
 
 int fpoll(void* h)
 {
-#if defined(WIN32) || defined(__WIN32) || defined(__WIN32__)
+#ifdef _WIN32
     return win_fpoll(h);
 #else
     FILE* f = (FILE*)h;
@@ -138,7 +138,7 @@ int fpoll(void* h)
 }
 
 void *do_popen(const char *cmd, const char *mode) {
-#if defined(WIN32) || defined(__WIN32) || defined(__WIN32__)
+#ifdef _WIN32
     FILE *f = win32_u8popen(cmd, mode);
 #else
     FILE *f = popen(cmd, mode);

--- a/src/IRTS/CodegenC.hs
+++ b/src/IRTS/CodegenC.hs
@@ -83,7 +83,7 @@ codegenC' defs out exec incs objs libs flags exports iface dbg
              let args = gccDbg dbg ++
                         gccFlags iface ++
                         -- # Any flags defined here which alter the RTS API must also be added to config.mk
-                        ["-DHAS_PTHREAD", "-DIDRIS_ENABLE_STATS",
+                        ["-std=c99", "-D_POSIX_C_SOURCE=200809L", "-DHAS_PTHREAD", "-DIDRIS_ENABLE_STATS",
                          "-I."] ++ objs ++ envFlags ++
                         (if (exec == Executable) then [] else ["-c"]) ++
                         [tmpn] ++


### PR DESCRIPTION
Currently the exact C language used by the runtime and the C code generator is not set and therefore different compilers may use different standards depending on their default behaviour. This may lead to inconsistencies in builds, such a sucessful build in one machine failing in another.
