### PR TITLE
Fix discrepancy in behaviour of run-time and complile-time str-to-int…

### DIFF
--- a/src/Idris/Primitives.hs
+++ b/src/Idris/Primitives.hs
@@ -416,9 +416,13 @@ getInt (BI x : xs) = x : getInt xs
 getInt _ = []
 
 strToInt :: IntTy -> [Const] -> Maybe Const
-strToInt ity [Str x] = case reads x of
+strToInt ity [Str x] = case reads $ dropFirstPlus x of
                          [(n,s)] -> Just $ if all isSpace s then toInt ity (n :: Integer) else I 0
                          _       -> Just $ I 0
+  where
+    dropFirstPlus :: String -> String
+    dropFirstPlus ('+' : str) = str
+    dropFirstPlus str = str
 strToInt _ _ = Nothing
 
 intToFloat :: [Const] -> Maybe Const


### PR DESCRIPTION
Hi.
During implementation of [WASM Codegen Backend for Idris](https://github.com/SPY/idris-codegen-wasm/blob/master/rts/index.html) I have encountered a bug.
There is discrepancy in behaviour of run-time and compile-time implementation of str-to-int primitive.
Runtime implementation treats leading '+' as valid case(`strtol` and `parseInt` are the same here), but Haskell's `Read` instance for `Integer` counts sequences with leading '+' as invalid.
There is sample of wrong behaviour:
```idris
module Main

main : IO ()
main = do
  putStrLn . show $ the Int (cast "+11") -- cast evaluated in compile-time
  putStrLn . show $ the Int (cast $ head $ split (== ' ') "+11") -- cast evaluated at run-time
  putStrLn . show $ the Int (cast "+11") == the Int (cast $ head $ split (== ' ') "+11") -- prints False now
```
Could anyone guide me to write right test in right place? Should it be `regression` section in test case? How can I enforce compiler to optimize/not optimize my code to clean my code from `split`/`head` hack?

Thanks