### PR TITLE
fix Sphinx warning

### DIFF
--- a/docs/proofs/propositional.rst
+++ b/docs/proofs/propositional.rst
@@ -34,7 +34,7 @@ Replace
 
 This implements the *indiscernability of identicals* principle, if two terms are equal then they have the same properties. In other words, if ``x=y``, then we can substitute ``y`` for ``x`` in any expression. In our proofs we can express this as:
 
-.. code-block::
+.. code-block:: idris
 
    if x=y
    then P x = P y


### PR DESCRIPTION
This is a minor change to documentation markup. It removes the following warning when Sphinx is run. I tried this on Sphinx v1.7.6, earlier versions of Sphinx may not generate this warning but since Sphinx now considers this incorrect, I think its best to follow their latest requirements.

```
mjb@localhost:~> sphinx-build -b html Idris-dev/docs IdrisDoc
Running Sphinx v1.7.6
making output directory...
loading pickled environment... not yet created
building [mo]: targets for 0 po files that are out of date
building [html]: targets for 71 source files that are out of date
updating environment: 71 added, 0 changed, 0 removed
reading sources... [100%] tutorial/views
/home/mjb/Idris-dev/docs/proofs/propositional.rst:37: WARNING: Error in "code-block" directive:
1 argument(s) required, 0 supplied.

.. code-block::

   if x=y
   then P x = P y
looking for now-outdated files... none found
pickling environment... done
checking consistency... done
preparing documents... done
writing output... [100%] tutorial/views
```

This warning was introduced by the pull request here:
https://github.com/idris-lang/Idris-dev/pull/4776