### PR TITLE
XDG Base Directory Specification compliance

### DIFF
--- a/docs/reference/repl.rst
+++ b/docs/reference/repl.rst
@@ -40,12 +40,13 @@ Idris supports initialisation scripts.
 Initialisation scripts
 ~~~~~~~~~~~~~~~~~~~~~~
 
-When the Idris REPL starts up, it will attempt to open the file
-repl/init in Idris's application data directory. The application data
-directory is the result of the Haskell function call
-``getAppUserDataDirectory "idris"``, which on most Unix-like systems
-will return $HOME/.idris and on various versions of Windows will return
-paths such as ``C:/Documents And Settings/user/Application Data/appName``.
+When the Idris REPL starts up, it will attempt to open the file repl/init in
+Idris's application data directory. The application data directory is the result
+of the Haskell function call ``getAppUserDataDirectory "idris"``, if that
+exists, or ``getXdgDirectory XdgConfig "idris"`` otherwise. On most Unix-like
+systems that will return, respectively, $HOME/.idris or $HOME/.config/idris, and
+on various versions of Windows will return paths such as ``C:/Documents And
+Settings/user/Application Data/appName``.
 
 The file repl/init is a newline-separate list of REPL commands. Not all
 commands are supported in initialisation scripts — only the subset that

--- a/src/Idris/Info.hs
+++ b/src/Idris/Info.hs
@@ -17,7 +17,7 @@ module Idris.Info
   , getIdrisCC
   , getIdrisVersion
   , getIdrisVersionNoGit
-  , getIdrisUserDataDir
+  , getIdrisUserDirs
   , getIdrisInitScript
   , getIdrisHistoryFile
   , getIdrisInstalledPackages
@@ -68,20 +68,26 @@ getIdrisVersion = showVersion S.version ++ suffix
 
 getIdrisVersionNoGit = S.version
 
-
--- | Get the platform-specific, user-specific Idris dir
-getIdrisUserDataDir :: IO FilePath
-getIdrisUserDataDir = getAppUserDataDirectory "idris"
+-- | Locate XDG directories in the current system in a backwards-compatible
+-- manner
+getIdrisUserDirs :: XdgDirectory -> IO FilePath
+getIdrisUserDirs xdg = do
+    old <- getAppUserDataDirectory "idris"
+    exists <- doesDirectoryExist old
+    if exists then
+        return old
+    else
+        getXdgDirectory xdg "idris"
 
 -- | Locate the platform-specific location for the init script
 getIdrisInitScript :: IO FilePath
 getIdrisInitScript = do
-  idrisDir <- getIdrisUserDataDir
+  idrisDir <- getIdrisUserDirs XdgConfig
   return $ idrisDir </> "repl" </> "init"
 
 getIdrisHistoryFile :: IO FilePath
 getIdrisHistoryFile = do
-  udir <- getIdrisUserDataDir
+  udir <- getIdrisUserDirs XdgCache
   return (udir </> "repl" </> "history")
 
 getIdrisInstalledPackages :: IO [String]

--- a/src/Idris/Info/Show.hs
+++ b/src/Idris/Info/Show.hs
@@ -2,8 +2,8 @@ module Idris.Info.Show where
 
 import Idris.Info
 
+import System.Directory (XdgDirectory(XdgCache, XdgConfig))
 import System.Exit
-import System.Directory (XdgDirectory(XdgConfig, XdgCache))
 
 showIdrisCRTSDir :: IO ()
 showIdrisCRTSDir = do

--- a/src/Idris/Info/Show.hs
+++ b/src/Idris/Info/Show.hs
@@ -3,6 +3,7 @@ module Idris.Info.Show where
 import Idris.Info
 
 import System.Exit
+import System.Directory (XdgDirectory(XdgConfig, XdgCache))
 
 showIdrisCRTSDir :: IO ()
 showIdrisCRTSDir = do
@@ -107,7 +108,8 @@ showIdrisInfo = do
 
   putStrLn "Paths:"
   ldir <- getIdrisLibDir
-  udir <- getIdrisUserDataDir
+  cdir <- getIdrisUserDirs XdgConfig
+  cadir <- getIdrisUserDirs XdgCache
   ddir <- getIdrisDocDir
   idir <- getIdrisDataDir
   crdir <- getIdrisCRTSDir
@@ -116,7 +118,8 @@ showIdrisInfo = do
   putStrLn $ unwords ["-", "Library Dir:", ldir]
   putStrLn $ unwords ["-", "C RTS Dir:", crdir]
   putStrLn $ unwords ["-", "JS RTS Dir:", jrdir]
-  putStrLn $ unwords ["-", "User Dir:",    udir]
+  putStrLn $ unwords ["-", "User Config Dir:", cdir]
+  putStrLn $ unwords ["-", "User Cache Dir:", cadir]
   putStrLn $ unwords ["-", "Documentation Dir:", ddir]
 
   putStrLn "Flags:"

--- a/src/Idris/Main.hs
+++ b/src/Idris/Main.hs
@@ -205,11 +205,15 @@ idrisMain opts =
          Nothing -> return ()
          Just expr -> execScript expr
 
-       -- Create Idris data dir + repl history and config dir
-       idrisCatch (do dir <- runIO $ getIdrisUserDataDir
-                      exists <- runIO $ doesDirectoryExist dir
-                      unless exists $ logLvl 1 ("Creating " ++ dir)
-                      runIO $ createDirectoryIfMissing True (dir </> "repl"))
+       -- Create Idris cache dir + repl history and config dir
+       idrisCatch (do config_dir <- runIO $ getIdrisUserDirs XdgConfig
+                      cache_dir <- runIO $ getIdrisUserDirs XdgCache
+                      config_exists <- runIO $ doesDirectoryExist config_dir
+                      cache_exists <- runIO $ doesDirectoryExist cache_dir
+                      unless config_exists $ logLvl 1 ("Creating " ++ config_dir)
+                      unless cache_exists $ logLvl 1 ("Creating " ++ cache_dir)
+                      runIO $ createDirectoryIfMissing True config_dir
+                      runIO $ createDirectoryIfMissing True (cache_dir </> "repl"))
          (\e -> return ())
 
        historyFile <- runIO $ getIdrisHistoryFile


### PR DESCRIPTION
Idris currently stores it's configuration files and cache (history file) on the `~/.idris` directory. To comply with the [XDG Base Directory Specification](https://wiki.archlinux.org/index.php/XDG_Base_Directory), it should use `$XDG_CONFIG_HOME/idris` (`~/.config/idris` by default) for configurations and `$XDG_CACHE_HOME/idris` (`~/.cache/idris` by default) for cache data.

However, doing that in a backwards compatible manner requries a work-around.  With this commits, the REPL would use the old directory, *if it exists*, for both configuration and cache data, using the XDG ones otherwise (*c.f.* [this comment](https://github.com/haskell/directory/issues/6#issuecomment-96521020)).