### PR TITLE
getMsg leak

### DIFF
--- a/libs/base/System/Concurrency/Raw.idr
+++ b/libs/base/System/Concurrency/Raw.idr
@@ -8,7 +8,7 @@ import System
 
 ||| Send a message of any type to the thread with the given thread id
 ||| Returns channel ID if the message was sent successfully, 0 otherwise
-||| 
+|||
 ||| @channel an ID of a specific channel to send the message on. If 0,
 |||          the receiver will create a new channel ID
 sendToThread : (thread_id : Ptr) -> (channel : Int) -> a -> IO Int
@@ -29,7 +29,7 @@ checkMsgs = do me <- getMyVM
 checkMsgsTimeout : Int -> IO Bool
 checkMsgsTimeout timeout
           = do me <- getMyVM
-               msgs <- foreign FFI_C "idris_checkMessagesTimeout" 
+               msgs <- foreign FFI_C "idris_checkMessagesTimeout"
                             (Ptr -> Int -> IO Ptr) me timeout
                null <- nullPtr msgs
                pure (not null)
@@ -43,7 +43,7 @@ channel_id : Ptr -> IO Int
 channel_id msg = foreign FFI_C "idris_getChannel" (Ptr -> IO Int) msg
 
 ||| Check for messages initiating a conversation in the process inbox.
-||| Returns either 'Nothing', if none, or 'Just (pid, channel)' as pid 
+||| Returns either 'Nothing', if none, or 'Just (pid, channel)' as pid
 ||| of sender and new channel id.
 listenMsgs : IO (Maybe (Ptr, Int))
 listenMsgs = do me <- getMyVM
@@ -58,7 +58,7 @@ listenMsgs = do me <- getMyVM
 ||| Check for messages from a specific sender/channel in the process inbox
 ||| If channel is '0', accept on any channel.
 checkMsgsFrom : Ptr -> (channel : Int) -> IO Bool
-checkMsgsFrom sender channel 
+checkMsgsFrom sender channel
   = do me <- getMyVM
        msgs <- foreign FFI_C "idris_checkMessagesFrom" (Ptr -> Int -> Ptr -> IO Ptr)
                              me channel sender
@@ -73,6 +73,7 @@ getMsg : IO a
 getMsg {a} = do me <- getMyVM
                 m <- foreign FFI_C "idris_recvMessage" (Ptr -> IO Ptr) me
                 MkRaw x <- foreign FFI_C "idris_getMsg" (Ptr -> IO (Raw a)) m
+                foreign FFI_C "idris_freeMsg" (Ptr -> IO ()) m
                 pure x
 
 ||| Check inbox for messages. If there are none, blocks until a message
@@ -80,9 +81,9 @@ getMsg {a} = do me <- getMyVM
 ||| Note that this is not at all type safe! It is intended to be used in
 ||| a type safe wrapper.
 getMsgWithSender : IO (Ptr, Int, a)
-getMsgWithSender {a} 
+getMsgWithSender {a}
            = do me <- getMyVM
-                m <- foreign FFI_C "idris_recvMessage" 
+                m <- foreign FFI_C "idris_recvMessage"
                              (Ptr -> IO Ptr) me
                 MkRaw x <- foreign FFI_C "idris_getMsg" (Ptr -> IO (Raw a)) m
                 vm <- sender m
@@ -94,12 +95,12 @@ getMsgWithSender {a}
 ||| blocks until a message arrives. Returns `Nothing` if the sender isn't
 ||| alive
 getMsgFrom : Ptr -> (channel : Int) -> IO (Maybe a)
-getMsgFrom {a} sender channel 
+getMsgFrom {a} sender channel
   = do me <- getMyVM
        m <- foreign FFI_C "idris_recvMessageFrom"
                     (Ptr -> Int -> Ptr -> IO Ptr) me channel sender
        null <- nullPtr m
-       if null 
+       if null
           then pure Nothing
           else do
              MkRaw x <- foreign FFI_C "idris_getMsg" (Ptr -> IO (Raw a)) m
@@ -110,5 +111,3 @@ stopThread : IO a
 stopThread = do vm <- getMyVM
                 MkRaw res <- foreign FFI_C "idris_stopThread" (Ptr -> IO (Raw a)) vm
                 pure res
-
-


### PR DESCRIPTION
Shouldn't `getMsg` call `idris_freeMsg`?