### PR TITLE
Fix typo in package name

### DIFF
--- a/docs/reference/packages.rst
+++ b/docs/reference/packages.rst
@@ -123,7 +123,7 @@ Package files support comments using the standard Idris singleline ``--`` and mu
 Using Package files
 ===================
 
-Given an Idris package file ``text.ipkg`` it can be used with the Idris compiler as follows:
+Given an Idris package file ``test.ipkg`` it can be used with the Idris compiler as follows:
 
 + ``idris --build test.ipkg`` will build all modules in the package
 


### PR DESCRIPTION
Simple correction of a typo from `text.ipkg` to `test.ipkg` in the package documentation.