### PR TITLE
fix formatting error which caused missing code block

### DIFF
--- a/docs/proofs/interactive.rst
+++ b/docs/proofs/interactive.rst
@@ -153,6 +153,7 @@ This has been normalised to ``0 = 0`` so now we have to prove that ``0`` equals 
 is easy to prove by reflexivity from the pruviloj library:
 
 .. code-block:: idris
+
     -Main.plusredZ_Z> reflexivity
     plusredZ_Z: No more goals.
 


### PR DESCRIPTION
The fixes an issue reported by Phiroc here:
https://github.com/idris-lang/Idris-dev/issues/4717

There was no empty line after the code-block in the rst file.
This prevented the code block from being displayed in the documentation.

This patch adds the blank line and the code should now be displayed correctly.