### PR TITLE
Strengthen `elemSmallerThanBound`

### DIFF
--- a/libs/contrib/Data/Fin/Extra.idr
+++ b/libs/contrib/Data/Fin/Extra.idr
@@ -4,6 +4,6 @@ import Data.Fin
 
 ||| Proof that an element **n** of Fin **m** , when converted to Nat is smaller than the bound **m**.
 public export
-elemSmallerThanBound : (n : Fin m) -> LTE (finToNat n) m
-elemSmallerThanBound FZ = LTEZero
+elemSmallerThanBound : (n : Fin m) -> LT (finToNat n) m
+elemSmallerThanBound FZ = LTESucc LTEZero
 elemSmallerThanBound (FS x) = LTESucc (elemSmallerThanBound x)


### PR DESCRIPTION
I found myself proving something along the lines of `Data.Fin.Extra.elemSmallerThanBound`, before stumbling over this implementation. However, my version was a tiny bit stronger, and I think this one should be, too. :wink:

For a `n : Fin m`, we have `n < m`, whereas `elemSmallerThanBound` only proves `n <= m`, even though the name and the docstring suggest otherwise.

If we want the old behavior back, something like

```idris
elemLteBound : (n : Fin m) -> LTE (finToNat n) m
elemLteBound = lteSuccLeft . elemSmallerThanBound
```

should suffice. However, I don't think that it's worth including that in the library, but that's not a strong opinion.