### PR TITLE
Add `--optimise-nat-like-types`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,12 @@
   interfaces (i.e. types for names declared `export` and definitions of names
   declared `public export`) are unchanged.
 
+## Miscellaneous updates
++ Compiler flag `--optimise-nat-like-types` enables compilation
+  of `Nat`-like type families to big integers. A type family
+  is `Nat`-like if, after erasure, it has two constructors,
+  one nullary, the other one with exactly one recursive field.
+
 # New in 1.3.1
 
 ## Tool updates

--- a/man/idris.1
+++ b/man/idris.1
@@ -99,6 +99,10 @@ should not necessarily be seen as production ready nor for industrial use.
                            e.g. corei7 or cortex-m3.
   --color,--colour         Force coloured output
   --nocolor,--nocolour     Disable coloured output
+  --optimise-nat-like-types,--optimize-nat-like-types
+                           Compile Nat-like types to big ints
+  --no-optimise-nat-like-types,--no-optimize-nat-like-types
+                           Do not compile Nat-like types to big ints
   --consolewidth WIDTH     Select console width: auto, infinite, nat
   --highlight              Emit source code highlighting
   --no-tactic-deprecation-warnings

--- a/src/IRTS/Compiler.hs
+++ b/src/IRTS/Compiler.hs
@@ -417,13 +417,12 @@ irTerm top vs env tm@(App _ f a) = do
                 -> return . padLams $ \[vn] -> LApp False (LV n) [LV vn]
 
                 -- compile Nat-likes as bigints
-                -- not sure if prim applications must be saturated
-                -- let's wrap it in a lambda just to be sure
+                -- it seems that prim applications needn't be saturated
                 | Just LikeS <- isLikeNat ist n
-                -> LLam [sMN 0 "nh"] <$>
-                    (irTerm top vs env $
-                        mkApp (P Ref (sUN "prim__addBigInt") Erased)
-                            [Constant $ BI 1, P Ref (sMN 0 "nh") Erased])
+                -> irTerm top vs env $
+                    App Complete
+                        (P Ref (sUN "prim__addBigInt") Erased)
+                        (Constant $ BI 1)
 
                 -- not a newtype, just apply to a constructor
                 | otherwise

--- a/src/IRTS/Compiler.hs
+++ b/src/IRTS/Compiler.hs
@@ -526,6 +526,8 @@ isLikeNat ist cn
     = if | cn == z -> Just LikeZ
          | cn == s -> Just LikeS
          | otherwise -> error $ "isLikeNat: constructor not found in its own family: " ++ show (cn, tyN)
+
+    | otherwise = Nothing
   where
     natLikeCtors :: Name -> Type -> Maybe (Name, Name)
     natLikeCtors tyN cTy = case lookupCtxtExact tyN $ idris_datatypes ist of

--- a/src/IRTS/Compiler.hs
+++ b/src/IRTS/Compiler.hs
@@ -521,6 +521,10 @@ data LikeNat = LikeZ | LikeS
 
 isLikeNat :: IState -> Name -> Maybe LikeNat
 isLikeNat ist cn
+    -- if the optimisation is disabled then nothing looks like Nat
+    | GeneralisedNatHack `notElem` opt_optimise (idris_options ist)
+    = Nothing
+
     | Just cTy <- lookupTyExact cn $ tt_ctxt ist
     , (P TCon{} tyN _, _) <- unApply $ getRetTy cTy
     , Just (z, s) <- natLikeCtors tyN cTy

--- a/src/IRTS/Compiler.hs
+++ b/src/IRTS/Compiler.hs
@@ -529,18 +529,28 @@ getNatLikeCtors ist =
         $ lookupCtxtExact n
         $ idris_callgraph ist
 
+    isRecursive :: Name -> Name -> Bool
+    isRecursive tyN cn
+        | Just (Bind _ Pi{binderTy = P _ argTyN _} _) <- lookupTyExact cn $ tt_ctxt ist
+        , argTyN == tyN
+        = True
+
+        | otherwise = False
+
     natLikeTypes :: [(Name, Name)]
     natLikeTypes = do
