### PR TITLE
Use last element instead of first to seed foldr1

### DIFF
--- a/libs/base/Data/Vect.idr
+++ b/libs/base/Data/Vect.idr
@@ -315,7 +315,8 @@ concat (v::vs) = v ++ concat vs
 
 ||| Foldr without seeding the accumulator
 foldr1 : (t -> t -> t) -> Vect (S n) t -> t
-foldr1 f (x::xs) = foldr f x xs
+foldr1 f [x]        = x
+foldr1 f (x::y::xs) = f x (foldr1 f (y::xs))
 
 ||| Foldl without seeding the accumulator
 foldl1 : (t -> t -> t) -> Vect (S n) t -> t


### PR DESCRIPTION
`foldr1` currently uses the first element of the vector to seed the accumulator, instead of the last as is customary. An example erroneous result of this is that `Data.Vect.foldr1 (++) ["1","2","3","4"]` evaluates to  `"2341"`` instead of `"1234"`.

I realize that my PR is not optimal given that we probably want `foldr1` to be implemented in terms of `foldr`, but I was unable to find a satisfactory implementation. Looking at Haskell's implementation  in `Data.Foldable`, they solve it using a `Maybe` wrapper:

```haskell
foldr1 :: (a -> a -> a) -> t a -> a
foldr1 f xs = fromMaybe (errorWithoutStackTrace "foldr1: empty structure")
                        (foldr mf Nothing xs)
      where
        mf x m = Just (case m of
                         Nothing -> x
                         Just y  -> f x y)
```

Translated to Idris, this gives us the following, but the call to `fromMaybe` feels very unsatisfactory to me, since we know that the result will never be `Nothing`. I suspect that some kind of proof could be passed along the chain, but am not enough of a wizard to figure that out.

```idris
foldr1' : (a -> a -> a) -> Vect (S n) a -> a
foldr1' f xs = fromMaybe (head xs) (foldr mf Nothing xs)
  where
    mf : a -> Maybe a -> Maybe a
    mf x m = Just (case m of
                     Nothing => x
                     Just y  => f x y)
```