### PR TITLE
Fixes error in type definition for So.

### DIFF
--- a/docs/effects/simpleeff.rst
+++ b/docs/effects/simpleeff.rst
@@ -212,7 +212,8 @@ from the result of a dynamic check:
 
 .. code-block:: idris
 
-    data So : Bool -> Type = Oh : So True
+    data So : Bool -> Type where
+      Oh : So True
 
     choose : (b : Bool) -> Either (So b) (So (not b))
 


### PR DESCRIPTION
The type definition for So used the syntax:
```
data So : Bool -> Type = Oh : So True 
```
which is not valid idris.

Fixes #4683