### PR TITLE
Strip unreachable code/data

### DIFF
--- a/config.mk
+++ b/config.mk
@@ -14,7 +14,7 @@ RANLIB          ?=ranlib
 CABAL           :=cabal
 # IDRIS_ENABLE_STATS should not be set in final release
 # Any flags defined here which alter the RTS API must also be added to src/IRTS/CodegenC.hs
-CFLAGS          :=-O2 -Wall -std=c99 -D_POSIX_C_SOURCE=200809L -DHAS_PTHREAD -DIDRIS_ENABLE_STATS $(CFLAGS)
+CFLAGS          :=-O2 -Wall -std=c99 -pipe -fdata-sections -ffunction-sections -D_POSIX_C_SOURCE=200809L -DHAS_PTHREAD -DIDRIS_ENABLE_STATS $(CFLAGS)
 
 # CABALFLAGS	:=
 CABALFLAGS      += --enable-tests

--- a/src/Util/System.hs
+++ b/src/Util/System.hs
@@ -10,6 +10,7 @@ module Util.System( tempfile
                   , withTempdir
                   , rmFile
                   , catchIO
+                  , isDarwin
                   , isWindows
                   , writeSource
                   , writeSourceText
@@ -49,6 +50,9 @@ catchIO = CE.catch
 
 isWindows :: Bool
 isWindows = os `elem` ["win32", "mingw32", "cygwin32"]
+
+isDarwin :: Bool
+isDarwin = os == "darwin"
 
 -- | Create a temp file with the extensiom ext (in the format ".xxx")
 tempfile :: String -> IO (FilePath, Handle)


### PR DESCRIPTION
This should yield smaller executables. I added also `-pipe`, it could help with compilation times.