### PR TITLE
Add an upper bound on megaparsec

### DIFF
--- a/idris.cabal
+++ b/idris.cabal
@@ -289,7 +289,7 @@ Library
                 , fingertree >= 0.1.4.1 && < 0.2
                 , haskeline >= 0.7 && < 0.8
                 , ieee754 >= 0.7 && < 0.9
-                , megaparsec >= 6.2
+                , megaparsec >= 6.2 && < 7
                 , mtl >= 2.1 && < 2.3
                 , network < 2.8
                 , optparse-applicative >= 0.13 && < 0.15


### PR DESCRIPTION
Megaparsec has redone how the source positions in
errors are handled in an incompatible way.

Fixes #4551