### PR TITLE
Update link to Idris 2 repo in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -45,5 +45,5 @@ where some interesting projects are being hosted.
 For those interested in contributing to Idris directly we kindly ask that
 prospective developers please consult the [Contributing Guide](CONTRIBUTING.md) first.
 
-[Idris 2](https://github.com/edwinb/Idris2) is an early preview of the next generation
+[Idris 2](https://github.com/idris-lang/Idris2) is an early preview of the next generation
 of Idris, implemented in Idris.


### PR DESCRIPTION
It looks like idris-lang/Idris2 is the “main” repo now.