### PR TITLE
Initialise error while opening a directory.

### DIFF
--- a/rts/idris_stdfgn.c
+++ b/rts/idris_stdfgn.c
@@ -108,6 +108,7 @@ void* idris_dirOpen(char* dname) {
     } else {
         DirInfo* di = malloc(sizeof(DirInfo));
         di->dirptr = d;
+        di->error = 0;
 
         return (void*)di;
     }


### PR DESCRIPTION
On at least some machines, the field error of DirInfo isn't actually automatically initialised as zero; this is enforced in this commit.