### PR TITLE
Correct documentation showing 'compute' tactic where it should not be.

### DIFF
--- a/docs/proofs/interactive.rst
+++ b/docs/proofs/interactive.rst
@@ -270,7 +270,7 @@ because this gives the following error:
   unexpected "in"
   expecting dependent type signature
 
-We can try putting the proof into a seperate function like this:
+However if we put the proof into a seperate function like this:
 
 .. code-block:: idris
 
@@ -279,34 +279,17 @@ We can try putting the proof into a seperate function like this:
 
   %language ElabReflection
 
-  plusredZ_S : (n : Nat) -> (n = plus n Z) -> (S n = S (plus n Z))
-  plusredZ_S k ih = %runElab (do intro `{{k}}
-                                 intro `{{ih}}
-                                 rewriteWith (Var `{{ih}})
-                                 reflexivity)
+  plusredZ_S : (k : Nat) -> (ih:(k = plus k Z)) -> (S k = S (plus k Z))
+  plusredZ_S = %runElab (do intro `{{k}}
+                            intro `{{ih}}
+                            rewriteWith (Var `{{ih}})
+                            reflexivity)
 
   plusReducesZ' : (n:Nat) -> n = plus n Z
   plusReducesZ' Z     = %runElab (do reflexivity)
   plusReducesZ' (S k) = let ih = plusReducesZ' k in plusredZ_S k ih
 
-but this gives:
-
-.. code-block:: idris
-
-  Idris> :load elabInteractiveEx4.idr
-  Type checking ./elabInteractiveEx4.idr
-  elabInteractiveEx4.idr:7:19-10:43:
-    |
-  7 | plusredZ_S k ih = %runElab (do intro `{{k}}
-    |                   ~~~~~~~~~~~~~~~~~~~~~~~~~ ...
-  When checking right hand side of plusredZ_S with expected type
-        S k = S (plus k 0)
-
-  Can't use lambda here: type is S k = S (plus k 0)
-
-  Holes: Main.plusredZ_S
-
-Issues like this are discussed here [#f1]_
+This then loads.
 
 .. [#f1] https://github.com/idris-lang/Idris-dev/issues/4556
 

--- a/docs/proofs/interactive.rst
+++ b/docs/proofs/interactive.rst
@@ -237,7 +237,6 @@ which is trivially provable using reflexivity:
     Proof completed!
     Main.plusredZ_S = %runElab (do intro `{{k}}
                                    intro `{{ih}}
-                                   compute
                                    rewriteWith (Var `{{ih}})
                                    reflexivity)
 

--- a/docs/proofs/interactive.rst
+++ b/docs/proofs/interactive.rst
@@ -4,7 +4,7 @@ Interactive Theorem Proving
 
 Idris supports interactive theorem proving via elaborator reflection.
 
-:ref:'elaborator-reflection' is also used to convert high-level Idris code into
+:ref:`elaborator-reflection` is also used to convert high-level Idris code into
 the core language and for customising the language. Here we show how to use it
 to interactively construct proofs.
 

--- a/docs/proofs/interactive.rst
+++ b/docs/proofs/interactive.rst
@@ -270,7 +270,7 @@ because this gives the following error:
   unexpected "in"
   expecting dependent type signature
 
-However if we put the proof into a seperate function like this:
+However if we put the proof into a separate function like this:
 
 .. code-block:: idris
 


### PR DESCRIPTION
This pull request changes documentation only.

The documentation shows a 'compute' command being generated by Elab which it does not do in this example, so this PR removes the 'compute' tactic output line.

This may have caused the issue in this forum discussion:

https://groups.google.com/forum/#!topic/idris-lang/ivH9fpTmMKE

It is also documented here:

https://github.com/idris-lang/Idris-dev/issues/4730

Is there an underlying issue with the code? In that Elab can generate output without generating errors, but if cut&pasted into the hole will produce an error? This PR does not address this issue so it may not resolve the above linked issue.

Martin