### PR TITLE
Stack 'fixes'

### DIFF
--- a/INSTALL.md
+++ b/INSTALL.md
@@ -81,9 +81,9 @@ To install Idris:
 * `stack install`
 
 Stack will install Idris (and related executables) into `$HOME/.local/bin/`
-on Unix based systems and an appropriate place on Windows. The libraries that 
-are included with Idris (e.g. Builtins, Prelude) will 'install' into `<source 
-dir>/.stack_work/install/...` so you'll need to keep your source directory 
+on Unix based systems and an appropriate place on Windows. The libraries that
+are included with Idris (e.g. Builtins, Prelude) will 'install' into `<source
+dir>/.stack_work/install/...` so you'll need to keep your source directory
 around after you've installed Idris using Stack.
 
 Of note: If you haven't used stack before commands will also setup the
@@ -125,4 +125,20 @@ encounter this then the fix is to augment the `PKG_CONFIG_PATH` for
 
 ```
 PKG_CONFIG_PATH=/usr/local/opt/libffi/lib/pkgconfig stack build
-``` 
+```
+
+## Issue with GHC on Ubuntu/Fedora
+
+There is an upstream issue with GHC on some Ubuntu and Fedora machines.
+The issue is that for GHC versions greater than 8.4.X linking to libFFI is broken.
+See the following GHC issue page for more information:
+
+  <https://gitlab.haskell.org/ghc/ghc/issues/15397>
+
+This means that an Idris built with `libFFI` support will fail at runtime as the executable would not be able to find the correct `libffi` shared object.
+This will cause the build to fail.
+Specifically, one will see an error message along the lines of:
+
+> error while loading shared libraries: libffi.so.7: cannot open shared object file: No such file or directory
+
+We have supplied an alternative stack configuration file (`stack-alt.yaml`) that will use a version of GHC prior to the upstream issue being introduced.

--- a/stack-alt.yaml
+++ b/stack-alt.yaml
@@ -1,0 +1,25 @@
+#recheck extra-deps next on resolver or cabal file change
+resolver: lts-11.4
+
+packages:
+  - location: .
+
+extra-deps:
+  - network-2.8.0.0@sha256:aae171e6c6028a7791dbe4de5b9d2da398056359e3cc7927465ffa3cdae1aa0b
+  - Cabal-2.2.0.1@sha256:2a80d8fb655474f0eaeb20434c47f64f84e6302e55973056f00df8ca050b9683
+  - megaparsec-7.0.4
+  - parser-combinators-1.0.0
+  - zip-archive-0.3.3@sha256:47cf2d66cc8e237f7226837758e1b041e24048ef3820d3d10276c500edb921bf
+  - containers-0.5.11.0@sha256:28ad7337057442f75bc689315ab4ec7bdf5e6b2c39668f306672cecd82c02798
+
+flags:
+  idris:
+    FFI: true
+    GMP: true
+
+ghc-options:
+  idris: -fwarn-unused-imports -fwarn-unused-binds
+
+nix:
+  enable: false
+  shell-file: stack-shell.nix

--- a/stack.yaml
+++ b/stack.yaml
@@ -1,5 +1,5 @@
 #recheck extra-deps next on resolver or cabal file change
-resolver: lts-13.0
+resolver: lts-13.21
 
 packages:
   - location: .


### PR DESCRIPTION
Two 'fixes'

1. Bump Stack to latest version.
2. Address upstream GHC issues on Ubuntu and Fedora machines.