### PR TITLE
Add tryCatch as an Elab action in Language.Reflection.Elab

### DIFF
--- a/libs/prelude/Language/Reflection/Elab.idr
+++ b/libs/prelude/Language/Reflection/Elab.idr
@@ -16,6 +16,7 @@ import Prelude.Maybe
 import Prelude.Monad
 import Prelude.Nat
 import Language.Reflection
+import Language.Reflection.Errors
 
 %access public export
 
@@ -138,6 +139,7 @@ data Elab : Type -> Type where
   Prim__BindElab : {a, b : Type} -> Elab a -> (a -> Elab b) -> Elab b
 
   Prim__Try : {a : Type} -> Elab a -> Elab a -> Elab a
+  Prim__TryCatch : {a : Type} -> Elab a -> (Err -> Elab a) -> Elab a
   Prim__Fail : {a : Type} -> List ErrorReportPart -> Elab a
 
   Prim__Env : Elab (List (TTName, Binder TT))
@@ -217,6 +219,13 @@ namespace Tactics
 
   implementation Monad Elab where
     x >>= f = Prim__BindElab x f
+
+  ||| `tryCatch t (\err => t')` will run `t`, and if it
+  ||| fails, roll back the elaboration state and run `t'`,
+  ||| but with access to the knowledge of why `t` failed.
+  export
+  tryCatch : Elab a -> (Err -> Elab a) -> Elab a
+  tryCatch x f = Prim__TryCatch x f
 
   ||| Halt elaboration with an error
   export

--- a/src/Idris/Elab/Term.hs
+++ b/src/Idris/Elab/Term.hs
@@ -2026,6 +2026,14 @@ runElabAction info ist fc env tm ns = do tm' <- eval tm
            first' <- eval first
            alt' <- eval alt
            try' (runTacTm first') (runTacTm alt') True
+      | n == tacN "Prim__TryCatch"
+      = do ~[_a, first, f] <- tacTmArgs 3 tac args
+           first' <- eval first
+           f' <- eval f
+           tryCatch (runTacTm first') $ \err ->
+             do (err', _) <- checkClosed (reflectErr err)
+                f' <- eval (App Complete f err')
+                runTacTm f'
       | n == tacN "Prim__Fill"
       = do ~[raw] <- tacTmArgs 1 tac args
            raw' <- reifyRaw =<< eval raw


### PR DESCRIPTION
There already is `tryCatch :: Elab' aux a -> (Err -> Elab' aux a) -> Elab' aux a` in Idris.Core.Elaborate in the compiler, but there's no matching Elab action in Language.Reflection.Elab in the Idris prelude.

Now we have a new Elab action `tryCatch : Elab a -> (Err -> Elab a) -> Elab a` that lets us learn *why* the first Elab action failed and do different things based on the error.

## Example

```idris
import Language.Reflection.Elab

%language ElabReflection

f : Err -> Elab ()
f (Msg _) = fill `("message error")
f (CantUnify _ _ _ _ _ _) = fill `("unification error")
f _ = fill `("other")

s1 : String
s1 = %runElab (do tryCatch (fail []) f ; solve)

s2 : String
s2 = %runElab (do tryCatch (fill `(True)) f ; solve)

main : IO ()
main = do putStrLn s1 ; putStrLn s2
```

This program would print
```
message error
unification error
```