### PR TITLE
Reverse improvements

### DIFF
--- a/libs/contrib/Data/List/Extra.idr
+++ b/libs/contrib/Data/List/Extra.idr
@@ -1,0 +1,22 @@
+module Data.List.Extra
+
+%default total
+%access export
+
+||| Serves as a specification for reverseOnto.
+reverseOntoSpec : (xs, ys : List a) -> reverseOnto xs ys = reverse ys ++ xs
+reverseOntoSpec _  [] = Refl
+reverseOntoSpec xs (y::ys) =
+  trans (reverseOntoSpec (y::xs) ys)
+        (trans (appendAssociative (reverse ys) [y] xs)
+               (cong {f = \l => l ++ xs} (sym (reverseOntoSpec [y] ys))))
+
+||| The reverse of an empty list is an empty list.  Together with reverseCons,
+||| serves as a specification for reverse.
+reverseNil : reverse [] = []
+reverseNil = Refl
+
+||| The reverse of a cons is the reverse of the tail followed by the head.
+||| Together with reverseNil serves as a specification for reverse.
+reverseCons : (x : a) -> (xs : List a) -> reverse (x::xs) = reverse xs ++ [x]
+reverseCons x xs = reverseOntoSpec [x] xs

--- a/libs/contrib/Data/List/Extra.idr
+++ b/libs/contrib/Data/List/Extra.idr
@@ -20,3 +20,25 @@ reverseNil = Refl
 ||| Together with reverseNil serves as a specification for reverse.
 reverseCons : (x : a) -> (xs : List a) -> reverse (x::xs) = reverse xs ++ [x]
 reverseCons x xs = reverseOntoSpec [x] xs
+
+||| Reversing an append is appending reversals backwards.
+reverseAppend : (xs, ys : List a) ->
+  reverse (xs ++ ys) = reverse ys ++ reverse xs
+reverseAppend [] ys = sym (appendNilRightNeutral (reverse ys))
+reverseAppend (x :: xs) ys =
+  trans (trans (reverseCons x (xs ++ ys))
+               (cong {f = \l => l ++ [x]} (reverseAppend xs ys)))
+        (sym (trans (cong (reverseCons x xs))
+                    (appendAssociative (reverse ys) (reverse xs) [x])))
+
+||| Reversing a singleton list is a no-op.
+reverseSingletonId : (x : a) -> reverse [x] = [x]
+reverseSingletonId _ = Refl
+
+||| Reversing a reverse gives the original.
+reverseReverseId : (xs : List a) -> reverse (reverse xs) = xs
+reverseReverseId [] = Refl
+reverseReverseId (x :: xs) =
+  trans (cong (reverseCons x xs))
+        (trans (reverseAppend (reverse xs) [x])
+               (cong (reverseReverseId xs)))

--- a/libs/contrib/contrib.ipkg
+++ b/libs/contrib/contrib.ipkg
@@ -36,6 +36,7 @@ modules = CFFI
         , Data.Heap
         , Data.IOArray
         , Data.List.Zipper
+        , Data.List.Extra
 
         , Data.Matrix
         , Data.Matrix.Algebraic

--- a/libs/prelude/Prelude/List.idr
+++ b/libs/prelude/Prelude/List.idr
@@ -394,13 +394,14 @@ scanl1 f (x::xs) = scanl f x xs
 -- Transformations
 --------------------------------------------------------------------------------
 
+||| Reverse a list onto an existing tail.
+reverseOnto : List a -> List a -> List a
+reverseOnto acc [] = acc
+reverseOnto acc (x::xs) = reverseOnto (x::acc) xs
+
 ||| Return the elements of a list in reverse order.
 reverse : List a -> List a
-reverse = reverse' []
-  where
-    reverse' : List a -> List a -> List a
-    reverse' acc []      = acc
-    reverse' acc (x::xs) = reverse' (x::acc) xs
+reverse = reverseOnto []
 
 ||| Insert some separator between the elements of a list.
 |||


### PR DESCRIPTION
Inspired by my recent frustration of having to write my own reverse in order to prove anything about it and the earlier discussion in #2099.

Last commit is totally optional, but a good idea I think; it hides the implementation of reverse (and dependents).  With the way reverse was implemented previously, I don't think external proofs could have been made about it (or isSuffixOf) because there was no way to reference the local function definition, so I doubt it will break anyone.  The "specification" properties should be enough to make any proofs needed about reverse or reverseOnto without exposing their implementation, which gives us some flexibility if (for some reason) we need to change their implementation again.  (Unfortunately, there's no "specification" for isSuffixOf or isSuffixOfBy, so any proofs about them will have to be in this module, but that was the old status quo as well.)