### PR TITLE
Add Effects.runPureEnv

### DIFF
--- a/libs/effects/Effects.idr
+++ b/libs/effects/Effects.idr
@@ -440,6 +440,11 @@ runEnv : Applicative m => Env m xs -> EffM m a xs xs' ->
          m (x : a ** Env m (xs' x))
 runEnv env prog = eff env prog (\r, env => pure (r ** env))
 
+||| Similar to 'runEnv', but the context (m) is 'pure'
+%no_implicit
+runPureEnv : (env : Env Basics.id xs) -> (prog : EffM Basics.id a xs xs') -> (x : a ** Env Basics.id (xs' x))
+runPureEnv env prog = eff env prog (\r, env => (r ** env))
+
 -- ----------------------------------------------- [ some higher order things ]
 
 mapE : (a -> EffM m b xs (\_ => xs)) -> List a -> EffM m (List b) xs (\_ => xs)

--- a/libs/effects/Effects.idr
+++ b/libs/effects/Effects.idr
@@ -434,6 +434,7 @@ runPureInit env prog = eff env prog (\r, env => r)
 runWith : (a -> m a) -> Env m xs -> EffM m a xs xs' -> m a
 runWith inj env prog = eff env prog (\r, env => inj r)
 
+||| Similar to 'runInit', but take the result of `Env`.
 %no_implicit
 runEnv : Applicative m => Env m xs -> EffM m a xs xs' ->
          m (x : a ** Env m (xs' x))


### PR DESCRIPTION
This allows programs that are like below

```idris
import Effect.State
import Effects

-- runPureEnv : (env : Env Basics.id xs) -> (prog : EffM Basics.id a xs xs') -> (x : a ** Env Basics.id (xs' x))
-- runPureEnv env prog = eff env prog (\r, env => (r ** env))

main : IO ()
main = do
  let (_ ** [s]) = runPureEnv [default] (do update (+1))
  printLn s
```

This maybe used in any effect, like Haskell's `Reader` :smile:

Also a document comment of `runEnv` is added as the preparing :dog2:

PS.
`%no_implicit` is inserted on `runPureEnv`, but I don't know what is `%no_implicit` :bow:
Are problems nothing?