### PR TITLE
Add missing List modules to contrib.ipkg

### DIFF
--- a/libs/contrib/Data/List/Permutations.idr
+++ b/libs/contrib/Data/List/Permutations.idr
@@ -1,4 +1,4 @@
-module Permutations
+module Data.List.Permutations
 
 %access export
 

--- a/libs/contrib/contrib.ipkg
+++ b/libs/contrib/contrib.ipkg
@@ -43,8 +43,10 @@ modules = CFFI
         , Data.Hash
         , Data.Heap
         , Data.IOArray
-        , Data.List.Zipper
+        , Data.List.Group
+        , Data.List.Permutations
         , Data.List.Reverse
+        , Data.List.Zipper
 
         , Data.Matrix
         , Data.Matrix.Algebraic


### PR DESCRIPTION
Notably, I wanted to `import Data.List.Group`.