### PR TITLE
Fix EOF handling of replWith

### DIFF
--- a/libs/prelude/Prelude/Interactive.idr
+++ b/libs/prelude/Prelude/Interactive.idr
@@ -160,12 +160,14 @@ partial
 replWith : (state : a) -> (prompt : String) ->
            (onInput : a -> String -> Maybe (String, a)) -> IO ()
 replWith acc prompt fn
-   = do putStr prompt
-        x <- getLine
-        case fn acc x of
-             Just (out, acc') => do putStr out
-                                    replWith acc' prompt fn
-             Nothing => pure ()
+   = if !(fEOF stdin)
+        then pure ()
+        else do putStr prompt
+                x <- getLine
+                case fn acc x of
+                     Just (out, acc') => do putStr out
+                                            replWith acc' prompt fn
+                     Nothing => pure ()
 
 ||| A basic read-eval-print loop
 ||| @ prompt the prompt to show


### PR DESCRIPTION
Hi there,

I encountered this problem, which was previously reported as #3757.

The patch simply adds a check on `EOF` to avoid infinite recursion, similarly to `processHandle` above.

Regards.
