### PR TITLE
Update tutorial's "using" example to avoid errors

### DIFF
--- a/docs/tutorial/typesfuns.rst
+++ b/docs/tutorial/typesfuns.rst
@@ -574,10 +574,10 @@ appear within the block:
 
 .. code-block:: idris
 
-    using (x:a, y:a, xs:Vect n a)
+    using (y:a, xs:Vect n a)
       data IsElem : a -> Vect n a -> Type where
-         Here  : IsElem x (x :: xs)
-         There : IsElem x xs -> IsElem x (y :: xs)
+         Here  : {x:a} -> IsElem x (x :: xs)
+         There : {x:a} -> IsElem x xs -> IsElem x (y :: xs)
 
 Note: Declaration Order and ``mutual`` blocks
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~


### PR DESCRIPTION
As a beginner, I just interpolated between the working example, and the broken example with "using". This fix renders the example less perfect for introducing "using" notation, but at least it goes through without errors in my installation (Idris 1.3.0). Is there a better fix which keeps {x:a}  up in the "using" clause?