### PR TITLE
update test/pkg010/ to follow changes in idris --help output

### DIFF
--- a/test/pkg010/expected.out
+++ b/test/pkg010/expected.out
@@ -4,26 +4,28 @@ Uncaught error: user error (wrongopts.ipkg:4:1:
   | ^
 Invalid option `-total'
 
-Usage:  [--nobanner | (-q|--quiet) | --ide-mode | --ide-mode-socket | 
-          --client ARG | --log LEVEL | --logging-categories CATS | 
-          --nobasepkgs | --noprelude | --nobuiltins | --check | 
-          (-o|--output FILE) | --interface | --typeintype | --total | 
-          --partial | --warnpartial | --warnreach | --warnipkg | --nocoverage | 
-          --errorcontext | --info | --listlogcats | --link | --listlibs | 
-          --libdir | --docdir | --include | --V2 | --V1 | (-V|--V0|--verbose) | 
-          --ibcsubdir FILE | (-i|--idrispath ARG) | --sourcepath ARG | --warn | 
-          (-p|--package ARG) | --port PORT | --build IPKG | --install IPKG | 
-          --repl IPKG | --clean IPKG | --mkdoc IPKG | --installdoc IPKG | 
-          --checkpkg IPKG | --testpkg IPKG | --indent-with INDENT | 
-          --indent-clause INDENT | --bytecode ARG | (-S|--codegenonly) | 
-          (-c|--compileonly) | --dumpdefuns ARG | --dumpcases ARG | 
-          --codegen TARGET | --portable-codegen TARGET | --cg-opt ARG | 
-          (-e|--eval EXPR) | --execute | --exec EXPR | (-X|--extension EXT) | 
-          --O3 | --O2 | --O1 | --O0 | --partial-eval | --no-partial-eval | 
-          (--optimise-nat-like-types|--optimize-nat-like-types) | 
-          (--no-optimise-nat-like-types|--no-optimize-nat-like-types) | 
-          (-O|--level ARG) | --target TRIPLE | --cpu CPU | (--color|--colour) | 
-          (--nocolor|--nocolour) | --consolewidth WIDTH | --highlight | 
-          --no-tactic-deprecation-warnings | 
-          --allow-capitalized-pattern-variables] [FILES] [-v|--version]
+Usage:  ([--nobanner] | [-q|--quiet] | [--ide-mode] | [--ide-mode-socket] |
+        [--client ARG] | [--log LEVEL] | [--logging-categories CATS] |
+        [--nobasepkgs] | [--noprelude] | [--nobuiltins] | [--check] |
+        [-o|--output FILE] | [--interface] | [--typeintype] | [--total] |
+        [--partial] | [--warnpartial] | [--warnreach] | [--warnipkg] |
+        [--nocoverage] | [--errorcontext] | [--info] | [--listlogcats] |
+        [--link] | [--listlibs] | [--libdir] | [--docdir] | [--include] | [--V2]
+        | [--V1] | [-V|--V0|--verbose] | [--ibcsubdir FILE] |
+        [-i|--idrispath ARG] | [--sourcepath ARG] | [--warn] |
+        [-p|--package ARG] | [--port PORT] | [--build IPKG] | [--install IPKG] |
+        [--repl IPKG] | [--clean IPKG] | [--mkdoc IPKG] | [--installdoc IPKG] |
+        [--checkpkg IPKG] | [--testpkg IPKG] | [--indent-with INDENT] |
+        [--indent-clause INDENT] | [--bytecode ARG] | [-S|--codegenonly] |
+        [-c|--compileonly] | [--dumpdefuns ARG] | [--dumpcases ARG] |
+        [--codegen TARGET] | [--portable-codegen TARGET] | [--cg-opt ARG] |
+        [-e|--eval EXPR] | [--execute] | [--exec EXPR] | [-X|--extension EXT] |
+        [--O3] | [--O2] | [--O1] | [--O0] | [--partial-eval] |
+        [--no-partial-eval] |
+        [--optimise-nat-like-types|--optimize-nat-like-types] |
+        [--no-optimise-nat-like-types|--no-optimize-nat-like-types] |
+        [-O|--level ARG] | [--target TRIPLE] | [--cpu CPU] | [--color|--colour]
+        | [--nocolor|--nocolour] | [--consolewidth WIDTH] | [--highlight] |
+        [--no-tactic-deprecation-warnings] |
+        [--allow-capitalized-pattern-variables]) [FILES] [-v|--version]
 )


### PR DESCRIPTION
i'm not sure about this one. when building on Guix, this test fails the entire build due to a differently formatted `--help` output.

maybe it's due to being built with a different version of one of the dependencies?