### PR TITLE
Fix function name in one of the erasure examples

### DIFF
--- a/docs/reference/erasure.rst
+++ b/docs/reference/erasure.rst
@@ -35,7 +35,7 @@ in the `original proposal
 
     uninterleave : {n : Nat} -> Vect (n * 2) a -> (Vect n a, Vect n a)
     uninterleave [] = ([] , [])
-    uninterleave (x :: y :: rest) with (unzipPairs rest)
+    uninterleave (x :: y :: rest) with (uninterleave rest)
       | (xs, ys) = (x :: xs, y :: ys)
 
 Notice that in this case, the second argument is the important one and


### PR DESCRIPTION
Hi, first time contributing.. I found this name mismatch while reading the docs.
Maybe I should also indicate in a comment in the example itself that the function doesn't typecheck without specifying `n`, to drive the point.