### PR TITLE
Fix missing import

### DIFF
--- a/src/Util/DynamicLinker.hs
+++ b/src/Util/DynamicLinker.hs
@@ -21,7 +21,7 @@ import System.FilePath.Windows ((</>))
 import System.Win32.DLL
 import System.Win32.Types
 #else
-import Control.Exception (IOException, try)
+import Control.Exception (IOException, throwIO, try)
 import Foreign.Ptr (FunPtr, nullFunPtr, nullPtr)
 #ifdef linux_HOST_OS
 import Data.Array (bounds, inRange, (!))


### PR DESCRIPTION
This PR adds a missing import of `throwIO` for the conditional usage:
https://github.com/idris-lang/Idris-dev/blob/cf481823edef2130b550b87287f1a2085037e4dc/src/Util/DynamicLinker.hs#L118-L120