### PR TITLE
More interface implementations for Data.Morphisms

### DIFF
--- a/libs/base/Data/Morphisms.idr
+++ b/libs/base/Data/Morphisms.idr
@@ -32,7 +32,7 @@ Semigroup a => Semigroup (Morphism r a) where
   f <+> g = [| f <+> g |]
 
 Monoid a => Monoid (Morphism r a) where
-  neutral = Mor $ const neutral
+  neutral = [| neutral |]
 
 Semigroup (Endomorphism a) where
   (Endo f) <+> (Endo g) = Endo $ g . f
@@ -55,7 +55,7 @@ Monad f => Monad (Kleislimorphism f a) where
   f <+> g = [| f <+> g |]
 
 (Monoid a, Applicative f) => Monoid (Kleislimorphism f r a) where
-  neutral = Kleisli $ const $ pure neutral
+  neutral = [| neutral |]
 
 Cast (Endomorphism a) (Morphism a a) where
   cast (Endo f) = Mor f

--- a/libs/base/Data/Morphisms.idr
+++ b/libs/base/Data/Morphisms.idr
@@ -28,6 +28,12 @@ Applicative (Morphism r) where
 Monad (Morphism r) where
   (Mor h) >>= f = Mor $ \r => applyMor (f $ h r) r
 
+Semigroup a => Semigroup (Morphism r a) where
+  f <+> g = [| f <+> g |]
+
+Monoid a => Monoid (Morphism r a) where
+  neutral = Mor $ const neutral
+
 Semigroup (Endomorphism a) where
   (Endo f) <+> (Endo g) = Endo $ g . f
 
@@ -43,6 +49,13 @@ Applicative f => Applicative (Kleislimorphism f a) where
 
 Monad f => Monad (Kleislimorphism f a) where
   (Kleisli f) >>= g = Kleisli $ \r => applyKleisli (g !(f r)) r
+
+-- Applicative is a bit too strong, but there is no suitable superclass
+(Semigroup a, Applicative f) => Semigroup (Kleislimorphism f r a) where
+  f <+> g = [| f <+> g |]
+
+(Monoid a, Applicative f) => Monoid (Kleislimorphism f r a) where
+  neutral = Kleisli $ const $ pure neutral
 
 Cast (Endomorphism a) (Morphism a a) where
   cast (Endo f) = Mor f

--- a/libs/base/Data/Morphisms.idr
+++ b/libs/base/Data/Morphisms.idr
@@ -34,6 +34,16 @@ Semigroup (Endomorphism a) where
 Monoid (Endomorphism a) where
   neutral = Endo id
 
+Functor f => Functor (Kleislimorphism f a) where
+  map f (Kleisli g) = Kleisli (map f . g)
+
+Applicative f => Applicative (Kleislimorphism f a) where
+  pure a = Kleisli $ const $ pure a
+  (Kleisli f) <*> (Kleisli a) = Kleisli $ \r => f r <*> a r
+
+Monad f => Monad (Kleislimorphism f a) where
+  (Kleisli f) >>= g = Kleisli $ \r => applyKleisli (g !(f r)) r
+
 Cast (Endomorphism a) (Morphism a a) where
   cast (Endo f) = Mor f
 


### PR DESCRIPTION
* `data` types + accessor functions turned into `record`s
* `Monad` constraint on `Kleislimorphism` nixed
   * Side note: is it possible to remove the duplication between `Kleislimorphism` and `ReaderT`?
* "Reader-style" `Semigroup` and `Monoid` for (`Kleisli`)`Morphism`
* `Functor`/`Applicative`/`Monad` for `Kleislimorphism`