### PR TITLE
Show visibility in doc comments.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,7 @@
 + Modules no longer require building if imports have changed but all
   interfaces (i.e. types for names declared `export` and definitions of names
   declared `public export`) are unchanged.
++ The result of calling `:doc` now details the accessbility of items as well as their totality.
 
 ## Miscellaneous updates
 + Compiler flag `--optimise-nat-like-types` enables compilation

--- a/src/Idris/Core/Evaluate.hs
+++ b/src/Idris/Core/Evaluate.hs
@@ -24,6 +24,7 @@ module Idris.Core.Evaluate(normalise, normaliseTrace, normaliseC,
                 lookupNames, lookupTyName, lookupTyNameExact, lookupTy, lookupTyExact,
                 lookupP, lookupP_all, lookupDef, lookupNameDef, lookupDefExact, lookupDefAcc, lookupDefAccExact, lookupVal,
                 mapDefCtxt, tcReducible,
+                lookupTotalAccessibility,
                 lookupTotal, lookupTotalExact, lookupInjectiveExact,
                 lookupRigCount, lookupRigCountExact,
                 lookupNameTotal, lookupMetaInformation, lookupTyEnv, isTCDict,
@@ -1166,6 +1167,12 @@ lookupDefAcc n mkpublic ctxt
   -- io_bind a special case for REPL prettiness
   where mkp (d, _, inj, a, _, _) = if mkpublic && (not (n == sUN "io_bind" || n == sUN "io_pure"))
                                       then (d, Public) else (d, a)
+
+lookupTotalAccessibility :: Name -> Context -> [(Totality,Accessibility)]
+lookupTotalAccessibility n ctxt = fmap unpack $ lookupCtxt n (definitions ctxt)
+
+  where
+    unpack ((_,_,_,a,t,_)) = (t,a)
 
 lookupDefAccExact :: Name -> Bool -> Context ->
                      Maybe (Def, Accessibility)

--- a/src/Idris/Docs.hs
+++ b/src/Idris/Docs.hs
@@ -94,11 +94,9 @@ pprintFD ist totalityFlag nsFlag (FD n doc args ty f) =
            (if not (null argshow)
              then nest 4 $ text "Arguments:" <$> vsep argshow
              else empty)
-      -- show totality status
-      <> let totality = getTotality in
-           (if totalityFlag && not (null totality)
-              then line <> (vsep . map (\t -> text "The function is" <+> t) $ totality)
-              else empty))
+      -- show totality and visibility status
+      <> showTotalVisibility
+      )
 
     where
       ppo = ppOptionIst ist
@@ -135,7 +133,14 @@ pprintFD ist totalityFlag nsFlag (FD n doc args ty f) =
             showArgs args ((n, True):bnd)
       showArgs []                                    _   = [] -- end of arguments
 
-      getTotality = map (text . show) $ lookupTotal n (tt_ctxt ist)
+      showTotalVisibility =
+        case lookupTotalAccessibility n (tt_ctxt ist) of
+          [] -> empty
+          xs -> line <> vsep (map (doShowTotalVisibility) xs)
+
+      doShowTotalVisibility (t,v) = if totalityFlag
+                                       then text "The function is:" <+> ((text . show) t) <+> (text "&") <+> ((text . show) v)
+                                       else text "The function is:" <+> ((text . show) v)
 
 pprintFDWithTotality :: IState -> Bool -> FunDoc -> Doc OutputAnnotation
 pprintFDWithTotality ist = pprintFD ist True

--- a/test/docs001/expected
+++ b/test/docs001/expected
@@ -8,7 +8,7 @@ Methods:
     m : C t => t
         member of interface
         
-        The function is Total
+        The function is: Total & public export
 Implementations:
     C A
         implementation of interface

--- a/test/docs002/expected
+++ b/test/docs002/expected
@@ -1,12 +1,12 @@
 T1 : Type
     Some documentation
     
-    The function is Total
+    The function is: Total & public export
 T2 : Type
     Some other documentation
     
-    The function is Total
+    The function is: Total & public export
 T3 : Int
     Some provided postulate
     
-    The function is not yet checked for totality
+    The function is: not yet checked for totality & public export

--- a/test/docs003/expected
+++ b/test/docs003/expected
@@ -8,7 +8,7 @@ Methods:
     map : Functor f => (func : a -> b) -> f a -> f b
         Apply a function across everything of type 'a' in a parameterised type
         
