### PR TITLE
Allow vector 0.13

### DIFF
--- a/idris.cabal
+++ b/idris.cabal
@@ -355,7 +355,7 @@ Library
                 , uniplate >=1.6 && < 1.7
                 , unordered-containers < 0.3
                 , utf8-string < 1.1
-                , vector < 0.13
+                , vector < 0.14
                 , vector-binary-instances < 0.3
                 , zip-archive > 0.2.3.5 && < 0.5
                 , fsnotify >= 0.2 && < 0.4


### PR DESCRIPTION
Tested to build fine with the new version.