### PR TITLE
Bump ansi-terminal upper bound to <0.9

### DIFF
--- a/idris.cabal
+++ b/idris.cabal
@@ -260,7 +260,7 @@ Library
                   Util.Pretty
                 , Util.Net
 
-                
+
 
                 -- Auto Generated
                 , Paths_idris
@@ -270,7 +270,7 @@ Library
   Build-depends:  base >=4 && <5
                 , aeson >= 0.6 && < 1.3
                 , annotated-wl-pprint >= 0.7 && < 0.8
-                , ansi-terminal < 0.8
+                , ansi-terminal < 0.9
                 , ansi-wl-pprint < 0.7
                 , array >= 0.4.0.1 && < 0.6
                 , base64-bytestring < 1.1


### PR DESCRIPTION
Bump `ansi-terminal` upper bound to <0.9, in response to https://github.com/fpco/stackage/issues/3143.