-        The function is Total
+        The function is: Total & public export
 Implementations:
     Functor (Pair a)
     Functor List
@@ -33,7 +33,9 @@ Named implementation:
     docs003.mine : Functor List
         
         
+        The function is: public export
 Named implementation:
     docs003.another : Functor List
         More functors!
         
+        The function is: public export

--- a/test/docs004/expected
+++ b/test/docs004/expected
@@ -7,12 +7,12 @@ Main.MkFoo : (bar : Nat) -> (baz : Bool) -> Foo a
         
         baz : Bool  -- A field baz
         
-    The function is Total
+    The function is: Total & public export
 Main.Foo.bar : (rec : Foo a) -> Nat
     A field bar
     
-    The function is Total
+    The function is: Total & public export
 Main.Foo.baz : (rec : Foo a) -> Bool
     A field baz
     
-    The function is Total
+    The function is: Total & public export

--- a/test/docs005/expected
+++ b/test/docs005/expected
@@ -1,6 +1,7 @@
 Data type docs005.Foobar : Type
     A foobar with an auto implicit
     
+    The function is: public export
 Constructors:
     NewFoo : (xs : List String) ->
         (ys : List Nat) -> {auto prf : NonEmpty ys} -> Foobar
@@ -14,6 +15,7 @@ Constructors:
             
             (auto implicit) prf : NonEmpty ys  -- The prf
             
+        The function is: public export
 docs005.NewFoo : (xs : List String) ->
     (ys : List Nat) -> {auto prf : NonEmpty ys} -> Foobar
     New Foo
@@ -26,4 +28,4 @@ docs005.NewFoo : (xs : List String) ->
         
         (auto implicit) prf : NonEmpty ys  -- The prf
         
-    The function is Total
+    The function is: Total & public export

--- a/test/docs006/expected
+++ b/test/docs006/expected
@@ -11,6 +11,6 @@ Methods:
     m : Foo t => t
         member of interface
         
-        The function is Total
+        The function is: Total & public export
 Implementations:
     <no implementations>

--- a/test/idrisdoc009/expected
+++ b/test/idrisdoc009/expected
@@ -1,10 +1,12 @@
 Data type Test.Test : Type
     Docs for datatype Test.
     
+    The function is: public export
 Constructors:
     MkTest : Test
         
         
+        The function is: public export
 Module Test:
     Docs for module Test.
     

--- a/test/interactive005/expected
+++ b/test/interactive005/expected
@@ -3,7 +3,7 @@ Hello, World
 Main.main : IO ()
     This is a docstring
     
-    The function is Total
+    The function is: Total & public export
 Main.main is Total
 Hello, World
 id : a -> a
@@ -27,10 +27,10 @@ Main.main : IO ()
     is a
     docstring
     
-    The function is Total
+    The function is: Total & public export
 Main.main : IO ()
     This is a docstring
     
-    The function is Total
+    The function is: Total & public export
 Nat2 : Type
 Invalid filename for compiler output "Test.idr"

--- a/test/interfaces001/expected
+++ b/test/interfaces001/expected
@@ -8,7 +8,7 @@ Methods:
     myShow : MyShow a => (x : a) -> String
         The shower
         
-        The function is Total
+        The function is: Total & public export
 Implementation constructor:
     MkMyShow : (myShow : a -> String) -> MyShow a
         Build a MyShow
@@ -17,6 +17,7 @@ Implementation constructor:
             
             myShow : a -> String  -- The shower
             
+        The function is: public export
 Implementations:
     MyShow Integer
 MkMyShow : (myShow : a -> String) -> MyShow a
@@ -26,4 +27,4 @@ MkMyShow : (myShow : a -> String) -> MyShow a
         
         myShow : a -> String  -- The shower
         
-    The function is Total
+    The function is: Total & public export


### PR DESCRIPTION
Currently the result of `:doc` displays totality information for functions.
However there are two scenarios where having the accessiblity/visibility information would be beneficial:

1. Type-level computations failing to reduce.

A computed value in your type might fail to reduce in the definition of the computing function is not public c.f. exportation of functions computing type synonyms.
A good numpty check would be to add this information to the doc output, much as we do for totality status.

2. Working with 'Exported' constructors.

Much like exported functions, some data types might be exported rather than public exported.
One has to assert the functions visibility by checking the source code, this is cumbersome.

This commit adds visibility status to the documentation output.
Such that if totality information is to be displayed we output the totality and accessibility information, otherwise we just output the accessibility information.