### PR TITLE
Update documentation to add the options for CATS in logging

### DIFF
--- a/docs/reference/compilation.rst
+++ b/docs/reference/compilation.rst
@@ -63,17 +63,17 @@ For those that develop on the Idris compiler, the internal operation
 of Idris is captured using a category based logger. Currently, the
 logging infrastructure has support for the following categories:
 
-+ Parser
-+ Elaborator
-+ Code generation
-+ Erasure
-+ Coverage Checking
-+ IBC generation
++ Parser (``parser``)
++ Elaborator (``elab``)
++ Code generation (``codegen``)
++ Erasure (``erasure``)
++ Coverage Checking (``coverage``)
++ IBC generation (``ibc``)
 
 
 These categories are specified using the command-line option:
 ``--logging-categories CATS``, where ``CATS`` is a quoted colon
-seperated string of the categories you want to see. By default if this
+separated string of the categories you want to see. By default if this
 option is not specified all categories are allowed.  Sub-categories
 have yet to be defined but will be in the future, especially for the
 elaborator.


### PR DESCRIPTION
In the [documentation about internal logging](http://docs.idris-lang.org/en/latest/reference/compilation.html#logging-internal-operation), the options for `CATS` are listed but there is no way to know what the syntax is for those options. It would be nice to have that in the documentation instead of looking up `strLogCat` in `Idris.Options` every time.