### PR TITLE
Support skipping any number of shebang lines.

### DIFF
--- a/src/Idris/Parser.hs
+++ b/src/Idris/Parser.hs
@@ -1497,7 +1497,7 @@ parseImports fname input
                                  [ImportInfo],
                                  Maybe Mark),
                                 [(FC, OutputAnnotation)], IState)
-        imports = do optional shebang
+        imports = do many shebang
                      whiteSpace
                      (mdoc, mname, annots) <- moduleHeader
                      ps_exp        <- many import_

--- a/stack-shell.nix
+++ b/stack-shell.nix
@@ -7,6 +7,8 @@ let
     zlib
     ncurses
     gmp
+    nodejs
+    perl
   ];
   native_libs = lib.optionals stdenv.isDarwin (with darwin.apple_sdk.frameworks; [
     Cocoa

--- a/test/interactive017/expected
+++ b/test/interactive017/expected
@@ -5,3 +5,5 @@ hello from node
 Hello ["aaa"]
 Hello ["bbb", "aaa"]
 Hello from a module
+hello from C with multiple shebangs
+hello from node with multiple shebangs

--- a/test/interactive017/run
+++ b/test/interactive017/run
@@ -7,3 +7,5 @@ PATH="../../scripts:$PATH"
 ./shebang-args.idr aaa
 ./shebang-args.idr bbb aaa
 ./shebang-import.idr
+./shebang-multiple.idr
+./shebang-node-multiple.idr

--- a/test/interactive017/shebang-multiple.idr
+++ b/test/interactive017/shebang-multiple.idr
@@ -1,0 +1,5 @@
+#!/usr/bin/env runidris
+#! shebang 2
+
+main : IO ()
+main = putStrLn "hello from C with multiple shebangs"

--- a/test/interactive017/shebang-node-multiple.idr
+++ b/test/interactive017/shebang-node-multiple.idr
@@ -1,0 +1,6 @@
+#!/usr/bin/env runidris-node
+#! shebangs
+#! shemoves
+
+main : IO ()
+main = putStrLn "hello from node with multiple shebangs"


### PR DESCRIPTION
Hello :) I just started learning Idris and I wanted to be able to run my scripts with nix-shell and found that the second shebang line was causing a parse error with Idris. I ran tests locally with `stack --nix test` and everything passed. Thanks for any feedback.

Below is what I'm talking about:

```
#! /usr/bin/env nix-shell
#! nix-shell -i idris -p idris

main : IO ()
main = putStrLn "Hello world from nix-shell shebang!"
```

Additional changes:

Updates `stack-shell.nix` to include perl and nodejs.

I was getting errors about perl and node missing when I tried to run `stack --nix test.`