### PR TITLE
Stop ignoring dots for implicits

### DIFF
--- a/src/Idris/AbsSyntax.hs
+++ b/src/Idris/AbsSyntax.hs
@@ -1659,7 +1659,8 @@ getUnboundImplicits i t tm = getImps t (collectImps tm)
             argInfo n (Imp opt _ _ _ _ _) Placeholder
                    = (True, PImp 0 True opt n Placeholder)
             argInfo n (Imp opt _ _ _ _ _) t'
-                   = (False, PImp (getPriority i t') True opt n t')
+                   = (InaccessibleArg `elem` opt,
+                          PImp (getPriority i t') True opt n t')
             argInfo n (Exp opt _ _ _) t'
                    = (InaccessibleArg `elem` opt,
                           PExp (getPriority i t') opt n t')


### PR DESCRIPTION
`JanBessai` on IRC reported the following MFE: https://gist.github.com/JanBessai/999c7162f35eb782a53de0d2bf61fe9c

The compiler does not emit an erasure warning, despite `--warnreach`. I looked into it and found that implicits are hardcoded to be always *un*dotted, so I changed it.