-        (_typeName, TI{con_names}) <- toAlist $ idris_datatypes ist
+        (typeName, TI{con_names}) <- toAlist $ idris_datatypes ist
         case con_names of
             [z, s]
                 | getUsedCount z == 0
                 , getUsedCount s == 1
+                , isRecursive typeName s
                 -> [(z, s)]
 
             [s, z]
                 | getUsedCount z == 0
                 , getUsedCount s == 1
+                , isRecursive typeName s
                 -> [(z, s)]
 
             _ -> []  -- not a 2-constructor family

--- a/src/IRTS/Compiler.hs
+++ b/src/IRTS/Compiler.hs
@@ -5,7 +5,8 @@ Description : Coordinates the compilation process.
 License     : BSD3
 Maintainer  : The Idris Community.
 -}
-{-# LANGUAGE CPP, FlexibleContexts, PatternGuards, TypeSynonymInstances, NamedFieldPuns, MultiWayIf #-}
+{-# LANGUAGE CPP, FlexibleContexts, MultiWayIf, NamedFieldPuns, PatternGuards,
+             TypeSynonymInstances #-}
 
 module IRTS.Compiler(compile, generate) where
 
@@ -33,8 +34,8 @@ import Prelude hiding (id, (.))
 import Control.Category
 import Control.Monad.State
 import Data.List
-import Data.Maybe (maybe)
 import qualified Data.Map as M
+import Data.Maybe (maybe)
 import Data.Ord
 import qualified Data.Set as S
 import System.Directory

--- a/src/IRTS/Compiler.hs
+++ b/src/IRTS/Compiler.hs
@@ -524,7 +524,10 @@ data LikeNat = LikeZ | LikeS
 
 isLikeNat :: IState -> Name -> Maybe LikeNat
 isLikeNat ist cn
-    -- if the optimisation is disabled then nothing looks like Nat
+    -- Nat itself is special-cased in Idris/DataOpts.hs,
+    -- which will have already happened at this point.
+
+    -- If the optimisation is disabled then nothing looks like Nat.
     | GeneralisedNatHack `notElem` opt_optimise (idris_options ist)
     = Nothing
 

--- a/src/IRTS/Compiler.hs
+++ b/src/IRTS/Compiler.hs
@@ -525,7 +525,7 @@ isLikeNat ist cn
     , Just (z, s) <- natLikeCtors tyN cTy
     = if | cn == z -> Just LikeZ
          | cn == s -> Just LikeS
-         | otherwise -> Nothing
+         | otherwise -> error $ "isLikeNat: constructor not found in its own family: " ++ show (cn, tyN)
   where
     natLikeCtors :: Name -> Type -> Maybe (Name, Name)
     natLikeCtors tyN cTy = case lookupCtxtExact tyN $ idris_datatypes ist of

--- a/src/Idris/CmdOptions.hs
+++ b/src/Idris/CmdOptions.hs
@@ -209,10 +209,16 @@ parseFlags = many $
   <|> flag' (AddOpt PETransform) (long "partial-eval")
   <|> flag' (RemoveOpt PETransform) (long "no-partial-eval" <> help "Switch off partial evaluation, mainly for debugging purposes")
 
-  <|> flag' (AddOpt GeneralisedNatHack) (long "opt-nat-likes"
-    <> help "Enable compilation of Nat-like types to bigints")
-  <|> flag' (RemoveOpt GeneralisedNatHack) (long "no-opt-nat-likes"
-    <> help "Disable compilation of Nat-like types to bigints")
+  <|> flag' (AddOpt GeneralisedNatHack) (
+    long "optimise-nat-like-types"
+    <> long "optimize-nat-like-types"
+    <> help "Enable compilation of Nat-like types to bigints"
+  )
+  <|> flag' (RemoveOpt GeneralisedNatHack) (
+    long "no-optimise-nat-like-types"
+    <> long "no-optimize-nat-like-types"
+    <> help "Disable compilation of Nat-like types to bigints"
+  )
 
   <|> OptLevel <$> option auto (short 'O' <> long "level")
 

