### PR TITLE
Fix printerdepth handling

### DIFF
--- a/src/Idris/AbsSyntaxTree.hs
+++ b/src/Idris/AbsSyntaxTree.hs
@@ -1992,7 +1992,7 @@ pprintPTerm ppo bnd docArgs infixes = prettySe (ppopt_depth ppo) startPrec bnd
     prettyArgS d bnd (PConstraint _ _ _ tm)     = prettyArgSc d bnd tm
     prettyArgS d bnd (PTacImplicit _ _ n _ tm)  = prettyArgSti d bnd (n, tm)
 
-    prettyArgSe d bnd arg       = prettySe d (funcAppPrec + 1) bnd arg
+    prettyArgSe d bnd arg       = prettySe (decD d) (funcAppPrec + 1) bnd arg
     prettyArgSi d bnd (n, val)  = lbrace <> pretty n <+> text "=" <+> prettySe (decD d) startPrec bnd val <> rbrace
     prettyArgSc d bnd val       = lbrace <> lbrace <> prettySe (decD d) startPrec bnd val <> rbrace <> rbrace
     prettyArgSti d bnd (n, val) = lbrace <> kwd "auto" <+> pretty n <+> text "=" <+> prettySe (decD d) startPrec bnd val <> rbrace


### PR DESCRIPTION
Before patching:

```
Idris> :set desugarnats
Idris> the Nat 10
S (S (S (S (S (S (S (S (S (S Z))))))))) : Nat
Idris> :printerdepth 3
Idris> the Nat 10
S (S (S (S (S (S (S (S (S (S Z))))))))) : Nat
Idris>
```

After:

```
Idris> :set desugarnats
Idris> :printerdepth 3
Idris> the Nat 10
S (S (S ...)) : Nat
Idris> 
```