### PR TITLE
Corrections in the `docs/reference`

### DIFF
--- a/docs/reference/codegen.rst
+++ b/docs/reference/codegen.rst
@@ -1,3 +1,5 @@
+.. _code-generation-targets:
+
 ************************
 Code Generation Targets
 ************************

--- a/docs/reference/compilation.rst
+++ b/docs/reference/compilation.rst
@@ -54,7 +54,7 @@ by setting a verbosity level.
   Checking, and the individual steps prior to code generation.
 
 
-By default Idris' progress reporting is set to quiet-``-q``, or ``--quiet``.
+By default Idris' progress reporting is set to quiet: ``-q``, or ``--quiet``.
 
 Logging Internal Operation
 ===========================
@@ -100,32 +100,32 @@ Environment Variables
 Several paths set by default within the Idris compiler can be
 overridden through environment variables.  The provided variables are:
 
-* `IDRIS_CC` Change the `C` compiler used by the `C` backend.
-* `IDRIS_CFLAGS` Change the `C` flags passed to the `C` compiler.
-* `TARGET`   Change the target directory i.e. `data dir` where Idris installs files when installing using Cabal/Stack.
-* `IDRIS_LIBRARY_PATH` Change the location of where installed packages are found/installed.
-* `IDRIS_DOC_PATH`  Change the location of where generated idrisdoc for packages are installed.
+* ``IDRIS_CC`` Change the *C compiler* used by the *C backend*.
+* ``IDRIS_CFLAGS`` Change the *C flags* passed to the *C compiler*.
+* ``TARGET``   Change the target directory i.e. *data dir* where Idris installs files when installing using Cabal/Stack.
+* ``IDRIS_LIBRARY_PATH`` Change the location of where installed packages are found/installed.
+* ``IDRIS_DOC_PATH``  Change the location of where generated idrisdoc for packages are installed.
 
 .. note::
 
    In versions of Idris prior to 0.12.3 the environment variables
-   `IDRIS_LIBRARY_PATH` and `TARGET` were both used to affect the
+   ``IDRIS_LIBRARY_PATH`` and ``TARGET`` were both used to affect the
    installation of single packages and direct where Idris installed
    its data. The meaning of these variables has changed, and command
    line options are preferred when changing where individual packages
    are installed.
 
-The CLI option `--ibcsubdir` can be used to direct where generated IBC
+The CLI option ``--ibcsubdir`` can be used to direct where generated IBC
 files are placed.  However, this means Idris will install files in a
 non-standard location separate from the rest of the installed
-packages. The CLI option `--idrispath <dir>` allows you to add a
+packages. The CLI option ``--idrispath <dir>`` allows you to add a
 directory to the library search path; this option can be used multiple
-times and can be shortened to `-i <dir>`. Similary, the `--sourcepath
-<dir>` option can be used to add directories to the source search
-path. There is no shortened version for this option as `-s` is a
+times and can be shortened to ``-i <dir>``. Similary, the ``--sourcepath
+<dir>`` option can be used to add directories to the source search
+path. There is no shortened version for this option as ``-s`` is a
 reserved flag.
 
 Further, Idris also supports options to augment the paths used, and
-pass options to the code generator backend.  The option `--cg-opt
-<ARG>` can be used to pass options to the code generator. The format
-of `<ARG>` is dependent on the selected backend.
+pass options to the code generator backend.  The option ``--cg-opt
+<ARG>`` can be used to pass options to the code generator. The format
+of ``<ARG>`` is dependent on the selected backend.

--- a/docs/reference/erasure.rst
+++ b/docs/reference/erasure.rst
@@ -269,7 +269,7 @@ Usage warnings are quite bad and unhelpful at the moment. We should
 include more information and at least translate argument numbers to
 their names.
 
-There is no decent documentation yet. This wiki page is the first one.
+There is no decent documentation yet. This page is the first one.
 
 There is no generally accepted terminology. We switch between
 "dotted", "unused", "erased", "irrelevant", "inaccessible", while each

