### PR TITLE
Flushing progress reports after every newline

### DIFF
--- a/src/Idris/AbsSyntax.hs
+++ b/src/Idris/AbsSyntax.hs
@@ -1065,7 +1065,7 @@ iReport level msg = do
   i <- getIState
   when (level <= verbosity) $
     case idris_outputmode i of
-      RawOutput h -> runIO $ hPutStrLn h msg
+      RawOutput h -> runIO $ hPutStrLn h msg >> hFlush h
       IdeMode n h -> runIO . hPutStrLn h $ convSExp "write-string" msg n
   return ()
 


### PR DESCRIPTION
This makes progress reporting work even on non-tty outputs, e.g. when piping to a file.

My main motivation is to have this for [nixpkgs](https://github.com/NixOS/nixpkgs), which currently doesn't have any indication of progress throughout a package build, see https://github.com/NixOS/nixpkgs/pull/42647 for a hacky fix.