### PR TITLE
Bump to LTS 11.3 and fingertree-0.1.4.1

### DIFF
--- a/idris.cabal
+++ b/idris.cabal
@@ -286,7 +286,7 @@ Library
                 , deepseq < 1.5
                 , directory >= 1.2.2.0 && < 1.2.3.0 || > 1.2.3.0
                 , filepath < 1.5
-                , fingertree >= 0.1 && < 0.2
+                , fingertree >= 0.1.4.1 && < 0.2
                 , haskeline >= 0.7 && < 0.8
                 , ieee754 >= 0.7 && < 0.9
                 , megaparsec >= 6.2

--- a/stack.yaml
+++ b/stack.yaml
@@ -1,5 +1,5 @@
 #recheck extra-deps next on resolver or cabal file change
-resolver: lts-10.4
+resolver: lts-11.3
 
 packages:
   - location: .


### PR DESCRIPTION
The types in the fingertree module have Generic instances now. In order to create NFData instances, we need that. (We currently don't have an NFData instance for any fingertree type but my next pull request will require that)