### PR TITLE
Extend and Fix Parser Library Documentation

### DIFF
--- a/docs/parserLibrary/introduction.rst
+++ b/docs/parserLibrary/introduction.rst
@@ -25,21 +25,21 @@ complicated parser can be made out of many smaller ones.
         - Lexer - This takes the input string and turns it into a list of Tokens.
         - Parser - This takes the list of tokens and outputs the code.
 
-.. image:: ../image/parserTopLevel.png
-   :width: 307px
-   :height: 76px
-   :alt: diagram illustrating these stages of lexer and parser
+    - .. image:: ../image/parserTopLevel.png
+         :width: 307px
+         :height: 76px
+         :alt: diagram illustrating these stages of lexer and parser
 
 The advantage of using two stages, like this, is that things like whitespace and
 comments don't need to be considered in every parser rule.
 
-The  Idris parser library differs from Parsec in that you need to say in the
-Recogniser whether a rule is guaranteed to consume input. This means that the
+The  Idris parser library differs from Parsec in that you need to say, in the
+Recogniser, whether a rule is guaranteed to consume input. This means that the
 Idris type system prevents the construction of recognisers/rules that can't
 consume the input.
 
 The Lexer is similar but works at the level of characters rather than tokens, and
-you need to provide a TokenMap which says how to build a token representation from
+you need to provide a TokenMap which defines how to build a token from
 a string when a rule is matched.
 
 The following pages contain a tutorial for the :ref:`parserLibraryLexer` and a

--- a/docs/parserLibrary/lexer.rst
+++ b/docs/parserLibrary/lexer.rst
@@ -10,13 +10,16 @@ module:
 
  lex : TokenMap a -> String -> (List (TokenData a), (Int, Int, String))
 
-This function takes a String and returns a list of tokens. With the tokens we
-have indexes back to the original string which can be used in error messages:
+.. list-table::
 
-.. image:: ../image/tokenise.png
-   :width: 330px
-   :height: 73px
-   :alt: diagram illustrating these stages of lexer
+  * - This function takes a String and returns a list of tokens. With the
+      tokens we have indexes back to the original string which can be used
+      in error messages:
+
+    - .. image:: ../image/tokenise.png
+         :width: 330px
+         :height: 73px
+         :alt: diagram illustrating these stages of lexer
 
 TokenMap
 --------
@@ -34,21 +37,24 @@ this information:
   (Lexer, String -> tokenType)
 
 So for each Lexer in the list, if a substring in the input matches, run
-the associated function to produce a token of type `tokenType`
+the associated function to produce a token of type ``tokenType``
 
-from Text.Lexer.Core:
+.. list-table::
 
-.. code-block:: idris
+  * - from Text.Lexer.Core
+      : https://github.com/idris-lang/Idris-dev/blob/master/libs/contrib/Text/Lexer/Core.idr
 
-  TokenMap : (tokenType : Type) -> Type
-  TokenMap tokenType = List (Lexer, String -> tokenType)
+    - .. code-block:: idris
 
-We can create a tokenMap by using a function like this:
+        TokenMap : (tokenType : Type) -> Type
+        TokenMap tokenType = List (Lexer, String -> tokenType)
 
-.. code-block:: idris
+  * - We can create a tokenMap by using a function like this:
 
-  myTokenMap : TokenMap Token
-  myTokenMap = [(is 'a',CharLit)]
+    - .. code-block:: idris
+
+        myTokenMap : TokenMap Token
+        myTokenMap = [(is 'a',CharLit)]
 
 Once we have a TokenMap we can use it to lex many strings.
 
@@ -74,7 +80,7 @@ combined, for example,
 
 .. list-table::
 
-  * - <+> means sequence two recognisers. If either consumes a character,
+  * - ``<+>`` means sequence two recognisers. If either consumes a character,
       the sequence is guaranteed to consume a character.
 
     -  .. code-block:: idris
@@ -83,7 +89,7 @@ combined, for example,
          SeqEat (Pred (\ARG => intToBool (prim__eqChar ARG 'a')))
                (Delay (is 'b')) : Recognise True
 
-  * - <|> means if both consume, the combination is guaranteed
+  * - ``<|>`` means if both consume, the combination is guaranteed
       to consumer a character:
 
     - .. code-block:: idris
