### PR TITLE
Raise an error if too many "with" arguments are provided

### DIFF
--- a/src/Idris/Elab/Clause.hs
+++ b/src/Idris/Elab/Clause.hs
@@ -660,11 +660,13 @@ elabClause info opts (cnum, PClause fc fname lhs_in_as withs rhs_in_as wherebloc
         i <- getIState
         inf <- isTyInferred fname
 
-        -- Check if we have "with" patterns outside of "with" block
-        when (isOutsideWith lhs_in && (not $ null withs)) $
+        -- Check if we have extra "with" patterns
+        when (not $ null withs) $
             ierror (At (fromMaybe NoFC $ highestFC lhs_in_as)
                        (Elaborating "left hand side of " fname Nothing
-                        (Msg "unexpected patterns outside of \"with\" block")))
+                        (Msg $ if isOutsideWith lhs_in
+                               then "unexpected patterns outside of \"with\" block"
+                               else "unexpected extra \"with\" patterns")))
 
         -- get the parameters first, to pass through to any where block
         let fn_ty = case lookupTy fname ctxt of

--- a/test/error006/WithPatsNoWith.idr
+++ b/test/error006/WithPatsNoWith.idr
@@ -4,3 +4,14 @@ foo : Int -> Bool
 foo 1 | 2 | 3 = True
 foo _ = False
 
+foo2: Int -> Bool
+foo2 n with (succ n)
+  foo2 n | 1 | 2 = True
+  foo2 _ | _ = False
+
+foo3: Int -> Int -> Bool
+foo3 n m with (succ n)
+  foo3 _ m | 2 with (succ m)
+    foo3 _ _ | 2 | 3 | 4 = True
+    foo3 _ _ | 2 | _     = False
+  foo3 _ _ | _ = True

--- a/test/error006/expected
+++ b/test/error006/expected
@@ -5,3 +5,17 @@ WithPatsNoWith.idr:4:1-13:
 When checking left hand side of foo:
 unexpected patterns outside of "with" block
 
+WithPatsNoWith.idr:9:3-16:
+  |
+9 |   foo2 n | 1 | 2 = True
+  |   ~~~~~~~~~~~~~~
+When checking left hand side of with block in WithPatsNoWith.foo2:
+unexpected extra "with" patterns
+
+WithPatsNoWith.idr:15:5-24:
+   |
+15 |     foo3 _ _ | 2 | 3 | 4 = True
+   |     ~~~~~~~~~~~~~~~~~~~~
+When checking left hand side of with block in with block in WithPatsNoWith.foo3:
+unexpected extra "with" patterns
+


### PR DESCRIPTION
Fixes #4238 

It appears that during elaboration, any `withs` in a  `PClause` are extraneous, so we can throw an error if they are present. I'm not 100% confident about that however, so please let me know if I'm missing any case.