### PR TITLE
Use a newer cabal with 7.10

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -11,9 +11,9 @@ matrix:
   include:
     - env: CABALVER="2.2" GHCVER="8.4.1" STACKVER="7.14" STYLISH=YES
       addons: {apt: {packages: [cabal-install-2.2,ghc-8.4.1,hscolour], sources: [hvr-ghc]}}
-    - env: CABALVER="1.22" GHCVER="7.10.3" TESTS="test_c"
+    - env: CABALVER="2.2" GHCVER="7.10.3" TESTS="test_c"
       compiler: ": #GHC 7.10.3"
-      addons: {apt: {packages: [cabal-install-1.22,ghc-7.10.3,cppcheck,hscolour], sources: [hvr-ghc]}}
+      addons: {apt: {packages: [cabal-install-2.2,ghc-7.10.3,cppcheck,hscolour], sources: [hvr-ghc]}}
     - env: CABALVER="1.24" GHCVER="8.0.1" TESTS="test_c"
       compiler: ": #GHC 8.0.1"
       addons: {apt: {packages: [cabal-install-1.24,ghc-8.0.1,cppcheck,hscolour], sources: [hvr-ghc]}}
@@ -26,7 +26,8 @@ matrix:
     - env: CABALVER="2.0" GHCVER="8.2.2" TESTS="test_c"
       compiler: ": #GHC 8.2.2"
       addons: {apt: {packages: [cabal-install-2.0,ghc-8.2.2,cppcheck,hscolour], sources: [hvr-ghc]}}
-#TODO: Uncomment when tasty-rerun has been updated for base-4.11
+#TODO: The idris built with those fails due to libffi dynamic linking version mismatch.
+#      Caused by the GHC backport to Trusty?
 #    - env: CABALVER="2.2" GHCVER="8.4.1" TESTS="lib_doc doc"
 #      compiler: ": #GHC 8.4.1"
 #      addons: {apt: {packages: [cabal-install-2.2,ghc-8.4.1,cppcheck,hscolour], sources: [hvr-ghc]}}


### PR DESCRIPTION
The 7.10 build fails when the cabal executable crashes in the configure step.

It works with a new cabal, so let's use that. Any 7.10 user can install a newer
cabal-install if it would turn out to be more than a Travis environment issue.

Update comment for why 8.4 is disabled with new roadblock (sigh).