### PR TITLE
Bump the network upper bounds.

### DIFF
--- a/idris.cabal
+++ b/idris.cabal
@@ -291,7 +291,7 @@ Library
                 , ieee754 >= 0.7 && < 0.9
                 , megaparsec >= 6.2
                 , mtl >= 2.1 && < 2.3
-                , network < 2.7
+                , network < 2.8
                 , optparse-applicative >= 0.13 && < 0.15
                 , pretty < 1.2
                 , process < 1.7


### PR DESCRIPTION
This is already being done to build the Idris package on Arch Linux:
https://git.archlinux.org/svntogit/community.git/tree/trunk/PKGBUILD?h=packages/idris#n30