### PR TITLE
Update dependencies for GHC 9.6

### DIFF
--- a/idris.cabal
+++ b/idris.cabal
@@ -319,16 +319,16 @@ Library
                   , BuildFlags_idris
 
   Build-depends:  base >=4 && <5
-                , aeson >= 0.6 && < 1.6
+                , aeson >= 0.6 && < 2.2
                 , annotated-wl-pprint >= 0.7 && < 0.8
-                , ansi-terminal < 0.12
+                , ansi-terminal < 0.12 || ^>= 1.0
                 , ansi-wl-pprint < 0.7
                 , array >= 0.4.0.1 && < 0.6
                 , base64-bytestring < 1.3
                 , binary >= 0.8.4.1 && < 0.9
                 , blaze-html >= 0.6.1.3 && < 0.10
                 , blaze-markup >= 0.5.2.1 && < 0.10
-                , bytestring < 0.11
+                , bytestring < 0.12
                 , cheapskate >= 0.1.1.2 && < 0.2
                 , code-page >= 0.1 && < 0.3
                 , containers >= 0.5 && < 0.7
@@ -340,8 +340,8 @@ Library
                 , ieee754 >= 0.7 && < 0.9
                 , megaparsec >= 7.0.4 && < 10
                 , mtl >= 2.1 && < 2.4
-                , network >= 2.7 && < 3.1.2
-                , optparse-applicative >= 0.13 && < 0.17
+                , network >= 2.7 && < 3.1.5
+                , optparse-applicative >= 0.13 && < 0.18
                 , parser-combinators >= 1.0.0
                 , pretty < 1.2
                 , process < 1.7
@@ -349,9 +349,9 @@ Library
                 , safe >= 0.3.9
                 , split < 0.3
                 , terminal-size < 0.4
-                , text >=1.2.1.0 && < 1.4
+                , text >=1.2.1.0 && < 1.4 || ^>= 2.0.2
                 , time >= 1.4 && < 2.0
-                , transformers >= 0.5 && < 0.6
+                , transformers >= 0.5 && < 0.7
                 , uniplate >=1.6 && < 1.7
                 , unordered-containers < 0.3
                 , utf8-string < 1.1
@@ -372,7 +372,7 @@ Library
      build-depends: mintty >= 0.1 && < 0.2
                   , Win32 < 2.7
   else
-     build-depends: unix < 2.8
+     build-depends: unix < 2.9
   if flag(FFI)
      build-depends: libffi < 0.3
      cpp-options:   -DIDRIS_FFI
@@ -416,7 +416,7 @@ Test-suite regression-and-feature-tests
                , filepath
                , directory
                , haskeline >= 0.7
-               , optparse-applicative >= 0.13 && < 0.17
+               , optparse-applicative >= 0.13 && < 0.18
                , tagged
                , tasty >= 0.8
                , tasty-golden >= 2.0


### PR DESCRIPTION
Builds and tests fine with GHC 9.6.3 and against latest Arch Linux packages
`custom-setup` isn't used on Arch, so no change there as untested.

### Tested versions
GHC: 9.6.3
aeson: 2.1.2.1
ansi-terminal: 1.0
bytestring: 0.11.5.2
network: 3.1.4.0
optparse-applicative: 0.17.1.0
text: 2.0.2
transformers: 0.6.1.0
unix: 2.8.1.0