### PR TITLE
Fix Readthedocs PDF generation

### DIFF
--- a/docs/conf.py
+++ b/docs/conf.py
@@ -301,8 +301,8 @@ latex_elements = {
 # (source start file, target name, title,
 #  author, documentclass [howto, manual, or own class]).
 latex_documents = [
-    (master_doc,  'idris.tex',  u'Documentation for the Idris Language',    u'The Idris Community', 'report')
-   , ('tutorial/index',  'idris-tutorial.tex',  u'The Idris Tutorial',    u'The Idris Community', 'howto'),
+    # (master_doc,  'idris.tex',  u'Documentation for the Idris Language',    u'The Idris Community', 'report')
+   ('tutorial/index',  'idris-tutorial.tex',  u'The Idris Tutorial',    u'The Idris Community', 'howto'),
 ]
 
 


### PR DESCRIPTION
RTD is consistently not building the PDF of the Idris Documentation. I think it is because we have two documents built.
I have made the opinion to only have the main tutorial build, as this would be of most interest to others.