### PR TITLE
[ docs ] definitions in the same order as in the source file

### DIFF
--- a/src/Idris/IdrisDoc.hs
+++ b/src/Idris/IdrisDoc.hs
@@ -427,13 +427,12 @@ createNsDoc :: IState   -- ^ Needed to determine the types of names
                         --   documentation will be written.
             -> IO ()
 createNsDoc ist ns content out =
-  do let tpath                   = out </> "docs" </> (genRelNsPath ns "html")
-         dir                     = takeDirectory tpath
-         file                    = takeFileName tpath
-         haveDocs (_, Just d, _) = [d]
-         haveDocs _              = []
+  do let tpath               = out </> "docs" </> (genRelNsPath ns "html")
+         dir                 = takeDirectory tpath
+         file                = takeFileName tpath
+         haveDocs (_, md, _) = md
                                  -- We cannot do anything without a Doc
-         content'                = concatMap haveDocs (nsContents content)
+         content'            = reverse $ mapMaybe haveDocs $ nsContents content
      createDirectoryIfMissing True dir
      (path, h) <- openTempFileWithDefaultPermissions dir file
      BS2.hPut h $ renderHtml $ wrapper (Just ns) $ do


### PR DESCRIPTION
I got annoyed with the fact that docs were listing definitions in
reverse order with respect to the source file. This mean that they
were presenting traversals before the type they are working on has
been introduced. This fixes that problem.

Also, we don't need to go *via* lists to get rid of the `Nothing`s.