@@ -161,7 +167,7 @@ able to parse simple arithmetic expressions, like this:
 so we need:
 
 - Numbers (for now integer literals are good enough).
-- Some operators (for now '+', '-' and '*' will do.
+- Some operators (for now ``+``, ``-`` and ``*`` will do.
 - Opening and closing Parentheses.
 
 We can define these, as tokens, like this:
@@ -178,7 +184,7 @@ We can define these, as tokens, like this:
            | EndInput
 
 It may help with debugging and to implement error messages to
-implement 'show' for these tokens:
+implement ``show`` for these tokens:
 
 .. code-block:: idris
 

--- a/docs/parserLibrary/parser.rst
+++ b/docs/parserLibrary/parser.rst
@@ -3,7 +3,7 @@
 Parser
 ======
 
-To run the parser we call ``parse``. This requires a Grammar and the output
+To run the parser we call ``parse``. This requires a grammar and the output
 from the lexer (which is a list of tokens).
 
 .. code-block:: idris
@@ -18,13 +18,13 @@ If successful this returns 'Right' with a pair of
 
 otherwise it returns 'Left' with the error message.
 
-So we need to define the Grammar for our parser, this is done using the following
+So we need to define the grammar for our parser, this is done using the following
 'Grammar' data structure. This is a combinator structure, similar in principle
 to the recogniser combinator for the lexer, which was discussed on the
 previous page.
 
-As with the Recogniser the Grammar type is dependent on a boolean 'consumes'
-value which allows us to ensure that complicated Grammar structures will always
+As with the Recogniser the ``Grammar`` type is dependent on a boolean 'consumes'
+value which allows us to ensure that complicated ``Grammar`` structures will always
 consume input.
 
 .. code-block:: idris
@@ -53,7 +53,7 @@ consume input.
            Grammar tok c1 ty -> Grammar tok c2 ty ->
            Grammar tok (c1 && c2) ty
 
-So an example of a Grammer type may look something like this:
+So an example of a grammer type may look something like this:
 ``Grammar (TokenData ExpressionToken) True Integer``.
 This is a complicated type name and a given parser will need to use it a lot.
 So to reduce the amount of typing we can use the following type synonym (similar
@@ -89,7 +89,7 @@ this page we will go on to add a parser for this running example.
 
 .. list-table::
 
-  * - To start, here is a Grammar to parse an integer literal (that is, a
+  * - To start, here is a grammar to parse an integer literal (that is, a
       sequence of numeric characters).
 
     - .. code-block:: idris
@@ -280,13 +280,15 @@ So lets try to use this to define a grammar which recognises either:
 - An integer literal inside parenthesis inside parenthesis
 - ... and so on.
 
-This requires a recursively defined structure like this:
+.. list-table::
 
-.. code-block:: idris
+  * - This requires a recursively defined structure like this:
 
-  partial
-  expr : Rule Integer
-  expr = intLiteral <|> (paren expr)
+    - .. code-block:: idris
+
+        partial
+        expr : Rule Integer
+        expr = intLiteral <|> (paren expr)
 
 This is a valid grammar because every time it is called it is guaranteed to
 consume a token. However, as an Idris structure, it is problematic due to
@@ -330,7 +332,7 @@ defined like this:
                 pure r
 
 This can be more flexible than using the ``<*>`` operator. Also it is defined
-using ``Inf`` so we can implement recursively defined grammars like the above.
+using ``Inf`` so we can implement recursively defined grammars as above.
 
 Implementing the Arithmetic Operators
 -------------------------------------
@@ -359,7 +361,7 @@ In order to work up to this gradually lets start with prefix operators
 
         expr = (add (op "+") expr expr)
 
-where `op` is defined like this:
+where ``op`` is defined like this:
 
 .. code-block:: idris
 
@@ -374,6 +376,12 @@ where `op` is defined like this:
 
   * - and ``add`` is defined like this:
 
+      Where:
+
+      - x is the add operator.
+      - y is the first operand.
+      - z is the second operand.
+
     - .. code-block:: idris
 
         addInt : Integer -> Integer -> Integer
@@ -386,40 +394,37 @@ where `op` is defined like this:
             Grammar tok ((c1 || c2) || c3) Integer
         add x y z = map addInt (x *> y) <*> z
 
-Where:
 
-- x is the add operator.
-- y is the first operand.
-- z is the second operand.
 
 The resulting integer will be the sum of the two operands.
 
-The other operators are defined in a similar way:
+.. list-table::
 
-.. code-block:: idris
+  * - The other operators are defined in a similar way:
 
-  subInt : Integer -> Integer -> Integer
-  subInt a b = a-b
+    - .. code-block:: idris
 
-  export
-  sub : Grammar tok c1 Integer ->
-      Grammar tok c2 Integer ->
-      Grammar tok c3 Integer ->
-      Grammar tok ((c1 || c2) || c3) Integer
-  sub x y z = map subInt (x *> y) <*> z
+        subInt : Integer -> Integer -> Integer
+        subInt a b = a-b
 
+        export
+        sub : Grammar tok c1 Integer ->
+            Grammar tok c2 Integer ->
+            Grammar tok c3 Integer ->
+            Grammar tok ((c1 || c2) || c3) Integer
+        sub x y z = map subInt (x *> y) <*> z
 
-  multInt : Integer -> Integer -> Integer
-  multInt a b = a*b
+        multInt : Integer -> Integer -> Integer
+        multInt a b = a*b
 
-  export
-  mult : Grammar tok c1 Integer ->
-      Grammar tok c2 Integer ->
-      Grammar tok c3 Integer ->
-      Grammar tok ((c1 || c2) || c3) Integer
-  mult x y z = map multInt (x *> y) <*> z
+        export
+        mult : Grammar tok c1 Integer ->
+            Grammar tok c2 Integer ->
+            Grammar tok c3 Integer ->
+            Grammar tok ((c1 || c2) || c3) Integer
+        mult x y z = map multInt (x *> y) <*> z
 
-So the top level Grammar can now be defined as follows. Note that this is
+So the top level ``Grammar`` can now be defined as follows. Note that this is
 partial as it is a potentially infinite structure and so not total.
 
 .. code-block:: idris
@@ -472,7 +477,7 @@ Then an invalid syntax:
                                         List (TokenData ExpressionToken))
 
 However if we try something that is invalid, but starts with a valid token,
-then it will return 'Right' (to indicate success)
+then it will return ``Right`` (to indicate success)
 
 .. code-block:: idris
 
@@ -499,20 +504,9 @@ Infix Notation
 --------------
 
 So far we have implemented a prefix notation for operators (like this:
-'+ expr expr') but the aim is to implemented an infix notation (like this:
-'expr + expr'). To do this we must be able to deal with potentially
+``+ expr expr``) but the aim is to implemented an infix notation (like this:
+``expr + expr``). To do this we must be able to deal with potentially
 infinite data structures (see Codata Types here :ref:`sect-typefuns`).
-
-.. code-block:: idris
-
-  expression = ["+"|"-"] term {("+"|"-") term} .
-
-  term = factor {("*"|"/") factor} .
-
-  factor =
-     ident
-     | number
-     | "(" expression ")"
 
 First alter the grammar to have infix operations:
 
@@ -569,10 +563,10 @@ If we have a rule like this:
 
   A -> (x<*>y) <|> (x<*>z)
 
-If 'x<*>y' fails but 'x<*>z' would succeed a problem is that, 'x<*>y' has
-already consumed 'x', so now 'x<*>z' will fail.
+If ``x<*>y`` fails but ``x<*>z`` would succeed a problem is that, ``x<*>y`` has
+already consumed ``x``, so now ``x<*>z`` will fail.
 
-so we could write code to backtrack. That is 'try' 'x<*>y' without consuming
+so we could write code to backtrack. That is ``try`` ``x<*>y`` without consuming
 so that, if the first token succeeds but the following tokens fail, then the
 first tokens would not be consumed.
 
@@ -599,9 +593,22 @@ That is we convert a general context-free grammar to a LL(1) grammar. Although
 not every context-free grammar can be converted to a LL(1) grammar.
 
 This still does not solve the infinite recursion issue and there is another
-problem: the precedence of the operators +, - and * is not explicit.
+problem: the precedence of the operators ``+``, ``-`` and ``*`` is not explicit.
 
-To resolve this we can alter the example like this:
+.. list-table::
+
+  * - To resolve this we can alter the example to have a BNF like this:
+
+    - .. code-block:: idris
+
+        'expression' ::=  ['+'|'-'] 'term' {('+'|'-') 'term'}
+
+        'term' ::=  'factor' {'*' 'factor'}
+
+        'factor' ::=
+           number
+           | '(' 'expression' ')'
+
 
 .. code-block:: idris
 

--- a/docs/parserLibrary/parser.rst
+++ b/docs/parserLibrary/parser.rst
@@ -3,8 +3,8 @@
 Parser
 ======
 
-To run our parser we call 'parse'. This requires a Grammar and the output
-from the lexer (a list of tokens).
+To run the parser we call ``parse``. This requires a Grammar and the output
+from the lexer (which is a list of tokens).
 
 .. code-block:: idris
 
@@ -54,12 +54,12 @@ consume input.
            Grammar tok (c1 && c2) ty
 
 So an example of a Grammer type may look something like this:
-'Grammar (TokenData ExpressionToken) True Integer'.
-
+``Grammar (TokenData ExpressionToken) True Integer``.
 This is a complicated type name and a given parser will need to use it a lot.
 So to reduce the amount of typing we can use the following type synonym (similar
 to what is done in Idris 2
 : https://github.com/edwinb/Idris2/blob/master/src/Parser/Support.idr
+)
 
 .. code-block:: idris
 
@@ -71,12 +71,12 @@ Parser Example
 --------------
 
 On the previous page we implemented a lexer to 'lex' a very simple expression, on
-this page we will go on to implement a parser for this running example.
+this page we will go on to add a parser for this running example.
 
 .. list-table::
 
-  * - Expressed in Backus–Naur form (BNF) the syntax we are aiming at is something
-      like this:
+  * - The syntax we are aiming at is something
+      like this (expressed in Backus–Naur form (BNF)):
     - .. code-block:: idris
 
          <expr> ::= <integer literal>
@@ -90,7 +90,7 @@ this page we will go on to implement a parser for this running example.
 .. list-table::
 
   * - To start, here is a Grammar to parse an integer literal (that is, a
-      sequence of numbers).
+      sequence of numeric characters).
 
     - .. code-block:: idris
 
@@ -144,7 +144,7 @@ successful, this is because we are not specifically checking for end-of-file.
 
 .. list-table::
 
-  * - The 'intLiteral' function above uses the 'terminal' function to
+  * - The ``intLiteral`` function above uses the ``terminal`` function to
       construct the grammar
     - .. code-block:: idris
 
@@ -174,10 +174,10 @@ Idris 2 uses a slightly different version which stores an error message like
                            OParen => Just 0
                            _ => Nothing)
 
