### PR TITLE
fix the type of end grammar in someTill'

### DIFF
--- a/libs/contrib/Text/Parser.idr
+++ b/libs/contrib/Text/Parser.idr
@@ -118,7 +118,7 @@ mutual
 ||| list of values from `p`, along with a proof that the resulting list is
 ||| non-empty.
 someTill' : {c : Bool} ->
-            (end : Grammar tok c a) ->
+            (end : Grammar tok c e) ->
             (p : Grammar tok True a) ->
             Grammar tok True (xs : List a ** NonEmpty xs)
 someTill' end p


### PR DESCRIPTION
The type of `someTill'` currently assumes that the `end` marker has the same type as the `List` being collected. This doesn't align with the types of `someTill` and `manyTill` and seems like a typo.