### PR TITLE
Fix CRLF encoding of idemode commands on windows.

### DIFF
--- a/src/Idris/Output.hs
+++ b/src/Idris/Output.hs
@@ -311,7 +311,7 @@ iputStr :: String -> Idris ()
 iputStr s = do i <- getIState
                case idris_outputmode i of
                    RawOutput h  -> runIO $ hPutStr h s
-                   IdeMode n h -> runIO . hPutStr h $ convSExp "write-string" s n
+                   IdeMode n h -> runIO . hPutStrLn h $ convSExp "write-string" s n
 
 idemodePutSExp :: SExpable a => String -> a -> Idris ()
 idemodePutSExp cmd info = do i <- getIState

--- a/src/Idris/REPL.hs
+++ b/src/Idris/REPL.hs
@@ -256,6 +256,7 @@ idemodeStart :: Bool -> IState -> [FilePath] -> Idris ()
 idemodeStart s orig mods
   = do h <- runIO $ if s then initIdemodeSocket else return stdout
        setIdeMode True h
+       runIO $ hSetNewlineMode h (NewlineMode { inputNL = CRLF, outputNL = LF })
        i <- getIState
        case idris_outputmode i of
          IdeMode n h ->


### PR DESCRIPTION
Accept CRLF or LF, just emit LF, so the length becomes correct.

From: https://github.com/meraymond2/idris-ide-client/issues/20