### PR TITLE
fix ffi008 test: add -fcommon to accommodate for gcc v9+

### DIFF
--- a/test/ffi008/run.sh
+++ b/test/ffi008/run.sh
@@ -1,4 +1,4 @@
 #!/usr/bin/env bash
-${IDRIS:-idris} $@ ffi008.idr -o ffi008 -p contrib --cg-opt "ffi008.c"
+IDRIS_CFLAGS=-fcommon ${IDRIS:-idris} $@ ffi008.idr -o ffi008 -p contrib --cg-opt "ffi008.c"
 ./ffi008
 rm -f ffi008 *.ibc


### PR DESCRIPTION
Otherwise it fails with: "multiple definition of `mystruct'".

For further details see:
https://gcc.gnu.org/bugzilla/show_bug.cgi?id=85678
https://stackoverflow.com/questions/52294245/how-to-declare-global-variable-for-an-anonymous-structure-in-c