### PR TITLE
Added Proposition interface.

### DIFF
--- a/libs/contrib/Interfaces/Proposition.idr
+++ b/libs/contrib/Interfaces/Proposition.idr
@@ -1,0 +1,32 @@
+module Interfaces.Proposition
+
+%default total
+%access public export
+
+
+||| A canonical proof that some type containing no more than one value,
+||| comprising a mere proposition.
+interface Proposition t where
+  ||| If there are two values of t, prove that they are actually the same
+  atMostOneValue : (x : t) -> (y : t) -> x = y
+
+Proposition () where
+  atMostOneValue () () = Refl
+
+Proposition Void where
+  atMostOneValue _ _ impossible
+  
+Proposition (x = y) where
+  atMostOneValue Refl Refl = Refl
+
+Proposition (LTE m n) where
+  atMostOneValue {m=Z} LTEZero LTEZero = Refl
+  atMostOneValue {m=S _} (LTESucc x) (LTESucc y) = cong $ atMostOneValue x y
+  
+Proposition (NonEmpty xs) where
+  atMostOneValue IsNonEmpty IsNonEmpty = Refl
+
+(Proposition a, Proposition b) => Proposition (a, b) where
+  atMostOneValue (x1, y1) (x2, y2) =
+    rewrite atMostOneValue x1 x2 in
+      rewrite atMostOneValue y1 y2 in Refl

--- a/libs/contrib/contrib.ipkg
+++ b/libs/contrib/contrib.ipkg
@@ -70,6 +70,7 @@ modules = CFFI
 
         , Interfaces.Correlative
         , Interfaces.Verified
+        , Interfaces.Proposition
 
         , Language.JSON
         , Language.JSON.Data


### PR DESCRIPTION
Suggested a standard proof, that some type has at most one value. It can be useful for some equality proofs, e.g. in [this example](https://github.com/stop-cran/Idris-Fraction/blob/master/Fraction.idr#L105).
As per [previous discussion](https://github.com/idris-lang/Idris-dev/pull/4575) moved the definition to `contrib` and renamed the interface:

```
interface Proposition t where
  atMostOneValue : (x : t) -> (y : t) -> x = y
```