### PR TITLE
Change lines of code of JavaScript to 60 for Hello World example in docs

### DIFF
--- a/docs/reference/codegen.rst
+++ b/docs/reference/codegen.rst
@@ -36,10 +36,10 @@ issue the following command:
     $ idris --codegen javascript hello.idr -o hello.js
 
 
-Idris can produce very big chunks of JavaScript code (hello world
-weighs in at 1500 lines). However, the generated code can be minified
-using the `closure-compiler
-<https://developers.google.com/closure/compiler/>`__ from Google.
+Idris can produce big chunks of JavaScript code (hello world weighs in at about
+60 lines). However, the generated code can be minified using the
+`closure-compiler <https://developers.google.com/closure/compiler/>`__ from
+Google.
 
 ::
 


### PR DESCRIPTION
A simple hello world program now produces about 60 lines of code:
```
~/projects/learn-idris ξ cat hello.idr
main : IO ()
main = putStrLn "Hello, world!"
~/projects/learn-idris ξ idris --codegen javascript hello.idr -o hello.js
~/projects/learn-idris ξ wc -l hello.js
61 hello.js
```

Far from 1500! Hooray :)