### PR TITLE
`total` implementation for `List.transpose`

### DIFF
--- a/libs/prelude/Prelude/List.idr
+++ b/libs/prelude/Prelude/List.idr
@@ -436,12 +436,12 @@ intercalate sep xss = concat $ intersperse sep xss
 |||
 |||     transpose [[], [1, 2]] = [[1], [2]]
 |||     transpose (transpose [[], [1, 2]]) = [[1, 2]]
-|||
-||| TODO: Solution which satisfies the totality checker?
 transpose : List (List a) -> List (List a)
 transpose [] = []
-transpose ([] :: xss) = transpose xss
-transpose ((x::xs) :: xss) = assert_total $ (x :: (mapMaybe head' xss)) :: (transpose (xs :: (map (drop 1) xss)))
+transpose (heads :: tails) = spreadHeads heads (transpose tails) where
+  spreadHeads []              tails           = tails
+  spreadHeads (head :: heads) []              = [head] :: spreadHeads heads []
+  spreadHeads (head :: heads) (tail :: tails) = (head :: tail) :: spreadHeads heads tails
 
 --------------------------------------------------------------------------------
 -- Membership tests


### PR DESCRIPTION
The behaviour of the original non-total version was poorly specified (the example in the doc comment gives some hints, but not many).  This version:

* Transposes "rectangular" matrices (i.e. it agrees with `Vect.transpose` where that would apply)

* For non-rectangular matrices it (conceptually) squashes gaps from below before transposing:

    ```
    [ 1 2   ] *
    [ 3 4 5 ]
    ==>
    [ 1 2 5 ] *
    [ 3 4   ]
    ==>
    [ 1 3 ]
    [ 2 4 ]
    [ 5   ]
    ```

* This version agrees with the documentation example (which is a special case of the previous bullet)