### PR TITLE
Improve IDE REPL

### DIFF
--- a/codegen/idris-codegen-node/Main.hs
+++ b/codegen/idris-codegen-node/Main.hs
@@ -7,8 +7,6 @@ import Idris.Options
 import IRTS.CodegenJavaScript
 import IRTS.Compiler
 
-import Paths_idris
-
 import Control.Monad
 
 import System.Environment

--- a/src/IRTS/Compiler.hs
+++ b/src/IRTS/Compiler.hs
@@ -35,7 +35,6 @@ import Control.Category
 import Control.Monad.State
 import Data.List
 import qualified Data.Map as M
-import Data.Maybe (maybe)
 import Data.Ord
 import qualified Data.Set as S
 import System.Directory

--- a/src/IRTS/JavaScript/Codegen.hs
+++ b/src/IRTS/JavaScript/Codegen.hs
@@ -23,10 +23,8 @@ import IRTS.JavaScript.Specialize
 import IRTS.Lang
 import IRTS.System
 
-import Control.Applicative (pure, (<$>))
 import Control.Monad
 import Control.Monad.Trans.State
-import Data.Foldable (foldMap)
 import Data.Generics.Uniplate.Data
 import Data.List
 import Data.Map.Strict (Map)

--- a/src/IRTS/LangOpts.hs
+++ b/src/IRTS/LangOpts.hs
@@ -14,9 +14,6 @@ import Idris.Core.TT
 import IRTS.Lang
 
 import Control.Monad.State hiding (lift)
-import Data.List
-
-import Debug.Trace
 
 inlineAll :: [(Name, LDecl)] -> [(Name, LDecl)]
 inlineAll lds = let defs = addAlist lds emptyContext in

--- a/src/IRTS/System.hs
+++ b/src/IRTS/System.hs
@@ -27,7 +27,6 @@ import Paths_idris
 #endif
 import BuildFlags_idris
 
-import Control.Applicative ((<$>))
 import Data.List.Split
 import Data.Maybe (fromMaybe)
 import System.Environment

--- a/src/Idris/CmdOptions.hs
+++ b/src/Idris/CmdOptions.hs
@@ -24,7 +24,6 @@ import Control.Monad.Trans.Except (throwE)
 import Control.Monad.Trans.Reader (ask)
 import Data.Char
 import Data.Maybe
-import Data.Monoid ((<>))
 import Options.Applicative
 import Options.Applicative.Arrows
 import Options.Applicative.Types (ReadM(..))

--- a/src/Idris/Core/Binary.hs
+++ b/src/Idris/Core/Binary.hs
@@ -12,7 +12,6 @@ module Idris.Core.Binary where
 
 import Idris.Core.TT
 
-import Control.Applicative ((<$>), (<*>))
 import Data.Binary
 import Data.Binary.Get
 import Data.Binary.Put

--- a/src/Idris/Core/ProofState.hs
+++ b/src/Idris/Core/ProofState.hs
@@ -28,7 +28,6 @@ import Idris.Core.WHNF
 
 import Util.Pretty hiding (fill)
 
-import Control.Arrow ((***))
 import Control.Monad.State.Strict
 import Data.List
 

