### PR TITLE
Support mtl 2.3

### DIFF
--- a/idris.cabal
+++ b/idris.cabal
@@ -339,7 +339,7 @@ Library
                 , haskeline >= 0.8 && < 0.9
                 , ieee754 >= 0.7 && < 0.9
                 , megaparsec >= 7.0.4 && < 10
-                , mtl >= 2.1 && < 2.3
+                , mtl >= 2.1 && < 2.4
                 , network >= 2.7 && < 3.1.2
                 , optparse-applicative >= 0.13 && < 0.17
                 , parser-combinators >= 1.0.0

--- a/src/IRTS/Compiler.hs
+++ b/src/IRTS/Compiler.hs
@@ -32,6 +32,7 @@ import IRTS.Simplified
 import Prelude hiding (id, (.))
 
 import Control.Category
+import Control.Monad
 import Control.Monad.State
 import Data.List
 import qualified Data.Map as M

--- a/src/Idris/AbsSyntax.hs
+++ b/src/Idris/AbsSyntax.hs
@@ -27,6 +27,7 @@ import System.Directory (canonicalizePath, doesFileExist)
 import System.IO
 
 import Control.Applicative
+import Control.Monad
 import Control.Monad.State
 import Prelude hiding (Applicative, Foldable, Traversable, (<$>))
 

--- a/src/Idris/Core/Constraints.hs
+++ b/src/Idris/Core/Constraints.hs
@@ -11,6 +11,7 @@ module Idris.Core.Constraints ( ucheck ) where
 import Idris.Core.TT (ConstraintFC(..), Err'(..), TC(..), UConstraint(..),
                       UExp(..))
 
+import Control.Monad
 import Control.Monad.State.Strict
 import Data.List (partition)
 import qualified Data.Map.Strict as M

--- a/src/Idris/Core/Elaborate.hs
+++ b/src/Idris/Core/Elaborate.hs
@@ -24,6 +24,7 @@ import Idris.Core.TT
 import Idris.Core.Typecheck
 import Idris.Core.Unify
 
+import Control.Monad
 import Control.Monad.State.Strict
 import Data.List
 

--- a/src/Idris/Core/Evaluate.hs
+++ b/src/Idris/Core/Evaluate.hs
@@ -37,6 +37,7 @@ module Idris.Core.Evaluate(normalise, normaliseTrace, normaliseC,
 import Idris.Core.CaseTree
 import Idris.Core.TT
 
+import Control.Monad
 import Control.Monad.State
 import Data.List
 import Data.Maybe (listToMaybe)

--- a/src/Idris/Core/ProofState.hs
+++ b/src/Idris/Core/ProofState.hs
@@ -28,6 +28,7 @@ import Idris.Core.WHNF
 
 import Util.Pretty hiding (fill)
 
+import Control.Monad
 import Control.Monad.State.Strict
 import Data.List
 

--- a/src/Idris/Core/ProofTerm.hs
+++ b/src/Idris/Core/ProofTerm.hs
@@ -19,6 +19,7 @@ module Idris.Core.ProofTerm(
 import Idris.Core.Evaluate
 import Idris.Core.TT
 
+import Control.Monad
 import Control.Monad.State.Strict
 
 -- | A zipper over terms, in order to efficiently update proof terms.

--- a/src/Idris/Core/TT.hs
+++ b/src/Idris/Core/TT.hs
@@ -70,6 +70,7 @@ import qualified Prelude as S (Semigroup(..))
 import Control.Applicative (Alternative, Applicative(..))
 import qualified Control.Applicative as A (Alternative(..))
 import Control.DeepSeq (($!!))
+import Control.Monad
 import qualified Control.Monad.Fail as Fail
 import Control.Monad.State.Strict
 import Data.Binary hiding (get, put)

--- a/src/Idris/Core/Typecheck.hs
+++ b/src/Idris/Core/Typecheck.hs
@@ -14,6 +14,7 @@ module Idris.Core.Typecheck where
 import Idris.Core.Evaluate
 import Idris.Core.TT
 
+import Control.Monad
 import Control.Monad.State
 
 -- To check conversion, normalise each term wrt the current environment.

--- a/src/Idris/Coverage.hs
+++ b/src/Idris/Coverage.hs
@@ -17,6 +17,7 @@ import Idris.Delaborate
 import Idris.Elab.Utils
 import Idris.Error
 
+import Control.Monad
 import Control.Monad.State.Strict
 import Data.Char
 import Data.List

--- a/src/Idris/DSL.hs
+++ b/src/Idris/DSL.hs
@@ -13,6 +13,7 @@ module Idris.DSL (debindApp, desugar) where
 import Idris.AbsSyntax
 import Idris.Core.TT
 
+import Control.Monad
 import Control.Monad.State.Strict
 import Data.Generics.Uniplate.Data (transform)
 

--- a/src/Idris/Erasure.hs
+++ b/src/Idris/Erasure.hs
@@ -22,6 +22,7 @@ import Prelude hiding (id, (.))
 
 import Control.Arrow
 import Control.Category
+import Control.Monad
 import Control.Monad.State
 import Data.IntMap (IntMap)
 import qualified Data.IntMap as IM

--- a/src/Idris/Imports.hs
+++ b/src/Idris/Imports.hs
@@ -16,6 +16,7 @@ import Idris.Core.TT
 import Idris.Error
 import IRTS.System (getIdrisLibDir)
 
+import Control.Monad
 import Control.Monad.State.Strict
 import Data.Char (isAlpha, isDigit, toLower)
 import Data.List (isSuffixOf)

--- a/src/Idris/Package/Parser.hs
+++ b/src/Idris/Package/Parser.hs
@@ -19,6 +19,7 @@ import Idris.Parser.Helpers (Parser, Parsing, eol, iName, identifier,
                              someSpace, stringLiteral)
 
 import Control.Applicative
+import Control.Monad
 import Control.Monad.State.Strict
 import Data.List (union)
 import qualified Options.Applicative as Opts

--- a/src/Idris/PartialEval.hs
+++ b/src/Idris/PartialEval.hs
@@ -19,6 +19,7 @@ import Idris.Core.Evaluate
 import Idris.Core.TT
 import Idris.Delaborate
 
+import Control.Monad
 import Control.Monad.State
 
 -- | Data type representing binding-time annotations for partial evaluation of arguments

--- a/src/Idris/Prover.hs
+++ b/src/Idris/Prover.hs
@@ -39,6 +39,7 @@ import Idris.TypeSearch (searchByType)
 import Util.Pretty
 
 import Control.DeepSeq
+import Control.Monad
 import Control.Monad.State.Strict
 import System.Console.Haskeline
 import System.Console.Haskeline.History

--- a/src/Idris/Termination.hs
+++ b/src/Idris/Termination.hs
@@ -19,6 +19,7 @@ import Idris.Error
 import Idris.Options
 import Idris.Output (iWarn)
 
+import Control.Monad
 import Control.Monad.State.Strict
 import Data.Either
 import Data.List


### PR DESCRIPTION
`mtl` 2.3 removes re-exports of `Control.Monad`. This leads to various `Variable not in scope` errors.

This PR solves them by adding the explicit import of `Control.Monad` to the affected files. This also works with earlier versions of `mtl`, as it just replaces the implicit import with an explicit one.
This also enables support for GHC 9.6.