### PR TITLE
Add 'Ord' instance to 'Maybe'

### DIFF
--- a/libs/prelude/Prelude/Maybe.idr
+++ b/libs/prelude/Prelude/Maybe.idr
@@ -100,6 +100,12 @@ maybe_bind (Just x) k = k x
   (Just _) == Nothing  = False
   (Just a) == (Just b) = a == b
 
+(Ord a) => Ord (Maybe a) where
+  compare Nothing  Nothing  = EQ
+  compare Nothing  (Just _) = LT
+  compare (Just _) Nothing  = GT
+  compare (Just a) (Just b) = compare a b
+
 ||| Prioritised choice. Just like the `Alternative` implementation, the
 ||| `Semigroup` for `Maybe a` keeps the first succeeding computation.
 |||


### PR DESCRIPTION
Haskell programming language has `Ord` instance for `Maybe` type. This instance is derived in Haskell:

* https://hackage.haskell.org/package/base-4.11.0.0/docs/src/GHC.Base.html#Maybe

But Idris implementation has same meaning. This instance is convenient to have. Here you can see couple examples where it's convenient to have such instance:

### Maximal value in nested ADT

```idrs
data Shape 
    = Triangle Double Double -- base length and height
    | Rectangle Double Double -- width and height
    | Circle Double -- radius

area : Shape -> Double

||| Describes set of transformations performed on given set of 'Shape's.
data Picture 
    = Primitive Shape 
    | Combine Picture Picture

||| Returns the area of the biggest triangle in a picture
biggestTriangle : Picture -> Maybe Double
biggestTriangle (Combine x y) = max (biggestTriangle x) (biggestTriangle y)
biggestTriangle (Primitive x) = case x of
    t@(Triangle _ _) => Just (area t)
    _                => Nothing
```

### Second maximum in the list

Using this instance it's extremely easy to implement safe function which returns second maximum in list.

```idris
secondMax : Ord a => List a -> Maybe a
secondMax = snd . foldr sorter (Nothing, Nothing)
  where
    top2 : List (Maybe a) -> (Maybe a, Maybe a)
    top2 [_, sndMax, fstMax] = (fstMax, sndMax)
    top2 _ = (Nothing, Nothing)

    sorter : Ord a => a -> (Maybe a, Maybe a) -> (Maybe a, Maybe a)
    sorter elem (fstMax, sndMax) = top2 $ sort [Just elem, sndMax, fstMax]
```

In REPL:
```
λΠ> secondMax [1,2,3]
Just 2 : Maybe Integer
λΠ> secondMax $ [1.. 10] ++ [50,49..1]
Just 49 : Maybe Integer
```