### PR TITLE
Fix Appveyor by pinning cabal

### DIFF
--- a/appveyor.yml
+++ b/appveyor.yml
@@ -1,7 +1,7 @@
 version: 1.0.{build}
 init:
 - ps: >-
-    choco install cabal --no-progress
+    choco install cabal --version=2.4.1.0 --no-progress
 
     mkdir C:\ghc
 


### PR DESCRIPTION
Cabal 3 doesn't work, for some reason the paths to the exes are absolute, and make uses them as relative when building the libs.