### PR TITLE
Fixes #4880

### DIFF
--- a/docs/tutorial/interfaces.rst
+++ b/docs/tutorial/interfaces.rst
@@ -144,8 +144,8 @@ give the constraints on the type variables left of the fat arrow
     sort : Ord a => List a -> List a
 
 Functions, interfaces and implementations can have multiple
-constraints. Multiple constraints are written in brackets in a comma
-separated list, for example:
+constraints. Multiple constraints are written in round brackets (parentheses) 
+in a comma separated list, for example:
 
 .. code-block:: idris
 


### PR DESCRIPTION
Without suitable context the term 'bracket' is ambiguous, let's make it unambiguous.