### PR TITLE
fix some documentation markup warnings

### DIFF
--- a/docs/proofs/interactive.rst
+++ b/docs/proofs/interactive.rst
@@ -190,7 +190,7 @@ accessible by pattern matching) and ``ih`` — the local variable
 containing the result of the recursive call. We can introduce these as
 assumptions using the ``intro`` tactic twice. The parameter is entered as
 a constant of type ``TTName`` which is entered as a backtick with double
-braces `{{ih}}. This gives:
+braces \`{{ih}}. This gives:
 
 .. code-block:: idris
 
@@ -289,7 +289,7 @@ However if we put the proof into a separate function like this:
   plusReducesZ' Z     = %runElab (do reflexivity)
   plusReducesZ' (S k) = let ih = plusReducesZ' k in plusredZ_S k ih
 
-This then loads.
+This then loads [#f1]_ .
 
 .. [#f1] https://github.com/idris-lang/Idris-dev/issues/4556
 

--- a/docs/reference/ffi.rst
+++ b/docs/reference/ffi.rst
@@ -121,12 +121,14 @@ Linking foreign code
 This is the example of linking C code. 
 
 .. code-block:: idris
+
     %include C "mylib.h"
     %link C "mylib.o"
 
 Example Makefile
 
 .. code-block:: shell
+
     DEFAULT: mylib.o main.idr
     	idris main.idr -o executableFile
 

--- a/docs/tutorial/miscellany.rst
+++ b/docs/tutorial/miscellany.rst
@@ -131,7 +131,7 @@ an extension of ``.lidr`` then it is assumed to be a literate file. In
 literate programs, everything is assumed to be a comment unless the line
 begins with a greater than sign ``>``, for example:
 
-.. code-block:: idris
+.. code-block:: literate-idris
 
     > module literate
 


### PR DESCRIPTION
This pull request corrects some errors in the markup of documentation pages which cause warnings to be output.

Currently (without this patch) warnings are given when the html documentation is generated (see listing below).

I am using Sphinx v1.7.6 because thats what comes with my distribution.
Note: there is a new warning: 'WARNING: Could not lex literal_block as "idris"' which is seen from Sphinx v1.3.5 onward (so may not be seen on Github/readthedocs?).

I have not changed anything for this particular warning so this will still be produced on certain versions of Sphinx.
It looks to me that the language specific highlighter for Sphinx need to be updated to cope with the following cases (but I'm no expert, I have no knowledge of how this works):

In docs/reference/syntax-guide.rst  this produces a warning:

```
.. code-block:: idris

    # import public Data.Vect
```

In docs/tutorial/miscellany.rst this produces a warning:

```
.. code-block:: idris

    > module literate

    This is a comment. The main program is below

    > main : IO ()
    > main = putStrLn "Hello literate world!\n"
```

In docs/tutorial/modules.rst this produces a warning:

```
.. code-block:: idris

    module A

    import B
    import public C
```

Also I have not changed anything to fix the 'Sphinx math extension' and '_static' does not exist' warnings since these seem to be more about the general environment rather than a markup issue. As far as I can see these warnings would be generated by the makefile but I don't know enough about the build environment to know.

So this patch fixes some of the warnings but you may want someone more knowledgeable than me to look at the others.

Martin

-------------------------
Output without this patch:
-------------------------
```
mjb@localhost:~> sphinx-build -b html Idris-dev/docs IdrisDoc
Running Sphinx v1.7.6
making output directory...
loading pickled environment... not yet created
building [mo]: targets for 0 po files that are out of date
building [html]: targets for 64 source files that are out of date
updating environment: 64 added, 0 changed, 0 removed
reading sources... [100%] tutorial/views                                                           
/home/mjb/Idris-dev/docs/proofs/interactive.rst:188: WARNING: Inline interpreted text or phrase reference start-string without end-string.
/home/mjb/Idris-dev/docs/proofs/interactive.rst:294: WARNING: Footnote [#] is not referenced.
/home/mjb/Idris-dev/docs/reference/ffi.rst:123: WARNING: Error in "code-block" directive:
maximum 1 argument(s) allowed, 7 supplied.

.. code-block:: idris
    %include C "mylib.h"
    %link C "mylib.o"
/home/mjb/Idris-dev/docs/reference/ffi.rst:129: WARNING: Error in "code-block" directive:
maximum 1 argument(s) allowed, 8 supplied.

.. code-block:: shell
    DEFAULT: mylib.o main.idr
        idris main.idr -o executableFile

    clean:
        rm -f executableFile mylib.o main.ibc
looking for now-outdated files... none found
pickling environment... done
checking consistency... done
preparing documents... done
writing output... [100%] tutorial/views
/home/mjb/Idris-dev/docs/reference/syntax-guide.rst:84: WARNING: Could not lex literal_block as "idris". Highlighting skipped.
/home/mjb/Idris-dev/docs/tutorial/miscellany.rst:134: WARNING: Could not lex literal_block as "idris". Highlighting skipped.
/home/mjb/Idris-dev/docs/tutorial/modules.rst:182: WARNING: Could not lex literal_block as "idris". Highlighting skipped.
/home/mjb/Idris-dev/docs/tutorial/theorems.rst: WARNING: using "math" markup without a Sphinx math extension active, please use one of the math extensions described at http://sphinx-doc.org/en/master/ext/math.html
generating indices... genindex
writing additional pages... search
copying images... [100%] st/../image/login.png
copying static files... WARNING: html_static_path entry '/home/mjb/Idris-dev/docs/_static' does not exist
done
copying extra files... done
dumping search index in English (code: en) ... done
dumping object inventory... done
build succeeded, 9 warnings.

The HTML pages are in IdrisDoc.
mjb@localhost:~> 

```