### PR TITLE
allow ansi-terminal-0.11 and megaparsec-9

### DIFF
--- a/idris.cabal
+++ b/idris.cabal
@@ -321,7 +321,7 @@ Library
   Build-depends:  base >=4 && <5
                 , aeson >= 0.6 && < 1.6
                 , annotated-wl-pprint >= 0.7 && < 0.8
-                , ansi-terminal < 0.11
+                , ansi-terminal < 0.12
                 , ansi-wl-pprint < 0.7
                 , array >= 0.4.0.1 && < 0.6
                 , base64-bytestring < 1.3
@@ -338,7 +338,7 @@ Library
                 , fingertree >= 0.1.4.1 && < 0.2
                 , haskeline >= 0.8 && < 0.9
                 , ieee754 >= 0.7 && < 0.9
-                , megaparsec >= 7.0.4 && < 9
+                , megaparsec >= 7.0.4 && < 10
                 , mtl >= 2.1 && < 2.3
                 , network >= 2.7 && < 3.1.2
                 , optparse-applicative >= 0.13 && < 0.17


### PR DESCRIPTION
With this it should be possible to build with Stackage LTS 18