--- a/src/Idris/CmdOptions.hs
+++ b/src/Idris/CmdOptions.hs
@@ -209,6 +209,11 @@ parseFlags = many $
   <|> flag' (AddOpt PETransform) (long "partial-eval")
   <|> flag' (RemoveOpt PETransform) (long "no-partial-eval" <> help "Switch off partial evaluation, mainly for debugging purposes")
 
+  <|> flag' (AddOpt GeneralisedNatHack) (long "generalised-nat-hack"
+    <> help "Enable compilation of Nat-like types to bigints")
+  <|> flag' (RemoveOpt GeneralisedNatHack) (long "no-generalised-nat-hack"
+    <> help "Disable compilation of Nat-like types to bigints")
+
   <|> OptLevel <$> option auto (short 'O' <> long "level")
 
   <|> TargetTriple <$> strOption (long "target" <> metavar "TRIPLE" <> help "If supported the codegen will target the named triple.")

--- a/src/Idris/CmdOptions.hs
+++ b/src/Idris/CmdOptions.hs
@@ -209,9 +209,9 @@ parseFlags = many $
   <|> flag' (AddOpt PETransform) (long "partial-eval")
   <|> flag' (RemoveOpt PETransform) (long "no-partial-eval" <> help "Switch off partial evaluation, mainly for debugging purposes")
 
-  <|> flag' (AddOpt GeneralisedNatHack) (long "generalised-nat-hack"
+  <|> flag' (AddOpt GeneralisedNatHack) (long "opt-nat-likes"
     <> help "Enable compilation of Nat-like types to bigints")
-  <|> flag' (RemoveOpt GeneralisedNatHack) (long "no-generalised-nat-hack"
+  <|> flag' (RemoveOpt GeneralisedNatHack) (long "no-opt-nat-likes"
     <> help "Disable compilation of Nat-like types to bigints")
 
   <|> OptLevel <$> option auto (short 'O' <> long "level")

--- a/src/Idris/Options.hs
+++ b/src/Idris/Options.hs
@@ -125,7 +125,7 @@ data HowMuchDocs = FullDocs | OverviewDocs
 
 data OutputFmt = HTMLOutput | LaTeXOutput
 
-data Optimisation = PETransform -- ^ partial eval and associated transforms
+data Optimisation = PETransform | GeneralisedNatHack -- ^ partial eval and associated transforms
   deriving (Show, Eq, Generic)
 
 -- | Recognised logging categories for the Idris compiler.

--- a/test/pkg010/expected
+++ b/test/pkg010/expected
@@ -21,8 +21,11 @@ Usage:  ([--nobanner] | [-q|--quiet] | [--ide-mode] | [--ide-mode-socket] |
         [--codegen TARGET] | [--portable-codegen TARGET] | [--cg-opt ARG] |
         [-e|--eval EXPR] | [--execute] | [--exec EXPR] | [-X|--extension EXT] |
         [--O3] | [--O2] | [--O1] | [--O0] | [--partial-eval] |
-        [--no-partial-eval] | [-O|--level ARG] | [--target TRIPLE] | [--cpu CPU]
-        | [--color|--colour] | [--nocolor|--nocolour] | [--consolewidth WIDTH] |
-        [--highlight] | [--no-tactic-deprecation-warnings] |
+        [--no-partial-eval] |
+        [--optimise-nat-like-types|--optimize-nat-like-types] |
+        [--no-optimise-nat-like-types|--no-optimize-nat-like-types] |
+        [-O|--level ARG] | [--target TRIPLE] | [--cpu CPU] | [--color|--colour]
+        | [--nocolor|--nocolour] | [--consolewidth WIDTH] | [--highlight] |
+        [--no-tactic-deprecation-warnings] |
         [--allow-capitalized-pattern-variables]) [FILES] [-v|--version]
 )


### PR DESCRIPTION
This patch compiles all type families that end up looking like `Nat` after erasure into bigints.

This includes `Nat`, but also `Fin`, various `Elem` predicates, etc.