### PR TITLE
Allow building on GHC 8.4.1

### DIFF
--- a/idris.cabal
+++ b/idris.cabal
@@ -100,7 +100,7 @@ source-repository head
 
 custom-setup
   setup-depends:
-    Cabal >= 1.10 && <2.1,
+    Cabal >= 1.10 && <2.3,
     base  >= 4 && <5,
     directory,
     filepath,
@@ -309,7 +309,7 @@ Library
                 , vector-binary-instances < 0.3
                 , zip-archive > 0.2.3.5 && < 0.4
                 , fsnotify >= 0.2 && < 2.2
-                , async < 2.2
+                , async < 2.3
 
   if !impl(ghc >= 8.0)
     Build-Depends: semigroups == 0.18.*


### PR DESCRIPTION
Thankfully, only the `Setup` script needs to be changed:

* `FlagAssignment` is now an abstract type, so we need to use the `lookupFlagAssignment` function instead of `lookup`.
* `rewriteFile` is now deprecated in favor of `rewriteFileEx`.

I also needed to bump the upper version bounds on `Cabal` and `async` to support GHC 8.4.1.