### PR TITLE
add to proof documentation

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,4 +1,5 @@
 # New in next version
++ Documentation added to proof section
 
 ## Tool updates
 + Modules no longer require building if imports have changed but all

--- a/CONTRIBUTORS
+++ b/CONTRIBUTORS
@@ -143,6 +143,7 @@ Luke Palmer
 Mark Farrell
 Markus Klink
 Markus Pfeiffer
+Martin Baker
 Mathnerd314
 Mattias Lundell
 Matvey B. Aksenov

--- a/docs/proofs/definitional.rst
+++ b/docs/proofs/definitional.rst
@@ -6,8 +6,6 @@ In order to understand how to write proofs in Idris I think its worth clarifying
 -  Definitional and propositional equalities
 -  Axiomatic and constructive approaches
 
-If you have experience in logic or using proof assistants like Coq then     you may already know this stuff so you can  skip this page.
-
 Propositions and Judgments
 ==========================
 

--- a/docs/proofs/definitional.rst
+++ b/docs/proofs/definitional.rst
@@ -13,29 +13,29 @@ Propositions and Judgments
 
 Propositions are the subject of our proofs, before the proof then we can't formally say if they are true or not. If the proof is successful then the result is a 'judgment'.
 For instance, if the ``proposition`` is,
-  <table border="1">
-    <tr>
-      <td>1+1=2</td>
-    </tr>
-  </table>
+
++-------+
+| 1+1=2 |
++-------+
+
 When we prove it, the ``judgment`` is,
-  <table border="1">
-    <tr>
-      <td>1+1=2 true</td>
-    </tr>
-  </table>
+
++------------+
+| 1+1=2 true |
++------------+
+
 Or if the ``proposition`` is,
-  <table border="1">
-    <tr>
-      <td>1+1=3</td>
-    </tr>
-  </table>
+
++-------+
+| 1+1=3 |
++-------+
+
 Obviously  we can't prove it is true, but it is still a valid proposition and perhaps we can prove it is false so the ``judgment`` is, 
-  <table border="1">
-    <tr>
-      <td>1+1=3 false</td>
-    </tr>
-  </table>
+
++-------------+
+| 1+1=3 false |
++-------------+
+
 This may seem a bit pedantic but it is important to be careful,  in mathematics not every proposition is true or false for instance, a proposition may be unproven or even unprovable.
 
 So the logic here is different from the logic that comes from boolean algebra. In that case what is not true is false and what is not false is true. The logic we are using here does not have this 'law of excluded middle' so we have to be careful not to use it.
@@ -60,29 +60,26 @@ The way that this works is that a  proposition is a type so this,
 
 is a proposition and it is also a type. This is built into Idris so when an '=' equals sign appears in a function type an equality type is generated. The following will also produce an equality type:
 
-<table border="1">
-    <tr>
-      <td><pre>Idris> 1+1=3
-<span class="style1">2 = <span class="style1">3 : Type</pre></td>
-    </tr>
-</table>
+
+.. code-block:: idris
+
+   Idris> 1+1=3
+   2 = 3 : Type
 
 Both of these are valid propositions so both are valid equality types. But how do we represent true judgment, that is, how do we denote 1+1=2 is true but not 1+1=3.
 A type that is true is inhabited, that is, it can be constructed. An equality type has only on constructor 'Refl' so a proof of 1+1=2 is
 
-<table border="1">
-    <tr>
-      <td><pre>onePlusOne : 1+1=2
-onePlusOne = Refl</pre></td>
-    </tr>
-</table>
+.. code-block:: idris
+
+   onePlusOne : 1+1=2
+   onePlusOne = Refl
 
 So how can Refl, which is a constructor without any parameters, construct and equality type? If we type it on its own then it can't:
 
 .. code-block:: idris
 
   Idris> Refl
-  (input):Can't infer argument A to <span class="style1">Refl, Can't infer argument x to <span class="style1">Refl
+  (input):Can't infer argument A to Refl, Can't infer argument x to Refl
 
 So it must pattern match on its return type:
 
