### PR TITLE
Fix Travis build

### DIFF
--- a/stack.yaml
+++ b/stack.yaml
@@ -9,6 +9,7 @@ extra-deps:
   - zip-archive-0.3.3@sha256:47cf2d66cc8e237f7226837758e1b041e24048ef3820d3d10276c500edb921bf
   - containers-0.5.11.0@sha256:28ad7337057442f75bc689315ab4ec7bdf5e6b2c39668f306672cecd82c02798
   - tasty-rerun-1.1.14@sha256:ba9c19a281535bea566e1044bc02c36ef17abcb310af4b6a149ec11780c7ce35
+  - binary-0.8.7.0@sha256:ae3e6cca723ac55c54bbb3fa771bcf18142bc727afd57818e66d6ee6c8044f12
 
 flags:
   idris:

--- a/stack.yaml
+++ b/stack.yaml
@@ -1,9 +1,6 @@
 #recheck extra-deps next on resolver or cabal file change
 resolver: lts-13.21
 
-packages:
-  - location: .
-
 extra-deps:
   - network-2.8.0.0@sha256:aae171e6c6028a7791dbe4de5b9d2da398056359e3cc7927465ffa3cdae1aa0b
   - Cabal-2.2.0.1@sha256:2a80d8fb655474f0eaeb20434c47f64f84e6302e55973056f00df8ca050b9683


### PR DESCRIPTION
The Travis build [seems to be complaining](https://travis-ci.org/idris-lang/Idris-dev/jobs/554976050) about something in the `package`s field. Instead of trying to find a formulation that works across various GHC/stack versions, I removed it because  `.` is the default value, anyway.