### PR TITLE
Why nub a list when you can use a set.

### DIFF
--- a/src/Idris/Core/TT.hs
+++ b/src/Idris/Core/TT.hs
@@ -197,10 +197,10 @@ instance Show FC where
     show (FileFC f) = f
 
 -- | Output annotation for pretty-printed name - decides colour
-data NameOutput = TypeOutput | FunOutput | DataOutput | MetavarOutput | PostulateOutput deriving (Show, Eq, Generic)
+data NameOutput = TypeOutput | FunOutput | DataOutput | MetavarOutput | PostulateOutput deriving (Show, Eq, Ord, Generic)
 
 -- | Text formatting output
-data TextFormatting = BoldText | ItalicText | UnderlineText deriving (Show, Eq, Generic)
+data TextFormatting = BoldText | ItalicText | UnderlineText deriving (Show, Eq, Ord, Generic)
 
 -- | Output annotations for pretty-printing
 data OutputAnnotation = AnnName Name (Maybe NameOutput) (Maybe String) (Maybe String)
@@ -227,7 +227,7 @@ data OutputAnnotation = AnnName Name (Maybe NameOutput) (Maybe String) (Maybe St
                       | AnnQuasiquote
                       | AnnAntiquote
                       | AnnSyntax String -- ^ type of syntax element: backslash or braces etc.
-  deriving (Show, Eq, Generic)
+  deriving (Show, Eq, Generic, Ord)
 
 -- | Used for error reflection
 data ErrorReportPart = TextPart String

--- a/src/Idris/Directives.hs
+++ b/src/Idris/Directives.hs
@@ -13,6 +13,8 @@ import Idris.Core.TT
 import Idris.Imports
 import Idris.Output (sendHighlighting)
 
+import qualified Data.Set as S
+
 import Util.DynamicLinker
 
 -- | Run the action corresponding to a directive
@@ -81,7 +83,7 @@ directiveAction (DNameHint ty tyFC ns) = do
   ty' <- disambiguate ty
   mapM_ (addNameHint ty' . fst) ns
   mapM_ (\n -> addIBC (IBCNameHint (ty', fst n))) ns
-  sendHighlighting $ [(tyFC, AnnName ty' Nothing Nothing Nothing)] ++ map (\(n, fc) -> (fc, AnnBoundName n False)) ns
+  sendHighlighting $ S.fromList $ [(FC' tyFC, AnnName ty' Nothing Nothing Nothing)] ++ map (\(n, fc) -> (FC' fc, AnnBoundName n False)) ns
 
 directiveAction (DErrorHandlers fn nfc arg afc ns) = do
   fn' <- disambiguate fn
@@ -90,10 +92,10 @@ directiveAction (DErrorHandlers fn nfc arg afc ns) = do
                   return (n', fc)) ns
   addFunctionErrorHandlers fn' arg (map fst ns')
   mapM_ (addIBC . IBCFunctionErrorHandler fn' arg . fst) ns'
-  sendHighlighting $
-       [ (nfc, AnnName fn' Nothing Nothing Nothing)
-       , (afc, AnnBoundName arg False)
-       ] ++ map (\(n, fc) -> (fc, AnnName n Nothing Nothing Nothing)) ns'
+  sendHighlighting $ S.fromList $
+       [ (FC' nfc, AnnName fn' Nothing Nothing Nothing)
+       , (FC' afc, AnnBoundName arg False)
+       ] ++ map (\(n, fc) -> (FC' fc, AnnName n Nothing Nothing Nothing)) ns'
 
 directiveAction (DLanguage ext) = addLangExt ext
 

--- a/src/Idris/Elab/Clause.hs
+++ b/src/Idris/Elab/Clause.hs
@@ -44,6 +44,7 @@ import qualified Control.Monad.State.Lazy as LState
 import Control.Monad.State.Strict as State
 import Data.List
 import Data.Maybe
+import qualified Data.Set as S
 import Data.Word
 import Debug.Trace
 import Numeric
@@ -1028,7 +1029,7 @@ elabClause info opts (_, PWith fc fname lhs_in withs wval_in pn_in withblock)
                        Just (n, nfc) -> Just (uniqueName n (map fst bargs))
 
         -- Highlight explicit proofs
-        sendHighlighting [(fc, AnnBoundName n False) | (n, fc) <- maybeToList pn_in]
+        sendHighlighting $ S.fromList [(FC' fc, AnnBoundName n False) | (n, fc) <- maybeToList pn_in]
 
         logElab 10 ("With type " ++ show (getRetTy cwvaltyN) ++
                   " depends on " ++ show pdeps ++ " from " ++ show pvars)

--- a/src/Idris/Elab/Data.hs
+++ b/src/Idris/Elab/Data.hs
@@ -37,6 +37,7 @@ import Data.Char (isLetter, toLower)
 import Data.List
 import qualified Data.Map as Map
 import Data.Maybe
+import qualified Data.Set as S
 import qualified Data.Text as T
 
 warnLC :: FC -> Name -> Idris ()
@@ -53,7 +54,7 @@ elabData info syn doc argDocs fc opts (PLaterdecl n nfc t_in)
 
          addIBC (IBCDef n)
          updateContext (addTyDecl n (TCon 0 0) cty) -- temporary, to check cons
-         sendHighlighting [(nfc, AnnName n Nothing Nothing Nothing)]
+         sendHighlighting $ S.fromList [(FC' nfc, AnnName n Nothing Nothing Nothing)]
 
 elabData info syn doc argDocs fc opts (PDatadecl n nfc t_in dcons)
     = do let codata = Codata `elem` opts
@@ -118,9 +119,9 @@ elabData info syn doc argDocs fc opts (PDatadecl n nfc t_in dcons)
          when (n /= sUN "=") $
             elabRewriteLemma info n cty
          -- Emit highlighting info
-         sendHighlighting $ [(nfc, AnnName n Nothing Nothing Nothing)] ++
+         sendHighlighting $ S.fromList $ [(FC' nfc, AnnName n Nothing Nothing Nothing)] ++
            map (\(_, _, n, nfc, _, _, _) ->
-                 (nfc, AnnName n Nothing Nothing Nothing))
+                 (FC' nfc, AnnName n Nothing Nothing Nothing))
                dcons
   where
         checkDefinedAs fc n t i

--- a/src/Idris/Elab/Interface.hs
+++ b/src/Idris/Elab/Interface.hs
@@ -26,6 +26,7 @@ import Control.Monad
 import Data.Generics.Uniplate.Data (transform)
 import Data.List
 import Data.Maybe
+import qualified Data.Set as S
 
 data MArgTy = IA Name | EA Name | CA deriving Show
 
@@ -167,11 +168,11 @@ elabInterface info_in syn_in doc what fc constraints tn tnfc ps pDocs fds ds mcn
              mapM_ (rec_elabDecl info EAll info) (concatMap (snd.snd) defs)
              addIBC (IBCInterface tn)
 
-             sendHighlighting $
-               [(tnfc, AnnName tn Nothing Nothing Nothing)] ++
-               [(pnfc, AnnBoundName pn False) | (pn, pnfc, _) <- ps] ++
-               [(fdfc, AnnBoundName fc False) | (fc, fdfc) <- fds] ++
-               maybe [] (\(conN, conNFC) -> [(conNFC, AnnName conN Nothing Nothing Nothing)]) mcn
+             sendHighlighting $ S.fromList $
+               [(FC' tnfc, AnnName tn Nothing Nothing Nothing)] ++
+               [(FC' pnfc, AnnBoundName pn False) | (pn, pnfc, _) <- ps] ++
+               [(FC' fdfc, AnnBoundName fc False) | (fc, fdfc) <- fds] ++
+               maybe [] (\(conN, conNFC) -> [(FC' conNFC, AnnName conN Nothing Nothing Nothing)]) mcn
 
   where
     info = info_in { noCaseLift = tn : noCaseLift info_in }

--- a/src/Idris/Elab/Record.hs
+++ b/src/Idris/Elab/Record.hs
@@ -20,6 +20,7 @@ import Idris.Output (sendHighlighting)
 import Control.Monad
 import Data.List
 import Data.Maybe
+import qualified Data.Set as S
 
 -- | Elaborate a record declaration
 elabRecord :: ElabInfo
@@ -66,10 +67,10 @@ elabRecord info what doc rsyn fc opts tyn nfc params paramDocs fields cname cdoc
            logElab 1 $ "fieldsWIthNameAndDoc " ++ show fieldsWithNameAndDoc
            elabRecordFunctions info rsyn fc tyn paramsAndDoc fieldsWithNameAndDoc dconName target
 
-           sendHighlighting $
-             [(nfc, AnnName tyn Nothing Nothing Nothing)] ++
-             maybe [] (\(_, cnfc) -> [(cnfc, AnnName dconName Nothing Nothing Nothing)]) cname ++
-             [(ffc, AnnBoundName fn False) | (fn, ffc, _, _, _) <- fieldsWithName]
+           sendHighlighting $ S.fromList $
+             [(FC' nfc, AnnName tyn Nothing Nothing Nothing)] ++
+             maybe [] (\(_, cnfc) -> [(FC' cnfc, AnnName dconName Nothing Nothing Nothing)]) cname ++
+             [(FC' ffc, AnnBoundName fn False) | (fn, ffc, _, _, _) <- fieldsWithName]
 
   where
     -- | Generates a type constructor.

--- a/src/Idris/Elab/Term.hs
+++ b/src/Idris/Elab/Term.hs
@@ -56,7 +56,7 @@ data ElabResult = ElabResult {
     -- | Meta-info about the new type declarations
   , resultTyDecls :: [RDeclInstructions]
     -- | Saved highlights from elaboration
-  , resultHighlighting :: [(FC, OutputAnnotation)]
+  , resultHighlighting :: S.Set (FC', OutputAnnotation)
     -- | The new global name counter
   , resultName :: Int
   }

--- a/src/Idris/Elab/Type.hs
+++ b/src/Idris/Elab/Type.hs
@@ -205,7 +205,7 @@ elabType' norm info syn doc argDocs fc opts n nfc ty' = {- let ty' = piBind (par
                  else ifail $ "The type " ++ show nty' ++ " is invalid for an error handler"
              else ifail "Error handlers can only be defined when the ErrorReflection language extension is enabled."
          -- Send highlighting information about the name being declared
-         sendHighlighting [(nfc, AnnName n Nothing Nothing Nothing)]
+         sendHighlighting $ S.fromList [(FC' nfc, AnnName n Nothing Nothing Nothing)]
          -- if it's an export list type, make a note of it
          case (unApply usety) of
               (P _ ut _, _)
@@ -238,7 +238,7 @@ elabPostulate info syn doc fc nfc opts n ty = do
     elabType info syn doc [] fc opts n NoFC ty
     putIState . (\ist -> ist{ idris_postulates = S.insert n (idris_postulates ist) }) =<< getIState
     addIBC (IBCPostulate n)
-    sendHighlighting [(nfc, AnnName n (Just PostulateOutput) Nothing Nothing)]
+    sendHighlighting $ S.fromList [(FC' nfc, AnnName n (Just PostulateOutput) Nothing Nothing)]
 
     -- remove it from the deferred definitions list
     solveDeferred fc n

--- a/src/Idris/Elab/Value.hs
+++ b/src/Idris/Elab/Value.hs
@@ -26,6 +26,7 @@ import Prelude hiding (id, (.))
 
 import Control.Category
 import Data.Char (toLower)
+import qualified Data.Set as S ()
 import qualified Data.Traversable as Traversable
 
 -- | Elaborate a value, returning any new bindings created (this will only

--- a/src/Idris/ElabDecls.hs
+++ b/src/Idris/ElabDecls.hs
@@ -41,7 +41,9 @@ import Control.Category
 import Control.Monad
 import Control.Monad.State.Strict as State
 import Data.Maybe
+import qualified Data.Set as S
 import qualified Data.Text as T
+
 
 -- | Top level elaborator info, supporting recursive elaboration
 recinfo :: FC -> ElabInfo
@@ -260,7 +262,7 @@ elabDecl' what info (POpenInterfaces f ns ds)
 elabDecl' what info (PNamespace n nfc ps) =
   do mapM_ (elabDecl' what ninfo) ps
      let ns = reverse (map T.pack newNS)
-     sendHighlighting [(nfc, AnnNamespace ns Nothing)]
+     sendHighlighting $ S.fromList [(FC' nfc, AnnNamespace ns Nothing)]
   where
     newNS = n : namespace info
     ninfo = info { namespace = newNS }

--- a/src/Idris/Parser/Helpers.hs
+++ b/src/Idris/Parser/Helpers.hs
@@ -89,6 +89,7 @@ import Data.List
 import qualified Data.List.NonEmpty as NonEmpty
 import qualified Data.Map as M
 import Data.Maybe
+import qualified Data.Set as S
 import qualified Data.Text as T
 import Text.Megaparsec ((<?>))
 import qualified Text.Megaparsec as P
@@ -112,7 +113,7 @@ token p = trackExtent p <* whiteSpace
 highlight :: (MonadState IState m, Parsing m) => OutputAnnotation -> m a -> m a
 highlight annot p = do
   (result, fc) <- withExtent p
-  modify $ \ist -> ist { idris_parserHighlights = (fc, annot) : idris_parserHighlights ist }
+  modify $ \ist -> ist { idris_parserHighlights = S.insert (FC' fc, annot) (idris_parserHighlights ist) }
   return result
 
 -- | Parse a reserved identfier, highlighting it as a keyword


### PR DESCRIPTION
Highlighting information was contained in an association list. Not
only were there duplicates in the list, nubbing the list resulted in
performance losses on proper sized code bases.

We migrate the lists to sets and use `FC'` to ensure no false
positives are returned when comparing to elements in the list. `FC'`
is `FC` but with equality.

Anecdotal tests show good performance improvements wrt to code highlighting.