--- a/docs/reference/ffi.rst
+++ b/docs/reference/ffi.rst
@@ -204,9 +204,10 @@ unable to pass the closed-over values through C. If we want to pass Idris values
 to the callback we have to pass them through C explicitly. Non-primitive Idris
 values can be passed to C via the ``Raw`` type.
 
-The other big limitation is that it doesn't support IO functions. Use
-``unsafePerformIO`` to wrap them (i.e. to make an IO function usable as a callback, change the return type
-from IOr to r, and change the = do to = unsafePerformIO $ do).
+The other big limitation is that it doesn't support ``IO`` functions. Use
+``unsafePerformIO`` to wrap them (i.e. to make an ``IO`` function usable as a
+callback, change the return type from ``IO r`` to ``r``, and change the ``= do``
+to ``= unsafePerformIO $ do``).
 
 There are two special function names:
 ``%wrapper`` returns the function pointer that wraps an Idris function. This
@@ -258,7 +259,7 @@ useful to access constants that are preprocessor definitions (like ``INT_MAX``).
     main = print !intMax
 
 For more complicated interactions with C (such as reading and setting fields
-of a C struct), there is a module CFFI available in the contrib package.
+of a C ``struct``), there is a module C FFI available in the contrib package.
 
 C heap
 ------
@@ -371,7 +372,7 @@ Usage from C code
 The ``Raw`` type constructor allows you to access or return a runtime
 representation of the value. For instance, if you want to copy a string
 generated from C code into an Idris value, you may want to return a
-``Raw String``instead of a ``String`` and use ``MKSTR`` or ``MKSTRlen`` to
+``Raw String`` instead of a ``String`` and use ``MKSTR`` or ``MKSTRlen`` to
 copy it over.
 
 .. code-block:: idris
@@ -393,7 +394,7 @@ FFI implementation
 ------------------
 
 In order to write bindings to external libraries, the details of how
-``foreign`` works are unnecessary --- you simply need to know that
+``foreign`` works are unnecessary: you simply need to know that
 ``foreign`` takes an FFI descriptor, the function name, and its
 type. It is instructive to look a little deeper, however:
 

--- a/docs/reference/internals.rst
+++ b/docs/reference/internals.rst
@@ -10,8 +10,8 @@ free to contribute.
 This document assumes that you are already familiar with Idris. It is
 intended for those who want to work on the internals.
 
-People looking to develop new back ends may want to look at [[Idris back
-end IRs\|Idris-back-end-IRs]]
+People looking to develop new back ends may want to look at
+:ref:`code-generation-targets`
 
 Core/TT.hs
 ==========
@@ -53,7 +53,7 @@ with ``SC`` and ``CaseAlt`` to get GHC to generate a function for
 mapping over contained terms.
 
 Constructor cases (``ConCase`` in ``CaseAlt``) refer to numbered
-constructors. Every constructor is numbered 0,1,2,…. At this stage in
+constructors. Every constructor is numbered *0,1,2,…*. At this stage in
 the compiler, the tags are datatype-local. After defunctionalization,
 however, they are made globally unique.
 
@@ -91,12 +91,12 @@ dictionary which makes totality checking easier.
 The ``normalise*`` functions give different behaviors - but
 ``normalise`` is the most common.
 
-``normaliseC`` - "resolved" means with names converted to de Bruijn
-indices as appropriate.
+- ``normaliseC`` - "resolved" means with names converted to de Bruijn
+  indices as appropriate;
 
-``normaliseAll`` - reduce everything, even if it's non-total
+- ``normaliseAll`` - reduce everything, even if it's non-total;
 
-``normaliseTrace`` - special-purpose for debugging
+- ``normaliseTrace`` - special-purpose for debugging.
 
 ``simplify`` - reduce the things that are small - the list argument is
 the things to not reduce.
@@ -110,8 +110,8 @@ Core/Elaborate.hs
 =================
 
 Idris definitions are elaborated one by one and turned into the
