### PR TITLE
fix for odd-even bug in random

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,11 @@
 + REPL now prints an error message if program compiled by `:exec` terminates
   abnormally.
 
+## Library Updates
+
++ changed rndInt in Effect.Random so that it does not alternate between odd
+  and even.
+
 # New in 1.2.0
 
 ## Language updates

--- a/libs/effects/Effect/Random.idr
+++ b/libs/effects/Effect/Random.idr
@@ -5,6 +5,19 @@ import Data.Vect
 
 %access public export
 
+{-
+ - This code implements a 'Linear Congruential Generator' as described here
+ - https://en.wikipedia.org/wiki/Linear_congruential_generator
+ -
+ - Looking at the wiki page for 'linear congruential generator' it looks like the
+ - parameters used by Idris come from the 'Numerical Recipes' books. The web page
+ - does not give any known issues with these parameters, however another example is
+ - known to have this bug: "If Xn is even then Xn+1 will be odd, and vice versa-the
+ - lowest bit oscillates at each step." So although the 'Numerical Recipes' parameters
+ - are not listed with this issue they do have it. Some of the implementations do not
+ - use the lower significant bits so divBigInt v 2 has been added to do this.
+ -}
+
 data Random : Effect where 
      GetRandom : sig Random Integer Integer
      SetSeed   : Integer -> sig Random () Integer
@@ -21,10 +34,12 @@ RND = MkEff Integer Random
 ||| Generates a random Integer in a given range
 rndInt : Integer -> Integer -> Eff Integer [RND]
 rndInt lower upper = do v <- call $ GetRandom
-                        pure ((v `prim__sremBigInt` (upper - lower)) + lower)
+                        pure (((divBigInt v 2) `prim__sremBigInt` (upper - lower)) + lower)
+                        -- divBigInt v 2 is required to prevent low bit alternating between
+                        -- 0 and 1 (odd and even)
 
 ||| Generate a random number in Fin (S `k`)
-||| 
+|||
 ||| Note that rndFin k takes values 0, 1, ..., k.
 rndFin : (k : Nat) -> Eff (Fin (S k)) [RND]
 rndFin k = do let v = assert_total $ !(call GetRandom) `prim__sremBigInt` (cast (S k))
@@ -33,7 +48,8 @@ rndFin k = do let v = assert_total $ !(call GetRandom) `prim__sremBigInt` (cast 
        toFin x = case integerToFin x (S k) of
                       Just v => v
                       Nothing => toFin (assert_smaller x (x - cast (S k)))
-
+       -- TODO insert divBigInt x 2 to prevent low bit alternating between
+       -- 0 and 1 (odd and even)
 ||| Select a random element from a vector
 rndSelect' : Vect (S k) a -> Eff a [RND]
 rndSelect' {k} xs = pure (Vect.index !(rndFin k)  xs)

--- a/libs/effects/Effect/Random.idr
+++ b/libs/effects/Effect/Random.idr
@@ -43,13 +43,14 @@ rndInt lower upper = do v <- call $ GetRandom
 ||| Note that rndFin k takes values 0, 1, ..., k.
 rndFin : (k : Nat) -> Eff (Fin (S k)) [RND]
 rndFin k = do let v = assert_total $ !(call GetRandom) `prim__sremBigInt` (cast (S k))
-              pure (toFin v)
- where toFin : Integer -> Fin (S k) 
+              pure (toFin (divBigInt v 2))
+ where toFin : Integer -> Fin (S k)
        toFin x = case integerToFin x (S k) of
                       Just v => v
                       Nothing => toFin (assert_smaller x (x - cast (S k)))
-       -- TODO insert divBigInt x 2 to prevent low bit alternating between
+       -- divBigInt v 2 is required to prevent low bit alternating between
        -- 0 and 1 (odd and even)
+
 ||| Select a random element from a vector
 rndSelect' : Vect (S k) a -> Eff a [RND]
 rndSelect' {k} xs = pure (Vect.index !(rndFin k)  xs)

--- a/test/effects001/expected
+++ b/test/effects001/expected
@@ -1,4 +1,4 @@
 ["HELLO!!!\n", "WORLD!!!\n", ""]
 3
-15
-Answer: 99
+7
+Answer: 91

--- a/test/effects003/expected
+++ b/test/effects003/expected
@@ -4,7 +4,8 @@ hangman.idr:204:8-12:
     |        ~~~~~
 This style of tactic proof is deprecated. See %runElab for the replacement.
 
-------------
+----
+
 6 guesses left
 Enter guess: Good guess!
 -a-a

--- a/test/effects003/expected
+++ b/test/effects003/expected
@@ -5,43 +5,26 @@ hangman.idr:204:8-12:
 This style of tactic proof is deprecated. See %runElab for the replacement.
 
 ------------
+6 guesses left
+Enter guess: Good guess!
+-a-a
 
 6 guesses left
 Enter guess: No, sorry
-------------
+-a-a
 
 5 guesses left
-Enter guess: Good guess!
-----ee------
+Enter guess: No, sorry
+-a-a
 
-5 guesses left
-Enter guess: Good guess!
-----ee---i--
+4 guesses left
+Enter guess: No, sorry
+-a-a
 
-5 guesses left
+3 guesses left
 Enter guess: Good guess!
--o--ee---i--
+ja-a
 
-5 guesses left
+3 guesses left
 Enter guess: Good guess!
--offee---i--
-
-5 guesses left
-Enter guess: Good guess!
-coffee-c-i--
-
-5 guesses left
-Enter guess: Good guess!
-coffeesc-i--
-
-5 guesses left
-Enter guess: Good guess!
-coffeesc-ip-
-
-5 guesses left
-Enter guess: Good guess!
-coffeescrip-
-
-5 guesses left
-Enter guess: Good guess!
-You won! Successfully guessed coffeescript
+You won! Successfully guessed java

--- a/test/effects003/input
+++ b/test/effects003/input
@@ -2,9 +2,5 @@ a
 e
 i
 o
-f
-c
-s
-p
-r
-t
+j
+v


### PR DESCRIPTION
Fix for the following bug and also add comments.

When I call (rndInt 0 100) repeatedly the result does not look very psudorandom, for instance, it gives alternating odd and even numbers.

When I look at the Idris code here:
https://github.com/idris-lang/Idris-dev/blob/master/libs/effects/Effect/Random.idr
and I enter the code manually I also get alternating odd and even numbers:

```
Idris> :let seed = 1
Idris> :let seed=((1664525 * seed + 1013904223) `prim__sremBigInt` (pow 2 32))
Idris> seed
1015568748 : Integer
Idris> :let seed=((1664525 * seed + 1013904223) `prim__sremBigInt` (pow 2 32))
Idris> seed
1586005467 : Integer
Idris> :let seed=((1664525 * seed + 1013904223) `prim__sremBigInt` (pow 2 32))
Idris> seed
2165703038 : Integer
Idris> :let seed=((1664525 * seed + 1013904223) `prim__sremBigInt` (pow 2 32))
Idris> seed
3027450565 : Integer
Idris> :let seed=((1664525 * seed + 1013904223) `prim__sremBigInt` (pow 2 32))
Idris> seed
217083232 : Integer
Idris> :let seed=((1664525 * seed + 1013904223) `prim__sremBigInt` (pow 2 32))
Idris> seed
1587069247 : Integer
Idris> :let seed=((1664525 * seed + 1013904223) `prim__sremBigInt` (pow 2 32))
Idris> seed
3327581586 : Integer
```