--- a/src/Idris/Core/TT.hs
+++ b/src/Idris/Core/TT.hs
@@ -58,8 +58,8 @@ module Idris.Core.TT(
 import Util.Pretty hiding (Str)
 
 -- Work around AMP without CPP
-import Prelude (Bool(..), Double, Enum(..), Eq(..), FilePath, Functor(..), Int,
-                Integer, Maybe(..), Monad(..), Monoid(..), Num(..), Ord(..),
+import Prelude (Bool(..), Double, Enum(..), Eq(..), FilePath, Int,
+                Integer, Maybe(..), Monoid(..), Num(..), Ord(..),
                 Ordering(..), Show(..), String, div, error, fst, max, min, mod,
                 not, otherwise, read, snd, ($), (&&), (.), (||))
 

--- a/src/Idris/Docstrings.hs
+++ b/src/Idris/Docstrings.hs
@@ -27,11 +27,9 @@ import Prelude hiding ((<$>))
 import qualified Cheapskate as C
 import Cheapskate.Html (renderDoc)
 import qualified Cheapskate.Types as CT
-import Data.Foldable (Foldable)
 import qualified Data.Foldable as F
 import qualified Data.Sequence as S
 import qualified Data.Text as T
-import Data.Traversable (Traversable)
 import GHC.Generics (Generic)
 import Text.Blaze.Html (Html)
 

--- a/src/Idris/Elab/Data.hs
+++ b/src/Idris/Elab/Data.hs
@@ -32,13 +32,8 @@ import Prelude hiding (id, (.))
 
 import Control.Category
 import Control.Monad
-import Control.Monad.State.Strict as State
-import Data.Char (isLetter, toLower)
 import Data.List
-import qualified Data.Map as Map
-import Data.Maybe
 import qualified Data.Set as S
-import qualified Data.Text as T
 
 warnLC :: FC -> Name -> Idris ()
 warnLC fc n

--- a/src/Idris/Elab/Term.hs
+++ b/src/Idris/Elab/Term.hs
@@ -30,7 +30,6 @@ import Idris.ProofSearch
 import Idris.Reflection
 import Idris.Termination (buildSCG, checkDeclTotality, checkPositive)
 
-import Control.Applicative ((<$>))
 import Control.Monad
 import Control.Monad.State.Strict
 import Data.Foldable (for_)

--- a/src/Idris/IdrisDoc.hs
+++ b/src/Idris/IdrisDoc.hs
@@ -29,7 +29,6 @@ import qualified Data.ByteString.Lazy as BS2
 import qualified Data.List as L
 import qualified Data.Map as M hiding ((!))
 import Data.Maybe
-import Data.Monoid (mempty)
 import qualified Data.Set as S
 import qualified Data.Text as T
 import System.Directory

--- a/src/Idris/Imports.hs
+++ b/src/Idris/Imports.hs
@@ -16,7 +16,6 @@ import Idris.Core.TT
 import Idris.Error
 import IRTS.System (getIdrisLibDir)
 
-import Control.Applicative ((<$>))
 import Control.Monad.State.Strict
 import Data.Char (isAlpha, isDigit, toLower)
 import Data.List (isSuffixOf)

--- a/src/Idris/Package.hs
+++ b/src/Idris/Package.hs
@@ -9,7 +9,6 @@ Maintainer  : The Idris Community.
 module Idris.Package where
 
 import System.Directory
-import System.Directory (copyFile, createDirectoryIfMissing)
 import System.Environment
 import System.Exit
 import System.FilePath (addExtension, addTrailingPathSeparator, dropExtension,

--- a/src/Idris/Parser/Data.hs
+++ b/src/Idris/Parser/Data.hs
@@ -12,7 +12,6 @@ module Idris.Parser.Data where
 import Idris.AbsSyntax
 import Idris.Core.TT
 import Idris.Docstrings
-import Idris.Options
 import Idris.Parser.Expr
 import Idris.Parser.Helpers
 import Idris.Parser.Ops

--- a/src/Idris/ProofSearch.hs
+++ b/src/Idris/ProofSearch.hs
@@ -22,7 +22,6 @@ import Idris.Core.TT
 import Idris.Core.Unify
 import Idris.Delaborate
 
-import Control.Applicative ((<$>))
 import Control.Monad
 import Control.Monad.State.Strict
 import Data.List

--- a/src/Idris/REPL.hs
+++ b/src/Idris/REPL.hs
@@ -680,6 +680,7 @@ idemodeProcess fn (SetPrinterDepth d) = do process fn (SetPrinterDepth d)
                                            iPrintResult ""
 idemodeProcess fn (Apropos pkg a) = do process fn (Apropos pkg a)
                                        iPrintResult ""
+idemodeProcess fn (Browse ns) = process fn (Browse ns)
 idemodeProcess fn (WhoCalls n) = process fn (WhoCalls n)
 idemodeProcess fn (CallsWho n) = process fn (CallsWho n)
 idemodeProcess fn (PrintDef n) = process fn (PrintDef n)

--- a/src/Idris/REPL.hs
+++ b/src/Idris/REPL.hs
@@ -515,7 +515,7 @@ runIdeModeCommand h id orig fn modes (IdeMode.BrowseNS ns) =
                  prettyName True False [] n <>
                  case lookupTyExact n ctxt of
                    Just t ->
-                     space <> colon <> space <> align (group (pprintDelab ist t))
+                     space <> colon <> space <> align (group (pprintDelabTy' ist n t))
                    Nothing ->
                      empty
 

--- a/src/Idris/TypeSearch.hs
+++ b/src/Idris/TypeSearch.hs
@@ -38,20 +38,18 @@ import qualified Prelude as S (Semigroup(..))
 #else
 import Prelude hiding (pred)
 #endif
-import Control.Applicative (Applicative(..), (<$>), (<*>), (<|>))
+import Control.Applicative ((<|>))
 import Control.Arrow (first, second, (&&&), (***))
 import Control.Monad (guard, when)
 import Data.List (find, partition, (\\))
 import Data.Map (Map)
 import qualified Data.Map as M
 import Data.Maybe (catMaybes, fromMaybe, isJust, mapMaybe, maybeToList)
-import Data.Monoid (Monoid(mappend, mempty))
 import Data.Ord (comparing)
 import qualified Data.PriorityQueue.FingerTree as Q
 import Data.Set (Set)
 import qualified Data.Set as S
 import qualified Data.Text as T (isPrefixOf, pack)
-import Data.Traversable (traverse)
 
 searchByType :: [PkgName] -> PTerm -> Idris ()
 searchByType pkgs pterm = do

--- a/src/Util/DynamicLinker.hs
+++ b/src/Util/DynamicLinker.hs
@@ -21,11 +21,10 @@ import System.FilePath.Windows ((</>))
 import System.Win32.DLL
 import System.Win32.Types
 #else
-import Control.Exception (IOException, throwIO, try)
+import Control.Exception (IOException, try)
 import Foreign.Ptr (FunPtr, nullFunPtr, nullPtr)
 #ifdef linux_HOST_OS
 import Data.Array (bounds, inRange, (!))
-import Data.Functor ((<$>))
 import Data.Maybe (catMaybes)
 #else
 import Data.Array (bounds, (!))

--- a/stack-15.12.yaml
+++ b/stack-15.12.yaml
@@ -3,6 +3,7 @@ resolver: lts-15.12
 
 extra-deps:
 - cheapskate-0.1.1.2
+- haskeline-0.8.0.0@sha256:0630452b759a5b40e0e3e7ca2ef4b0d55d5161d95e8d7b0dd3cf55888971437f,5440
 
 flags:
   idris:

--- a/test/TestRun.hs
+++ b/test/TestRun.hs
@@ -6,7 +6,6 @@ import TestData
 import Control.Monad
 import Data.Char (isLetter)
 import qualified Data.IntMap as IMap
-import Data.Monoid ((<>))
 import Data.Proxy
 import Data.Typeable
 import Options.Applicative


### PR DESCRIPTION
With this PR
- `:browse-namespace` should respond with the appropriate output
- `:browse` should now be supported in the IDE REPL

Also
- Redundant import warnings should now be gone
- `stack-15.12.yaml` should include the required extra-dep

Relevant Issues
- https://github.com/idris-lang/Idris-dev/issues/4002
- https://github.com/idris-lang/Idris-dev/issues/2799