### PR TITLE
Fix `lamToLet` in `Erasure.hs`

### DIFF
--- a/src/Idris/Erasure.hs
+++ b/src/Idris/Erasure.hs
@@ -607,14 +607,13 @@ buildDepMap ci used externs ctx startNames
     -- convert applications of lambdas to lets
     -- note that this transformation preserves de bruijn numbering
     lamToLet :: Term -> Term
-    lamToLet tm = lamToLet' args f
+    lamToLet tm = lamToLet' 0 args f
       where
         (f, args) = unApply tm
 
-    lamToLet' :: [Term] -> Term -> Term
-    lamToLet' (v:vs) (Bind n (Lam rig ty) tm) = Bind n (Let rig ty v) $ lamToLet' vs tm
-    lamToLet'    []  tm = tm
-    lamToLet'    vs  tm = mkApp tm vs
+    lamToLet' :: Int -> [Term] -> Term -> Term
+    lamToLet' wk (v:vs) (Bind n (Lam rig ty) tm) = Bind n (Let rig ty (weakenTm wk v)) $ lamToLet' (wk+1) vs tm
+    lamToLet' wk    vs  tm = mkApp tm $ map (weakenTm wk) vs
 
     -- split "\x_i -> T(x_i)" into [x_i] and T
     unfoldLams :: Term -> ([Name], Term)

--- a/src/Idris/Erasure.hs
+++ b/src/Idris/Erasure.hs
@@ -614,9 +614,7 @@ buildDepMap ci used externs ctx startNames
     lamToLet' :: [Term] -> Term -> Term
     lamToLet' (v:vs) (Bind n (Lam rig ty) tm) = Bind n (Let rig ty v) $ lamToLet' vs tm
     lamToLet'    []  tm = tm
-    lamToLet'    vs  tm = error $
-        "Erasure.hs:lamToLet': unexpected input: "
-            ++ "vs = " ++ show vs ++ ", tm = " ++ show tm
+    lamToLet'    vs  tm = mkApp tm vs
 
     -- split "\x_i -> T(x_i)" into [x_i] and T
     unfoldLams :: Term -> ([Name], Term)

--- a/src/Idris/IBC.hs
+++ b/src/Idris/IBC.hs
@@ -41,7 +41,7 @@ import System.Directory
 import System.FilePath
 
 ibcVersion :: Word16
-ibcVersion = 166
+ibcVersion = 167
 
 -- | When IBC is being loaded - we'll load different things (and omit
 -- different structures/definitions) depending on which phase we're in.


### PR DESCRIPTION
There were two bugs:
* The original code did not address overapplied lambdas but there should be no problem with these -- just reapply the extra arguments under the let bindings.
* The original code did not weaken terms when moving them under `let` binders.

This caused problems in https://github.com/edwinb/Idris2/pull/333 and is (hopefully) fixed in this patch.