### PR TITLE
Rts stdfgn

### DIFF
--- a/rts/idris_bitstring.c
+++ b/rts/idris_bitstring.c
@@ -1,5 +1,3 @@
-#include <assert.h>
-
 #include "idris_rts.h"
 
 VAL idris_b8const(VM *vm, uint8_t a) {

--- a/rts/idris_rts.c
+++ b/rts/idris_rts.c
@@ -1158,16 +1158,6 @@ void idris_disableBuffering(void) {
   setvbuf(stdout, NULL, _IONBF, 0);
 }
 
-#ifndef SEL4
-int idris_usleep(int usec) {
-    struct timespec t;
-    t.tv_sec = usec / 1000000;
-    t.tv_nsec = (usec % 1000000) * 1000;
-
-    return nanosleep(&t, NULL);
-}
-#endif // SEL4
-
 void stackOverflow(void) {
   fprintf(stderr, "Stack overflow");
   exit(-1);

--- a/rts/idris_rts.h
+++ b/rts/idris_rts.h
@@ -507,10 +507,6 @@ const char *idris_getArg(int i);
 // disable stdin/stdout buffering
 void idris_disableBuffering(void);
 
-#ifndef SEL4
-int idris_usleep(int usec);
-#endif // SEL4
-
 // Handle stack overflow.
 // Just reports an error and exits.
 

--- a/rts/idris_stdfgn.c
+++ b/rts/idris_stdfgn.c
@@ -228,6 +228,16 @@ VAL idris_clock(VM* vm) {
     return result;
 }
 
+#ifndef SEL4
+int idris_usleep(int usec) {
+    struct timespec t;
+    t.tv_sec = usec / 1000000;
+    t.tv_nsec = (usec % 1000000) * 1000;
+
+    return nanosleep(&t, NULL);
+}
+#endif // SEL4
+
 VAL idris_mkFileError(VM* vm) {
     VAL result;
     switch(errno) {

--- a/rts/idris_stdfgn.h
+++ b/rts/idris_stdfgn.h
@@ -54,6 +54,9 @@ char* getEnvPair(int i);
 
 VAL idris_time();
 VAL idris_clock(VM* vm);
+#ifndef SEL4
+int idris_usleep(int usec);
+#endif // SEL4
 
 void idris_forceGC();
 

--- a/rts/idris_utf8.c
+++ b/rts/idris_utf8.c
@@ -1,5 +1,4 @@
 #include "idris_utf8.h"
-#include <stdio.h>
 #include <string.h>
 #include <stdlib.h>
 


### PR DESCRIPTION
Move the usleep implementation to the idris_stdfgn file. It seems to belong more there than in idris_rts. Also remove some unused headers in the C RTS.