@@ -170,10 +167,11 @@ Especially when working with equalities containing variable terms (inside functi
 
 plusReducesR gives the following error:
 
-<table border="1">
-    <tr>
-      <td><pre>- + Errors (1)
- `-- proof.idr line 6 col 17:
+
+.. code-block:: idris
+
+   - + Errors (1)
+   `-- proof.idr line 6 col 17:
      When checking right hand side of plusReducesR with expected type
              plus n 0 = n
 
@@ -186,9 +184,7 @@ plusReducesR gives the following error:
              Type mismatch between
                      n
              and
-                     plus n 0</pre></td>
-    </tr>
-</table>
+                     plus n 0
 
 So why is 'Refl' able to prove some equality types but not others?
 
@@ -200,7 +196,7 @@ So when we type 1+1 in Idris it is immediately converted to 2 because definition
 
 .. code-block:: idris
 
-    Idris&gt; 1+1
+    Idris> 1+1
     2 : Integer
 
 In the following pages we discuss how to resolve propositionaly equalies.
@@ -218,12 +214,11 @@ Then we can implement '+' so that it respects these axioms (presumably implement
 
 These are axioms, that is a propositions/types that are asserted to be true without proof. In Idris we can use the 'postulate' keyword 
 
-  <table border="1">
-    <tr>
-      <td><pre>comutePlus ``postulate``: x -&gt; y -&gt; plus x y = plus y x
-</pre></td>
-    </tr>
-  </table>
+
+.. code-block:: idris
+
+   commutePlus ``postulate``: x -> y -> plus x y = plus y x
+
 Alternatively we could define the natural numbers based on Zero and Successor. The axioms above then become derived rules and we also gain the ability to do inductive proofs.
 
 As we know, Idris uses both of these approaches with automatic coercion between them which gives the best of both worlds.
@@ -232,3 +227,7 @@ So what can we learn from this to implement out own types:
 
 -  Should we try to implement both approaches?
 -  Should we define our types by constructing up from primitive types?
+
+Proof theory affects these design decisions.
+
+

--- a/docs/proofs/definitional.rst
+++ b/docs/proofs/definitional.rst
@@ -52,34 +52,37 @@ Curry-Howard correspondence
 So how to we relate these proofs to Idris programs? It turns out that there is a correspondence between constructive logic and type theory. They are the same structure and we can switch backward and forward between the two notations because they are the same thing.
 
 The way that this works is that a  proposition is a type so this,
-  <table border="1">
-    <tr>
-      <td><pre>Idris> 1+1=2
-<span class="style1">2</span> <span class="style2">=</span> <span class="style1">2</span> : <span class="style2">Type</span>
-</pre></td>
-    </tr>
-  </table>
+
+.. code-block:: idris
+
+   Idris> 1+1=2
+   2 = 2 : Type
+
 is a proposition and it is also a type. This is built into Idris so when an '=' equals sign appears in a function type an equality type is generated. The following will also produce an equality type:
-  <table border="1">
+
+<table border="1">
     <tr>
       <td><pre>Idris> 1+1=3
-<span class="style1">2</span> <span class="style2">=</span> <span class="style1">3</span> : <span class="style2">Type</span></pre></td>
+<span class="style1">2 = <span class="style1">3 : Type</pre></td>
     </tr>
-  </table>
+</table>
+
 Both of these are valid propositions so both are valid equality types. But how do we represent true judgment, that is, how do we denote 1+1=2 is true but not 1+1=3.
 A type that is true is inhabited, that is, it can be constructed. An equality type has only on constructor 'Refl' so a proof of 1+1=2 is
-  <table border="1">
+
+<table border="1">
     <tr>
       <td><pre>onePlusOne : 1+1=2
 onePlusOne = Refl</pre></td>
     </tr>
-  </table>
-  <p>So how can Refl, which is a constructor without any parameters, construct and equality type? If we type it on its own then it can't: </p>
+</table>
+
+So how can Refl, which is a constructor without any parameters, construct and equality type? If we type it on its own then it can't:
 
 .. code-block:: idris
 
   Idris> Refl
-  (input):Can't infer argument A to <span class="style1">Refl</span>, Can't infer argument x to <span class="style1">Refl</span>
+  (input):Can't infer argument A to <span class="style1">Refl, Can't infer argument x to <span class="style1">Refl
 
 So it must pattern match on its return type:
 
@@ -90,48 +93,24 @@ So it must pattern match on its return type:
 
 So now that we can represent propositions as types other aspects of propositional logic can also be translated to types as follows:
 
-<table border="1">
-    <tr>
-      <th bgcolor="#FFFF00" scope="col">&nbsp;</th>
-      <th bgcolor="#FFFF00" scope="col">propositions</th>
-      <th bgcolor="#FFFF00" scope="col"> example of possible type</th>
-    </tr>
-    <tr>
-      <th bgcolor="#FFFF00" scope="row">A</th>
-      <td>A</td>
-      <td>x=y</td>
-    </tr>
-    <tr>
-      <th bgcolor="#FFFF00" scope="row">B</th>
-      <td>B</td>
-      <td>y=z</td>
-    </tr>
-    <tr>
-      <th bgcolor="#FFFF00" scope="row">and</th>
-      <td>A /\ B </td>
-      <td>Pair(x=y,y=z)</td>
-    </tr>
-    <tr>
-      <th bgcolor="#FFFF00" scope="row">or</th>
-      <td>A \/ B</td>
-      <td>Either(x=y,y=z)</td>
-    </tr>
-    <tr>
-      <th bgcolor="#FFFF00" scope="row">implies</th>
-      <td>A -&gt; B</td>
-      <td>(x=y) -&gt; (y=x)</td>
-    </tr>
-    <tr>
-      <th bgcolor="#FFFF00" scope="row">for all </th>
-      <td>&nbsp;</td>
-      <td>&nbsp;</td>
-    </tr>
-    <tr>
-      <th bgcolor="#FFFF00" scope="row">exists</th>
-      <td>&nbsp;</td>
-      <td>&nbsp;</td>
-    </tr>
-  </table>
++----------+-------------------+--------------------------+
+|          | propositions      | example of possible type |
++----------+-------------------+--------------------------+
+| A        | x=y               |                          |
++----------+-------------------+--------------------------+
+| B        | y=z               |                          |
++----------+-------------------+--------------------------+
+| and      | A /\ B            | Pair(x=y,y=z)            |
++----------+-------------------+--------------------------+
+| or       | A \/ B            | Either(x=y,y=z)          |
++----------+-------------------+--------------------------+
+| implies  | A -> B            | (x=y) -> (y=x)           |
++----------+-------------------+--------------------------+
+| for all  | y=z               |                          |
++----------+-------------------+--------------------------+
+| exists   | y=z               |                          |
++----------+-------------------+--------------------------+
+
 
 And (conjunction)
 -----------------
@@ -190,7 +169,8 @@ Especially when working with equalities containing variable terms (inside functi
    plusReducesR n = Refl
 
 plusReducesR gives the following error:
-  <table border="1">
+
+<table border="1">
     <tr>
       <td><pre>- + Errors (1)
  `-- proof.idr line 6 col 17:
@@ -208,7 +188,7 @@ plusReducesR gives the following error:
              and
                      plus n 0</pre></td>
     </tr>
-  </table>
+</table>
 
 So why is 'Refl' able to prove some equality types but not others?
 
@@ -221,7 +201,7 @@ So when we type 1+1 in Idris it is immediately converted to 2 because definition
 .. code-block:: idris
 
     Idris&gt; 1+1
-    2</span> : Integer
+    2 : Integer
 
 In the following pages we discuss how to resolve propositionaly equalies.
 

--- a/docs/proofs/definitional.rst
+++ b/docs/proofs/definitional.rst
@@ -1,0 +1,254 @@
+In order to understand how to write proofs in Idris I think its worth clarifying some fundamentals, such as,
+
+-  Propositions and judgments
+-  Boolean and constructive logic
+-  Curry-Howard correspondence
+-  Definitional and propositional equalities
+-  Axiomatic and constructive approaches
+
+If you have experience in logic or using proof assistants like Coq then     you may already know this stuff so you can  skip this page.
+
+Propositions and Judgments
+==========================
+
+Propositions are the subject of our proofs, before the proof then we can't formally say if they are true or not. If the proof is successful then the result is a 'judgment'.
+For instance, if the ``proposition`` is,
+  <table border="1">
+    <tr>
+      <td>1+1=2</td>
+    </tr>
+  </table>
+When we prove it, the ``judgment`` is,
+  <table border="1">
+    <tr>
+      <td>1+1=2 true</td>
+    </tr>
+  </table>
+Or if the ``proposition`` is,
+  <table border="1">
+    <tr>
+      <td>1+1=3</td>
+    </tr>
+  </table>
+Obviously  we can't prove it is true, but it is still a valid proposition and perhaps we can prove it is false so the ``judgment`` is, 
+  <table border="1">
+    <tr>
+      <td>1+1=3 false</td>
+    </tr>
+  </table>
+This may seem a bit pedantic but it is important to be careful,  in mathematics not every proposition is true or false for instance, a proposition may be unproven or even unprovable.
+
+So the logic here is different from the logic that comes from boolean algebra. In that case what is not true is false and what is not false is true. The logic we are using here does not have this 'law of excluded middle' so we have to be careful not to use it.
+
+A false proposition is taken to be a contradiction and if we have a contradiction then we can prove anything, so we need to avoid this. Some languages, used in proof assistants, prevent contradictions but such languages cannot be Turing complete, so Idris does not prevent contradictions.
+
+The logic we are using  is called constructive (or sometimes intuitional) because we are constructing a 'database' of judgments.
+
+There are also many other types of logic, another important type of logic for Idris programmers is '``linear logic``' but that's not discussed on this page.
+
+Curry-Howard correspondence
+===========================
+
+So how to we relate these proofs to Idris programs? It turns out that there is a correspondence between constructive logic and type theory. They are the same structure and we can switch backward and forward between the two notations because they are the same thing.
+
+The way that this works is that a  proposition is a type so this,
+  <table border="1">
+    <tr>
+      <td><pre>Idris> 1+1=2
+<span class="style1">2</span> <span class="style2">=</span> <span class="style1">2</span> : <span class="style2">Type</span>
+</pre></td>
+    </tr>
+  </table>
+is a proposition and it is also a type. This is built into Idris so when an '=' equals sign appears in a function type an equality type is generated. The following will also produce an equality type:
+  <table border="1">
+    <tr>
+      <td><pre>Idris> 1+1=3
+<span class="style1">2</span> <span class="style2">=</span> <span class="style1">3</span> : <span class="style2">Type</span></pre></td>
+    </tr>
+  </table>
+Both of these are valid propositions so both are valid equality types. But how do we represent true judgment, that is, how do we denote 1+1=2 is true but not 1+1=3.
+A type that is true is inhabited, that is, it can be constructed. An equality type has only on constructor 'Refl' so a proof of 1+1=2 is
+  <table border="1">
+    <tr>
+      <td><pre>onePlusOne : 1+1=2
+onePlusOne = Refl</pre></td>
+    </tr>
+  </table>
+  <p>So how can Refl, which is a constructor without any parameters, construct and equality type? If we type it on its own then it can't: </p>
+
+.. code-block:: idris
+
+  Idris> Refl
+  (input):Can't infer argument A to <span class="style1">Refl</span>, Can't infer argument x to <span class="style1">Refl</span>
+
+So it must pattern match on its return type:
+
+.. code-block:: idris
+
+    Idris> the (1=1) Refl
+    Refl : 1 = 1
+
+So now that we can represent propositions as types other aspects of propositional logic can also be translated to types as follows:
+
+<table border="1">
+    <tr>
+      <th bgcolor="#FFFF00" scope="col">&nbsp;</th>
+      <th bgcolor="#FFFF00" scope="col">propositions</th>
+      <th bgcolor="#FFFF00" scope="col"> example of possible type</th>
+    </tr>
+    <tr>
+      <th bgcolor="#FFFF00" scope="row">A</th>
+      <td>A</td>
+      <td>x=y</td>
+    </tr>
+    <tr>
+      <th bgcolor="#FFFF00" scope="row">B</th>
+      <td>B</td>
+      <td>y=z</td>
+    </tr>
+    <tr>
+      <th bgcolor="#FFFF00" scope="row">and</th>
+      <td>A /\ B </td>
+      <td>Pair(x=y,y=z)</td>
+    </tr>
+    <tr>
+      <th bgcolor="#FFFF00" scope="row">or</th>
+      <td>A \/ B</td>
+      <td>Either(x=y,y=z)</td>
+    </tr>
+    <tr>
+      <th bgcolor="#FFFF00" scope="row">implies</th>
+      <td>A -&gt; B</td>
+      <td>(x=y) -&gt; (y=x)</td>
+    </tr>
+    <tr>
+      <th bgcolor="#FFFF00" scope="row">for all </th>
+      <td>&nbsp;</td>
+      <td>&nbsp;</td>
+    </tr>
+    <tr>
+      <th bgcolor="#FFFF00" scope="row">exists</th>
+      <td>&nbsp;</td>
+      <td>&nbsp;</td>
+    </tr>
+  </table>
+
+And (conjunction)
+-----------------
+
+We can have a type which corresponds to conjunction:
+
+.. code-block:: idris
+
+   AndIntro : a -> b -> A a b
+
+There is a built in type called 'Pair'.
+
+Or (disjunction)
+----------------
+
+We can have a type which corresponds to disjunction:
+
+.. code-block:: idris
+
+   data Or : Type -&gt; Type -&gt; Type where
+   OrIntroLeft : a -&gt; A a b
+   OrIntroRight : b -&gt; A a b
+
+There is a built in type called 'Either'.
+
+Definitional and Propositional Equalities
+=========================================
+
+We have seen that  we can 'prove' a type by finding a way to construct a term. In the case of equality types there is only one constructor which is 'Refl'.
+We have also seen that each side of the equation does not have to be identical like '2=2'. It is enough that both sides are ``definitionaly equal`` like this:
+
+.. code-block:: idris
+
+   onePlusOne : 1+1=2
+   onePlusOne = Refl
+
+So both sides of this equation nomalise to 2 and so Refl will type match and the proposition is proved.
+
+We don't have to stick to terms, can also use symbolic parameters so the following  will compile:
+
+.. code-block:: idris
+
+   varIdentity : m = m
+   varIdentity = Refl
+
+If a proposition/equality type is not definitionaly equal but is still true then it is ``propositionaly equal``. In this case we may still be able to prove it but some steps in the proof may require us to add something into the terms or at least to take some sideways steps to get to a proof.
+
+Especially when working with equalities containing variable terms (inside functions) it can be hard to know which equality types are definitially equal, in this example plusReducesL is '``definitially equal``' but plusReducesR is not (although it is '``propositionaly equal``'). The only difference between them is the order of the operands.
+
+.. code-block:: idris
+
+   plusReducesL : (n:Nat) -&gt; plus Z n = n
+   plusReducesL n = Refl
+
+   plusReducesR : (n:Nat) -&gt; plus n Z = n
+   plusReducesR n = Refl
+
+plusReducesR gives the following error:
+  <table border="1">
+    <tr>
+      <td><pre>- + Errors (1)
+ `-- proof.idr line 6 col 17:
+     When checking right hand side of plusReducesR with expected type
+             plus n 0 = n
+
+     Type mismatch between
+             n = n (Type of Refl)
+     and
+             plus n 0 = n (Expected type)
+
+     Specifically:
+             Type mismatch between
+                     n
+             and
+                     plus n 0</pre></td>
+    </tr>
+  </table>
+
+So why is 'Refl' able to prove some equality types but not others?
+
+The first answer is that 'plus' is defined in such a way that it splits on its first argument so it is simple to prove when 0 is the first argument but not the second. So what is the general way to know if Refl will work?
+
+If an equality type can be proved/constructed by using Refl alone it is known as a ``definitional equality``. In order to be definitinally equal both sides of the equation must normalise to unique values. That is, each step in the proof must reduce the term so each step is effectively forced.
+
+So when we type 1+1 in Idris it is immediately converted to 2 because definitional equality is built in.
+
+.. code-block:: idris
+
+    Idris&gt; 1+1
+    2</span> : Integer
+
+In the following pages we discuss how to resolve propositionaly equalies.
+
+Axiomatic and Constructive Approaches
+=====================================
+
+How should we define types so that  we can do proofs on them? In the natural numbers with plus example we could have started by treating it as a group based on the plus operator. So we have axioms:
+
+-  for all x,y : ``x+y=y+x``
+-  for all x: ``x + 0 = x = 0 + x``
+-  for all x,y,z: ``(x + y) + z = x + (x + z)``
+
+Then we can implement '+' so that it respects these axioms (presumably implemented in hardware).
+
+These are axioms, that is a propositions/types that are asserted to be true without proof. In Idris we can use the 'postulate' keyword 
+
+  <table border="1">
+    <tr>
+      <td><pre>comutePlus ``postulate``: x -&gt; y -&gt; plus x y = plus y x
+</pre></td>
+    </tr>
+  </table>
+Alternatively we could define the natural numbers based on Zero and Successor. The axioms above then become derived rules and we also gain the ability to do inductive proofs.
+
+As we know, Idris uses both of these approaches with automatic coercion between them which gives the best of both worlds.
+
+So what can we learn from this to implement out own types:
+
+-  Should we try to implement both approaches?
+-  Should we define our types by constructing up from primitive types?

--- a/docs/proofs/index.rst
+++ b/docs/proofs/index.rst
@@ -22,5 +22,6 @@ A tutorial on theorem proving in Idris.
    pluscomm
    inductive
    patterns
+   propositional
    interactive
 

--- a/docs/proofs/index.rst
+++ b/docs/proofs/index.rst
@@ -18,6 +18,7 @@ A tutorial on theorem proving in Idris.
 .. toctree::
    :maxdepth: 1
 
+   definitional
    pluscomm
    inductive
    patterns

--- a/docs/proofs/propositional.rst
+++ b/docs/proofs/propositional.rst
@@ -1,0 +1,94 @@
+This page attempts to explain some of the techniques used in Idris to prove propositional equalities.
+
+Proving Propositional Equality
+==============================
+
+We have seen that definitional equalities can be proved using Refl since they always normalise to unique values that can be compared directly.
+
+However with propositional equalities we are using symbolic variables they do not always normalse.
+
+So to take the previous example:
+
+plusReducesR : (n:Nat) -> plus n Z = n
+
+In this case 'plus n Z' does not normalise to n. Even though both sides are equal we cannot pattern match Refl.
+
+If the pattern match cannot match for all 'n' then the way around this is to separately match all possible values of 'n'. In the case of natural numbers we do this by induction.
+
+So here:
+
+.. code-block:: idris
+
+   plusReducesR : n = plus n 0
+   plusReducesR {n = Z} = Refl
+   plusReducesR {n = (S k)} = let rec = plus_commutes_Z {n=k} in
+                                  rewrite rec in Refl
+
+we don't call Refl to match on 'n = plus n 0' forall 'n' we call it for every number separately. So, in the second line, somehow the pattern matcher knows to substitute Z for n in the type being matched.
+
+Replace
+=======
+
+If two terms are equal then they have the same properties. In our proofs we can express this as:
+
+   if x=y
+   then P x = P y
+
+where P is a pure function.
+
+To use this in our proofs there is the following function in the prelude: 
+
+.. code-block:: idris
+
+   ||| Perform substitution in a term according to some equality.
+   replace : {a:_} -> {x:_} -> {y:_} -> {P : a -> Type} -> x = y -> P x -> P y
+   replace Refl prf = prf
+
+Rewrite
+=======
+
+Similar to 'replace' above but Idris provides a nicer syntax which makes 'rewrite' easier to use in examples like plusReducesR above.
+
+.. code-block:: idris
+
+   ||| Perform substitution in a term according to some equality.
+   |||
+   ||| Like `replace`, but with an explicit predicate, and applying the rewrite
+   ||| in the other direction, which puts it in a form usable by the `rewrite`
+   ||| tactic and term.
+   rewrite__impl : (P : a -> Type) -> x = y -> P y -> P x
+   rewrite__impl p Refl prf = prf
+
+Symmetry and Transitivity
+=========================
+
+In addition to 'reflexivity' equality also obeys 'symmetry' and 'transitivity' and these are also included in the prelude:
+
+.. code-block:: idris
+
+   ||| Symmetry of propositional equality
+   sym : {left:a} -> {right:b} -> left = right -> right = left
+   sym Refl = Refl
+
+   ||| Transitivity of propositional equality
+   trans : {a:x} -> {b:y} -> {c:z} -> a = b -> b = c -> a = c
+   trans Refl Refl = Refl
+
+Heterogeneous Equality
+======================
+
+Also included in the prelude: 
+
+.. code-block:: idris
+
+   ||| Explicit heterogeneous ("John Major") equality. Use this when Idris
+   ||| incorrectly chooses homogeneous equality for `(=)`.
+   ||| @ a the type of the left side
+   ||| @ b the type of the right side
+   ||| @ x the left side
+   ||| @ y the right side
+   (~=~) : (x : a) -> (y : b) -> Type
+   (~=~) x y = (x = y)
+
+
+

--- a/docs/proofs/propositional.rst
+++ b/docs/proofs/propositional.rst
@@ -24,25 +24,44 @@ So here:
    plusReducesR {n = (S k)} = let rec = plus_commutes_Z {n=k} in
                                   rewrite rec in Refl
 
-we don't call Refl to match on 'n = plus n 0' forall 'n' we call it for every number separately. So, in the second line, somehow the pattern matcher knows to substitute Z for n in the type being matched.
+we don't call Refl to match on 'n = plus n 0' forall 'n' we call it for every number separately. So, in the second line, the pattern matcher knows to substitute Z for n in the type being matched. This uses 'rewrite' which is explained below.
 
 Replace
 =======
 
-If two terms are equal then they have the same properties. In our proofs we can express this as:
+This implements the 'indiscernability of identicals' principle, if two terms are equal then they have the same properties. In other words, if x=y, then we can substitute y for x in any expression. In our proofs we can express this as:
 
    if x=y
    then P x = P y
 
-where P is a pure function.
+where P is a pure function representing the property. In the examples below P is an expression in some variable with a type like this: P: n -> Type
 
-To use this in our proofs there is the following function in the prelude: 
+So if n is a natural number variable then P could be something like 2*n + 3.
+
+To use this in our proofs there is the following function in the prelude:
 
 .. code-block:: idris
 
    ||| Perform substitution in a term according to some equality.
    replace : {a:_} -> {x:_} -> {y:_} -> {P : a -> Type} -> x = y -> P x -> P y
    replace Refl prf = prf
+
+Removing the implicits, if we supply an equality (x=y) and a proof of a property of x (P x) then we get a proof of a property of y (P y)
+
+.. code-block:: idris
+
+   > :t replace
+   replace : (x = y) -> P x -> P y
+
+So, in the following example, if we supply p1 x which is a proof that x=2 and the equality x=y then we get a proof that y=2.
+
+.. code-block:: idris
+
+   p1: Nat -> Type
+   p1 n = (n=2)
+
+   testReplace: (x=y) -> (p1 x) -> (p1 y)
+   testReplace a b = replace a b
 
 Rewrite
 =======
@@ -51,13 +70,28 @@ Similar to 'replace' above but Idris provides a nicer syntax which makes 'rewrit
 
 .. code-block:: idris
 
-   ||| Perform substitution in a term according to some equality.
-   |||
-   ||| Like `replace`, but with an explicit predicate, and applying the rewrite
-   ||| in the other direction, which puts it in a form usable by the `rewrite`
-   ||| tactic and term.
    rewrite__impl : (P : a -> Type) -> x = y -> P y -> P x
    rewrite__impl p Refl prf = prf
+
+The difference from 'replace' above is nicer syntax and the property p1 is explicitly supplied and it goes in the opposite direction (input and output reversed).
+
+Example: again we supply p1 which is a proof that x=2 and the equality x=y then we get a proof that y=2.
+
+.. code-block:: idris
+
+   p1: Nat -> Type
+   p1 x = (x=2)
+
+   testRewrite2: (x=y) -> (p1 y) -> (p1 x)
+   testRewrite2 a b = rewrite a in b
+
+We can think of rewrite doing this:
+
+ * Start with a equation x=y and a property P: x -> Type
+ * Searches y in P
+ * Replaces all occurrences of y with x in P.
+
+That is, we are doing a substitution.
 
 Symmetry and Transitivity
 =========================


### PR DESCRIPTION
The documentation for proofs assumes the reader already understands:

    Propositions and judgments
    Boolean and constructive logic
    Curry-Howard correspondence
    Definitional and propositional equalities
    Axiomatic and constructive approaches

This is fine if the reader has studied proof theory or has used a proof assistant like Coq.

I think it would be good if people with a general programming background could understand this documentation. I have therefore added a page to explain these issues.

Should you wish to accept this change I hereby give permission to use it under CC0 licence.