### PR TITLE
Effects tutorial fix and additon of small clarification

### DIFF
--- a/docs/effects/depeff.rst
+++ b/docs/effects/depeff.rst
@@ -156,9 +156,12 @@ file management follows a resource usage protocol with the following
 These requirements can be expressed formally by creating a
 ``FILE_IO`` effect parameterised over a file handle state, which is
 either empty, open for reading, or open for writing. The ``FILE_IO``
-effect’s definition is given below. Note that this
-effect is mainly for illustrative purposes—typically we would also like
-to support random access files and better reporting of error conditions.
+effect’s definition is given below.
+
+.. note::
+    This effect is mainly for illustrative purposes.
+    Typically we would also like to support random access files and
+    better reporting of error conditions.
 
 .. code-block:: idris
 

--- a/docs/effects/depeff.rst
+++ b/docs/effects/depeff.rst
@@ -153,7 +153,7 @@ file management follows a resource usage protocol with the following
 
 -  When a file is closed, its handle should no longer be used
 
-These requirements can be expressed formally in , by creating a
+These requirements can be expressed formally by creating a
 ``FILE_IO`` effect parameterised over a file handle state, which is
 either empty, open for reading, or open for writing. The ``FILE_IO``
 effect’s definition is given below. Note that this
@@ -173,7 +173,7 @@ to support random access files and better reporting of error conditions.
 
     open : (fname : String)
            -> (m : Mode)
-           -> Eff Bool [FILE_IO ()] 
+           -> Eff Bool [FILE_IO ()]
                        (\res => [FILE_IO (case res of
                                                True => OpenFile m
                                                False => ())])
@@ -191,7 +191,7 @@ In particular, consider the type of ``open``:
 
     open : (fname : String)
            -> (m : Mode)
-           -> Eff Bool [FILE_IO ()] 
+           -> Eff Bool [FILE_IO ()]
                        (\res => [FILE_IO (case res of
                                                True => OpenFile m
                                                False => ())])
@@ -207,7 +207,7 @@ we continue the protocol accordingly.
 
     readFile : Eff (List String) [FILE_IO (OpenFile Read)]
     readFile = readAcc [] where
-        readAcc : List String -> Eff (List String) [FILE_IO (OpenFile Read)] 
+        readAcc : List String -> Eff (List String) [FILE_IO (OpenFile Read)]
         readAcc acc = if (not !eof)
                          then readAcc (!readLine :: acc)
                          else pure (reverse acc)

--- a/docs/effects/depeff.rst
+++ b/docs/effects/depeff.rst
@@ -163,6 +163,12 @@ effect’s definition is given below.
     Typically we would also like to support random access files and
     better reporting of error conditions.
 
+    Moreover, the ``FILE`` effect in the ``Effect.File`` module of
+    the ``effects`` library uses slightly more complicated types to
+    support erroneous behaviour of each function and to support more
+    compilcated modes of opening, like for reading **and** writing,
+    appending or truncating.
+
 .. code-block:: idris
 
     module Effect.File

--- a/docs/effects/summary.rst
+++ b/docs/effects/summary.rst
@@ -43,16 +43,16 @@ FILE\_IO
     data OpenFile : Mode -> Type
 
     open : (fname : String)
-           -> (m : Mode)
-           -> Eff Bool [FILE_IO ()] 
-                       (\res => [FILE_IO (case res of
-                                               True => OpenFile m
-                                               False => ())])
+        -> (m : Mode)
+        -> Eff Bool [FILE_IO ()]
+                    (\res => [FILE_IO (case res of
+                                            True => OpenFile m
+                                            False => ())])
     close : Eff () [FILE_IO (OpenFile m)] [FILE_IO ()]
 
-    readLine  : Eff String [FILE_IO (OpenFile Read)]
+    readLine  :           Eff String [FILE_IO (OpenFile Read)]
     writeLine : String -> Eff () [FILE_IO (OpenFile Write)]
-    eof       : Eff Bool [FILE_IO (OpenFile Read)]
+    eof       :           Eff Bool [FILE_IO (OpenFile Read)]
 
     Handler FileIO IO where { ... }
 
@@ -69,9 +69,9 @@ RND
 
     RND : EFFECT
 
-    srand  : Integer ->            Eff m () [RND]
-    rndInt : Integer -> Integer -> Eff m Integer [RND]
-    rndFin : (k : Nat) ->          Eff m (Fin (S k)) [RND]
+    srand  : Integer ->            Eff () [RND]
+    rndInt : Integer -> Integer -> Eff Integer [RND]
+    rndFin : (k : Nat) ->          Eff (Fin (S k)) [RND]
 
     Handler Random m where { ... }
 
@@ -86,7 +86,7 @@ SELECT
 
     SELECT : EFFECT
 
-    select : List a -> Eff m a [SELECT]
+    select : List a -> Eff a [SELECT]
 
     Handler Selection Maybe where { ... }
     Handler Selection List where { ... }
@@ -102,10 +102,10 @@ STATE
 
     STATE : Type -> EFFECT
 
-    get    :             Eff m x [STATE x]
-    put    : x ->        Eff m () [STATE x]
-    putM   : y ->        Eff m () [STATE x] [STATE y]
-    update : (x -> x) -> Eff m () [STATE x]
+    get    :             Eff x [STATE x]
+    put    : x ->        Eff () [STATE x]
+    putM   : y ->        Eff () [STATE x] [STATE y]
+    update : (x -> x) -> Eff () [STATE x]
 
     Handler State m where { ... }
 
@@ -121,12 +121,12 @@ STDIO
 
     STDIO : EFFECT
 
-    putChar  : Handler StdIO m => Char ->   Eff m () [STDIO]
-    putStr   : Handler StdIO m => String -> Eff m () [STDIO]
-    putStrLn : Handler StdIO m => String -> Eff m () [STDIO]
+    putChar  : Char   -> Eff () [STDIO]
+    putStr   : String -> Eff () [STDIO]
+    putStrLn : String -> Eff () [STDIO]
 
-    getStr   : Handler StdIO m =>           Eff m String [STDIO]
-    getChar  : Handler StdIO m =>           Eff m Char [STDIO]
+    getStr   :           Eff String [STDIO]
+    getChar  :           Eff Char [STDIO]
 
     Handler StdIO IO where { ... }
     Handler StdIO (IOExcept a) where { ... }
@@ -144,9 +144,9 @@ SYSTEM
 
     SYSTEM : EFFECT
 
-    getArgs : Handler System e =>           Eff e (List String) [SYSTEM]
-    time    : Handler System e =>           Eff e Int [SYSTEM]
-    getEnv  : Handler System e => String -> Eff e (Maybe String) [SYSTEM]
+    getArgs :           Eff (List String) [SYSTEM]
+    time    :           Eff Int [SYSTEM]
+    getEnv  : String -> Eff (Maybe String) [SYSTEM]
 
     Handler System IO where { ... }
     Handler System (IOExcept a) where { ... }


### PR DESCRIPTION
The summary of the `effects` library used incorrect (maybe old?) type of the `Eff` type with explicit `m : Type -> Type` argument. Also, some of functions in the summary required explicitly `Handler`s (which they should not require). I've fixed it.

Also, the styling (indenting) of the `FILE_IO` part was made to be consistent with the rest of the summary.

Also, I made one existing note as a _ReST's note_ and extended it for those people who may want to use the `FILE` effect after the effects tutorial reading (to make the wonder a bit less).