### PR TITLE
Add conversions between BoundedList and Vect

### DIFF
--- a/libs/contrib/Data/BoundedList.idr
+++ b/libs/contrib/Data/BoundedList.idr
@@ -1,6 +1,7 @@
 module Data.BoundedList
 
 import Data.Fin
+import Data.Vect
 
 %access public export
 %default total
@@ -49,6 +50,20 @@ toList (x :: xs) = x :: Data.BoundedList.toList xs
 fromList : (xs : List a) -> BoundedList (length xs) a
 fromList [] = []
 fromList (x :: xs) = x :: fromList xs
+
+--------------------------------------------------------------------------------
+-- Conversions to and from vector
+--------------------------------------------------------------------------------
+
+||| Convert bounded list to vector.
+toVect : (xs : BoundedList n a) -> Vect (finToNat (length xs)) a
+toVect [] = []
+toVect (x :: xs) = x :: toVect xs
+
+||| Convert vector to bounded list.
+fromVect : (xs : Vect n a) -> BoundedList n a
+fromVect [] = []
+fromVect (x :: xs) = x :: fromVect xs
 
 --------------------------------------------------------------------------------
 -- Building (bigger) bounded lists


### PR DESCRIPTION
A small addition to `contrib`, suggested in a StackOverflow [comment](https://stackoverflow.com/questions/49193132/how-to-write-an-idris-function-that-accepts-a-vect-of-length-less-than-3#comment85397084_49195458).