### PR TITLE
Update arguments to MKSTR() in FFI docs.

### DIFF
--- a/docs/reference/ffi.rst
+++ b/docs/reference/ffi.rst
@@ -384,7 +384,7 @@ copy it over.
     const VAL get_string ()
     {
         char * c_string = get_string_allocated_with_malloc()
-        const VAL idris_string = MKSTR(c_string);
+        const VAL idris_string = MKSTR(get_vm(), c_string);
         free(c_string);
         return idris_string
     }


### PR DESCRIPTION
I came across this issue when writing some toy programs which call into C code via the FFI API. The example given in the reference manual calls `MKSTR()` with only one argument (a `char *`) when the function as defined in `idris_rts.h` takes a handle to the currently running Idris VM as well as the string to duplicate. Inserting a call to `get_vm()` for this parameter in my testing code appears to fix this (based on a look around `rts/` to see what other parts of the C runtime do), so I've updated the example to match this.