### PR TITLE
Replace hardcoded constants from <sys/socket.h> with FFI references

### DIFF
--- a/libs/contrib/Network/Socket/Data.idr
+++ b/libs/contrib/Network/Socket/Data.idr
@@ -71,15 +71,15 @@ Show SocketFamily where
   show AF_INET6  = "AF_INET6"
 
 ToCode SocketFamily where
-  toCode AF_UNSPEC = 0
-  toCode AF_INET   = 2
-  toCode AF_INET6  = 10
+  toCode AF_UNSPEC = unsafePerformIO (foreign FFI_C "#AF_UNSPEC" (IO Int))
+  toCode AF_INET   = unsafePerformIO (foreign FFI_C "#AF_INET" (IO Int))
+  toCode AF_INET6  = unsafePerformIO (foreign FFI_C "#AF_INET6" (IO Int))
 
 getSocketFamily : Int -> Maybe SocketFamily
 getSocketFamily i =
-    Prelude.List.lookup i [ (0, AF_UNSPEC)
-                          , (2, AF_INET)
-                          , (10, AF_INET6)
+    Prelude.List.lookup i [ (toCode AF_UNSPEC, AF_UNSPEC)
+                          , (toCode AF_INET, AF_INET)
+                          , (toCode AF_INET6, AF_INET6)
                           ]
 
 -- ------------------------------------------------------------ [ Socket Types ]


### PR DESCRIPTION
Current contrib module `Network.Socket` hardcodes constants from the Linux headers (e.g. AF_INET6 = 10). On Linux systems (and probably others) this is not a problem, however on other OSes (namely Darwin/macOS) those constants have different values (e.g. on macOS 10.14, AF_INET6 = 30).

This change guarantees that the mapped Int values are correct across platforms. More specifically, it allows creating IPv6 sockets on macOS.

I'm not sure about the `unsafePerformIO` wrappers, but I found similar code in the `strError` function in `Prelude.File`, so hopefully this is acceptable.

# Code to reproduce

```idris
module Main

import Network.Socket

main : IO ()
main = do
  putStrLn ("toCode AF_INET6 == " ++ (show (toCode AF_INET6)))
  putStrLn ("getSocketFamily 30 == " ++ (show (getSocketFamily 30)))
  sock <- socket AF_INET Stream 0
  case sock of
       Right _ => putStrLn "INET ok"
       Left _ => putStrLn "INET fail"
  sock <- socket AF_INET6 Stream 0
  case sock of
       Right _ => putStrLn "INET6 ok"
       Left _ => putStrLn "INET6 fail"
```

# Expected Behavior (on macOS)
```
toCode AF_INET6 == 30
getSocketFamily 30 == Just AF_INET6
INET ok
INET6 ok
```
(This is the behaviour after applying this patch)

# Observed Behavior with current master (on macOS)
```
toCode AF_INET6 == 10
getSocketFamily 30 == Nothing
INET ok
INET6 fail
```