### PR TITLE
Add a travis target building Idris 2

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -19,6 +19,8 @@ matrix:
     - env: CABALVER="2.4" GHCVER="8.2.2" TESTS="test_c"
       compiler: ": #GHC 8.2.2"
       addons: {apt: {packages: [cabal-install-2.4,ghc-8.2.2,cppcheck,hscolour], sources: [hvr-ghc]}}
+    - env: CABALVER="3.0" GHCVER="8.8.2" IDRIS2=YES
+      addons: {apt: {packages: [cabal-install-3.0,ghc-8.8.2], sources: [hvr-ghc]}}
 
 #    - env: CABALVER="3.0" GHCVER="8.8.1" TESTS="lib_doc doc"
 #      compiler: ": #GHC 8.8.1"
@@ -47,7 +49,7 @@ before_install:
   - unset CC
   - if [[ $TRAVIS_OS_NAME == 'linux' ]];
     then
-        export PATH=/opt/ghc/$GHCVER/bin:/opt/cabal/$CABALVER/bin:$HOME/.cabal/bin:$PATH;
+        export PATH=/opt/ghc/$GHCVER/bin:/opt/cabal/$CABALVER/bin:$HOME/.cabal/bin:$HOME/opt/scheme/bin/:$PATH;
         export SED=sed;
         export ZCAT=zcat;
     fi
@@ -62,6 +64,21 @@ before_install:
         export PKG_CONFIG_PATH=/usr/local/opt/libffi/lib/pkgconfig:$PKG_CONFIG_PATH;
     fi
   - if [ -n "$STYLISH" ]; then ./stylize.sh; exit $?; fi
+  - if [ -n "$IDRIS2" ];
+    then
+      git clone https://github.com/edwinb/Idris2 &&
+      wget https://github.com/cisco/ChezScheme/archive/v9.5.2.tar.gz &&
+      tar xvzf v9.5.2.tar.gz &&
+      cd ChezScheme-9.5.2 &&
+      ./configure --threads --installprefix=$HOME/opt/scheme &&
+      make -j install &&
+      cd .. &&
+      cabal v1-update &&
+      travis_wait cabal v1-install &&
+      cd Idris2 &&
+      make idris2 && make base && make contrib;
+      exit $?;
+    fi
 
 install:
   - which cabal
@@ -102,6 +119,7 @@ install:
       cp -a $HOME/.ghc $HOME/.cabsnap/ghc;
       cp -a $HOME/.cabal/lib $HOME/.cabal/share $HOME/.cabal/bin installplan.txt $HOME/.cabsnap/;
     fi
+  
 
 before_script:
   - ORIGINAL_DIR=$(pwd)

--- a/stack.yaml
+++ b/stack.yaml
@@ -10,6 +10,8 @@ extra-deps:
   - tasty-rerun-1.1.14@sha256:ba9c19a281535bea566e1044bc02c36ef17abcb310af4b6a149ec11780c7ce35
   - binary-0.8.7.0@sha256:ae3e6cca723ac55c54bbb3fa771bcf18142bc727afd57818e66d6ee6c8044f12
   - text-1.2.4.0@sha256:8c24450feb8e3bbb7ea3e17af24ef57e85db077c4bf53e5bcc345b283d1b1d5b
+  - HsYAML-0.2.1.0@sha256:e4677daeba57f7a1e9a709a1f3022fe937336c91513e893166bd1f023f530d68,5311
+  - HsYAML-aeson-0.2.0.0@sha256:04796abfc01cffded83f37a10e6edba4f0c0a15d45bef44fc5bb4313d9c87757,1791
 
 flags:
   idris:


### PR DESCRIPTION
This builds idris and then builds idris 2 and libs (leaving off network because it runs tests in the build that doesn't work on xenial).

As a bonus I build it with GHC 8.8 and leave off FFI, so we cover newer GHCs a bit too.