-corresponding TT. This is done with a tactic language as an EDSL in the
-Elab monad (or Elab' when there's a custom state).
+corresponding ``TT``. This is done with a tactic language as an EDSL in the
+``Elab`` monad (or ``Elab'`` when there's a custom state).
 
 Lots of plumbing for errors.
 
@@ -122,17 +122,17 @@ The string in the pair returned by elaborate is log information.
 See JFP paper, but the names don't necessarily map to each other. The
 paper is the "idealized version" without logging, additional state, etc.
 
-All the tactics take Raws, typechecking happens there.
+All the tactics take ``Raw`` s, typechecking happens there.
 
-claim (x : t) assumes a new x : t.
+``claim (x : t)`` assumes a new ``x : t``.
 
 PLEASE TIDY THINGS UP!
 
-proofSearch flag to try' is whether the failure came from a human (so
+``proofSearch`` flag is to try whether the failure came from a human (so
 fail) or from a machine (so continue)
 
-Idris-level syntax for providing alternatives explicitly: (\| x, y, z
-\|) try x, y, z in order, and take the first that succeeds.
+Idris-level syntax for providing alternatives explicitly: ``(| x, y, z
+|)`` try ``x``, ``y``, ``z`` in order, and take the first that succeeds.
 
 Core/ProofState.hs
 ==================
@@ -140,37 +140,40 @@ Core/ProofState.hs
 Core/Unify.hs
 =============
 
-Deals with unification. Unification can reply with: - this works - this
-can never work - this will work if these other unification problems work
-out (eg unifying f x with 1)
+Deals with unification. Unification can reply with:
 
-match\_unify: same thing as unification except it's just matching name
-against name, term against term. x + y matches to 0 + y with x = 0. Used
-for <== syntax as well as type class resolution.
+- this works
+- this can never work
+- this will work if these other unification problems work out (e.g.
+  unifying ``f x`` with ``1``)
+
+``match_unify``: same thing as unification except it's just matching name
+against name, term against term. ``x + y`` matches to ``0 + y`` with
+``x = 0``. Used for ``<==`` syntax as well as type class resolution.
 
 Idris/AbsSyntaxTree.hs
 ======================
 
-PTerm is the datatype of Idris syntax. P is for Program. Each PTerm
-turns into a TT term by applying a series of tactics.
+``PTerm`` is the datatype of Idris syntax. ``P`` is for *Program*.
+Each ``PTerm`` turns into a TT term by applying a series of tactics.
 
-IState is the major interpreter state. The global context is the
-tt\_ctxt field.
+``IState`` is the major interpreter state. The global context is the
+``tt_ctxt`` field.
 
-Ctxt maps possibly ambiguous names to their referents.
+``Ctxt`` maps possibly ambiguous names to their referents.
 
 Idris/ElabDecls.hs
 ==================
 
-This is where the actual elaboration from PTerm to TT happens.
+This is where the actual elaboration from ``PTerm`` to ``TT`` happens.
 
 Idris/ElabTerm.hs
 =================
 
-build is the function that creates a Raw. All the "junk" is to deal with
+``build`` is the function that creates a ``Raw``. All the "junk" is to deal with
 things like metavars and so forth. It has to remember what names are
 still to be defined, and it doesn't yet know the type (filled in by
 unificaiton later). Also case expressions have to turn into top-level
 functions.
 
-resolveTC is type class resolution.
+``resolveTC`` is type class resolution.

--- a/docs/reference/uniqueness-types.rst
+++ b/docs/reference/uniqueness-types.rst
@@ -199,7 +199,7 @@ return it in exactly the condition in which it was received!
 The restriction is that when a ``Borrowed`` type is matched, any
 pattern variables under the ``Read`` which have a unique type may not
 be referred to at all on the right hand side (unless they are
-themselves ``lent`` to another function).
+themselves lent to another function).
 
 Uniqueness information is stored in the type, and in particular in
 function types. Once we're in a unique context, any new function which


### PR DESCRIPTION
Mostly backticks, but also old wiki artifacts (incl. references) were corrected. Also, an attempt of structuring in pretty non-structured file.