### PR TITLE
Update Runtime-node.js

### DIFF
--- a/jsrts/Runtime-node.js
+++ b/jsrts/Runtime-node.js
@@ -16,7 +16,7 @@ $JSRTS.prim_writeStr = function (x) { return process.stdout.write(x) };
 
 $JSRTS.prim_readStr = function () {
     var ret = '';
-    var b = new Buffer(1024);
+    var b = Buffer.alloc(1024);
     var i = 0;
     while (true) {
         $JSRTS.fs.readSync(0, b, i, 1)
@@ -26,7 +26,7 @@ $JSRTS.prim_readStr = function () {
         }
         i++;
         if (i == b.length) {
-            var nb = new Buffer(b.length * 2);
+            var nb = Buffer.alloc(b.length * 2);
             b.copy(nb)
             b = nb;
         }


### PR DESCRIPTION
Node codegen generates a warning once the file has finished execution:

```
$ idris --codegen node leftpad.idr -o leftpad.js
$ node leftpad.js
Enter string: 
hey
Enter char: 
a
Enter length: 
5
xxhey
(node:15146) [DEP0005] DeprecationWarning: Buffer() is deprecated due to security and usability issues. Please use the Buffer.alloc(), Buffer.allocUnsafe(), or Buffer.from() methods instead.
$
```

After this change it does not create any warnings.