### PR TITLE
Add correct version of the `network` pkg as extra dep

### DIFF
--- a/stack.yaml
+++ b/stack.yaml
@@ -7,6 +7,7 @@ packages:
 extra-deps:
   - megaparsec-7.0.4
   - parser-combinators-1.0.0
+  - network-2.8.0.0
 
 
 flags:


### PR DESCRIPTION
The version of the `network` package in the chosen Stackage snapshot does not match the one needed by Idris. This change adds the needed package as an external package.