### PR TITLE
Add 'tasty-rerun' to extra deps in stack.yaml

### DIFF
--- a/stack.yaml
+++ b/stack.yaml
@@ -11,6 +11,7 @@ extra-deps:
   - parser-combinators-1.0.0
   - zip-archive-0.3.3@sha256:47cf2d66cc8e237f7226837758e1b041e24048ef3820d3d10276c500edb921bf
   - containers-0.5.11.0@sha256:28ad7337057442f75bc689315ab4ec7bdf5e6b2c39668f306672cecd82c02798
+  - tasty-rerun-1.1.14@sha256:ba9c19a281535bea566e1044bc02c36ef17abcb310af4b6a149ec11780c7ce35
 
 flags:
   idris:


### PR DESCRIPTION
`stack test` command in repo root fails with the following error:

```

Error: While constructing the build plan, the following exceptions were encountered:

In the dependencies for idris-1.3.1(+FFI +GMP):
    tasty-rerun must match >=1.0.0, but the stack configuration has no specified version  (latest matching version is 1.1.14)
needed since idris is a build target.

Some different approaches to resolving this:

  * Consider trying 'stack solver', which uses the cabal-install solver to attempt to find some working build configuration. This can be convenient when dealing with many
    complicated constraint errors, but results may be unpredictable.

  * Recommended action: try adding the following to your extra-deps in /Users/dmitry/Code/idris-dev/stack.yaml:

tasty-rerun-1.1.14@sha256:ba9c19a281535bea566e1044bc02c36ef17abcb310af4b6a149ec11780c7ce35

Plan construction failed.
``` 

So after this fix it just works.