### PR TITLE
Make Identity an instance of Semigroup/Monoid

### DIFF
--- a/libs/base/Control/Monad/Identity.idr
+++ b/libs/base/Control/Monad/Identity.idr
@@ -29,3 +29,9 @@ Enum a => Enum (Identity a) where
   toNat (Id x) = toNat x
   fromNat n = Id $ fromNat n
   pred (Id n) = Id $ pred n
+
+(Semigroup a) => Semigroup (Identity a) where
+  (<+>) x y = Id (runIdentity x <+> runIdentity y)
+
+(Monoid a) => Monoid (Identity a) where
+  neutral = Id (neutral)


### PR DESCRIPTION
Make Identity an instance of Semigroup/Monoid (for Semigroup/Monoid datatypes).

#4635