### PR TITLE
Define IDRIS_GMP if compiling with real GMP

### DIFF
--- a/rts/Makefile
+++ b/rts/Makefile
@@ -1,28 +1,24 @@
 include ../config.mk
 
 OBJS = idris_rts.o idris_heap.o idris_gc.o idris_gmp.o idris_bitstring.o \
-       idris_opts.o idris_stats.o idris_utf8.o idris_stdfgn.o mini-gmp.o \
+       idris_opts.o idris_stats.o idris_utf8.o idris_stdfgn.o \
        idris_buffer.o getline.o idris_net.o
 HDRS = idris_rts.h idris_heap.h idris_gc.h idris_gmp.h idris_bitstring.h \
-       idris_opts.h idris_stats.h mini-gmp.h idris_stdfgn.h idris_net.h \
+       idris_opts.h idris_stats.h idris_stdfgn.h idris_net.h \
        idris_buffer.h idris_utf8.h getline.h
 CFLAGS := $(CFLAGS)
 CFLAGS += $(GMP_INCLUDE_DIR) $(GMP) -DIDRIS_TARGET_OS="\"$(OS)\""
 CFLAGS += -DIDRIS_TARGET_TRIPLE="\"$(MACHINE)\""
 
-# NOTE: This works around glibc 2.11 not declaring pthread_mutexattr_settype
-# and PTHREAD_MUTEX_RECURSIVE by default, causing compilation failures on
-# Debian 6 and Ubuntu 10.04 LTS.
-ifeq ($(OS), unix)
-ifneq ($(shell ldd --version | head -n 1 | grep 2.11),)
-	CFLAGS += -D_GNU_SOURCE
-endif
-endif
-
 ifeq ($(OS), windows)
 	OBJS += windows/win_utils.o
 else
 	CFLAGS += -fPIC
+endif
+
+ifndef IDRIS_GMP
+	OBJS += mini-gmp.o
+	HDRS += mini-gmp.h
 endif
 
 LIBTARGET = libidris_rts.a

--- a/src/IRTS/System.hs
+++ b/src/IRTS/System.hs
@@ -83,7 +83,7 @@ extraInclude = []
 #endif
 
 #ifdef IDRIS_GMP
-gmpLib = ["-lgmp"]
+gmpLib = ["-lgmp", "-DIDRIS_GMP"]
 #else
 gmpLib = []
 #endif


### PR DESCRIPTION
Only add minigmp to the rts if needed.

Remove obsolete hack.

Fixes #4470