### PR TITLE
Fixes for GHC 8.6

### DIFF
--- a/src/Idris/Core/CaseTree.hs
+++ b/src/Idris/Core/CaseTree.hs
@@ -549,19 +549,19 @@ caseGroups (v:vs) gs err = do g <- altGroups gs
 
     altGroup n i args
          = do inacc <- inaccessibleArgs n
-              (newVars, accVars, inaccVars, nextCs) <- argsToAlt inacc args
+              ~(newVars, accVars, inaccVars, nextCs) <- argsToAlt inacc args
               matchCs <- match (accVars ++ vs ++ inaccVars) nextCs err
               return $ ConCase n i newVars matchCs
 
-    altFnGroup n args = do (newVars, _, [], nextCs) <- argsToAlt [] args
+    altFnGroup n args = do ~(newVars, _, [], nextCs) <- argsToAlt [] args
                            matchCs <- match (newVars ++ vs) nextCs err
                            return $ FnCase n newVars matchCs
 
-    altSucGroup args = do ([newVar], _, [], nextCs) <- argsToAlt [] args
+    altSucGroup args = do ~([newVar], _, [], nextCs) <- argsToAlt [] args
                           matchCs <- match (newVar:vs) nextCs err
                           return $ SucCase newVar matchCs
 
-    altConstGroup n args = do (_, _, [], nextCs) <- argsToAlt [] args
+    altConstGroup n args = do ~(_, _, [], nextCs) <- argsToAlt [] args
                               matchCs <- match vs nextCs err
                               return $ ConstCase n matchCs
 

--- a/src/Idris/Elab/Term.hs
+++ b/src/Idris/Elab/Term.hs
@@ -448,7 +448,7 @@ elab ist info emode opts fn tm
              -- the full set.
              uns <- get_usedns
              let as' = map (mkUniqueNames (uns ++ map snd ms) ms) as_pruned
-             (h : hs) <- get_holes
+             ~(h : hs) <- get_holes
              ty <- goal
              case as' of
                   [] -> do hds <- mapM showHd as
@@ -984,7 +984,7 @@ elab ist info emode opts fn tm
                                             (elab' ina fc Placeholder)
                                             (show f)
     elab' ina fc Placeholder
-        = do (h : hs) <- get_holes
+        = do ~(h : hs) <- get_holes
              movelast h
     elab' ina fc (PMetavar nfc n) =
           do ptm <- get_term
@@ -1251,7 +1251,7 @@ elab ist info emode opts fn tm
     elab' ina fc (PHidden t)
       | reflection = elab' ina fc t
       | otherwise
-        = do (h : hs) <- get_holes
+        = do ~(h : hs) <- get_holes
              -- Dotting a hole means that either the hole or any outer
              -- hole (a hole outside any occurrence of it)
              -- must be solvable by unification as well as being filled
@@ -1259,7 +1259,7 @@ elab ist info emode opts fn tm
              -- Delay dotted things to the end, then when we elaborate them
              -- we can check the result against what was inferred
              movelast h
-             (h' : hs) <- get_holes
+             ~(h' : hs) <- get_holes
              -- If we're at the end anyway, do it now
              if h == h' then elabHidden h
                         else delayElab 10 $ elabHidden h

--- a/src/Idris/Parser/Stack.hs
+++ b/src/Idris/Parser/Stack.hs
@@ -117,9 +117,9 @@ addExtent = tell
 -- extent is taking trailing whitespace, it's likely there's a double-wrapped
 -- parser (usually via @Idris.Parser.Helpers.token@).
 trackExtent :: Parsing m => m a -> m a
-trackExtent p = do (FC f (sr, sc) _) <- getFC
+trackExtent p = do ~(FC f (sr, sc) _) <- getFC
                    result <- p
-                   (FC f _ (er, ec)) <- getFC
+                   ~(FC f _ (er, ec)) <- getFC
                    addExtent (FC f (sr, sc) (er, max 1 (ec - 1)))
                    return result
 


### PR DESCRIPTION
The MonadFail proposal  removes fail from some of our monads, changing
the desugaring of some patterns in do-blocks.
Assume that we know what we're doing and make the patterns irrefutable.