### PR TITLE
Made fromIntegerNat use `case` instead of `if`

### DIFF
--- a/libs/prelude/Prelude/Nat.idr
+++ b/libs/prelude/Prelude/Nat.idr
@@ -72,10 +72,13 @@ mult (S left) right = plus right $ mult left right
 
 ||| Convert an Integer to a Nat, mapping negative numbers to 0
 fromIntegerNat : Integer -> Nat
-fromIntegerNat i =
-  case (i > 0) of
+fromIntegerNat i = 
+  case (i > 0) of 
     True  => S (fromIntegerNat (assert_smaller i (i - 1)))
     False => Z
+-- Using if here would cause infinite looping in some cases.
+-- This could be fixed by redundantly matching on 0 explicitly, but that would stop
+--   fromIntegerNat from reducing in proofs.
 
 ||| Convert a Nat to an Integer
 toIntegerNat : Nat -> Integer

--- a/libs/prelude/Prelude/Nat.idr
+++ b/libs/prelude/Prelude/Nat.idr
@@ -72,12 +72,10 @@ mult (S left) right = plus right $ mult left right
 
 ||| Convert an Integer to a Nat, mapping negative numbers to 0
 fromIntegerNat : Integer -> Nat
-fromIntegerNat 0 = Z
-fromIntegerNat n =
-  if (n > 0) then
-    S (fromIntegerNat (assert_smaller n (n - 1)))
-  else
-    Z
+fromIntegerNat i =
+  case (i > 0) of
+    True  => S (fromIntegerNat (assert_smaller i (i - 1)))
+    False => Z
 
 ||| Convert a Nat to an Integer
 toIntegerNat : Nat -> Integer


### PR DESCRIPTION
Using `if` with an `assert_smaller` could cause infinite compile-time looping. To prevent this, a pattern match on `0` was needed, but functions that match on Integers don't reduce in proofs. This should fix that for `fromIntegerNat` by avoiding the original issue (tested, this version doesn't loop on `\i=>fromIntegerNat i` at the REPL, which the old version did without the `0` match).

The new code has been tested correct for (-1), 0, 5, 10, 100, 1000 and 1234. It does seem to be slightly slower than the original, but neither is very fast. Proving things for `Integer` is probably still not a good idea, but it should now at least be possible to convert a `So (i > 0)` to an `IsSucc (fromIntegerNat i)` (untested, I'm bad at proofs, but `compute` does now reduce `fromIntegerNat i` to a `case` block).

As a minor simultaneous change, the `fromIntegerNat` takes an argument `i`, for `Integer`, rather than `n` for `Nat`.