-Integer value is not really relevant for parenthesis so '0' is used as
+Integer value is not really relevant for parenthesis so ``0`` (zero) is used as
 a default value.
 
-As before, we can test this out with a function like this:
+As before, this can be tested with a function like this:
 
 .. code-block:: idris
 
@@ -202,10 +202,10 @@ error for anything else:
                                               List (TokenData ExpressionToken))
 
 Now we have two Grammars we can try combining them. The following test looks
-for 'openParen' followed by 'intLiteral', the two Grammars are combined using
-'<*>'. The 'map const' part uses the integer value from the first.
+for ``openParen`` followed by ``intLiteral``, the two Grammars are combined using
+``<*>``. The ``map const`` part uses the integer value from the first.
 
-The following test is looking for '(' followed by a number:
+The following test is looking for ``(`` followed by a number:
 
 .. code-block:: idris
 
@@ -213,8 +213,8 @@ The following test is looking for '(' followed by a number:
                         (Integer, List (TokenData ExpressionToken))
   test3 s = parse (map const openParen <*> intLiteral) (fst (lex expressionTokens s))
 
-We can see below that '(' followed by a number is successfully parsed but other
-token lists are not:
+We can see below that ``(`` followed by a number is successfully parsed but, as
+required, other token lists are not:
 
 .. code-block:: idris
 
@@ -270,21 +270,85 @@ token lists are not:
         paren : Rule Integer -> Rule Integer
         paren exp = openParen *> exp <* closeParen
 
-The use of '*>' and '<*' instead of '<*>' is an easy way to use the integer
+The use of ``*>`` and ``<*`` instead of ``<*>`` is an easy way to use the integer
 value from the inner expression.
+
+So lets try to use this to define a grammar which recognises either:
+
+- An integer literal
+- An integer literal inside parenthesis
+- An integer literal inside parenthesis inside parenthesis
+- ... and so on.
+
+This requires a recursively defined structure like this:
+
+.. code-block:: idris
+
+  partial
+  expr : Rule Integer
+  expr = intLiteral <|> (paren expr)
+
+This is a valid grammar because every time it is called it is guaranteed to
+consume a token. However, as an Idris structure, it is problematic due to
+the recursion. Defining it as partial allows it to compile but at runtime
+we are likely to get a crash with an (unhelpful) error message like
+``killed by signal 11``.
+
+So a better method is to use ``do`` notation as described in the following
+section.
+
+Monadic Combinator
+------------------
+
+In addition to ``<|>`` and ``<*>`` there is a ``>>=`` combinator, which is
+defined like this:
+
+.. code-block:: idris
+
+  ||| Sequence two grammars. If either consumes some input, the sequence is
+  ||| guaranteed to consume some input. If the first one consumes input, the
+  ||| second is allowed to be recursive (because it means some input has been
+  ||| consumed and therefore the input is smaller)
+  export %inline
+  (>>=) : {c1 : Bool} ->
+        Grammar tok c1 a ->
+        inf c1 (a -> Grammar tok c2 b) ->
+        Grammar tok (c1 || c2) b
+  (>>=) {c1 = False} = SeqEmpty
+  (>>=) {c1 = True} = SeqEat
 
 .. list-table::
 
-  * - Now for the operations, in this case: '+', '-' and '*'.
-      The syntax we require is that operators like '+' are infix operators, which
-      would require a definition like this:
+  * - This allows us to use ``do`` notation for the previous parenthesis example:
 
     - .. code-block:: idris
 
-        expr = (add expr (op "+") expr)
+         expr = intLiteral <|> do
+                openParen
+                r <- expr
+                closeParen
+                pure r
 
-This is a potentially infinite structure which is not total.
-In order to work up to this gradually I will start with prefix operators
+This can be more flexible than using the ``<*>`` operator. Also it is defined
+using ``Inf`` so we can implement recursively defined grammars like the above.
+
+Implementing the Arithmetic Operators
+-------------------------------------
+
+.. list-table::
+
+  * - Now for the operations, in this case: ``+``, ``-`` and ``*``.
+      The syntax we require for these infix operators
+      would require recursive grammars like this:
+
+    - .. code-block:: idris
+
+        expr = expr (op "+") expr
+
+As already explained, ``do`` notation can allow us to use recursive
+definitions but not necessarily left-recursion like this.
+
+In order to work up to this gradually lets start with prefix operators
 (sometimes known as Polish notation) then modify later for infix operators.
 
 .. list-table::
@@ -295,7 +359,7 @@ In order to work up to this gradually I will start with prefix operators
 
         expr = (add (op "+") expr expr)
 
-where 'op' is defined like this:
+where `op` is defined like this:
 
 .. code-block:: idris
 
@@ -308,7 +372,7 @@ where 'op' is defined like this:
 
 .. list-table::
 
-  * - and 'add' is defined like this:
+  * - and ``add`` is defined like this:
 
     - .. code-block:: idris
 
@@ -438,6 +502,17 @@ So far we have implemented a prefix notation for operators (like this:
 '+ expr expr') but the aim is to implemented an infix notation (like this:
 'expr + expr'). To do this we must be able to deal with potentially
 infinite data structures (see Codata Types here :ref:`sect-typefuns`).
+
+.. code-block:: idris
+
+  expression = ["+"|"-"] term {("+"|"-") term} .
+
+  term = factor {("*"|"/") factor} .
+
+  factor =
+     ident
+     | number
+     | "(" expression ")"
 
 First alter the grammar to have infix operations:
 


### PR DESCRIPTION
This PR changes documentation only.

It extends (and fixes some typos) in the pages, about the parser library, that I wrote earlier that were merged recently.