### PR TITLE
Add perl, nodejs to stack-shell.nix

### DIFF
--- a/stack-shell.nix
+++ b/stack-shell.nix
@@ -3,10 +3,12 @@ with (import <nixpkgs> {});
 
 let
   libs = [
-    libffi
-    zlib
-    ncurses
     gmp
+    libffi
+    ncurses
+    nodejs
+    perl
+    zlib
   ];
   native_libs = lib.optionals stdenv.isDarwin (with darwin.apple_sdk.frameworks; [
     Cocoa


### PR DESCRIPTION
Currently, `stack --nix test` fails because the tests depend on `nodejs` and `perl`.

This pull-request adds them to the build dependencies for the stack shell.