### PR TITLE
Document alternative type declaration syntax

### DIFF
--- a/docs/tutorial/typesfuns.rst
+++ b/docs/tutorial/typesfuns.rst
@@ -86,10 +86,27 @@ follows:
 The above declarations are taken from the standard library. Unary
 natural numbers can be either zero (``Z``), or the successor of
 another natural number (``S k``). Lists can either be empty (``Nil``)
-or a value added to the front of another list (``x :: xs``). In the
-declaration for ``List``, we used an infix operator ``::``. New
-operators such as this can be added using a fixity declaration, as
-follows:
+or a value added to the front of another list (``x :: xs``).
+
+Data types may also be declared by giving the just the *types* of the
+constructors. These definitions are equivalent to those above:
+
+.. code-block:: idris
+
+    data Nat : Type where
+        Z : Nat
+        S : Nat -> Nat
+
+    data List : Type -> Type where
+        Nil : List a
+        (::) : a -> List a -> List a
+
+This syntax is more verbose, but more flexible, and is used for
+types that can't be described with the simpler syntax.
+
+In the declaration for ``List``, we used an infix operator ``::``.
+New operators such as this can be added using a fixity declaration,
+as follows:
 
 ::
 

--- a/docs/tutorial/typesfuns.rst
+++ b/docs/tutorial/typesfuns.rst
@@ -88,7 +88,7 @@ natural numbers can be either zero (``Z``), or the successor of
 another natural number (``S k``). Lists can either be empty (``Nil``)
 or a value added to the front of another list (``x :: xs``).
 
-Data types may also be declared by giving the just the *types* of the
+Data types may also be declared by giving just the *types* of the
 constructors. These definitions are equivalent to those above:
 
 .. code-block:: idris


### PR DESCRIPTION
In the introduction to syntax for declaring data types, document the ability
to declare types via constructor signatures in addition to the Haskell-like
syntax.

This syntax seems to be documented nowhere (not even in the book), and
is just used without explanation when introducing dependent types like
`Fin` that require it. From personal experience, this is *extremely* confusing
to newcomers to Idris.

(I'm not sure if this is the best place to document it, but it needs to be
somewhere where it will be easily found, and this is what comes up for
a Google search for "idris data types".)