### PR TITLE
Make binary files the default when opening.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,9 @@
 # New in next version
 
+
+## Library updates
++ `openFile` opens the file in binary mode on Windows.
+
 ## Tool updates
 + Modules no longer require building if imports have changed but all
   interfaces (i.e. types for names declared `export` and definitions of names

--- a/libs/prelude/Prelude/File.idr
+++ b/libs/prelude/Prelude/File.idr
@@ -13,6 +13,7 @@ import Prelude.Basics
 import Prelude.Interfaces
 import Prelude.Either
 import Prelude.Show
+
 import IO
 
 %access public export
@@ -108,12 +109,12 @@ validFile (FHandle h) = do x <- nullPtr h
 data Mode = Read | WriteTruncate | Append | ReadWrite | ReadWriteTruncate | ReadAppend
 
 modeStr : Mode -> String
-modeStr Read              = "r"
-modeStr WriteTruncate     = "w"
-modeStr Append            = "a"
-modeStr ReadWrite         = "r+"
-modeStr ReadWriteTruncate = "w+"
-modeStr ReadAppend        = "a+"
+modeStr Read              = "rb"
+modeStr WriteTruncate     = "wb"
+modeStr Append            = "ab"
+modeStr ReadWrite         = "rb+"
+modeStr ReadWriteTruncate = "wb+"
+modeStr ReadAppend        = "ab+"
 
 ||| Open a file
 ||| @ f the filename

--- a/src/Idris/Core/Execute.hs
+++ b/src/Idris/Core/Execute.hs
@@ -345,7 +345,7 @@ execForeign env ctxt arity ty fn xs onfail
            = case (fileStr, modeStr) of
                (EConstant (Str f), EConstant (Str mode)) ->
                  do f <- execIO $
-                         catch (do let m = case mode of
+                         catch (do let m = case filter (/= 'b') mode of
                                              "r"  -> Right ReadMode
                                              "w"  -> Right WriteMode
                                              "a"  -> Right AppendMode


### PR DESCRIPTION
The reason is that most things on windows handles unix line endings just
fine and this leads to terrible bugs when writing binary files.

fopen still allows opening of files without the "b".

This only has effect on Windows, but POSIX systems allows the "b" as a
noop.